### PR TITLE
chore: improve max outgoing connections log

### DIFF
--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -331,7 +331,7 @@ proc getOutgoingSlot*(
     c.outSema.forceAcquire()
   elif not c.outSema.tryAcquire():
     trace "Too many outgoing connections!",
-      count = c.outSema.count, max = c.outSema.size
+      available = c.outSema.count, max = c.outSema.size
     raise newTooManyConnectionsError()
   return ConnectionSlot(connManager: c, direction: Out)
 


### PR DESCRIPTION
Running into the following log
```
TRC 2024-06-17 15:33:42.400+00:00 Too many outgoing connections!             topics="libp2p connmanager" tid=7 file=connmanager.nim:344 count=0 max=50
```

The `count` parameter is a little bit misleading and at first makes one think that there's 0 connections.
Looking at the code I see that it refers to the `count` field from `AsyncSemaphore` which indicates the available slots.

Changed the logging from `count` to `available` to avoid confusion, same as it is done in the semaphore module. For example
https://github.com/vacp2p/nim-libp2p/blob/02f6e6127cecf5b87ff027780be42e9b692a0db9/libp2p/utils/semaphore.nim#L38