### PR TITLE
chore: add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Formatted with nph 0.5.1
+dc83a1e9b68f00b3be7e09febdb1a3f877321b9a


### PR DESCRIPTION
Ignoring the formatting commit for the purpose of `git blame` by adding a file named `.git-blame-ignore-revs` containing the formatted source code to the root of the project.

Configure git to use it with: `git config --global  blame.ignoreRevsFile .git-blame-ignore-revs`