### PR TITLE
fix(yamux): future leak

### DIFF
--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -282,11 +282,12 @@ method readOnce*(
     let
       closedRemotelyFut = channel.closedRemotely.wait()
       receivedDataFut = channel.receivedData.wait()
+    defer:
+      if not closedRemotelyFut.finished():
+        await closedRemotelyFut.cancelAndWait()
+      if not receivedDataFut.finished():
+        await receivedDataFut.cancelAndWait()
     await closedRemotelyFut or receivedDataFut
-    if not closedRemotelyFut.finished():
-      await closedRemotelyFut.cancelAndWait()
-    if not receivedDataFut.finished():
-      await receivedDataFut.cancelAndWait()
     if channel.closedRemotely.isSet() and channel.recvQueue.len == 0:
       channel.isEof = true
       return

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -279,10 +279,14 @@ method readOnce*(
     raise newLPStreamRemoteClosedError()
   if channel.recvQueue.len == 0:
     channel.receivedData.clear()
-    try: # https://github.com/status-im/nim-chronos/issues/516
-      discard await race(channel.closedRemotely.wait(), channel.receivedData.wait())
-    except ValueError:
-      raiseAssert("Futures list is not empty")
+    let
+      closedRemotelyFut = channel.closedRemotely.wait()
+      receivedDataFut = channel.receivedData.wait()
+    await closedRemotelyFut or receivedDataFut
+    if not closedRemotelyFut.finished():
+      await closedRemotelyFut.cancelAndWait()
+    if not receivedDataFut.finished():
+      await receivedDataFut.cancelAndWait()
     if channel.closedRemotely.isSet() and channel.recvQueue.len == 0:
       channel.isEof = true
       return


### PR DESCRIPTION
At first glance, this fixes https://github.com/vacp2p/nim-libp2p/issues/1165.

It raises another issue: I always thought that Future unfinished caught in the GC were cancelled. But that doesn't always seem to be the case.