### PR TITLE
chore: enable Nim 2.0.x and fix compilation issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           nim --version
           nimble --version
-          nimble test
+          NIMFLAGS="${NIMFLAGS} --mm:refc" nimble test
 
   lint:
     name: "Lint"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
             cpu: amd64
           #- os: windows
             #cpu: i386
-        branch: [version-1-6]
+        branch: [version-1-6, version-2-0]
         include:
           - target:
               os: linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           nim --version
           nimble --version
-          NIMFLAGS="${NIMFLAGS} --mm:refc" nimble test
+          nimble test
 
   lint:
     name: "Lint"

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -124,10 +124,14 @@ task examples_build, "Build the samples":
   buildSample("tutorial_3_protobuf", true)
   buildSample("tutorial_4_gossipsub", true)
   buildSample("tutorial_5_discovery", true)
-  exec "nimble install -y nimpng@#HEAD"
+  if NimMajor >= 2 and defined(i386):
+    # while https://github.com/ftsf/nico/pull/126 hasn't been merged
+    echo "Skipping tutorial_6_game example on i386 and Nim 2.0"
+  else:
+    exec "nimble install -y nimpng@#HEAD"
     # this is to fix broken build on 1.7.3, remove it when nimpng version 0.3.2 or later is released
-  exec "nimble install -y https://github.com/diegomrsantos/nico@#86d5948ac89a8f3f417114957c7ca684b01c0241"
-  buildSample("tutorial_6_game", false, "--styleCheck:off")
+    exec "nimble install -y nico"
+    buildSample("tutorial_6_game", false, "--styleCheck:off")
 
 # pin system
 # while nimble lockfile

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -124,14 +124,10 @@ task examples_build, "Build the samples":
   buildSample("tutorial_3_protobuf", true)
   buildSample("tutorial_4_gossipsub", true)
   buildSample("tutorial_5_discovery", true)
-  if NimMajor >= 2 and defined(i386):
-    # while https://github.com/ftsf/nico/pull/126 hasn't been merged
-    echo "Skipping tutorial_6_game example on i386 and Nim 2.0"
-  else:
-    exec "nimble install -y nimpng@#HEAD"
+  exec "nimble install -y nimpng@#HEAD"
     # this is to fix broken build on 1.7.3, remove it when nimpng version 0.3.2 or later is released
-    exec "nimble install -y nico"
-    buildSample("tutorial_6_game", false, "--styleCheck:off")
+  exec "nimble install -y nico@#af99dd60bf2b395038ece815ea1012330a80d6e6"
+  buildSample("tutorial_6_game", false, "--styleCheck:off")
 
 # pin system
 # while nimble lockfile

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -126,7 +126,7 @@ task examples_build, "Build the samples":
   buildSample("tutorial_5_discovery", true)
   exec "nimble install -y nimpng@#HEAD"
     # this is to fix broken build on 1.7.3, remove it when nimpng version 0.3.2 or later is released
-  exec "nimble install -y nico"
+  exec "nimble install -y https://github.com/diegomrsantos/nico@#86d5948ac89a8f3f417114957c7ca684b01c0241"
   buildSample("tutorial_6_game", false, "--styleCheck:off")
 
 # pin system

--- a/tests/commontransport.nim
+++ b/tests/commontransport.nim
@@ -144,7 +144,7 @@ template commonTransportTest*(prov: TransportProvider, ma1: string, ma2: string 
       let transport1 = transpProvider()
       await transport1.start(addrs)
 
-      proc acceptHandler() {.async.} =
+      proc acceptHandler() {.async, gensym.} =
         while true:
           let conn = await transport1.accept()
           await conn.write(newSeq[byte](0))
@@ -208,7 +208,7 @@ template commonTransportTest*(prov: TransportProvider, ma1: string, ma2: string 
       let transport1 = transpProvider()
       await transport1.start(ma)
 
-      proc acceptHandler() {.async.} =
+      proc acceptHandler() {.async, gensym.} =
         let conn = await transport1.accept()
         await conn.close()
 

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -18,6 +18,9 @@ import strutils, os
 --d:
   unittestPrintTime
 --skipParentCfg
+--mm:
+  refc
+  # reconsider when there's a version-2-2 branch worth testing with as we might switch to orc
 
 # Only add chronicles param if the
 # user didn't specify any


### PR DESCRIPTION
This PR enables Nim 2.0.x with `refc` garbage collector on CI.

The following compilation error had to be fixed:  Error: undeclared identifier: 'acceptHandler`gensym435'; if declared in a template, this identifier may be inconsistently marked inject or gensym