### PR TITLE
fix(services): setup services before peerinfo is updated

### DIFF
--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -349,13 +349,11 @@ proc start*(s: Switch) {.async, public.} =
       s.acceptFuts.add(s.accept(t))
       s.peerInfo.listenAddrs &= t.addrs
 
-  await s.peerInfo.update()
-
-  await s.ms.start()
-
   for service in s.services:
     discard await service.setup(s)
 
+  await s.peerInfo.update()
+  await s.ms.start()
   s.started = true
 
   debug "Started libp2p node", peer = s.peerInfo

--- a/tests/hole-punching-interop/hole_punching.nim
+++ b/tests/hole-punching-interop/hole_punching.nim
@@ -1,8 +1,9 @@
-import std/[os, options, strformat]
+import std/[os, options, strformat, sequtils]
 import redis
 import chronos, chronicles
 import ../../libp2p/[builders,
                   switch,
+                  multicodec,
                   observedaddrmanager,
                   services/hpservice,
                   services/autorelayservice,
@@ -76,7 +77,7 @@ proc main() {.async.} =
     debug "Connected to relay", relayId
 
     # Wait for our relay address to be published
-    while switch.peerInfo.addrs.len == 0:
+    while not switch.peerInfo.addrs.anyIt(it.contains(multiCodec("p2p-circuit")).tryGet()):
       await sleepAsync(100.milliseconds)
 
     if isListener:

--- a/tests/testautonatservice.nim
+++ b/tests/testautonatservice.nim
@@ -23,7 +23,7 @@ import stubs/autonatclientstub
 proc createSwitch(autonatSvc: Service = nil, withAutonat = true, maxConnsPerPeer = 1, maxConns = 100, nameResolver: NameResolver = nil): Switch =
   var builder = SwitchBuilder.new()
     .withRng(newRng())
-    .withAddresses(@[ MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet() ])
+    .withAddresses(@[ MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet() ], false)
     .withTcpTransport()
     .withMaxConnsPerPeer(maxConnsPerPeer)
     .withMaxConnections(maxConns)

--- a/tests/testautorelay.nim
+++ b/tests/testautorelay.nim
@@ -20,7 +20,7 @@ import ./helpers
 proc createSwitch(r: Relay, autorelay: Service = nil): Switch =
   var builder = SwitchBuilder.new()
     .withRng(newRng())
-    .withAddresses(@[ MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet() ])
+    .withAddresses(@[ MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet() ], false)
     .withTcpTransport()
     .withMplex()
     .withNoise()


### PR DESCRIPTION
- Setup services before peerinfo is updated - this allows services to set address mappers.
- Fix HP interop tests - improve condition related to relay addr being published.
- Disable wildcard resolver in `testautonatservice` and test `testautorelay`.