### PR TITLE
libp2p/dialer.nim: tiny log change to make it clearer a connection upgrade

### DIFF
--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -85,7 +85,7 @@ proc dialAndUpgrade(
           # If we failed to establish the connection through one transport,
           # we won't succeeded through another - no use in trying again
           await dialed.close()
-          debug "Upgrade failed", err = exc.msg, peerId = peerId.get(default(PeerId))
+          debug "Connection upgrade failed", err = exc.msg, peerId = peerId.get(default(PeerId))
           if exc isnot CancelledError:
             if dialed.dir == Direction.Out:
               libp2p_failed_upgrades_outgoing.inc()


### PR DESCRIPTION
There may be an error during the connection transport upgrade (evolving from raw transport to a multiplexed stream.)

Simple simple change only makes it more explicit that the error refers to the connection upgrade and not to the app upgrade.

We've noticed this confusion in a user after upgrading the `nwaku` version.