### PR TITLE
chore: setting dialing canceled log to trace

### DIFF
--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -62,7 +62,7 @@ proc dialAndUpgrade(
           libp2p_total_dial_attempts.inc()
           await transport.dial(hostname, address, peerId)
         except CancelledError as exc:
-          debug "Dialing canceled", err = exc.msg, peerId = peerId.get(default(PeerId))
+          trace "Dialing canceled", err = exc.msg, peerId = peerId.get(default(PeerId))
           raise exc
         except CatchableError as exc:
           debug "Dialing failed", err = exc.msg, peerId = peerId.get(default(PeerId))


### PR DESCRIPTION
We are trying to reduce the logs load in our fleets, and one of the most recurrent one is

```
Dialing canceled                           topics="libp2p dialer" tid=1 file=dialer.nim:67 err="Future operation cancelled!" peerId=16U*XAFJX3
```

which is quite spammy and doesn't give much info. 

In addition to that, its corresponding `Dialing address` log is in trace.

So adjusting the log level of `Dialing canceled` to trace :)