### PR TITLE
fix: sendMsg must not raise errors

### DIFF
--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -299,7 +299,10 @@ proc sendMsgSlow(p: PubSubPeer, msg: seq[byte]) {.async.} =
     return
 
   trace "sending encoded msg to peer", conn, encoded = shortLog(msg), p
-  await sendMsgContinue(conn, conn.writeLp(msg))
+  try:
+    await sendMsgContinue(conn, conn.writeLp(msg))
+  except CancelledError as exc:
+    trace "Continuation for pending `sendMsg` future has been unexpectedly cancelled"
 
 proc sendMsg(p: PubSubPeer, msg: seq[byte]): Future[void] =
   if p.sendConn != nil and not p.sendConn.closed():


### PR DESCRIPTION
This error making nimbus crash has been reported:

```
/home/seamonkey/Downloads/holesky/nimbus-eth2/vendor/nim-testutils/testutils/moduletests.nim(21) moduletests
/home/seamonkey/Downloads/holesky/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2376) main
/home/seamonkey/Downloads/holesky/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2299) handleStartUpCmd
/home/seamonkey/Downloads/holesky/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(2200) doRunBeaconNode
/home/seamonkey/Downloads/holesky/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1957) start
/home/seamonkey/Downloads/holesky/nimbus-eth2/beacon_chain/nimbus_beacon_node.nim(1904) run
/home/seamonkey/Downloads/holesky/nimbus-eth2/vendor/nim-chronos/chronos/internal/asyncengine.nim(150) poll
Error: unhandled exception: Asynchronous task [sendMsgSlow() at pubsubpeer.nim:288] was cancelled! [FutureDefect]
```