### PR TITLE
feat: behaviour penalty when non-priority queue reaches maxNumElementsInNonPriorityQueue

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -663,6 +663,7 @@ proc onHeartbeat(g: GossipSub) {.raises: [].} =
           g.pruned(peer, t)
           g.mesh.removePeer(t, peer)
           prunes &= peer
+          peer.clearNonPriorityQueue()
       if prunes.len > 0:
         let prune = RPCMsg(control: some(ControlMessage(
           prune: @[ControlPrune(

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -37,6 +37,8 @@ when defined(pubsubpeer_queue_metrics):
 
 const
   DefaultMaxNumElementsInNonPriorityQueue* = 1024
+  BehaviourPenaltyFoNonPriorityQueueOverLimit = 0.0001  # this value is quite arbitrary and was found empirically
+  # to result in a behaviourPenalty around [0.1, 0.2] when the score is updated.
 
 type
   PeerRateLimitError* = object of CatchableError
@@ -352,7 +354,7 @@ proc sendEncoded*(p: PubSubPeer, msg: seq[byte], isHighPriority: bool): Future[v
     f
   else:
     if len(p.rpcmessagequeue.nonPriorityQueue) >= p.maxNumElementsInNonPriorityQueue:
-      p.behaviourPenalty += 0.0001
+      p.behaviourPenalty += BehaviourPenaltyFoNonPriorityQueueOverLimit
       trace "Peer has reached maxNumElementsInNonPriorityQueue. Discarding message and applying behaviour penalty.", peer = p, score = p.score,
         behaviourPenalty = p.behaviourPenalty, agent = p.getAgent()
       Future[void].completed()

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -349,11 +349,9 @@ proc sendEncoded*(p: PubSubPeer, msg: seq[byte], isHighPriority: bool): Future[v
     f
   else:
     if len(p.rpcmessagequeue.nonPriorityQueue) >= p.maxNumElementsInNonPriorityQueue:
-      if p.connected():
-        p.behaviourPenalty += 0.0001
-        trace "Peer has reached maxNumElementsInNonPriorityQueue. Discarding message and applying behaviour penalty.", peer = p, score = p.score,
-          behaviourPenalty = p.behaviourPenalty, agent = p.getAgent()
-
+      p.behaviourPenalty += 0.0001
+      trace "Peer has reached maxNumElementsInNonPriorityQueue. Discarding message and applying behaviour penalty.", peer = p, score = p.score,
+        behaviourPenalty = p.behaviourPenalty, agent = p.getAgent()
       Future[void].completed()
     else:
       let f = p.rpcmessagequeue.nonPriorityQueue.addLast(msg)

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -278,6 +278,9 @@ proc clearNonPriorityQueue*(p: PubSubPeer) =
   if len(p.rpcmessagequeue.nonPriorityQueue) > 0:
     p.rpcmessagequeue.nonPriorityQueue.clear()
 
+    when defined(pubsubpeer_queue_metrics):
+      libp2p_gossipsub_non_priority_queue_size.set(labelValues = [$p.peerId], value = 0)
+
 proc sendMsgContinue(conn: Connection, msgFut: Future[void]) {.async.} =
   # Continuation for a pending `sendMsg` future from below
   try:
@@ -465,11 +468,9 @@ proc stopSendNonPriorityTask*(p: PubSubPeer) =
     p.rpcmessagequeue.sendNonPriorityTask.cancelSoon()
     p.rpcmessagequeue.sendNonPriorityTask = nil
     p.rpcmessagequeue.sendPriorityQueue.clear()
-    p.clearNonPriorityQueue()
-
     when defined(pubsubpeer_queue_metrics):
       libp2p_gossipsub_priority_queue_size.set(labelValues = [$p.peerId], value = 0)
-      libp2p_gossipsub_non_priority_queue_size.set(labelValues = [$p.peerId], value = 0)
+    p.clearNonPriorityQueue()
 
 proc new(T: typedesc[RpcMessageQueue]): T =
   return T(


### PR DESCRIPTION
This PR applies a behavior penalty to peers whose non-prio queue reaches the max limit configured, instead of the previous strategy of disconnecting the peer. A conservative penalty of `0.0001` is added to behaviourPenalty for each message tried to be sent when the queue is over the limit, and the message is discarded. This usually results in a `behaviourPenalty` around [0.1, 0.2] when the score is updated and its value around [-0.4, -0.1]. 

It causes the peer to be pruned due to its negative score. This PR also clears the non-prio queue at this moment.