### PR TITLE
feat: rendezvous refactor

### DIFF
--- a/libp2p/discovery/rendezvousinterface.nim
+++ b/libp2p/discovery/rendezvousinterface.nim
@@ -73,6 +73,6 @@ proc new*(
     rdv: RendezVous,
     ttr: Duration = 1.minutes,
     tta: Duration = 1.minutes,
-    ttl: Duration = 2.hours,
+    ttl: Duration = MinimumDuration,
 ): RendezVousInterface =
   T(rdv: rdv, timeToRequest: ttr, timeToAdvertise: tta, ttl: ttl)

--- a/libp2p/discovery/rendezvousinterface.nim
+++ b/libp2p/discovery/rendezvousinterface.nim
@@ -73,6 +73,6 @@ proc new*(
     rdv: RendezVous,
     ttr: Duration = 1.minutes,
     tta: Duration = 1.minutes,
-    ttl: Duration = MinimumDuration,
+    ttl: Duration = 2.hours,
 ): RendezVousInterface =
   T(rdv: rdv, timeToRequest: ttr, timeToAdvertise: tta, ttl: ttl)

--- a/libp2p/protocols/rendezvous.nim
+++ b/libp2p/protocols/rendezvous.nim
@@ -515,7 +515,7 @@ proc batchAdvertise*(
     raise newException(RendezVousError, "Invalid namespace")
 
   if ttl notin rdv.minDuration .. rdv.maxDuration:
-    raise newException(RendezVousError, "Invalid time to live")
+    raise newException(RendezVousError, "Invalid time to live: " & $ttl)
 
   let sprBuff = rdv.switch.peerInfo.signedPeerRecord.encode().valueOr:
     raise newException(RendezVousError, "Wrong Signed Peer Record")
@@ -690,6 +690,15 @@ proc new*(
     minDuration = MinimumDuration,
     maxDuration = MaximumDuration,
 ): T =
+  if minDuration < 1.minutes:
+    raiseAssert("TTL too short: 1 minute minimum")
+
+  if maxDuration > 72.hours:
+    raiseAssert("TTL too long: 72 hours maximum")
+
+  if minDuration >= maxDuration:
+    raiseAssert("Minimum TTL longer than maximum")
+
   let
     minTTL = minDuration.seconds.uint64
     maxTTL = maxDuration.seconds.uint64

--- a/libp2p/protocols/rendezvous.nim
+++ b/libp2p/protocols/rendezvous.nim
@@ -689,15 +689,15 @@ proc new*(
     rng: ref HmacDrbgContext = newRng(),
     minDuration = MinimumDuration,
     maxDuration = MaximumDuration,
-): T =
+): T {.raises: [RendezVousError].} =
   if minDuration < 1.minutes:
-    raiseAssert("TTL too short: 1 minute minimum")
+    raise newException(RendezVousError, "TTL too short: 1 minute minimum")
 
   if maxDuration > 72.hours:
-    raiseAssert("TTL too long: 72 hours maximum")
+    raise newException(RendezVousError, "TTL too long: 72 hours maximum")
 
   if minDuration >= maxDuration:
-    raiseAssert("Minimum TTL longer than maximum")
+    raise newException(RendezVousError, "Minimum TTL longer than maximum")
 
   let
     minTTL = minDuration.seconds.uint64

--- a/libp2p/protocols/rendezvous.nim
+++ b/libp2p/protocols/rendezvous.nim
@@ -508,7 +508,7 @@ proc advertisePeer(rdv: RendezVous, peer: PeerId, msg: seq[byte]) {.async.} =
   await rdv.sema.acquire()
   discard await advertiseWrap().withTimeout(5.seconds)
 
-proc batchAdvertise*(
+proc advertise*(
     rdv: RendezVous, ns: string, ttl: Duration, peers: seq[PeerId]
 ) {.async.} =
   if ns.len notin 1 .. 255:
@@ -536,7 +536,7 @@ proc batchAdvertise*(
 method advertise*(
     rdv: RendezVous, ns: string, ttl: Duration = rdv.minDuration
 ) {.async, base.} =
-  await rdv.batchAdvertise(ns, ttl, rdv.peers)
+  await rdv.advertise(ns, ttl, rdv.peers)
 
 proc requestLocally*(rdv: RendezVous, ns: string): seq[PeerRecord] =
   let
@@ -552,7 +552,7 @@ proc requestLocally*(rdv: RendezVous, ns: string): seq[PeerRecord] =
   except KeyError as exc:
     @[]
 
-proc batchRequest*(
+proc request*(
     rdv: RendezVous, ns: string, l: int = DiscoverLimit.int, peers: seq[PeerId]
 ): Future[seq[PeerRecord]] {.async.} =
   var
@@ -634,7 +634,7 @@ proc batchRequest*(
 proc request*(
     rdv: RendezVous, ns: string, l: int = DiscoverLimit.int
 ): Future[seq[PeerRecord]] {.async.} =
-  await rdv.batchRequest(ns, l, rdv.peers)
+  await rdv.request(ns, l, rdv.peers)
 
 proc unsubscribeLocally*(rdv: RendezVous, ns: string) =
   let nsSalted = ns & rdv.salt
@@ -645,7 +645,7 @@ proc unsubscribeLocally*(rdv: RendezVous, ns: string) =
   except KeyError:
     return
 
-proc batchUnsubscribe*(rdv: RendezVous, ns: string, peerIds: seq[PeerId]) {.async.} =
+proc unsubscribe*(rdv: RendezVous, ns: string, peerIds: seq[PeerId]) {.async.} =
   if ns.len notin 1 .. 255:
     raise newException(RendezVousError, "Invalid namespace")
 
@@ -671,7 +671,7 @@ proc batchUnsubscribe*(rdv: RendezVous, ns: string, peerIds: seq[PeerId]) {.asyn
 proc unsubscribe*(rdv: RendezVous, ns: string) {.async.} =
   rdv.unsubscribeLocally(ns)
 
-  await rdv.batchUnsubscribe(ns, rdv.peers)
+  await rdv.unsubscribe(ns, rdv.peers)
 
 proc setup*(rdv: RendezVous, switch: Switch) =
   rdv.switch = switch

--- a/tests/testrendezvous.nim
+++ b/tests/testrendezvous.nim
@@ -126,7 +126,7 @@ suite "RendezVous":
 
   asyncTest "Various local error":
     let
-      rdv = RendezVous.new()
+      rdv = RendezVous.new(minDuration = 1.minutes, maxDuration = 72.hours)
       switch = createSwitch(rdv)
     expect RendezVousError:
       discard await rdv.request("A".repeat(300))
@@ -137,6 +137,14 @@ suite "RendezVous":
     expect RendezVousError:
       await rdv.advertise("A".repeat(300))
     expect RendezVousError:
-      await rdv.advertise("A", 2.weeks)
+      await rdv.advertise("A", 73.hours)
     expect RendezVousError:
-      await rdv.advertise("A", 5.minutes)
+      await rdv.advertise("A", 30.seconds)
+
+  test "Various config error":
+    expect RendezVousError:
+      discard RendezVous.new(minDuration = 30.seconds)
+    expect RendezVousError:
+      discard RendezVous.new(maxDuration = 73.hours)
+    expect RendezVousError:
+      discard RendezVous.new(minDuration = 15.minutes, maxDuration = 10.minutes)


### PR DESCRIPTION
Hello!

This PR aim to refactor rendezvous code so that it is easier to impl. Waku rdv strategy. The hardcoded min and max TTL were out of range with what we needed and specifying which peers to interact with is also needed since Waku deals with peers on multiple separate shards.

I tried to keep the changes to a minimum, specifically I did not change the name of any public procs which result in less than descriptive names in some cases. I also wanted to return results instead of raising exceptions but didn't. Would it be acceptable to do so?

Please advise on best practices, thank you.