### PR TITLE
chore: update os images on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,15 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-20.04
+            builder: ubuntu-22.04
             shell: bash
           - target:
               os: macos
-            builder: macos-12
+            builder: macos-14-large
             shell: bash
           - target:
               os: windows
-            builder: windows-2019
+            builder: windows-2022
             shell: msys2 {0}
 
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
             shell: bash
           - target:
               os: macos
-            builder: macos-14-large
+            builder: macos-13
             shell: bash
           - target:
               os: windows

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   Coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CICOV: YES
     steps:

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -31,13 +31,13 @@ jobs:
       matrix:
         platform:
           - os: linux
-            builder: ubuntu-20
+            builder: ubuntu-22.04
             shell: bash
           - os: macos
-            builder: macos-12
+            builder: macos-14-large
             shell: bash
           - os: windows
-            builder: windows-2019
+            builder: windows-2022
             shell: msys2 {0}
         branch: ${{ fromJSON(inputs.nim-branch) }}
         cpu: ${{ fromJSON(inputs.cpu) }}

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -34,7 +34,7 @@ jobs:
             builder: ubuntu-22.04
             shell: bash
           - os: macos
-            builder: macos-14-large
+            builder: macos-13
             shell: bash
           - os: windows
             builder: windows-2022

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 20
 
     name: 'Generate & upload documentation'
-    runs-on: 'ubuntu-20.04'
+    runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - name: Checkout


### PR DESCRIPTION
The main motivation was to update the Ubuntu version on the daily job as it seemed it wasn't supported anymore.

macOS 14 fails immediately with no error msg, so we are using 13 for now.