### PR TITLE
Remove isWire

### DIFF
--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -426,7 +426,7 @@ const
 
   Unreliable* = mapOr(UDP)
 
-  Reliable* = mapOr(TCP, UTP, QUIC)
+  Reliable* = mapOr(TCP, UTP, QUIC, WebSockets)
 
   IPFS* = mapAnd(Reliable, mapEq("p2p"))
 
@@ -943,59 +943,6 @@ proc `&=`*(m1: var MultiAddress, m2: MultiAddress) {.
 proc `==`*(m1: var MultiAddress, m2: MultiAddress): bool =
   ## Check of two MultiAddress are equal
   m1.data == m2.data
-
-proc isWire*(ma: MultiAddress): bool =
-  ## Returns ``true`` if MultiAddress ``ma`` is one of:
-  ## - {IP4}/{TCP, UDP}
-  ## - {IP6}/{TCP, UDP}
-  ## - {UNIX}/{PATH}
-
-  var state = 0
-  const
-    wireProtocols = toHashSet([
-                        multiCodec("ip4"), multiCodec("ip6"),
-                      ])
-    wireTransports = toHashSet([
-                        multiCodec("tcp"), multiCodec("udp")
-                      ])
-  try:
-    for rpart in ma.items():
-      if rpart.isErr():
-        return false
-      let part = rpart.get()
-
-      if state == 0:
-        let rcode = part.protoCode()
-        if rcode.isErr():
-          return false
-        let code = rcode.get()
-
-        if code in wireProtocols:
-          inc(state)
-          continue
-        elif code == multiCodec("unix"):
-          result = true
-          break
-        else:
-          result = false
-          break
-      elif state == 1:
-        let rcode = part.protoCode()
-        if rcode.isErr():
-          return false
-        let code = rcode.get()
-
-        if code in wireTransports:
-          inc(state)
-          result = true
-        else:
-          result = false
-          break
-      else:
-        result = false
-        break
-  except:
-    result = false
 
 proc matchPart(pat: MaPattern, protos: seq[MultiCodec]): MaPatResult =
   var empty: seq[MultiCodec]

--- a/tests/testmultiaddress.nim
+++ b/tests/testmultiaddress.nim
@@ -192,29 +192,6 @@ const
     "9003172F612F622F632F642F652F662F672F682F692E736F636B"
   ]
 
-  UtilitySuccessVectors = [
-    "/ip4/127.0.0.1/tcp/1024",
-    "/ip4/127.0.0.1/udp/1024",
-    "/ip4/0.0.0.0/tcp/1024",
-    "/ip4/0.0.0.0/udp/1024",
-    "/ip4/255.255.255.255/tcp/65535",
-    "/ip4/255.255.255.255/udp/65535",
-    "/ip6/::1/tcp/1024",
-    "/ip6/::1/udp/1024",
-    "/ip6/::/tcp/65535",
-    "/ip6/::/udp/65535",
-    "/ip6/::/udp/65535",
-    "/unix/tmp/test.socket"
-  ]
-
-  UtilityFailVectors = [
-    "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
-    "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
-    "/ip6/2001:8a0:7ac5:4201:3ac9:86ff:fe31:7095/tcp/8000/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
-    "/p2p-webrtc-star/ip4/127.0.0.1/tcp/9090/ws/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
-    "/ip4/127.0.0.1/udp/1234/quic"
-  ]
-
   PatternVectors = [
     PatternVector(pattern: IP,
       good: @["/ip4/0.0.0.0", "/ip6/fc00::"],
@@ -338,14 +315,6 @@ suite "MultiAddress test suite":
     check:
       $cma == "/ip4/127.0.0.1/udp/30000/p2p-circuit"
       $ma2 == "/ip4/127.0.0.1/udp/30000/p2p-circuit"
-
-  test "isWire() test":
-    for item in UtilitySuccessVectors:
-      var a = MultiAddress.init(item).get()
-      check a.isWire() == true
-    for item in UtilityFailVectors:
-      var a = MultiAddress.init(item).get()
-      check a.isWire() == false
 
   test "Path addresses serialization/deserialization":
     for i in 0..<len(PathVectors):


### PR DESCRIPTION
closes #639

Following discussion on discord,

`isWire` wasn't obvious in what it did, and it's hard to know for libp2p what is a valid MultiAddress

Instead, you can use the multiaddress helper to create your own `isWire`:
```nim
const
  ValidTransports = mapOr(TCP, WebSockets)
  ValidAddress = mapAnd(ValidTransports, mapEq("p2p"))
proc isValidAddress*(ma: MultiAddress): bool =
  ValidAddress.match(ma)
```

I also added WebSockets to `Reliable`, which was missing.

Note: I removed it instead of deprecating it, since we are in the process of removing every deprecated proc anyway