### PR TITLE
fix(test): interop transport

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -15,6 +15,12 @@ jobs:
     name: Run transport interoperability tests
     runs-on: ubuntu-22.04
     steps:
+      - name: Free Disk Space (Ubuntu)
+        # For some reason the original job (libp2p/test-plans) has enough disk space, but this one doesn't.
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
       - name: Build image


### PR DESCRIPTION
Free disk space before running the steps of interop's transport test.
The original job has enough space but in our repo it crashes  midway due to missing disk space.