### PR TITLE
chore(version): update libp2p.nimble to 1.4.0

### DIFF
--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName = "libp2p"
-version = "1.3.0"
+version = "1.4.0"
 author = "Status Research & Development GmbH"
 description = "LibP2P implementation"
 license = "MIT"


### PR DESCRIPTION
Update libp2p.nimble to version to 1.4.0.
This commit will be tagged as 1.4.0.