### PR TITLE
feat: adding onValidated observer

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -454,7 +454,7 @@ proc validateAndRelay(
     g.rewardDelivered(peer, topic, true)
 
     # trigger hooks
-    peer.recvAndValidatedObservers(msg, msgId)
+    peer.validatedObservers(msg, msgId)
 
     # The send list typically matches the idontwant list from above, but
     # might differ if validation takes time

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -453,6 +453,9 @@ proc validateAndRelay(
 
     g.rewardDelivered(peer, topic, true)
 
+    # trigger hooks
+    peer.recvAndValidatedObservers(msg, msgId)
+
     # The send list typically matches the idontwant list from above, but
     # might differ if validation takes time
     var toSendPeers = HashSet[PubSubPeer]()

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -175,13 +175,12 @@ proc recvObservers*(p: PubSubPeer, msg: var RPCMsg) =
         if not (isNil(obs.onRecv)):
           obs.onRecv(p, msg)
 
-proc recvAndValidatedObservers*(p: PubSubPeer, msg: Message, msgId: MessageId) =
+proc validatedObservers*(p: PubSubPeer, msg: Message, msgId: MessageId) =
   # trigger hooks
   if not (isNil(p.observers)) and p.observers[].len > 0:
     for obs in p.observers[]:
-      if not (isNil(obs)): # TODO: should never be nil, but...
-        if not (isNil(obs.onValidated)):
-          obs.onValidated(p, msg, msgId)
+      if not (isNil(obs.onValidated)):
+        obs.onValidated(p, msg, msgId)
 
 proc sendObservers(p: PubSubPeer, msg: var RPCMsg) =
   # trigger hooks

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -67,6 +67,8 @@ type
   PubSubObserver* = ref object
     onRecv*: proc(peer: PubSubPeer, msgs: var RPCMsg) {.gcsafe, raises: [].}
     onSend*: proc(peer: PubSubPeer, msgs: var RPCMsg) {.gcsafe, raises: [].}
+    onRecvAndValidated*:
+      proc(peer: PubSubPeer, msg: Message, msgId: MessageId) {.gcsafe, raises: [].}
 
   PubSubPeerEventKind* {.pure.} = enum
     StreamOpened
@@ -171,6 +173,13 @@ proc recvObservers*(p: PubSubPeer, msg: var RPCMsg) =
     for obs in p.observers[]:
       if not (isNil(obs)): # TODO: should never be nil, but...
         obs.onRecv(p, msg)
+
+proc recvAndValidatedObservers*(p: PubSubPeer, msg: Message, msgId: MessageId) =
+  # trigger hooks
+  if not (isNil(p.observers)) and p.observers[].len > 0:
+    for obs in p.observers[]:
+      if not (isNil(obs)): # TODO: should never be nil, but...
+        obs.onRecvAndValidated(p, msg, msgId)
 
 proc sendObservers(p: PubSubPeer, msg: var RPCMsg) =
   # trigger hooks

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -172,21 +172,24 @@ proc recvObservers*(p: PubSubPeer, msg: var RPCMsg) =
   if not (isNil(p.observers)) and p.observers[].len > 0:
     for obs in p.observers[]:
       if not (isNil(obs)): # TODO: should never be nil, but...
-        obs.onRecv(p, msg)
+        if not (isNil(obs.onRecv)):
+          obs.onRecv(p, msg)
 
 proc recvAndValidatedObservers*(p: PubSubPeer, msg: Message, msgId: MessageId) =
   # trigger hooks
   if not (isNil(p.observers)) and p.observers[].len > 0:
     for obs in p.observers[]:
       if not (isNil(obs)): # TODO: should never be nil, but...
-        obs.onRecvAndValidated(p, msg, msgId)
+        if not (isNil(obs.onRecvAndValidated)):
+          obs.onRecvAndValidated(p, msg, msgId)
 
 proc sendObservers(p: PubSubPeer, msg: var RPCMsg) =
   # trigger hooks
   if not (isNil(p.observers)) and p.observers[].len > 0:
     for obs in p.observers[]:
       if not (isNil(obs)): # TODO: should never be nil, but...
-        obs.onSend(p, msg)
+        if not (isNil(obs.onSend)):
+          obs.onSend(p, msg)
 
 proc handle*(p: PubSubPeer, conn: Connection) {.async.} =
   debug "starting pubsub read loop", conn, peer = p, closed = conn.closed

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -67,7 +67,7 @@ type
   PubSubObserver* = ref object
     onRecv*: proc(peer: PubSubPeer, msgs: var RPCMsg) {.gcsafe, raises: [].}
     onSend*: proc(peer: PubSubPeer, msgs: var RPCMsg) {.gcsafe, raises: [].}
-    onRecvAndValidated*:
+    onValidated*:
       proc(peer: PubSubPeer, msg: Message, msgId: MessageId) {.gcsafe, raises: [].}
 
   PubSubPeerEventKind* {.pure.} = enum
@@ -180,8 +180,8 @@ proc recvAndValidatedObservers*(p: PubSubPeer, msg: Message, msgId: MessageId) =
   if not (isNil(p.observers)) and p.observers[].len > 0:
     for obs in p.observers[]:
       if not (isNil(obs)): # TODO: should never be nil, but...
-        if not (isNil(obs.onRecvAndValidated)):
-          obs.onRecvAndValidated(p, msg, msgId)
+        if not (isNil(obs.onValidated)):
+          obs.onValidated(p, msg, msgId)
 
 proc sendObservers(p: PubSubPeer, msg: var RPCMsg) =
   # trigger hooks

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -360,7 +360,7 @@ suite "GossipSub":
           inc observed
       )
       obs2 = PubSubObserver(
-        onRecvAndValidated: proc(peer: PubSubPeer, msg: Message, msgId: MessageId) =
+        onValidated: proc(peer: PubSubPeer, msg: Message, msgId: MessageId) =
           inc observed
       )
       obs3 = PubSubObserver(

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -265,20 +265,15 @@ suite "GossipSub":
     # Send message that will be accepted by the receiver's validator
     tryPublish await nodes[0].publish("foo", "Hello!".toBytes()), 1
 
-    check await handlerFut
-
     check:
       recvCounter == 1
       validatedCounter == 1
       sendCounter == 1
 
-    # Reset future
-    handlerFut = newFuture[bool]()
+    check await handlerFut
 
     # Send message that will be rejected by the receiver's validator
     tryPublish await nodes[0].publish("bar", "Hello!".toBytes()), 1
-
-    check await handlerFut
 
     check:
       recvCounter == 2

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -357,6 +357,8 @@ suite "GossipSub":
     let
       obs1 = PubSubObserver(
         onRecv: proc(peer: PubSubPeer, msgs: var RPCMsg) =
+          inc observed,
+        onRecvAndValidated: proc(peer: PubSubPeer, msg: Message, msgId: MessageId) =
           inc observed
       )
       obs2 = PubSubObserver(
@@ -382,7 +384,7 @@ suite "GossipSub":
     await allFuturesThrowing(nodes[0].switch.stop(), nodes[1].switch.stop())
 
     await allFuturesThrowing(nodesFut.concat())
-    check observed == 2
+    check observed == 3
 
   asyncTest "e2e - GossipSub send over fanout A -> B for subscribed topic":
     var passed = newFuture[void]()

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -241,10 +241,9 @@ suite "GossipSub":
     let obs0 = PubSubObserver(onSend: onSend)
     let obs1 = PubSubObserver(onRecv: onRecv, onValidated: onValidated)
 
-    let
-      nodes = generateNodes(2, gossip = true)
-      # start switches
-      nodesFut = await allFinished(nodes[0].switch.start(), nodes[1].switch.start())
+    let nodes = generateNodes(2, gossip = true)
+    # start switches
+    discard await allFinished(nodes[0].switch.start(), nodes[1].switch.start())
 
     await subscribeNodes(nodes)
 
@@ -277,8 +276,6 @@ suite "GossipSub":
       sendCounter == 2
 
     await allFuturesThrowing(nodes[0].switch.stop(), nodes[1].switch.stop())
-
-    await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "GossipSub unsub - resub faster than backoff":
     var handlerFut = newFuture[bool]()

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -237,7 +237,7 @@ suite "GossipSub":
     proc onSend(peer: PubSubPeer, msgs: var RPCMsg) =
       inc sendCounter
 
-    proc onValidated(peer: PubSubPeer, msgs: var RPCMsg) =
+    proc onValidated(peer: PubSubPeer, msg: Message, msgId: MessageId) =
       inc validatedCounter
 
     let obs0 = PubSubObserver(onSend: onSend)

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -357,17 +357,20 @@ suite "GossipSub":
     let
       obs1 = PubSubObserver(
         onRecv: proc(peer: PubSubPeer, msgs: var RPCMsg) =
-          inc observed,
-        onRecvAndValidated: proc(peer: PubSubPeer, msg: Message, msgId: MessageId) =
           inc observed
       )
       obs2 = PubSubObserver(
+        onRecvAndValidated: proc(peer: PubSubPeer, msg: Message, msgId: MessageId) =
+          inc observed
+      )
+      obs3 = PubSubObserver(
         onSend: proc(peer: PubSubPeer, msgs: var RPCMsg) =
           inc observed
       )
 
     nodes[1].addObserver(obs1)
-    nodes[0].addObserver(obs2)
+    nodes[1].addObserver(obs2)
+    nodes[0].addObserver(obs3)
 
     tryPublish await nodes[0].publish("foobar", "Hello!".toBytes()), 1
 

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -222,14 +222,12 @@ suite "GossipSub":
 
   asyncTest "GossipSub's observers should run after message is sent, received and validated":
     var
-      handlerFut = newFuture[bool]()
       recvCounter = 0
       sendCounter = 0
       validatedCounter = 0
 
     proc handler(topic: string, data: seq[byte]) {.async.} =
-      check topic == "foo"
-      handlerFut.complete(true)
+      discard
 
     proc onRecv(peer: PubSubPeer, msgs: var RPCMsg) =
       inc recvCounter
@@ -269,8 +267,6 @@ suite "GossipSub":
       recvCounter == 1
       validatedCounter == 1
       sendCounter == 1
-
-    check await handlerFut
 
     # Send message that will be rejected by the receiver's validator
     tryPublish await nodes[0].publish("bar", "Hello!".toBytes()), 1


### PR DESCRIPTION
### Description

Adding an `onValidated` observer which will run every time a message is received and validated. This comes from the necessity of precisely track message deliveries and network activity.

`onRecv` observers run before any check is performed on the received message, which means that it runs every time a duplicate or invalid message arrives, which is inefficient and inaccurate for our purpose of tracking only received, unique and valid messages. Therefore, adding this extra option of running an observer for every message after all validation checks pass.

