### PR TITLE
chore: fix branch name from unstable to master in bumper workflow

### DIFF
--- a/.github/workflows/bumper.yml
+++ b/.github/workflows/bumper.yml
@@ -2,8 +2,7 @@ name: Bumper
 on:
   push:
     branches:
-      - unstable
-      - bumper
+      - master
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
After the branch name change, this file wasn't updated.