### PR TITLE
fix(ci): windows-amd64 (Nim version-1-6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           path: nimbledeps
           # Using nim.branch as a simple way to differentiate between nimble using the "pkgs" or "pkgs2" directories.
           # The change happened on Nimble v0.14.0.
-          key: nimbledeps-${{ matrix.branch }}-${{ hashFiles('.pinned') }}
+          key: nimbledeps-${{ matrix.branch }}-${{ hashFiles('.pinned') }} # hashFiles returns a different value on windows
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           path: nimbledep
           # Using nim.branch as a simple way to differentiate between nimble using the "pkgs" or "pkgs2" directories.
           # The change happened on Nimble v0.14.0.
-          key: nimbledeps-${{ matrix.nim.branch }}-${{ hashFiles('.pinned') }}
+          key: nimbledeps-${{ matrix.branch }}-${{ hashFiles('.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         id: deps-cache
         uses: actions/cache@v3
         with:
-          path: nimbledep
+          path: nimbledeps
           # Using nim.branch as a simple way to differentiate between nimble using the "pkgs" or "pkgs2" directories.
           # The change happened on Nimble v0.14.0.
           key: nimbledeps-${{ matrix.branch }}-${{ hashFiles('.pinned') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,10 @@ jobs:
         id: deps-cache
         uses: actions/cache@v3
         with:
-          path: nimbledeps
-          key: nimbledeps-${{ hashFiles('.pinned') }}
+          path: nimbledep
+          # Using nim.branch as a simple way to differentiate between nimble using the "pkgs" or "pkgs2" directories.
+          # The change happened on Nimble v0.14.0.
+          key: nimbledeps-${{ matrix.nim.branch }}-${{ hashFiles('.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
The failure is due to incompatibility (in caching) after Nimble's v.0.14.0 update, where they changed the dependencies directory name from `pkgs` to `pkgs2`.
This PR includes the nim branch in the cache key to avoid the directory name issue. 

In the future, if we deprecate support for Nim 1.6 we may remove this.

fixes https://github.com/vacp2p/nim-libp2p/issues/1157
