### PR TITLE
fix: add gcc 14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
         run: |
           nim --version
           nimble --version
+          gcc --version
           nimble test
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,20 @@ jobs:
             cpu: amd64
           - os: linux
             cpu: i386
+          - os: ubuntu-24-gcc-14
+            cpu: amd64
           - os: macos
             cpu: amd64
           - os: windows
             cpu: amd64
-          #- os: windows
-            #cpu: i386
         branch: [version-1-6, version-2-0]
         include:
           - target:
               os: linux
+            builder: ubuntu-22.04
+            shell: bash
+          - target:
+              os: ubuntu-24-gcc-14
             builder: ubuntu-24.04
             shell: bash
           - target:
@@ -87,7 +91,7 @@ jobs:
           nimble install_pinned
 
       - name: Use gcc 14
-        if : ${{ matrix.target.os == 'linux' }}
+        if : ${{ matrix.target.os == 'ubuntu-24-gcc-14'}}
         run: |
           # Add GCC-14 to alternatives
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,12 @@ jobs:
         run: |
           nimble install_pinned
 
+      - name: Install gcc 14
+        if : ${{ matrix.target.os == 'linux' }}
+        run: |
+          sudo add-apt-repository universe
+          sudo apt install gcc-14
+
       - name: Run tests
         run: |
           nim --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         include:
           - target:
               os: linux
-            builder: ubuntu-22.04
+            builder: ubuntu-24.04
             shell: bash
           - target:
               os: macos

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,11 +86,14 @@ jobs:
         run: |
           nimble install_pinned
 
-      - name: Install gcc 14
+      - name: Use gcc 14
         if : ${{ matrix.target.os == 'linux' }}
         run: |
-          sudo add-apt-repository universe
-          sudo apt install gcc-14
+          # Add GCC-14 to alternatives
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 14
+
+          # Set GCC-14 as the default
+          sudo update-alternatives --set gcc /usr/bin/gcc-14
 
       - name: Run tests
         run: |

--- a/.pinned
+++ b/.pinned
@@ -1,6 +1,6 @@
 bearssl;https://github.com/status-im/nim-bearssl@#3b84ffffc0ada79e8c888f86b0b79fa21c31f93c
 chronicles;https://github.com/status-im/nim-chronicles@#32ac8679680ea699f7dbc046e8e0131cac97d41a
-chronos;https://github.com/status-im/nim-chronos@#672db137b7cad9b384b8f4fb551fb6bbeaabfe1b
+chronos;https://github.com/status-im/nim-chronos@#39a02ca46d4d84ee5dc1221528d8f9cfe9e7e8bb
 dnsclient;https://github.com/ba0f3/dnsclient.nim@#23214235d4784d24aceed99bbfe153379ea557c8
 faststreams;https://github.com/status-im/nim-faststreams@#720fc5e5c8e428d9d0af618e1e27c44b42350309
 httputils;https://github.com/status-im/nim-http-utils@#3b491a40c60aad9e8d3407443f46f62511e63b18

--- a/.pinned
+++ b/.pinned
@@ -1,6 +1,6 @@
 bearssl;https://github.com/status-im/nim-bearssl@#667b40440a53a58e9f922e29e20818720c62d9ac
 chronicles;https://github.com/status-im/nim-chronicles@#32ac8679680ea699f7dbc046e8e0131cac97d41a
-chronos;https://github.com/status-im/nim-chronos@#39a02ca46d4d84ee5dc1221528d8f9cfe9e7e8bb
+chronos;https://github.com/status-im/nim-chronos@#dc3847e4d6733dfc3811454c2a9c384b87343e26
 dnsclient;https://github.com/ba0f3/dnsclient.nim@#23214235d4784d24aceed99bbfe153379ea557c8
 faststreams;https://github.com/status-im/nim-faststreams@#720fc5e5c8e428d9d0af618e1e27c44b42350309
 httputils;https://github.com/status-im/nim-http-utils@#3b491a40c60aad9e8d3407443f46f62511e63b18

--- a/.pinned
+++ b/.pinned
@@ -1,4 +1,4 @@
-bearssl;https://github.com/status-im/nim-bearssl@#e4157639db180e52727712a47deaefcbbac6ec86
+bearssl;https://github.com/status-im/nim-bearssl@#646fa2152b11980c24bf34b3e214b479c9d25f21
 chronicles;https://github.com/status-im/nim-chronicles@#32ac8679680ea699f7dbc046e8e0131cac97d41a
 chronos;https://github.com/status-im/nim-chronos@#672db137b7cad9b384b8f4fb551fb6bbeaabfe1b
 dnsclient;https://github.com/ba0f3/dnsclient.nim@#23214235d4784d24aceed99bbfe153379ea557c8

--- a/.pinned
+++ b/.pinned
@@ -1,4 +1,4 @@
-bearssl;https://github.com/status-im/nim-bearssl@#646fa2152b11980c24bf34b3e214b479c9d25f21
+bearssl;https://github.com/status-im/nim-bearssl@#3b84ffffc0ada79e8c888f86b0b79fa21c31f93c
 chronicles;https://github.com/status-im/nim-chronicles@#32ac8679680ea699f7dbc046e8e0131cac97d41a
 chronos;https://github.com/status-im/nim-chronos@#672db137b7cad9b384b8f4fb551fb6bbeaabfe1b
 dnsclient;https://github.com/ba0f3/dnsclient.nim@#23214235d4784d24aceed99bbfe153379ea557c8

--- a/.pinned
+++ b/.pinned
@@ -1,4 +1,4 @@
-bearssl;https://github.com/status-im/nim-bearssl@#3b84ffffc0ada79e8c888f86b0b79fa21c31f93c
+bearssl;https://github.com/status-im/nim-bearssl@#667b40440a53a58e9f922e29e20818720c62d9ac
 chronicles;https://github.com/status-im/nim-chronicles@#32ac8679680ea699f7dbc046e8e0131cac97d41a
 chronos;https://github.com/status-im/nim-chronos@#39a02ca46d4d84ee5dc1221528d8f9cfe9e7e8bb
 dnsclient;https://github.com/ba0f3/dnsclient.nim@#23214235d4784d24aceed99bbfe153379ea557c8

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -8,7 +8,7 @@ license = "MIT"
 skipDirs = @["tests", "examples", "Nim", "tools", "scripts", "docs"]
 
 requires "nim >= 1.6.0",
-  "nimcrypto >= 0.4.1", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.1.4",
+  "nimcrypto >= 0.4.1", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.5",
   "chronicles >= 0.10.2", "chronos >= 4.0.0", "metrics", "secp256k1", "stew#head",
   "websock", "unittest2"
 

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -9,7 +9,7 @@ skipDirs = @["tests", "examples", "Nim", "tools", "scripts", "docs"]
 
 requires "nim >= 1.6.0",
   "nimcrypto >= 0.4.1", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.5",
-  "chronicles >= 0.10.2", "chronos >= 4.0.0", "metrics", "secp256k1", "stew#head",
+  "chronicles >= 0.10.2", "chronos >= 4.0.2", "metrics", "secp256k1", "stew#head",
   "websock", "unittest2"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use

--- a/libp2p/crypto/curve25519.nim
+++ b/libp2p/crypto/curve25519.nim
@@ -75,7 +75,9 @@ proc public*(private: Curve25519Key): Curve25519Key =
 proc random*(_: type[Curve25519Key], rng: var HmacDrbgContext): Curve25519Key =
   var res: Curve25519Key
   let defaultBrEc = ecGetDefault()
-  let len = ecKeygen(addr rng.vtable, defaultBrEc, nil, addr res[0], EC_curve25519)
+  let len = ecKeygen(
+    PrngClassPointerConst(addr rng.vtable), defaultBrEc, nil, addr res[0], EC_curve25519
+  )
   # Per bearssl documentation, the keygen only fails if the curve is
   # unrecognised -
   doAssert len == Curve25519KeySize, "Could not generate curve"

--- a/libp2p/crypto/ecnist.nim
+++ b/libp2p/crypto/ecnist.nim
@@ -234,7 +234,11 @@ proc random*(
   var ecimp = ecGetDefault()
   var res = new EcPrivateKey
   if ecKeygen(
-    addr rng.vtable, ecimp, addr res.key, addr res.buffer[0], safeConvert[cint](kind)
+    PrngClassPointerConst(addr rng.vtable),
+    ecimp,
+    addr res.key,
+    addr res.buffer[0],
+    safeConvert[cint](kind),
   ) == 0:
     err(EcKeyGenError)
   else:


### PR DESCRIPTION
- Add ubuntu-24-gcc-14 target on CI.  https://github.com/vacp2p/nim-libp2p/issues/1156 prevents us from using only Ubuntu 24.
- Made the changes necessary to support gcc 14. More info on https://github.com/status-im/nim-bearssl/pull/62

Fixes https://github.com/vacp2p/nim-libp2p/issues/1150