### PR TITLE
fix: Asynchronous task [sendMsgSlow()] was cancelled [FutureDefect]

### DIFF
--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -304,7 +304,7 @@ proc sendMsgSlow(p: PubSubPeer, msg: seq[byte]) {.async.} =
   if p.sendConn == nil:
     # Wait for a send conn to be setup. `connectOnce` will
     # complete this even if the sendConn setup failed
-    await p.connectedFut
+    discard await race(p.connectedFut)
 
   var conn = p.sendConn
   if conn == nil or conn.closed():


### PR DESCRIPTION
Fix for:

`crash on Nimbus 24.4.0 in production 9:03 EDT. 09:03:24.578950-04:00 localhost nimbus-beacon[4803]: Error: unhandled exception: Asynchronous task [sendMsgSlow() at pubsubpeer.nim:301] was cancelled! [FutureDefect]`

Using `await` on a shared `Future` can raise an unexpected `CancelledError` if this `Future` gets canceled indirectly by another task. `race` (and `join` in newer versions of chronos) creates a separate future that "insulates" the shared future from the cancellation flow. See https://github.com/status-im/nim-chronos/commit/8166d7d0f16119ad74184dd3ccc001f3035537b7#diff-a6bc56e6ac55acab484b1a94671287d6f72bc6311b3ea43482b438b517ec9390R172.