### PR TITLE
salt `idontwant`

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -269,8 +269,7 @@ proc handleIDontWant*(g: GossipSub,
   for dontWant in iDontWants:
     for messageId in dontWant.messageIDs:
       if peer.heDontWants[^1].len > 1000: break
-      if messageId.len > 100: continue
-      peer.heDontWants[^1].incl(messageId)
+      peer.heDontWants[^1].incl(g.salt(messageId))
 
 proc handleIWant*(g: GossipSub,
                  peer: PubSubPeer,
@@ -639,7 +638,7 @@ proc onHeartbeat(g: GossipSub) {.raises: [].} =
         peer.sentIHaves.addFirst(default(HashSet[MessageId]))
         if peer.sentIHaves.len > g.parameters.historyLength:
           discard peer.sentIHaves.popLast()
-        peer.heDontWants.addFirst(default(HashSet[MessageId]))
+        peer.heDontWants.addFirst(default(HashSet[SaltedId]))
         if peer.heDontWants.len > g.parameters.historyLength:
           discard peer.heDontWants.popLast()
         peer.iHaveBudget = IHavePeerBudget

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -80,7 +80,10 @@ type
 
     score*: float64
     sentIHaves*: Deque[HashSet[MessageId]]
-    heDontWants*: Deque[HashSet[MessageId]]
+    heDontWants*: Deque[HashSet[SaltedId]]
+      ## IDONTWANT contains unvalidated message id:s which may be long and/or
+      ## expensive to look up, so we apply the same salting to them as during
+      ## unvalidated message processing
     iHaveBudget*: int
     pingBudget*: int
     maxMessageSize: int
@@ -504,5 +507,5 @@ proc new*(
     maxNumElementsInNonPriorityQueue: maxNumElementsInNonPriorityQueue
   )
   result.sentIHaves.addFirst(default(HashSet[MessageId]))
-  result.heDontWants.addFirst(default(HashSet[MessageId]))
+  result.heDontWants.addFirst(default(HashSet[SaltedId]))
   result.startSendNonPriorityTask()


### PR DESCRIPTION
Salting `idontwant` ensures the message id does not exceed reasonable length and prevents the hash table itself from being attacked while at the same time bounding memory consumption.