### PR TITLE
fix: remove explicit param from GossipSubParams constructor

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -51,7 +51,6 @@ when defined(libp2p_expensive_metrics):
 
 proc init*(
   _: type[GossipSubParams],
-  explicit = true,
   pruneBackoff = 1.minutes,
   unsubscribeBackoff = 5.seconds,
   floodPublish = true,

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -102,6 +102,11 @@ type
     behaviourPenalty*: float64 # the eventual penalty score
 
   GossipSubParams* {.public.} = object
+    # explicit is used to check if the GossipSubParams instance was created by the user either passing params to GossipSubParams(...)
+    # or GossipSubParams.init(...). In the first case explicit should be set to true when calling the Nim constructor.
+    # In the second case, the param isn't necessary and should be always be set to true by init.
+    # If none of those options were used, it means the instance was created using Nim default values.
+    # In this case, GossipSubParams.init() should be called when initing GossipSub to set the values to their default value defined by nim-libp2p.
     explicit*: bool
     pruneBackoff*: Duration
     unsubscribeBackoff*: Duration


### PR DESCRIPTION
I believe `explicit` is used to check if the `GossipSubParams` instance was created by the user either passing params  to `GossipSubParams(...)` or `GossipSubParams.init(...)`. In the first case `explicit` should be set to `true` when calling the `Nim` constructor, in the second case, the param isn't necessary and should be always be set to true by `init`. If none of those options were used, it means the instance was created by using Nim default values. In this case, `GossipSubParams.init()` should be called to set the values to their default value defined by nim-libp2p.
https://github.com/status-im/nim-libp2p/blob/5e55ca3b69e18a56a0a5a34941676f4df08523ae/libp2p/protocols/pubsub/gossipsub.nim#L774