### PR TITLE
fix(test): tor transport test fails with SIGSEGV on macOS M1

### DIFF
--- a/tests/commontransport.nim
+++ b/tests/commontransport.nim
@@ -45,12 +45,11 @@ template commonTransportTest*(prov: TransportProvider, ma1: string, ma2: string 
 
       await conn.close() #for some protocols, closing requires actively reading, so we must close here
 
+      await handlerWait.wait(1.seconds) # when no issues will not wait that long!
       await allFuturesThrowing(
         allFinished(
           transport1.stop(),
           transport2.stop()))
-
-      await handlerWait.wait(1.seconds) # when no issues will not wait that long!
 
     asyncTest "e2e: handle write":
       let ma = @[MultiAddress.init(ma1).tryGet()]
@@ -72,13 +71,14 @@ template commonTransportTest*(prov: TransportProvider, ma1: string, ma2: string 
 
       await conn.close() #for some protocols, closing requires actively reading, so we must close here
 
+      check string.fromBytes(msg) == "Hello!"
+      await handlerWait.wait(1.seconds) # when no issues will not wait that long!
+
       await allFuturesThrowing(
         allFinished(
           transport1.stop(),
           transport2.stop()))
 
-      check string.fromBytes(msg) == "Hello!"
-      await handlerWait.wait(1.seconds) # when no issues will not wait that long!
 
     asyncTest "e2e: handle read":
       let ma = @[MultiAddress.init(ma1).tryGet()]


### PR DESCRIPTION
```
Tor transport WRN 2024-05-27 20:05:11.446+02:00 TCP transport already stopped              topics="libp2p tcptransport" tid=117174872
.WRN 2024-05-27 20:05:11.448+02:00 TCP transport already stopped              topics="libp2p tcptransport" tid=117174872
.WRN 2024-05-27 20:05:11.450+02:00 TCP transport already stopped              topics="libp2p tcptransport" tid=117174872
.WRN 2024-05-27 20:05:11.467+02:00 TCP transport already stopped              topics="libp2p tcptransport" tid=117174872
.WRN 2024-05-27 20:05:11.469+02:00 TCP transport already stopped              topics="libp2p tcptransport" tid=117174872
..WRN 2024-05-27 20:05:11.471+02:00 TCP transport already stopped              topics="libp2p tcptransport" tid=117174872
Traceback (most recent call last)
/Users/diegomrsantos/workspace/nim-libp2p/nimbledeps/pkgs/unittest2-#2300fa9924a76e6c96bc4ea79d043e3a0f27120c/unittest2.nim(1151) testtortransport
/Users/diegomrsantos/workspace/nim-libp2p/nimbledeps/pkgs/unittest2-#2300fa9924a76e6c96bc4ea79d043e3a0f27120c/unittest2.nim(1074) runDirect
/Users/diegomrsantos/workspace/nim-libp2p/tests/helpers.nim(55) runTest`gensym308
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
Error: execution of an external program failed: '/nim-libp2p/tests/testnative '
```