### PR TITLE
IMReceiving message to minimize redundant large message transmissions

### DIFF
--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -75,6 +75,7 @@ type
     score*: float64
     sentIHaves*: Deque[HashSet[MessageId]]
     heDontWants*: Deque[HashSet[MessageId]]
+    heIsReceivings*:Deque[HashSet[MessageId]]
     iHaveBudget*: int
     pingBudget*: int
     maxMessageSize: int
@@ -480,4 +481,5 @@ proc new*(
   )
   result.sentIHaves.addFirst(default(HashSet[MessageId]))
   result.heDontWants.addFirst(default(HashSet[MessageId]))
+  result.heIsReceivings.addFirst(default(HashSet[MessageId]))
   result.startSendNonPriorityTask()

--- a/libp2p/protocols/pubsub/rpc/messages.nim
+++ b/libp2p/protocols/pubsub/rpc/messages.nim
@@ -51,6 +51,7 @@ type
       graft*: seq[ControlGraft]
       prune*: seq[ControlPrune]
       idontwant*: seq[ControlIWant]
+      imreceiving*: seq[ControlIWant]
 
     ControlIHave* = object
       topicId*: string
@@ -163,11 +164,12 @@ static: expectedFields(ControlPrune, @["topicId", "peers", "backoff"])
 proc byteSize(controlPrune: ControlPrune): int =
   controlPrune.topicId.len + controlPrune.peers.foldl(a + b.byteSize, 0) + 8 # 8 bytes for uint64
 
-static: expectedFields(ControlMessage, @["ihave", "iwant", "graft", "prune", "idontwant"])
+static: expectedFields(ControlMessage, @["ihave", "iwant", "graft", "prune", "idontwant", "imreceiving"])
 proc byteSize(control: ControlMessage): int =
   control.ihave.foldl(a + b.byteSize, 0) + control.iwant.foldl(a + b.byteSize, 0) +
   control.graft.foldl(a + b.byteSize, 0) + control.prune.foldl(a + b.byteSize, 0) +
-  control.idontwant.foldl(a + b.byteSize, 0)
+  control.idontwant.foldl(a + b.byteSize, 0) +
+  control.imreceiving.foldl(a + b.byteSize, 0)
 
 static: expectedFields(RPCMsg, @["subscriptions", "messages", "control", "ping", "pong"])
 proc byteSize*(rpc: RPCMsg): int =

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -89,6 +89,8 @@ proc write*(pb: var ProtoBuffer, field: int, control: ControlMessage) =
     ipb.write(4, prune)
   for idontwant in control.idontwant:
     ipb.write(5, idontwant)
+  for imreceiving in control.imreceiving:
+    ipb.write(6, imreceiving)
   if len(ipb.buffer) > 0:
     ipb.finish()
     pb.write(field, ipb)
@@ -213,6 +215,7 @@ proc decodeControl*(pb: ProtoBuffer): ProtoResult[Option[ControlMessage]] {.
     var graftpbs: seq[seq[byte]]
     var prunepbs: seq[seq[byte]]
     var idontwant: seq[seq[byte]]
+    var imreceiving: seq[seq[byte]]
     if ? cpb.getRepeatedField(1, ihavepbs):
       for item in ihavepbs:
         control.ihave.add(? decodeIHave(initProtoBuffer(item)))
@@ -228,6 +231,9 @@ proc decodeControl*(pb: ProtoBuffer): ProtoResult[Option[ControlMessage]] {.
     if ? cpb.getRepeatedField(5, idontwant):
       for item in idontwant:
         control.idontwant.add(? decodeIWant(initProtoBuffer(item)))
+    if ? cpb.getRepeatedField(6, imreceiving):
+      for item in imreceiving:
+        control.imreceiving.add(? decodeIWant(initProtoBuffer(item)))
     trace "decodeControl: message statistics", graft_count = len(control.graft),
                                                prune_count = len(control.prune),
                                                ihave_count = len(control.ihave),


### PR DESCRIPTION
Experimental PR (for discussion only)

1) On receiving message/IDontWant, we send IMReceiving message to peers (these peers can defer sending same message to us for some time)

2) We send IDontWant before message validation