### PR TITLE
fix: run workflows on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - unstable
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - unstable
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -5,7 +5,6 @@ on:
       - master
   workflow_dispatch:
 
-
 jobs:
   build:
     timeout-minutes: 20

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - unstable
+      - master
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
The `unstable` branch wasn't removed from some workflows and `interop` wasn't running on `master`.