### PR TITLE
remove valueOr template from utility module

### DIFF
--- a/libp2p/utility.nim
+++ b/libp2p/utility.nim
@@ -10,8 +10,9 @@
 {.push raises: [].}
 
 import std/[sets, options, macros]
-import stew/[byteutils, results]
+import stew/byteutils
 
+import results
 export results
 
 template public*() {.pragma.}
@@ -123,13 +124,6 @@ macro withValue*[T](self: Opt[T] | Option[T], value, body, elseStmt: untyped): u
       `body`
     else:
       `elseBody`
-
-template valueOr*[T](self: Option[T], body: untyped): untyped =
-  let temp = (self)
-  if temp.isSome:
-    temp.get()
-  else:
-    body
 
 template toOpt*[T, E](self: Result[T, E]): Opt[T] =
   let temp = (self)


### PR DESCRIPTION
The `valueOr` template is already defined in
https://github.com/arnetheduck/nim-results, which is the one that we are using in `nwaku`.

Therefore, we are willing to prevent conflicts between the two 'valueOr' implementations.