### PR TITLE
fix: reset accept fut in stop

### DIFF
--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -190,7 +190,9 @@ method stop*(self: TcpTransport) {.async.} =
     await allFutures(toWait)
 
     self.servers = @[]
-    self.acceptFuts = @[]
+
+    if self.acceptFuts.allIt(it.finished()):
+      self.acceptFuts = @[]
 
     trace "Transport stopped"
     untrackCounter(TcpTransportTrackerName)

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -222,6 +222,7 @@ method accept*(self: TcpTransport): Future[Connection] {.async.} =
       let observedAddr = MultiAddress.init(transp.remoteAddress).tryGet()
       return await self.connHandler(transp, Opt.some(observedAddr), Direction.In)
     except CancelledError as exc:
+      debug "CancelledError", exc = exc.msg
       transp.close()
       raise exc
     except CatchableError as exc:

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -190,6 +190,7 @@ method stop*(self: TcpTransport) {.async.} =
     await allFutures(toWait)
 
     self.servers = @[]
+    self.acceptFuts = @[]
 
     trace "Transport stopped"
     untrackCounter(TcpTransportTrackerName)

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -190,9 +190,7 @@ method stop*(self: TcpTransport) {.async.} =
     await allFutures(toWait)
 
     self.servers = @[]
-
-    if self.acceptFuts.allIt(it.finished()):
-      self.acceptFuts = @[]
+    self.acceptFuts = @[]
 
     trace "Transport stopped"
     untrackCounter(TcpTransportTrackerName)


### PR DESCRIPTION
Changes:

- Reset `acceptFuts` seq when `stop` is invoked: this is needed to properly perform connection restarts between nodes and this issue was detected in `nwaku` tests, as explained in https://github.com/waku-org/nwaku/issues/2145

- Add a debug log when an exception is caught. This change is not directly needed by the "reconnect" issue mentioned in the previous point.