### PR TITLE
chore(async): `{.async: (raises).}` for `connmanager`

### DIFF
--- a/libp2p/utils/semaphore.nim
+++ b/libp2p/utils/semaphore.nim
@@ -20,7 +20,7 @@ logScope:
 type AsyncSemaphore* = ref object of RootObj
   size*: int
   count: int
-  queue: seq[Future[void]]
+  queue: seq[Future[void].Raising([CancelledError])]
 
 proc newAsyncSemaphore*(size: int): AsyncSemaphore =
   AsyncSemaphore(size: size, count: size)
@@ -38,14 +38,14 @@ proc tryAcquire*(s: AsyncSemaphore): bool =
     trace "Acquired slot", available = s.count, queue = s.queue.len
     return true
 
-proc acquire*(s: AsyncSemaphore): Future[void] =
+proc acquire*(s: AsyncSemaphore): Future[void].Raising([CancelledError]) =
   ## Acquire a resource and decrement the resource
   ## counter. If no more resources are available,
   ## the returned future will not complete until
   ## the resource count goes above 0.
   ##
 
-  let fut = newFuture[void]("AsyncSemaphore.acquire")
+  let fut = Future[void].Raising([CancelledError]).init("AsyncSemaphore.acquire")
   if s.tryAcquire():
     fut.complete()
     return fut

--- a/tests/testsemaphore.nim
+++ b/tests/testsemaphore.nim
@@ -14,7 +14,7 @@ import chronos
 
 import ../libp2p/utils/semaphore
 
-import ./helpers
+import ./asyncunit
 
 randomize()
 


### PR DESCRIPTION
Add `{.async: (raises).}` to connmanager.nim and to semaphore.nim (which is needed by connmanager.nim)