### PR TITLE
chore(logs): remove duplicate msg key

### DIFF
--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -136,7 +136,8 @@ proc triggerConnEvent*(c: ConnManager, peerId: PeerId, event: ConnEvent) {.async
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    warn "Exception in triggerConnEvents", msg = exc.msg, peer = peerId, event = $event
+    warn "Exception in triggerConnEvents",
+      errMsg = exc.msg, peer = peerId, event = $event
 
 proc addPeerEventHandler*(
     c: ConnManager, handler: PeerEventHandler, kind: PeerEventKind
@@ -169,7 +170,7 @@ proc triggerPeerEvents*(c: ConnManager, peerId: PeerId, event: PeerEvent) {.asyn
   except CancelledError as exc:
     raise exc
   except CatchableError as exc: # handlers should not raise!
-    warn "Exception in triggerPeerEvents", exc = exc.msg, peer = peerId
+    warn "Exception in triggerPeerEvents", errMsg = exc.msg, peer = peerId
 
 proc expectConnection*(
     c: ConnManager, p: PeerId, dir: Direction
@@ -212,7 +213,7 @@ proc closeMuxer(muxer: Muxer) {.async.} =
     try:
       await muxer.handler # TODO noraises?
     except CatchableError as exc:
-      trace "Exception in close muxer handler", exc = exc.msg
+      trace "Exception in close muxer handler", errMsg = exc.msg
   trace "Cleaned up muxer", m = muxer
 
 proc muxCleanup(c: ConnManager, mux: Muxer) {.async.} =
@@ -235,7 +236,7 @@ proc muxCleanup(c: ConnManager, mux: Muxer) {.async.} =
   except CatchableError as exc:
     # This is top-level procedure which will work as separate task, so it
     # do not need to propagate CancelledError and should handle other errors
-    warn "Unexpected exception peer cleanup handler", mux, msg = exc.msg
+    warn "Unexpected exception peer cleanup handler", mux, errMsg = exc.msg
 
 proc onClose(c: ConnManager, mux: Muxer) {.async.} =
   ## connection close even handler
@@ -358,7 +359,7 @@ proc trackConnection*(cs: ConnectionSlot, conn: Connection) =
     try:
       await conn.join()
     except CatchableError as exc:
-      trace "Exception in semaphore monitor, ignoring", exc = exc.msg
+      trace "Exception in semaphore monitor, ignoring", errMsg = exc.msg
 
     cs.release()
 

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -137,7 +137,7 @@ proc triggerConnEvent*(c: ConnManager, peerId: PeerId, event: ConnEvent) {.async
     raise exc
   except CatchableError as exc:
     warn "Exception in triggerConnEvents",
-      errMsg = exc.msg, peer = peerId, event = $event
+      description = exc.msg, peer = peerId, event = $event
 
 proc addPeerEventHandler*(
     c: ConnManager, handler: PeerEventHandler, kind: PeerEventKind
@@ -170,7 +170,7 @@ proc triggerPeerEvents*(c: ConnManager, peerId: PeerId, event: PeerEvent) {.asyn
   except CancelledError as exc:
     raise exc
   except CatchableError as exc: # handlers should not raise!
-    warn "Exception in triggerPeerEvents", errMsg = exc.msg, peer = peerId
+    warn "Exception in triggerPeerEvents", description = exc.msg, peer = peerId
 
 proc expectConnection*(
     c: ConnManager, p: PeerId, dir: Direction
@@ -213,7 +213,7 @@ proc closeMuxer(muxer: Muxer) {.async.} =
     try:
       await muxer.handler # TODO noraises?
     except CatchableError as exc:
-      trace "Exception in close muxer handler", errMsg = exc.msg
+      trace "Exception in close muxer handler", description = exc.msg
   trace "Cleaned up muxer", m = muxer
 
 proc muxCleanup(c: ConnManager, mux: Muxer) {.async.} =
@@ -236,7 +236,7 @@ proc muxCleanup(c: ConnManager, mux: Muxer) {.async.} =
   except CatchableError as exc:
     # This is top-level procedure which will work as separate task, so it
     # do not need to propagate CancelledError and should handle other errors
-    warn "Unexpected exception peer cleanup handler", mux, errMsg = exc.msg
+    warn "Unexpected exception peer cleanup handler", mux, description = exc.msg
 
 proc onClose(c: ConnManager, mux: Muxer) {.async.} =
   ## connection close even handler
@@ -247,7 +247,8 @@ proc onClose(c: ConnManager, mux: Muxer) {.async.} =
     await mux.connection.join()
     trace "Connection closed, cleaning up", mux
   except CatchableError as exc:
-    debug "Unexpected exception in connection manager's cleanup", errMsg = exc.msg, mux
+    debug "Unexpected exception in connection manager's cleanup",
+      description = exc.msg, mux
   finally:
     await c.muxCleanup(mux)
 
@@ -359,7 +360,7 @@ proc trackConnection*(cs: ConnectionSlot, conn: Connection) =
     try:
       await conn.join()
     except CatchableError as exc:
-      trace "Exception in semaphore monitor, ignoring", errMsg = exc.msg
+      trace "Exception in semaphore monitor, ignoring", description = exc.msg
 
     cs.release()
 

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -63,10 +63,11 @@ proc dialAndUpgrade(
           await transport.dial(hostname, address, peerId)
         except CancelledError as exc:
           trace "Dialing canceled",
-            errMsg = exc.msg, peerId = peerId.get(default(PeerId))
+            description = exc.msg, peerId = peerId.get(default(PeerId))
           raise exc
         except CatchableError as exc:
-          debug "Dialing failed", errMsg = exc.msg, peerId = peerId.get(default(PeerId))
+          debug "Dialing failed",
+            description = exc.msg, peerId = peerId.get(default(PeerId))
           libp2p_failed_dials.inc()
           return nil # Try the next address
 
@@ -88,7 +89,7 @@ proc dialAndUpgrade(
           # we won't succeeded through another - no use in trying again
           await dialed.close()
           debug "Connection upgrade failed",
-            errMsg = exc.msg, peerId = peerId.get(default(PeerId))
+            description = exc.msg, peerId = peerId.get(default(PeerId))
           if dialed.dir == Direction.Out:
             libp2p_failed_upgrades_outgoing.inc()
           else:
@@ -201,7 +202,7 @@ proc internalConnect(
         PeerEvent(kind: PeerEventKind.Identified, initiator: true),
       )
     except CatchableError as exc:
-      trace "Failed to finish outgoung upgrade", errMsg = exc.msg
+      trace "Failed to finish outgoung upgrade", description = exc.msg
       await muxed.close()
       raise exc
 
@@ -328,7 +329,7 @@ method dial*(
     await cleanup()
     raise exc
   except CatchableError as exc:
-    debug "Error dialing", conn, errMsg = exc.msg
+    debug "Error dialing", conn, description = exc.msg
     await cleanup()
     raise exc
 

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -62,10 +62,11 @@ proc dialAndUpgrade(
           libp2p_total_dial_attempts.inc()
           await transport.dial(hostname, address, peerId)
         except CancelledError as exc:
-          trace "Dialing canceled", err = exc.msg, peerId = peerId.get(default(PeerId))
+          trace "Dialing canceled",
+            errMsg = exc.msg, peerId = peerId.get(default(PeerId))
           raise exc
         except CatchableError as exc:
-          debug "Dialing failed", err = exc.msg, peerId = peerId.get(default(PeerId))
+          debug "Dialing failed", errMsg = exc.msg, peerId = peerId.get(default(PeerId))
           libp2p_failed_dials.inc()
           return nil # Try the next address
 
@@ -87,7 +88,7 @@ proc dialAndUpgrade(
           # we won't succeeded through another - no use in trying again
           await dialed.close()
           debug "Connection upgrade failed",
-            err = exc.msg, peerId = peerId.get(default(PeerId))
+            errMsg = exc.msg, peerId = peerId.get(default(PeerId))
           if dialed.dir == Direction.Out:
             libp2p_failed_upgrades_outgoing.inc()
           else:
@@ -200,7 +201,7 @@ proc internalConnect(
         PeerEvent(kind: PeerEventKind.Identified, initiator: true),
       )
     except CatchableError as exc:
-      trace "Failed to finish outgoung upgrade", err = exc.msg
+      trace "Failed to finish outgoung upgrade", errMsg = exc.msg
       await muxed.close()
       raise exc
 
@@ -327,7 +328,7 @@ method dial*(
     await cleanup()
     raise exc
   except CatchableError as exc:
-    debug "Error dialing", conn, err = exc.msg
+    debug "Error dialing", conn, errMsg = exc.msg
     await cleanup()
     raise exc
 

--- a/libp2p/discovery/rendezvousinterface.nim
+++ b/libp2p/discovery/rendezvousinterface.nim
@@ -64,7 +64,7 @@ method advertise*(self: RendezVousInterface) {.async.} =
       try:
         await self.rdv.advertise(toAdv, self.ttl)
       except CatchableError as error:
-        debug "RendezVous advertise error: ", errMsg = error.msg
+        debug "RendezVous advertise error: ", description = error.msg
 
     await sleepAsync(self.timeToAdvertise) or self.advertisementUpdated.wait()
 

--- a/libp2p/discovery/rendezvousinterface.nim
+++ b/libp2p/discovery/rendezvousinterface.nim
@@ -64,7 +64,7 @@ method advertise*(self: RendezVousInterface) {.async.} =
       try:
         await self.rdv.advertise(toAdv, self.ttl)
       except CatchableError as error:
-        debug "RendezVous advertise error: ", msg = error.msg
+        debug "RendezVous advertise error: ", errMsg = error.msg
 
     await sleepAsync(self.timeToAdvertise) or self.advertisementUpdated.wait()
 

--- a/libp2p/errors.nim
+++ b/libp2p/errors.nim
@@ -31,7 +31,7 @@ macro checkFutures*[F](futs: seq[F], exclude: untyped = []): untyped =
           # We still don't abort but warn
           debug "A future has failed, enable trace logging for details",
             error = exc.name
-          trace "Exception message", msg = exc.msg, stack = getStackTrace()
+          trace "Exception message", errMsg = exc.msg, stack = getStackTrace()
   else:
     quote:
       for res in `futs`:
@@ -40,9 +40,9 @@ macro checkFutures*[F](futs: seq[F], exclude: untyped = []): untyped =
             let exc = res.readError()
             for i in 0 ..< `nexclude`:
               if exc of `exclude`[i]:
-                trace "A future has failed", error = exc.name, msg = exc.msg
+                trace "A future has failed", error = exc.name, errMsg = exc.msg
                 break check
             # We still don't abort but warn
             debug "A future has failed, enable trace logging for details",
               error = exc.name
-            trace "Exception details", msg = exc.msg
+            trace "Exception details", errMsg = exc.msg

--- a/libp2p/errors.nim
+++ b/libp2p/errors.nim
@@ -31,7 +31,7 @@ macro checkFutures*[F](futs: seq[F], exclude: untyped = []): untyped =
           # We still don't abort but warn
           debug "A future has failed, enable trace logging for details",
             error = exc.name
-          trace "Exception message", errMsg = exc.msg, stack = getStackTrace()
+          trace "Exception message", description = exc.msg, stack = getStackTrace()
   else:
     quote:
       for res in `futs`:
@@ -40,9 +40,9 @@ macro checkFutures*[F](futs: seq[F], exclude: untyped = []): untyped =
             let exc = res.readError()
             for i in 0 ..< `nexclude`:
               if exc of `exclude`[i]:
-                trace "A future has failed", error = exc.name, errMsg = exc.msg
+                trace "A future has failed", error = exc.name, description = exc.msg
                 break check
             # We still don't abort but warn
             debug "A future has failed, enable trace logging for details",
               error = exc.name
-            trace "Exception details", errMsg = exc.msg
+            trace "Exception details", description = exc.msg

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -212,7 +212,7 @@ proc handle*(
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    trace "Exception in multistream", conn, msg = exc.msg
+    trace "Exception in multistream", conn, errMsg = exc.msg
   finally:
     await conn.close()
 

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -212,7 +212,7 @@ proc handle*(
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    trace "Exception in multistream", conn, errMsg = exc.msg
+    trace "Exception in multistream", conn, description = exc.msg
   finally:
     await conn.close()
 

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -116,7 +116,7 @@ proc reset*(s: LPChannel) {.async: (raises: []).} =
         trace "sending reset message", s, conn = s.conn
         await noCancel s.conn.writeMsg(s.id, s.resetCode) # write reset
       except LPStreamError as exc:
-        trace "Can't send reset message", s, conn = s.conn, msg = exc.msg
+        trace "Can't send reset message", s, conn = s.conn, errMsg = exc.msg
         await s.conn.close()
 
     asyncSpawn resetMessage()
@@ -145,7 +145,7 @@ method close*(s: LPChannel) {.async: (raises: []).} =
       # It's harmless that close message cannot be sent - the connection is
       # likely down already
       await s.conn.close()
-      trace "Cannot send close message", s, id = s.id, msg = exc.msg
+      trace "Cannot send close message", s, id = s.id, errMsg = exc.msg
 
   await s.closeUnderlying() # maybe already eofed
 
@@ -256,7 +256,7 @@ proc completeWrite(
   except LPStreamEOFError as exc:
     raise exc
   except LPStreamError as exc:
-    trace "exception in lpchannel write handler", s, msg = exc.msg
+    trace "exception in lpchannel write handler", s, errMsg = exc.msg
     await s.reset()
     await s.conn.close()
     raise newLPStreamConnDownError(exc)

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -116,7 +116,7 @@ proc reset*(s: LPChannel) {.async: (raises: []).} =
         trace "sending reset message", s, conn = s.conn
         await noCancel s.conn.writeMsg(s.id, s.resetCode) # write reset
       except LPStreamError as exc:
-        trace "Can't send reset message", s, conn = s.conn, errMsg = exc.msg
+        trace "Can't send reset message", s, conn = s.conn, description = exc.msg
         await s.conn.close()
 
     asyncSpawn resetMessage()
@@ -145,7 +145,7 @@ method close*(s: LPChannel) {.async: (raises: []).} =
       # It's harmless that close message cannot be sent - the connection is
       # likely down already
       await s.conn.close()
-      trace "Cannot send close message", s, id = s.id, errMsg = exc.msg
+      trace "Cannot send close message", s, id = s.id, description = exc.msg
 
   await s.closeUnderlying() # maybe already eofed
 
@@ -256,7 +256,7 @@ proc completeWrite(
   except LPStreamEOFError as exc:
     raise exc
   except LPStreamError as exc:
-    trace "exception in lpchannel write handler", s, errMsg = exc.msg
+    trace "exception in lpchannel write handler", s, description = exc.msg
     await s.reset()
     await s.conn.close()
     raise newLPStreamConnDownError(exc)

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -70,7 +70,7 @@ proc cleanupChann(m: Mplex, chann: LPChannel) {.async: (raises: []), inline.} =
         labelValues = [$chann.initiator, $m.connection.peerId],
       )
   except CancelledError as exc:
-    warn "Error cleaning up mplex channel", m, chann, msg = exc.msg
+    warn "Error cleaning up mplex channel", m, chann, errMsg = exc.msg
 
 proc newStreamInternal*(
     m: Mplex,
@@ -175,7 +175,7 @@ method handle*(m: Mplex) {.async: (raises: []).} =
         except LPStreamClosedError as exc:
           # Channel is being closed, but `cleanupChann` was not yet triggered.
           trace "pushing data to channel failed",
-            m, channel, len = data.len, msg = exc.msg
+            m, channel, len = data.len, errMsg = exc.msg
           discard # Ignore message, same as if `cleanupChann` had completed.
       of MessageType.CloseIn, MessageType.CloseOut:
         await channel.pushEof()
@@ -185,11 +185,11 @@ method handle*(m: Mplex) {.async: (raises: []).} =
   except CancelledError:
     debug "Unexpected cancellation in mplex handler", m
   except LPStreamEOFError as exc:
-    trace "Stream EOF", m, msg = exc.msg
+    trace "Stream EOF", m, errMsg = exc.msg
   except LPStreamError as exc:
-    debug "Unexpected stream exception in mplex read loop", m, msg = exc.msg
+    debug "Unexpected stream exception in mplex read loop", m, errMsg = exc.msg
   except MuxerError as exc:
-    debug "Unexpected muxer exception in mplex read loop", m, msg = exc.msg
+    debug "Unexpected muxer exception in mplex read loop", m, errMsg = exc.msg
   finally:
     await m.close()
   trace "Stopped mplex handler", m

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -70,7 +70,7 @@ proc cleanupChann(m: Mplex, chann: LPChannel) {.async: (raises: []), inline.} =
         labelValues = [$chann.initiator, $m.connection.peerId],
       )
   except CancelledError as exc:
-    warn "Error cleaning up mplex channel", m, chann, errMsg = exc.msg
+    warn "Error cleaning up mplex channel", m, chann, description = exc.msg
 
 proc newStreamInternal*(
     m: Mplex,
@@ -175,7 +175,7 @@ method handle*(m: Mplex) {.async: (raises: []).} =
         except LPStreamClosedError as exc:
           # Channel is being closed, but `cleanupChann` was not yet triggered.
           trace "pushing data to channel failed",
-            m, channel, len = data.len, errMsg = exc.msg
+            m, channel, len = data.len, description = exc.msg
           discard # Ignore message, same as if `cleanupChann` had completed.
       of MessageType.CloseIn, MessageType.CloseOut:
         await channel.pushEof()
@@ -185,11 +185,11 @@ method handle*(m: Mplex) {.async: (raises: []).} =
   except CancelledError:
     debug "Unexpected cancellation in mplex handler", m
   except LPStreamEOFError as exc:
-    trace "Stream EOF", m, errMsg = exc.msg
+    trace "Stream EOF", m, description = exc.msg
   except LPStreamError as exc:
-    debug "Unexpected stream exception in mplex read loop", m, errMsg = exc.msg
+    debug "Unexpected stream exception in mplex read loop", m, description = exc.msg
   except MuxerError as exc:
-    debug "Unexpected muxer exception in mplex read loop", m, errMsg = exc.msg
+    debug "Unexpected muxer exception in mplex read loop", m, description = exc.msg
   finally:
     await m.close()
   trace "Stopped mplex handler", m

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -513,9 +513,9 @@ method close*(m: Yamux) {.async: (raises: []).} =
   try:
     await m.connection.write(YamuxHeader.goAway(NormalTermination))
   except CancelledError as exc:
-    trace "cancelled sending goAway", errMsg = exc.msg
+    trace "cancelled sending goAway", description = exc.msg
   except LPStreamError as exc:
-    trace "failed to send goAway", errMsg = exc.msg
+    trace "failed to send goAway", description = exc.msg
   await m.connection.close()
   trace "Closed yamux"
 
@@ -601,7 +601,7 @@ method handle*(m: Yamux) {.async: (raises: []).} =
           if header.length > 0:
             var buffer = newSeqUninitialized[byte](header.length)
             await m.connection.readExactly(addr buffer[0], int(header.length))
-            trace "Msg Rcv", errMsg = shortLog(buffer)
+            trace "Msg Rcv", description = shortLog(buffer)
             await channel.gotDataFromRemote(buffer)
 
         if MsgFlags.Fin in header.flags:
@@ -611,19 +611,19 @@ method handle*(m: Yamux) {.async: (raises: []).} =
           trace "remote reset channel"
           await channel.reset()
   except CancelledError as exc:
-    debug "Unexpected cancellation in yamux handler", errMsg = exc.msg
+    debug "Unexpected cancellation in yamux handler", description = exc.msg
   except LPStreamEOFError as exc:
-    trace "Stream EOF", errMsg = exc.msg
+    trace "Stream EOF", description = exc.msg
   except LPStreamError as exc:
-    debug "Unexpected stream exception in yamux read loop", errMsg = exc.msg
+    debug "Unexpected stream exception in yamux read loop", description = exc.msg
   except YamuxError as exc:
-    trace "Closing yamux connection", errMsg = exc.msg
+    trace "Closing yamux connection", description = exc.msg
     try:
       await m.connection.write(YamuxHeader.goAway(ProtocolError))
     except CancelledError, LPStreamError:
       discard
   except MuxerError as exc:
-    debug "Unexpected muxer exception in yamux read loop", errMsg = exc.msg
+    debug "Unexpected muxer exception in yamux read loop", description = exc.msg
     try:
       await m.connection.write(YamuxHeader.goAway(ProtocolError))
     except CancelledError, LPStreamError:

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -82,7 +82,8 @@ proc `$`(header: YamuxHeader): string =
       if a != "":
         a & ", " & $b
       else:
-        $b,
+        $b
+      ,
       "",
     ) & "}, " & "streamId: " & $header.streamId & ", " & "length: " & $header.length &
     "}"
@@ -175,7 +176,8 @@ proc `$`(channel: YamuxChannel): string =
         if a != "":
           a & ", " & b
         else:
-          b,
+          b
+        ,
         "",
       ) & "}"
 

--- a/libp2p/nameresolving/dnsresolver.nim
+++ b/libp2p/nameresolving/dnsresolver.nim
@@ -41,7 +41,7 @@ proc questionToBuf(address: string, kind: QKind): seq[byte] =
     discard requestStream.readData(addr buf[0], dataLen)
     return buf
   except CatchableError as exc:
-    info "Failed to created DNS buffer", errMsg = exc.msg
+    info "Failed to created DNS buffer", description = exc.msg
     return newSeq[byte](0)
 
 proc getDnsResponse(

--- a/libp2p/nameresolving/dnsresolver.nim
+++ b/libp2p/nameresolving/dnsresolver.nim
@@ -41,7 +41,7 @@ proc questionToBuf(address: string, kind: QKind): seq[byte] =
     discard requestStream.readData(addr buf[0], dataLen)
     return buf
   except CatchableError as exc:
-    info "Failed to created DNS buffer", msg = exc.msg
+    info "Failed to created DNS buffer", errMsg = exc.msg
     return newSeq[byte](0)
 
 proc getDnsResponse(

--- a/libp2p/protocols/connectivity/autonat/server.nim
+++ b/libp2p/protocols/connectivity/autonat/server.nim
@@ -84,13 +84,13 @@ proc tryDial(autonat: Autonat, conn: Connection, addrs: seq[MultiAddress]) {.asy
   except CancelledError as exc:
     raise exc
   except AllFuturesFailedError as exc:
-    debug "All dial attempts failed", addrs, errMsg = exc.msg
+    debug "All dial attempts failed", addrs, description = exc.msg
     await conn.sendResponseError(DialError, "All dial attempts failed")
   except AsyncTimeoutError as exc:
-    debug "Dial timeout", addrs, errMsg = exc.msg
+    debug "Dial timeout", addrs, description = exc.msg
     await conn.sendResponseError(DialError, "Dial timeout")
   except CatchableError as exc:
-    debug "Unexpected error", addrs, errMsg = exc.msg
+    debug "Unexpected error", addrs, description = exc.msg
     await conn.sendResponseError(DialError, "Unexpected error")
   finally:
     autonat.sem.release()
@@ -165,7 +165,7 @@ proc new*(
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      debug "exception in autonat handler", errMsg = exc.msg, conn
+      debug "exception in autonat handler", description = exc.msg, conn
     finally:
       trace "exiting autonat handler", conn
       await conn.close()

--- a/libp2p/protocols/connectivity/autonat/server.nim
+++ b/libp2p/protocols/connectivity/autonat/server.nim
@@ -84,13 +84,13 @@ proc tryDial(autonat: Autonat, conn: Connection, addrs: seq[MultiAddress]) {.asy
   except CancelledError as exc:
     raise exc
   except AllFuturesFailedError as exc:
-    debug "All dial attempts failed", addrs, exc = exc.msg
+    debug "All dial attempts failed", addrs, errMsg = exc.msg
     await conn.sendResponseError(DialError, "All dial attempts failed")
   except AsyncTimeoutError as exc:
-    debug "Dial timeout", addrs, exc = exc.msg
+    debug "Dial timeout", addrs, errMsg = exc.msg
     await conn.sendResponseError(DialError, "Dial timeout")
   except CatchableError as exc:
-    debug "Unexpected error", addrs, exc = exc.msg
+    debug "Unexpected error", addrs, errMsg = exc.msg
     await conn.sendResponseError(DialError, "Unexpected error")
   finally:
     autonat.sem.release()
@@ -165,7 +165,7 @@ proc new*(
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      debug "exception in autonat handler", exc = exc.msg, conn
+      debug "exception in autonat handler", errMsg = exc.msg, conn
     finally:
       trace "exiting autonat handler", conn
       await conn.close()

--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -146,13 +146,13 @@ proc askPeer(
       debug "dialMe answer is reachable"
       Reachable
     except AutonatUnreachableError as error:
-      debug "dialMe answer is not reachable", msg = error.msg
+      debug "dialMe answer is not reachable", errMsg = error.msg
       NotReachable
     except AsyncTimeoutError as error:
-      debug "dialMe timed out", msg = error.msg
+      debug "dialMe timed out", errMsg = error.msg
       Unknown
     except CatchableError as error:
-      debug "dialMe unexpected error", msg = error.msg
+      debug "dialMe unexpected error", errMsg = error.msg
       Unknown
   let hasReachabilityOrConfidenceChanged = await self.handleAnswer(ans)
   if hasReachabilityOrConfidenceChanged:
@@ -194,7 +194,7 @@ proc addressMapper(
         processedMA = peerStore.guessDialableAddr(listenAddr)
           # handle manual port forwarding
     except CatchableError as exc:
-      debug "Error while handling address mapper", msg = exc.msg
+      debug "Error while handling address mapper", errMsg = exc.msg
     addrs.add(processedMA)
   return addrs
 

--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -146,13 +146,13 @@ proc askPeer(
       debug "dialMe answer is reachable"
       Reachable
     except AutonatUnreachableError as error:
-      debug "dialMe answer is not reachable", errMsg = error.msg
+      debug "dialMe answer is not reachable", description = error.msg
       NotReachable
     except AsyncTimeoutError as error:
-      debug "dialMe timed out", errMsg = error.msg
+      debug "dialMe timed out", description = error.msg
       Unknown
     except CatchableError as error:
-      debug "dialMe unexpected error", errMsg = error.msg
+      debug "dialMe unexpected error", description = error.msg
       Unknown
   let hasReachabilityOrConfidenceChanged = await self.handleAnswer(ans)
   if hasReachabilityOrConfidenceChanged:
@@ -194,7 +194,7 @@ proc addressMapper(
         processedMA = peerStore.guessDialableAddr(listenAddr)
           # handle manual port forwarding
     except CatchableError as exc:
-      debug "Error while handling address mapper", errMsg = exc.msg
+      debug "Error while handling address mapper", description = exc.msg
     addrs.add(processedMA)
   return addrs
 

--- a/libp2p/protocols/connectivity/dcutr/client.nim
+++ b/libp2p/protocols/connectivity/dcutr/client.nim
@@ -88,7 +88,7 @@ proc startSync*(
     raise err
   except AllFuturesFailedError as err:
     debug "Dcutr initiator could not connect to the remote peer, all connect attempts failed",
-      peerDialableAddrs, errMsg = err.msg
+      peerDialableAddrs, description = err.msg
     raise newException(
       DcutrError,
       "Dcutr initiator could not connect to the remote peer, all connect attempts failed",
@@ -96,7 +96,7 @@ proc startSync*(
     )
   except AsyncTimeoutError as err:
     debug "Dcutr initiator could not connect to the remote peer, all connect attempts timed out",
-      peerDialableAddrs, errMsg = err.msg
+      peerDialableAddrs, description = err.msg
     raise newException(
       DcutrError,
       "Dcutr initiator could not connect to the remote peer, all connect attempts timed out",
@@ -104,7 +104,7 @@ proc startSync*(
     )
   except CatchableError as err:
     debug "Unexpected error when Dcutr initiator tried to connect to the remote peer",
-      errMsg = err.msg
+      description = err.msg
     raise newException(
       DcutrError,
       "Unexpected error when Dcutr initiator tried to connect to the remote peer", err,

--- a/libp2p/protocols/connectivity/dcutr/client.nim
+++ b/libp2p/protocols/connectivity/dcutr/client.nim
@@ -88,7 +88,7 @@ proc startSync*(
     raise err
   except AllFuturesFailedError as err:
     debug "Dcutr initiator could not connect to the remote peer, all connect attempts failed",
-      peerDialableAddrs, msg = err.msg
+      peerDialableAddrs, errMsg = err.msg
     raise newException(
       DcutrError,
       "Dcutr initiator could not connect to the remote peer, all connect attempts failed",
@@ -96,7 +96,7 @@ proc startSync*(
     )
   except AsyncTimeoutError as err:
     debug "Dcutr initiator could not connect to the remote peer, all connect attempts timed out",
-      peerDialableAddrs, msg = err.msg
+      peerDialableAddrs, errMsg = err.msg
     raise newException(
       DcutrError,
       "Dcutr initiator could not connect to the remote peer, all connect attempts timed out",
@@ -104,7 +104,7 @@ proc startSync*(
     )
   except CatchableError as err:
     debug "Unexpected error when Dcutr initiator tried to connect to the remote peer",
-      err = err.msg
+      errMsg = err.msg
     raise newException(
       DcutrError,
       "Unexpected error when Dcutr initiator tried to connect to the remote peer", err,

--- a/libp2p/protocols/connectivity/dcutr/server.nim
+++ b/libp2p/protocols/connectivity/dcutr/server.nim
@@ -80,13 +80,13 @@ proc new*(
       raise err
     except AllFuturesFailedError as err:
       debug "Dcutr receiver could not connect to the remote peer, " &
-        "all connect attempts failed", peerDialableAddrs, msg = err.msg
+        "all connect attempts failed", peerDialableAddrs, errMsg = err.msg
     except AsyncTimeoutError as err:
       debug "Dcutr receiver could not connect to the remote peer, " &
-        "all connect attempts timed out", peerDialableAddrs, msg = err.msg
+        "all connect attempts timed out", peerDialableAddrs, errMsg = err.msg
     except CatchableError as err:
       warn "Unexpected error when Dcutr receiver tried to connect " &
-        "to the remote peer", msg = err.msg
+        "to the remote peer", errMsg = err.msg
 
   let self = T()
   self.handler = handleStream

--- a/libp2p/protocols/connectivity/dcutr/server.nim
+++ b/libp2p/protocols/connectivity/dcutr/server.nim
@@ -80,13 +80,13 @@ proc new*(
       raise err
     except AllFuturesFailedError as err:
       debug "Dcutr receiver could not connect to the remote peer, " &
-        "all connect attempts failed", peerDialableAddrs, errMsg = err.msg
+        "all connect attempts failed", peerDialableAddrs, description = err.msg
     except AsyncTimeoutError as err:
       debug "Dcutr receiver could not connect to the remote peer, " &
-        "all connect attempts timed out", peerDialableAddrs, errMsg = err.msg
+        "all connect attempts timed out", peerDialableAddrs, description = err.msg
     except CatchableError as err:
       warn "Unexpected error when Dcutr receiver tried to connect " &
-        "to the remote peer", errMsg = err.msg
+        "to the remote peer", description = err.msg
 
   let self = T()
   self.handler = handleStream

--- a/libp2p/protocols/connectivity/relay/client.nim
+++ b/libp2p/protocols/connectivity/relay/client.nim
@@ -93,7 +93,7 @@ proc reserve*(
       except CancelledError as exc:
         raise exc
       except CatchableError as exc:
-        trace "error writing or reading reservation message", exc = exc.msg
+        trace "error writing or reading reservation message", errMsg = exc.msg
         raise newException(ReservationError, exc.msg)
 
   if msg.msgType != HopMessageType.Status:
@@ -139,7 +139,7 @@ proc dialPeerV1*(
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    trace "error writing hop request", exc = exc.msg
+    trace "error writing hop request", errMsg = exc.msg
     raise exc
 
   let msgRcvFromRelayOpt =
@@ -148,7 +148,7 @@ proc dialPeerV1*(
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "error reading stop response", exc = exc.msg
+      trace "error reading stop response", errMsg = exc.msg
       await sendStatus(conn, StatusV1.HopCantOpenDstStream)
       raise exc
 
@@ -190,13 +190,13 @@ proc dialPeerV2*(
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "error reading stop response", exc = exc.msg
+      trace "error reading stop response", errMsg = exc.msg
       raise newException(RelayV2DialError, exc.msg)
 
   if msgRcvFromRelay.msgType != HopMessageType.Status:
     raise newException(RelayV2DialError, "Unexpected stop response")
   if msgRcvFromRelay.status.get(UnexpectedMessage) != Ok:
-    trace "Relay stop failed", msg = msgRcvFromRelay.status
+    trace "Relay stop failed", errMsg = msgRcvFromRelay.status
     raise newException(RelayV2DialError, "Relay stop failure")
   conn.limitDuration = msgRcvFromRelay.limit.duration
   conn.limitData = msgRcvFromRelay.limit.data
@@ -302,7 +302,7 @@ proc new*(
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "exception in client handler", exc = exc.msg, conn
+      trace "exception in client handler", errMsg = exc.msg, conn
     finally:
       trace "exiting client handler", conn
       await conn.close()

--- a/libp2p/protocols/connectivity/relay/client.nim
+++ b/libp2p/protocols/connectivity/relay/client.nim
@@ -93,7 +93,7 @@ proc reserve*(
       except CancelledError as exc:
         raise exc
       except CatchableError as exc:
-        trace "error writing or reading reservation message", errMsg = exc.msg
+        trace "error writing or reading reservation message", description = exc.msg
         raise newException(ReservationError, exc.msg)
 
   if msg.msgType != HopMessageType.Status:
@@ -139,7 +139,7 @@ proc dialPeerV1*(
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    trace "error writing hop request", errMsg = exc.msg
+    trace "error writing hop request", description = exc.msg
     raise exc
 
   let msgRcvFromRelayOpt =
@@ -148,7 +148,7 @@ proc dialPeerV1*(
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "error reading stop response", errMsg = exc.msg
+      trace "error reading stop response", description = exc.msg
       await sendStatus(conn, StatusV1.HopCantOpenDstStream)
       raise exc
 
@@ -190,13 +190,13 @@ proc dialPeerV2*(
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "error reading stop response", errMsg = exc.msg
+      trace "error reading stop response", description = exc.msg
       raise newException(RelayV2DialError, exc.msg)
 
   if msgRcvFromRelay.msgType != HopMessageType.Status:
     raise newException(RelayV2DialError, "Unexpected stop response")
   if msgRcvFromRelay.status.get(UnexpectedMessage) != Ok:
-    trace "Relay stop failed", errMsg = msgRcvFromRelay.status
+    trace "Relay stop failed", description = msgRcvFromRelay.status
     raise newException(RelayV2DialError, "Relay stop failure")
   conn.limitDuration = msgRcvFromRelay.limit.duration
   conn.limitData = msgRcvFromRelay.limit.data
@@ -302,7 +302,7 @@ proc new*(
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "exception in client handler", errMsg = exc.msg, conn
+      trace "exception in client handler", description = exc.msg, conn
     finally:
       trace "exiting client handler", conn
       await conn.close()

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -167,7 +167,7 @@ proc handleConnect(r: Relay, connSrc: Connection, msg: HopMessage) {.async.} =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "error opening relay stream", dst, errMsg = exc.msg
+      trace "error opening relay stream", dst, description = exc.msg
       await sendHopStatus(connSrc, ConnectionFailed)
       return
   defer:
@@ -196,7 +196,7 @@ proc handleConnect(r: Relay, connSrc: Connection, msg: HopMessage) {.async.} =
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    trace "error sending stop message", errMsg = exc.msg
+    trace "error sending stop message", description = exc.msg
     await sendHopStatus(connSrc, ConnectionFailed)
     return
 
@@ -272,7 +272,7 @@ proc handleHop*(r: Relay, connSrc: Connection, msg: RelayMessage) {.async.} =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "error opening relay stream", dst, errMsg = exc.msg
+      trace "error opening relay stream", dst, description = exc.msg
       await sendStatus(connSrc, StatusV1.HopCantDialDst)
       return
   defer:
@@ -289,7 +289,8 @@ proc handleHop*(r: Relay, connSrc: Connection, msg: RelayMessage) {.async.} =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "error writing stop handshake or reading stop response", errMsg = exc.msg
+      trace "error writing stop handshake or reading stop response",
+        description = exc.msg
       await sendStatus(connSrc, StatusV1.HopCantOpenDstStream)
       return
 
@@ -369,7 +370,7 @@ proc new*(
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      debug "exception in relayv2 handler", errMsg = exc.msg, conn
+      debug "exception in relayv2 handler", description = exc.msg, conn
     finally:
       trace "exiting relayv2 handler", conn
       await conn.close()

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -333,7 +333,8 @@ proc setup*(r: Relay, switch: Switch) =
   r.switch = switch
   r.switch.addPeerEventHandler(
     proc(peerId: PeerId, event: PeerEvent) {.async.} =
-      r.rsvp.del(peerId),
+      r.rsvp.del(peerId)
+    ,
     Left,
   )
 

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -167,7 +167,7 @@ proc handleConnect(r: Relay, connSrc: Connection, msg: HopMessage) {.async.} =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "error opening relay stream", dst, exc = exc.msg
+      trace "error opening relay stream", dst, errMsg = exc.msg
       await sendHopStatus(connSrc, ConnectionFailed)
       return
   defer:
@@ -196,7 +196,7 @@ proc handleConnect(r: Relay, connSrc: Connection, msg: HopMessage) {.async.} =
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    trace "error sending stop message", msg = exc.msg
+    trace "error sending stop message", errMsg = exc.msg
     await sendHopStatus(connSrc, ConnectionFailed)
     return
 
@@ -213,7 +213,7 @@ proc handleHopStreamV2*(r: Relay, conn: Connection) {.async.} =
   let msg = HopMessage.decode(await conn.readLp(r.msgSize)).valueOr:
     await sendHopStatus(conn, MalformedMessage)
     return
-  trace "relayv2 handle stream", msg = msg
+  trace "relayv2 handle stream", hopMsg = msg
   case msg.msgType
   of HopMessageType.Reserve:
     await r.handleReserve(conn)
@@ -272,7 +272,7 @@ proc handleHop*(r: Relay, connSrc: Connection, msg: RelayMessage) {.async.} =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "error opening relay stream", dst, exc = exc.msg
+      trace "error opening relay stream", dst, errMsg = exc.msg
       await sendStatus(connSrc, StatusV1.HopCantDialDst)
       return
   defer:
@@ -289,12 +289,12 @@ proc handleHop*(r: Relay, connSrc: Connection, msg: RelayMessage) {.async.} =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "error writing stop handshake or reading stop response", exc = exc.msg
+      trace "error writing stop handshake or reading stop response", errMsg = exc.msg
       await sendStatus(connSrc, StatusV1.HopCantOpenDstStream)
       return
 
   let msgRcvFromDst = msgRcvFromDstOpt.valueOr:
-    trace "error reading stop response", msg = msgRcvFromDstOpt
+    trace "error reading stop response", response = msgRcvFromDstOpt
     await sendStatus(connSrc, StatusV1.HopCantOpenDstStream)
     return
 
@@ -333,8 +333,7 @@ proc setup*(r: Relay, switch: Switch) =
   r.switch = switch
   r.switch.addPeerEventHandler(
     proc(peerId: PeerId, event: PeerEvent) {.async.} =
-      r.rsvp.del(peerId)
-    ,
+      r.rsvp.del(peerId),
     Left,
   )
 
@@ -369,7 +368,7 @@ proc new*(
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      debug "exception in relayv2 handler", exc = exc.msg, conn
+      debug "exception in relayv2 handler", errMsg = exc.msg, conn
     finally:
       trace "exiting relayv2 handler", conn
       await conn.close()

--- a/libp2p/protocols/connectivity/relay/utils.nim
+++ b/libp2p/protocols/connectivity/relay/utils.nim
@@ -87,7 +87,7 @@ proc bridge*(
       trace "relay src closed connection", src = connSrc.peerId
     if connDst.closed() or connDst.atEof():
       trace "relay dst closed connection", dst = connDst.peerId
-    trace "relay error", exc = exc.msg
+    trace "relay error", errMsg = exc.msg
   trace "end relaying", bytesSentFromSrcToDst, bytesSentFromDstToSrc
   await futSrc.cancelAndWait()
   await futDst.cancelAndWait()

--- a/libp2p/protocols/connectivity/relay/utils.nim
+++ b/libp2p/protocols/connectivity/relay/utils.nim
@@ -87,7 +87,7 @@ proc bridge*(
       trace "relay src closed connection", src = connSrc.peerId
     if connDst.closed() or connDst.atEof():
       trace "relay dst closed connection", dst = connDst.peerId
-    trace "relay error", errMsg = exc.msg
+    trace "relay error", description = exc.msg
   trace "end relaying", bytesSentFromSrcToDst, bytesSentFromDstToSrc
   await futSrc.cancelAndWait()
   await futDst.cancelAndWait()

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -156,7 +156,7 @@ method init*(p: Identify) =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "exception in identify handler", exc = exc.msg, conn
+      trace "exception in identify handler", errMsg = exc.msg, conn
     finally:
       trace "exiting identify handler", conn
       await conn.closeWithEOF()
@@ -226,7 +226,7 @@ proc init*(p: IdentifyPush) =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      info "exception in identify push handler", exc = exc.msg, conn
+      info "exception in identify push handler", errMsg = exc.msg, conn
     finally:
       trace "exiting identify push handler", conn
       await conn.closeWithEOF()

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -156,7 +156,7 @@ method init*(p: Identify) =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "exception in identify handler", errMsg = exc.msg, conn
+      trace "exception in identify handler", description = exc.msg, conn
     finally:
       trace "exiting identify handler", conn
       await conn.closeWithEOF()
@@ -226,7 +226,7 @@ proc init*(p: IdentifyPush) =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      info "exception in identify push handler", errMsg = exc.msg, conn
+      info "exception in identify push handler", description = exc.msg, conn
     finally:
       trace "exiting identify push handler", conn
       await conn.closeWithEOF()

--- a/libp2p/protocols/perf/server.nim
+++ b/libp2p/protocols/perf/server.nim
@@ -49,7 +49,7 @@ proc new*(T: typedesc[Perf]): T {.public.} =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "exception in perf handler", exc = exc.msg, conn
+      trace "exception in perf handler", errMsg = exc.msg, conn
     await conn.close()
 
   p.handler = handle

--- a/libp2p/protocols/perf/server.nim
+++ b/libp2p/protocols/perf/server.nim
@@ -49,7 +49,7 @@ proc new*(T: typedesc[Perf]): T {.public.} =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "exception in perf handler", errMsg = exc.msg, conn
+      trace "exception in perf handler", description = exc.msg, conn
     await conn.close()
 
   p.handler = handle

--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -63,7 +63,7 @@ method init*(p: Ping) =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "exception in ping handler", exc = exc.msg, conn
+      trace "exception in ping handler", errMsg = exc.msg, conn
 
   p.handler = handle
   p.codec = PingCodec

--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -63,7 +63,7 @@ method init*(p: Ping) =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "exception in ping handler", errMsg = exc.msg, conn
+      trace "exception in ping handler", description = exc.msg, conn
 
   p.handler = handle
   p.codec = PingCodec

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -106,7 +106,7 @@ method rpcHandler*(f: FloodSub, peer: PubSubPeer, data: seq[byte]) {.async.} =
     debug "failed to decode msg from peer", peer, err = error
     raise newException(CatchableError, "Peer msg couldn't be decoded")
 
-  trace "decoded msg from peer", peer, msg = rpcMsg.shortLog
+  trace "decoded msg from peer", peer, payload = rpcMsg.shortLog
   # trigger hooks
   peer.recvObservers(rpcMsg)
 
@@ -187,7 +187,7 @@ method init*(f: FloodSub) =
       # do not need to propagate CancelledError.
       trace "Unexpected cancellation in floodsub handler", conn
     except CatchableError as exc:
-      trace "FloodSub handler leaks an error", exc = exc.msg, conn
+      trace "FloodSub handler leaks an error", errMsg = exc.msg, conn
 
   f.handler = handler
   f.codec = FloodSubCodec
@@ -219,7 +219,7 @@ method publish*(f: FloodSub, topic: string, data: seq[byte]): Future[int] {.asyn
       trace "Error generating message id, skipping publish", error = error
       return 0
 
-  trace "Created new message", msg = shortLog(msg), peers = peers.len, topic, msgId
+  trace "Created new message", payload = shortLog(msg), peers = peers.len, topic, msgId
 
   if f.addSeen(f.salt(msgId)):
     # custom msgid providers might cause this

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -187,7 +187,7 @@ method init*(f: FloodSub) =
       # do not need to propagate CancelledError.
       trace "Unexpected cancellation in floodsub handler", conn
     except CatchableError as exc:
-      trace "FloodSub handler leaks an error", errMsg = exc.msg, conn
+      trace "FloodSub handler leaks an error", description = exc.msg, conn
 
   f.handler = handler
   f.codec = FloodSubCodec

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -220,7 +220,7 @@ method init*(g: GossipSub) =
       # do not need to propogate CancelledError.
       trace "Unexpected cancellation in gossipsub handler", conn
     except CatchableError as exc:
-      trace "GossipSub handler leaks an error", exc = exc.msg, conn
+      trace "GossipSub handler leaks an error", errMsg = exc.msg, conn
 
   g.handler = handler
   g.codecs &= GossipSubCodec_12
@@ -368,7 +368,7 @@ proc handleControl(g: GossipSub, peer: PubSubPeer, control: ControlMessage) =
         else:
           libp2p_pubsub_broadcast_prune.inc(labelValues = ["generic"])
 
-    trace "sending control message", msg = shortLog(respControl), peer
+    trace "sending control message", payload = shortLog(respControl), peer
     g.send(peer, RPCMsg(control: some(respControl)), isHighPriority = true)
 
   if messages.len > 0:
@@ -491,7 +491,7 @@ proc validateAndRelay(
 
     await handleData(g, topic, msg.data)
   except CatchableError as exc:
-    info "validateAndRelay failed", msg = exc.msg
+    info "validateAndRelay failed", errMsg = exc.msg
 
 proc dataAndTopicsIdSize(msgs: seq[Message]): int =
   msgs.mapIt(it.data.len + it.topic.len).foldl(a + b, 0)
@@ -540,7 +540,7 @@ method rpcHandler*(g: GossipSub, peer: PubSubPeer, data: seq[byte]) {.async.} =
     for m in rpcMsg.messages:
       libp2p_pubsub_received_messages.inc(labelValues = [$peer.peerId, m.topic])
 
-  trace "decoded msg from peer", peer, msg = rpcMsg.shortLog
+  trace "decoded msg from peer", peer, payload = rpcMsg.shortLog
   await rateLimit(g, peer, g.messageOverhead(rpcMsg, msgSize))
 
   # trigger hooks - these may modify the message
@@ -771,7 +771,7 @@ method publish*(g: GossipSub, topic: string, data: seq[byte]): Future[int] {.asy
   logScope:
     msgId = shortLog(msgId)
 
-  trace "Created new message", msg = shortLog(msg), peers = peers.len
+  trace "Created new message", payload = shortLog(msg), peers = peers.len
 
   if g.addSeen(g.salt(msgId)):
     # If the message was received or published recently, don't re-publish it -
@@ -806,7 +806,7 @@ proc maintainDirectPeer(g: GossipSub, id: PeerId, addrs: seq[MultiAddress]) {.as
       trace "Direct peer dial canceled"
       raise exc
     except CatchableError as exc:
-      debug "Direct peer error dialing", msg = exc.msg
+      debug "Direct peer error dialing", errMsg = exc.msg
 
 proc addDirectPeer*(g: GossipSub, id: PeerId, addrs: seq[MultiAddress]) {.async.} =
   g.parameters.directPeers[id] = addrs

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -220,7 +220,7 @@ method init*(g: GossipSub) =
       # do not need to propogate CancelledError.
       trace "Unexpected cancellation in gossipsub handler", conn
     except CatchableError as exc:
-      trace "GossipSub handler leaks an error", errMsg = exc.msg, conn
+      trace "GossipSub handler leaks an error", description = exc.msg, conn
 
   g.handler = handler
   g.codecs &= GossipSubCodec_12
@@ -491,7 +491,7 @@ proc validateAndRelay(
 
     await handleData(g, topic, msg.data)
   except CatchableError as exc:
-    info "validateAndRelay failed", errMsg = exc.msg
+    info "validateAndRelay failed", description = exc.msg
 
 proc dataAndTopicsIdSize(msgs: seq[Message]): int =
   msgs.mapIt(it.data.len + it.topic.len).foldl(a + b, 0)
@@ -806,7 +806,7 @@ proc maintainDirectPeer(g: GossipSub, id: PeerId, addrs: seq[MultiAddress]) {.as
       trace "Direct peer dial canceled"
       raise exc
     except CatchableError as exc:
-      debug "Direct peer error dialing", errMsg = exc.msg
+      debug "Direct peer error dialing", description = exc.msg
 
 proc addDirectPeer*(g: GossipSub, id: PeerId, addrs: seq[MultiAddress]) {.async.} =
   g.parameters.directPeers[id] = addrs

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -135,7 +135,7 @@ proc disconnectPeer*(g: GossipSub, peer: PubSubPeer) {.async.} =
   try:
     await g.switch.disconnect(peer.peerId)
   except CatchableError as exc: # Never cancelled
-    trace "Failed to close connection", peer, errName = exc.name, errMsg = exc.msg
+    trace "Failed to close connection", peer, errName = exc.name, description = exc.msg
 
 proc disconnectIfBadScorePeer*(g: GossipSub, peer: PubSubPeer, score: float64) =
   if g.parameters.disconnectBadPeers and score < g.parameters.graylistThreshold and

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -135,7 +135,7 @@ proc disconnectPeer*(g: GossipSub, peer: PubSubPeer) {.async.} =
   try:
     await g.switch.disconnect(peer.peerId)
   except CatchableError as exc: # Never cancelled
-    trace "Failed to close connection", peer, error = exc.name, msg = exc.msg
+    trace "Failed to close connection", peer, errName = exc.name, errMsg = exc.msg
 
 proc disconnectIfBadScorePeer*(g: GossipSub, peer: PubSubPeer, score: float64) =
   if g.parameters.disconnectBadPeers and score < g.parameters.graylistThreshold and

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -197,7 +197,7 @@ proc send*(
   ## High priority messages are sent immediately, while low priority messages are queued and sent only after all high
   ## priority messages have been sent.
 
-  trace "sending pubsub message to peer", peer, msg = shortLog(msg)
+  trace "sending pubsub message to peer", peer, payload = shortLog(msg)
   peer.send(msg, p.anonymize, isHighPriority)
 
 proc broadcast*(
@@ -255,7 +255,7 @@ proc broadcast*(
       else:
         libp2p_pubsub_broadcast_prune.inc(npeers, labelValues = ["generic"])
 
-  trace "broadcasting messages to peers", peers = sendPeers.len, msg = shortLog(msg)
+  trace "broadcasting messages to peers", peers = sendPeers.len, payload = shortLog(msg)
 
   if anyIt(sendPeers, it.hasObservers):
     for peer in sendPeers:
@@ -403,7 +403,7 @@ proc handleData*(p: PubSub, topic: string, data: seq[byte]): Future[void] =
         for fut in futs:
           if fut.failed:
             let err = fut.readError()
-            warn "Error in topic handler", msg = err.msg
+            warn "Error in topic handler", errMsg = err.msg
 
       return waiter()
 
@@ -437,7 +437,7 @@ method handleConn*(p: PubSub, conn: Connection, proto: string) {.base, async.} =
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    trace "exception ocurred in pubsub handle", exc = exc.msg, conn
+    trace "exception ocurred in pubsub handle", errMsg = exc.msg, conn
   finally:
     await conn.closeWithEOF()
 

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -403,7 +403,7 @@ proc handleData*(p: PubSub, topic: string, data: seq[byte]): Future[void] =
         for fut in futs:
           if fut.failed:
             let err = fut.readError()
-            warn "Error in topic handler", errMsg = err.msg
+            warn "Error in topic handler", description = err.msg
 
       return waiter()
 
@@ -437,7 +437,7 @@ method handleConn*(p: PubSub, conn: Connection, proto: string) {.base, async.} =
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    trace "exception ocurred in pubsub handle", errMsg = exc.msg, conn
+    trace "exception ocurred in pubsub handle", description = exc.msg, conn
   finally:
     await conn.closeWithEOF()
 

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -205,10 +205,10 @@ proc handle*(p: PubSubPeer, conn: Connection) {.async.} =
         data = newSeq[byte]() # Release memory
     except PeerRateLimitError as exc:
       debug "Peer rate limit exceeded, exiting read while",
-        conn, peer = p, error = exc.msg
+        conn, peer = p, errMsg = exc.msg
     except CatchableError as exc:
       debug "Exception occurred in PubSubPeer.handle",
-        conn, peer = p, closed = conn.closed, exc = exc.msg
+        conn, peer = p, closed = conn.closed, errMsg = exc.msg
     finally:
       await conn.close()
   except CancelledError:
@@ -217,7 +217,7 @@ proc handle*(p: PubSubPeer, conn: Connection) {.async.} =
     trace "Unexpected cancellation in PubSubPeer.handle"
   except CatchableError as exc:
     trace "Exception occurred in PubSubPeer.handle",
-      conn, peer = p, closed = conn.closed, exc = exc.msg
+      conn, peer = p, closed = conn.closed, errMsg = exc.msg
   finally:
     debug "exiting pubsub read loop", conn, peer = p, closed = conn.closed
 
@@ -236,7 +236,7 @@ proc closeSendConn(p: PubSubPeer, event: PubSubPeerEventKind) {.async.} =
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    debug "Errors during diconnection events", error = exc.msg
+    debug "Errors during diconnection events", errMsg = exc.msg
   # don't cleanup p.address else we leak some gossip stat table
 
 proc connectOnce(p: PubSubPeer): Future[void] {.async.} =
@@ -283,7 +283,7 @@ proc connectImpl(p: PubSubPeer) {.async.} =
         return
       await connectOnce(p)
   except CatchableError as exc: # never cancelled
-    debug "Could not establish send connection", msg = exc.msg
+    debug "Could not establish send connection", errMsg = exc.msg
 
 proc connect*(p: PubSubPeer) =
   if p.connected:
@@ -325,7 +325,7 @@ proc sendMsgContinue(conn: Connection, msgFut: Future[void]) {.async.} =
   except CatchableError as exc: # never cancelled
     # Because we detach the send call from the currently executing task using
     # asyncSpawn, no exceptions may leak out of it
-    trace "Unable to send to remote", conn, msg = exc.msg
+    trace "Unable to send to remote", conn, errMsg = exc.msg
     # Next time sendConn is used, it will be have its close flag set and thus
     # will be recycled
 
@@ -341,7 +341,7 @@ proc sendMsgSlow(p: PubSubPeer, msg: seq[byte]) {.async.} =
 
   var conn = p.sendConn
   if conn == nil or conn.closed():
-    debug "No send connection", p, msg = shortLog(msg)
+    debug "No send connection", p, payload = shortLog(msg)
     return
 
   trace "sending encoded msg to peer", conn, encoded = shortLog(msg)
@@ -383,7 +383,7 @@ proc sendEncoded*(p: PubSubPeer, msg: seq[byte], isHighPriority: bool): Future[v
     ) == 0
 
   if msg.len <= 0:
-    debug "empty message, skipping", p, msg = shortLog(msg)
+    debug "empty message, skipping", p, payload = shortLog(msg)
     Future[void].completed()
   elif msg.len > p.maxMessageSize:
     info "trying to send a msg too big for pubsub",

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -310,7 +310,7 @@ proc decodeMessages*(pb: ProtoBuffer): ProtoResult[seq[Message]] {.inline.} =
   ok(msgs)
 
 proc encodeRpcMsg*(msg: RPCMsg, anonymize: bool): seq[byte] =
-  trace "encodeRpcMsg: encoding message", msg = msg.shortLog()
+  trace "encodeRpcMsg: encoding message", payload = msg.shortLog()
   var pb = initProtoBuffer(maxSize = uint.high)
   for item in msg.subscriptions:
     pb.write(1, item)
@@ -329,7 +329,7 @@ proc encodeRpcMsg*(msg: RPCMsg, anonymize: bool): seq[byte] =
   pb.buffer
 
 proc decodeRpcMsg*(msg: seq[byte]): ProtoResult[RPCMsg] {.inline.} =
-  trace "decodeRpcMsg: decoding message", msg = msg.shortLog()
+  trace "decodeRpcMsg: decoding message", payload = msg.shortLog()
   var pb = initProtoBuffer(msg, maxSize = uint.high)
   var rpcMsg = RPCMsg()
   assign(rpcMsg.messages, ?pb.decodeMessages())

--- a/libp2p/protocols/rendezvous.nim
+++ b/libp2p/protocols/rendezvous.nim
@@ -499,7 +499,7 @@ proc advertisePeer(rdv: RendezVous, peer: PeerId, msg: seq[byte]) {.async.} =
       else:
         trace "Successfully registered", peer, response = msgRecv.registerResponse
     except CatchableError as exc:
-      trace "exception in the advertise", error = exc.msg
+      trace "exception in the advertise", errMsg = exc.msg
     finally:
       rdv.sema.release()
 
@@ -618,7 +618,7 @@ proc request*(
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "exception catch in request", error = exc.msg
+      trace "exception catch in request", errMsg = exc.msg
   return toSeq(s.values()).mapIt(it[0])
 
 proc unsubscribeLocally*(rdv: RendezVous, ns: string) =
@@ -646,7 +646,7 @@ proc unsubscribe*(rdv: RendezVous, ns: string) {.async.} =
         await conn.close()
       await conn.writeLp(msg.buffer)
     except CatchableError as exc:
-      trace "exception while unsubscribing", error = exc.msg
+      trace "exception while unsubscribing", errMsg = exc.msg
 
   for peer in rdv.peers:
     discard await rdv.unsubscribePeer(peer).withTimeout(5.seconds)
@@ -692,7 +692,7 @@ proc new*(T: typedesc[RendezVous], rng: ref HmacDrbgContext = newRng()): T =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "exception in rendezvous handler", error = exc.msg
+      trace "exception in rendezvous handler", errMsg = exc.msg
     finally:
       await conn.close()
 

--- a/libp2p/protocols/rendezvous.nim
+++ b/libp2p/protocols/rendezvous.nim
@@ -499,7 +499,7 @@ proc advertisePeer(rdv: RendezVous, peer: PeerId, msg: seq[byte]) {.async.} =
       else:
         trace "Successfully registered", peer, response = msgRecv.registerResponse
     except CatchableError as exc:
-      trace "exception in the advertise", errMsg = exc.msg
+      trace "exception in the advertise", description = exc.msg
     finally:
       rdv.sema.release()
 
@@ -618,7 +618,7 @@ proc request*(
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "exception catch in request", errMsg = exc.msg
+      trace "exception catch in request", description = exc.msg
   return toSeq(s.values()).mapIt(it[0])
 
 proc unsubscribeLocally*(rdv: RendezVous, ns: string) =
@@ -646,7 +646,7 @@ proc unsubscribe*(rdv: RendezVous, ns: string) {.async.} =
         await conn.close()
       await conn.writeLp(msg.buffer)
     except CatchableError as exc:
-      trace "exception while unsubscribing", errMsg = exc.msg
+      trace "exception while unsubscribing", description = exc.msg
 
   for peer in rdv.peers:
     discard await rdv.unsubscribePeer(peer).withTimeout(5.seconds)
@@ -692,7 +692,7 @@ proc new*(T: typedesc[RendezVous], rng: ref HmacDrbgContext = newRng()): T =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "exception in rendezvous handler", errMsg = exc.msg
+      trace "exception in rendezvous handler", description = exc.msg
     finally:
       await conn.close()
 

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -155,7 +155,7 @@ method init*(s: Secure) =
       await conn.close()
       raise exc
     except LPStreamError as exc:
-      warn "securing connection failed", err = exc.msg, conn
+      warn "securing connection failed", errMsg = exc.msg, conn
       await conn.close()
 
   s.handler = handle

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -155,7 +155,7 @@ method init*(s: Secure) =
       await conn.close()
       raise exc
     except LPStreamError as exc:
-      warn "securing connection failed", errMsg = exc.msg, conn
+      warn "securing connection failed", description = exc.msg, conn
       await conn.close()
 
   s.handler = handle

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -326,4 +326,4 @@ proc closeWithEOF*(s: LPStream): Future[void] {.async: (raises: []), public.} =
   except LPStreamEOFError:
     trace "Expected EOF came", s
   except LPStreamError as exc:
-    debug "Unexpected error while waiting for EOF", s, errMsg = exc.msg
+    debug "Unexpected error while waiting for EOF", s, description = exc.msg

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -326,4 +326,4 @@ proc closeWithEOF*(s: LPStream): Future[void] {.async: (raises: []), public.} =
   except LPStreamEOFError:
     trace "Expected EOF came", s
   except LPStreamError as exc:
-    debug "Unexpected error while waiting for EOF", s, msg = exc.msg
+    debug "Unexpected error while waiting for EOF", s, errMsg = exc.msg

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -219,7 +219,7 @@ proc upgradeMonitor(
       libp2p_failed_upgrades_incoming.inc()
     if not isNil(conn):
       await conn.close()
-    trace "Exception awaiting connection upgrade", errMsg = exc.msg, conn
+    trace "Exception awaiting connection upgrade", description = exc.msg, conn
   finally:
     upgrades.release()
 
@@ -264,7 +264,7 @@ proc accept(s: Switch, transport: Transport) {.async.} = # noraises
       upgrades.release() # always release the slot
       return
     except CatchableError as exc:
-      error "Exception in accept loop, exiting", errMsg = exc.msg
+      error "Exception in accept loop, exiting", description = exc.msg
       upgrades.release() # always release the slot
       if not isNil(conn):
         await conn.close()
@@ -282,7 +282,7 @@ proc stop*(s: Switch) {.async, public.} =
     # Stop accepting incoming connections
     await allFutures(s.acceptFuts.mapIt(it.cancelAndWait())).wait(1.seconds)
   except CatchableError as exc:
-    debug "Cannot cancel accepts", errMsg = exc.msg
+    debug "Cannot cancel accepts", description = exc.msg
 
   for service in s.services:
     discard await service.stop(s)
@@ -296,7 +296,7 @@ proc stop*(s: Switch) {.async, public.} =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      warn "error cleaning up transports", errMsg = exc.msg
+      warn "error cleaning up transports", description = exc.msg
 
   await s.ms.stop()
 

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -219,7 +219,7 @@ proc upgradeMonitor(
       libp2p_failed_upgrades_incoming.inc()
     if not isNil(conn):
       await conn.close()
-    trace "Exception awaiting connection upgrade", exc = exc.msg, conn
+    trace "Exception awaiting connection upgrade", errMsg = exc.msg, conn
   finally:
     upgrades.release()
 
@@ -264,7 +264,7 @@ proc accept(s: Switch, transport: Transport) {.async.} = # noraises
       upgrades.release() # always release the slot
       return
     except CatchableError as exc:
-      error "Exception in accept loop, exiting", exc = exc.msg
+      error "Exception in accept loop, exiting", errMsg = exc.msg
       upgrades.release() # always release the slot
       if not isNil(conn):
         await conn.close()
@@ -282,7 +282,7 @@ proc stop*(s: Switch) {.async, public.} =
     # Stop accepting incoming connections
     await allFutures(s.acceptFuts.mapIt(it.cancelAndWait())).wait(1.seconds)
   except CatchableError as exc:
-    debug "Cannot cancel accepts", error = exc.msg
+    debug "Cannot cancel accepts", errMsg = exc.msg
 
   for service in s.services:
     discard await service.stop(s)
@@ -296,7 +296,7 @@ proc stop*(s: Switch) {.async, public.} =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      warn "error cleaning up transports", msg = exc.msg
+      warn "error cleaning up transports", errMsg = exc.msg
 
   await s.ms.stop()
 

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -99,8 +99,7 @@ proc new*(
       if ServerFlags.TcpNoDelay in flags:
         {SocketFlags.TcpNoDelay}
       else:
-        default(set[SocketFlags])
-    ,
+        default(set[SocketFlags]),
     upgrader: upgrade,
     networkReachability: NetworkReachability.Unknown,
     connectionsTimeout: connectionsTimeout,
@@ -249,10 +248,10 @@ method accept*(self: TcpTransport): Future[Connection] =
       try:
         await finished
       except TransportTooManyError as exc:
-        debug "Too many files opened", exc = exc.msg
+        debug "Too many files opened", errMsg = exc.msg
         return nil
       except TransportAbortedError as exc:
-        debug "Connection aborted", exc = exc.msg
+        debug "Connection aborted", errMsg = exc.msg
         return nil
       except TransportUseClosedError as exc:
         raise newTransportClosedError(exc)
@@ -273,7 +272,7 @@ method accept*(self: TcpTransport): Future[Connection] =
       except TransportOsError as exc:
         # The connection had errors / was closed before `await` returned control
         await transp.closeWait()
-        debug "Cannot read remote address", exc = exc.msg
+        debug "Cannot read remote address", errMsg = exc.msg
         return nil
 
     let observedAddr =

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -99,7 +99,8 @@ proc new*(
       if ServerFlags.TcpNoDelay in flags:
         {SocketFlags.TcpNoDelay}
       else:
-        default(set[SocketFlags]),
+        default(set[SocketFlags])
+    ,
     upgrader: upgrade,
     networkReachability: NetworkReachability.Unknown,
     connectionsTimeout: connectionsTimeout,

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -249,10 +249,10 @@ method accept*(self: TcpTransport): Future[Connection] =
       try:
         await finished
       except TransportTooManyError as exc:
-        debug "Too many files opened", errMsg = exc.msg
+        debug "Too many files opened", description = exc.msg
         return nil
       except TransportAbortedError as exc:
-        debug "Connection aborted", errMsg = exc.msg
+        debug "Connection aborted", description = exc.msg
         return nil
       except TransportUseClosedError as exc:
         raise newTransportClosedError(exc)
@@ -273,7 +273,7 @@ method accept*(self: TcpTransport): Future[Connection] =
       except TransportOsError as exc:
         # The connection had errors / was closed before `await` returned control
         await transp.closeWait()
-        debug "Cannot read remote address", errMsg = exc.msg
+        debug "Cannot read remote address", description = exc.msg
         return nil
 
     let observedAddr =

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -206,7 +206,7 @@ method stop*(self: WsTransport) {.async.} =
     self.httpservers = @[]
     trace "Transport stopped"
   except CatchableError as exc:
-    trace "Error shutting down ws transport", exc = exc.msg
+    trace "Error shutting down ws transport", errMsg = exc.msg
 
 proc connHandler(
     self: WsTransport, stream: WSSession, secure: bool, dir: Direction
@@ -223,7 +223,7 @@ proc connHandler(
 
       MultiAddress.init(remoteAddr).tryGet() & codec.tryGet()
     except CatchableError as exc:
-      trace "Failed to create observedAddr", exc = exc.msg
+      trace "Failed to create observedAddr", errMsg = exc.msg
       if not (isNil(stream) and stream.stream.reader.closed):
         await stream.close()
       raise exc
@@ -271,26 +271,26 @@ method accept*(self: WsTransport): Future[Connection] {.async.} =
       await req.stream.closeWait()
       raise exc
   except WebSocketError as exc:
-    debug "Websocket Error", exc = exc.msg
+    debug "Websocket Error", errMsg = exc.msg
   except HttpError as exc:
-    debug "Http Error", exc = exc.msg
+    debug "Http Error", errMsg = exc.msg
   except AsyncStreamError as exc:
-    debug "AsyncStream Error", exc = exc.msg
+    debug "AsyncStream Error", errMsg = exc.msg
   except TransportTooManyError as exc:
-    debug "Too many files opened", exc = exc.msg
+    debug "Too many files opened", errMsg = exc.msg
   except TransportAbortedError as exc:
-    debug "Connection aborted", exc = exc.msg
+    debug "Connection aborted", errMsg = exc.msg
   except AsyncTimeoutError as exc:
-    debug "Timed out", exc = exc.msg
+    debug "Timed out", errMsg = exc.msg
   except TransportUseClosedError as exc:
-    debug "Server was closed", exc = exc.msg
+    debug "Server was closed", errMsg = exc.msg
     raise newTransportClosedError(exc)
   except CancelledError as exc:
     raise exc
   except TransportOsError as exc:
-    debug "OS Error", exc = exc.msg
+    debug "OS Error", errMsg = exc.msg
   except CatchableError as exc:
-    info "Unexpected error accepting connection", exc = exc.msg
+    info "Unexpected error accepting connection", errMsg = exc.msg
     raise exc
 
 method dial*(

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -206,7 +206,7 @@ method stop*(self: WsTransport) {.async.} =
     self.httpservers = @[]
     trace "Transport stopped"
   except CatchableError as exc:
-    trace "Error shutting down ws transport", errMsg = exc.msg
+    trace "Error shutting down ws transport", description = exc.msg
 
 proc connHandler(
     self: WsTransport, stream: WSSession, secure: bool, dir: Direction
@@ -223,7 +223,7 @@ proc connHandler(
 
       MultiAddress.init(remoteAddr).tryGet() & codec.tryGet()
     except CatchableError as exc:
-      trace "Failed to create observedAddr", errMsg = exc.msg
+      trace "Failed to create observedAddr", description = exc.msg
       if not (isNil(stream) and stream.stream.reader.closed):
         await stream.close()
       raise exc
@@ -271,26 +271,26 @@ method accept*(self: WsTransport): Future[Connection] {.async.} =
       await req.stream.closeWait()
       raise exc
   except WebSocketError as exc:
-    debug "Websocket Error", errMsg = exc.msg
+    debug "Websocket Error", description = exc.msg
   except HttpError as exc:
-    debug "Http Error", errMsg = exc.msg
+    debug "Http Error", description = exc.msg
   except AsyncStreamError as exc:
-    debug "AsyncStream Error", errMsg = exc.msg
+    debug "AsyncStream Error", description = exc.msg
   except TransportTooManyError as exc:
-    debug "Too many files opened", errMsg = exc.msg
+    debug "Too many files opened", description = exc.msg
   except TransportAbortedError as exc:
-    debug "Connection aborted", errMsg = exc.msg
+    debug "Connection aborted", description = exc.msg
   except AsyncTimeoutError as exc:
-    debug "Timed out", errMsg = exc.msg
+    debug "Timed out", description = exc.msg
   except TransportUseClosedError as exc:
-    debug "Server was closed", errMsg = exc.msg
+    debug "Server was closed", description = exc.msg
     raise newTransportClosedError(exc)
   except CancelledError as exc:
     raise exc
   except TransportOsError as exc:
-    debug "OS Error", errMsg = exc.msg
+    debug "OS Error", description = exc.msg
   except CatchableError as exc:
-    info "Unexpected error accepting connection", errMsg = exc.msg
+    info "Unexpected error accepting connection", description = exc.msg
     raise exc
 
 method dial*(

--- a/tests/hole-punching-interop/hole_punching.nim
+++ b/tests/hole-punching-interop/hole_punching.nim
@@ -120,7 +120,7 @@ proc main() {.async.} =
       echo &"""{{"rtt_to_holepunched_peer_millis":{delay.millis}}}"""
       quit(0)
   except CatchableError as e:
-    error "Unexpected error", msg = e.msg
+    error "Unexpected error", errMsg = e.msg
 
 discard waitFor(main().withTimeout(4.minutes))
 quit(1)

--- a/tests/hole-punching-interop/hole_punching.nim
+++ b/tests/hole-punching-interop/hole_punching.nim
@@ -120,7 +120,7 @@ proc main() {.async.} =
       echo &"""{{"rtt_to_holepunched_peer_millis":{delay.millis}}}"""
       quit(0)
   except CatchableError as e:
-    error "Unexpected error", errMsg = e.msg
+    error "Unexpected error", description = e.msg
 
 discard waitFor(main().withTimeout(4.minutes))
 quit(1)


### PR DESCRIPTION
Chronicles uses `msg` for the string that describes the log, so this PR removes the duplicate `msg` usage.

closes: https://github.com/vacp2p/nim-libp2p/issues/1176