### PR TITLE
fix: stop services after transports

### DIFF
--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -284,9 +284,6 @@ proc stop*(s: Switch) {.async, public.} =
   except CatchableError as exc:
     debug "Cannot cancel accepts", error = exc.msg
 
-  for service in s.services:
-    discard await service.stop(s)
-
   # close and cleanup all connections
   await s.connManager.close()
 
@@ -297,6 +294,9 @@ proc stop*(s: Switch) {.async, public.} =
       raise exc
     except CatchableError as exc:
       warn "error cleaning up transports", msg = exc.msg
+
+  for service in s.services:
+    discard await service.stop(s)
 
   await s.ms.stop()
 


### PR DESCRIPTION
https://github.com/vacp2p/nim-libp2p/pull/843 Services stop duplication, but services should be stopped after Transports, as they are higher level.