### PR TITLE
feat: add max number of elements to non-prio queue

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -49,9 +49,6 @@ declareCounter(libp2p_gossipsub_received, "number of messages received (deduplic
 when defined(libp2p_expensive_metrics):
   declareCounter(libp2p_pubsub_received_messages, "number of messages received", labels = ["id", "topic"])
 
-const
-  DefaultMaxNumElementInNonPriorityQueue = 1024
-
 proc init*(_: type[GossipSubParams]): GossipSubParams =
   GossipSubParams(
       explicit: true,
@@ -87,7 +84,7 @@ proc init*(_: type[GossipSubParams]): GossipSubParams =
       bandwidthEstimatebps: 100_000_000, # 100 Mbps or 12.5 MBps
       overheadRateLimit: Opt.none(tuple[bytes: int, interval: Duration]),
       disconnectPeerAboveRateLimit: false,
-      maxNumElementInNonPriorityQueue: Opt.some(DefaultMaxNumElementInNonPriorityQueue)
+      maxNumElementsInNonPriorityQueue: DefaultMaxNumElementsInNonPriorityQueue
     )
 
 proc validateParameters*(parameters: GossipSubParams): Result[void, cstring] =
@@ -756,8 +753,5 @@ method getOrCreatePeer*(
   let peer = procCall PubSub(g).getOrCreatePeer(peerId, protos)
   g.parameters.overheadRateLimit.withValue(overheadRateLimit):
     peer.overheadRateLimitOpt = Opt.some(TokenBucket.new(overheadRateLimit.bytes, overheadRateLimit.interval))
-  g.parameters.maxNumElementInNonPriorityQueue.withValue(value):
-    peer.maxNumElementInNonPriorityQueue = value
-  do:
-    peer.maxNumElementInNonPriorityQueue = DefaultMaxNumElementInNonPriorityQueue
+  peer.maxNumElementsInNonPriorityQueue = DefaultMaxNumElementsInNonPriorityQueue
   return peer

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -83,7 +83,8 @@ proc init*(_: type[GossipSubParams]): GossipSubParams =
       enablePX: false,
       bandwidthEstimatebps: 100_000_000, # 100 Mbps or 12.5 MBps
       overheadRateLimit: Opt.none(tuple[bytes: int, interval: Duration]),
-      disconnectPeerAboveRateLimit: false
+      disconnectPeerAboveRateLimit: false,
+      maxNumElementInNonPriorityQueue: Opt.some(1024)
     )
 
 proc validateParameters*(parameters: GossipSubParams): Result[void, cstring] =
@@ -750,4 +751,6 @@ method getOrCreatePeer*(
   let peer = procCall PubSub(g).getOrCreatePeer(peerId, protos)
   g.parameters.overheadRateLimit.withValue(overheadRateLimit):
     peer.overheadRateLimitOpt = Opt.some(TokenBucket.new(overheadRateLimit.bytes, overheadRateLimit.interval))
+  g.parameters.maxNumElementInNonPriorityQueue.withValue(value):
+    peer.maxNumElementInNonPriorityQueue = value
   return peer

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -49,6 +49,9 @@ declareCounter(libp2p_gossipsub_received, "number of messages received (deduplic
 when defined(libp2p_expensive_metrics):
   declareCounter(libp2p_pubsub_received_messages, "number of messages received", labels = ["id", "topic"])
 
+const
+  DefaultMaxNumElementInNonPriorityQueue = 1024
+
 proc init*(_: type[GossipSubParams]): GossipSubParams =
   GossipSubParams(
       explicit: true,
@@ -84,7 +87,7 @@ proc init*(_: type[GossipSubParams]): GossipSubParams =
       bandwidthEstimatebps: 100_000_000, # 100 Mbps or 12.5 MBps
       overheadRateLimit: Opt.none(tuple[bytes: int, interval: Duration]),
       disconnectPeerAboveRateLimit: false,
-      maxNumElementInNonPriorityQueue: Opt.some(1024)
+      maxNumElementInNonPriorityQueue: Opt.some(DefaultMaxNumElementInNonPriorityQueue)
     )
 
 proc validateParameters*(parameters: GossipSubParams): Result[void, cstring] =
@@ -753,4 +756,6 @@ method getOrCreatePeer*(
     peer.overheadRateLimitOpt = Opt.some(TokenBucket.new(overheadRateLimit.bytes, overheadRateLimit.interval))
   g.parameters.maxNumElementInNonPriorityQueue.withValue(value):
     peer.maxNumElementInNonPriorityQueue = value
+  do:
+    peer.maxNumElementInNonPriorityQueue = DefaultMaxNumElementInNonPriorityQueue
   return peer

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -753,5 +753,5 @@ method getOrCreatePeer*(
   let peer = procCall PubSub(g).getOrCreatePeer(peerId, protos)
   g.parameters.overheadRateLimit.withValue(overheadRateLimit):
     peer.overheadRateLimitOpt = Opt.some(TokenBucket.new(overheadRateLimit.bytes, overheadRateLimit.interval))
-  peer.maxNumElementsInNonPriorityQueue = DefaultMaxNumElementsInNonPriorityQueue
+  peer.maxNumElementsInNonPriorityQueue = g.parameters.maxNumElementsInNonPriorityQueue
   return peer

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -147,6 +147,8 @@ type
     overheadRateLimit*: Opt[tuple[bytes: int, interval: Duration]]
     disconnectPeerAboveRateLimit*: bool
 
+    maxNumElementInNonPriorityQueue*: Opt[int]
+
   BackoffTable* = Table[string, Table[PeerId, Moment]]
   ValidationSeenTable* = Table[MessageId, HashSet[PubSubPeer]]
 

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -147,7 +147,7 @@ type
     overheadRateLimit*: Opt[tuple[bytes: int, interval: Duration]]
     disconnectPeerAboveRateLimit*: bool
 
-    maxNumElementInNonPriorityQueue*: Opt[int]
+    maxNumElementsInNonPriorityQueue*: int
 
   BackoffTable* = Table[string, Table[PeerId, Moment]]
   ValidationSeenTable* = Table[MessageId, HashSet[PubSubPeer]]

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -147,6 +147,7 @@ type
     overheadRateLimit*: Opt[tuple[bytes: int, interval: Duration]]
     disconnectPeerAboveRateLimit*: bool
 
+    # Max number of elements allowed in the non-priority queue. When this limit has been reached, the peer will be disconnected.
     maxNumElementsInNonPriorityQueue*: int
 
   BackoffTable* = Table[string, Table[PeerId, Moment]]

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -287,11 +287,14 @@ method onNewPeer(p: PubSub, peer: PubSubPeer) {.base, gcsafe.} = discard
 method onPubSubPeerEvent*(p: PubSub, peer: PubSubPeer, event: PubSubPeerEvent) {.base, gcsafe.} =
   # Peer event is raised for the send connection in particular
   case event.kind
-  of PubSubPeerEventKind.Connected:
+  of PubSubPeerEventKind.StreamOpened:
     if p.topics.len > 0:
       p.sendSubs(peer, toSeq(p.topics.keys), true)
-  of PubSubPeerEventKind.Disconnected:
+  of PubSubPeerEventKind.StreamClosed:
     discard
+  of PubSubPeerEventKind.DisconnectionRequested:
+    discard
+
 
 method getOrCreatePeer*(
     p: PubSub,

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -238,6 +238,10 @@ proc connectImpl(p: PubSubPeer) {.async.} =
     # send connection might get disconnected due to a timeout or an unrelated
     # issue so we try to get a new on
     while true:
+      if p.disconnected:
+        if not p.connectedFut.finished:
+          p.connectedFut.complete()
+        return
       await connectOnce(p)
   except CatchableError as exc: # never cancelled
     debug "Could not establish send connection", msg = exc.msg

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -351,7 +351,7 @@ proc sendEncoded*(p: PubSubPeer, msg: seq[byte], isHighPriority: bool): Future[v
         libp2p_gossipsub_priority_queue_size.inc(labelValues = [$p.peerId])
     f
   else:
-    if len(p.rpcmessagequeue.nonPriorityQueue) == p.maxNumElementsInNonPriorityQueue:
+    if len(p.rpcmessagequeue.nonPriorityQueue) >= p.maxNumElementsInNonPriorityQueue:
       if not p.disconnected:
         p.disconnected = true
         libp2p_pubsub_disconnects_over_non_priority_queue_limit.inc()


### PR DESCRIPTION
This PR adds a default limit to the number of elements in the non-priority queue. When this limit has been reached, the peer will be disconnected. This limit can also be configured through a new GossipSub param `maxNumElementsInNonPriorityQueue`.