### PR TITLE
chore(connmanager): also show peerID and dir when too many conns

### DIFF
--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -296,7 +296,8 @@ proc storeMuxer*(c: ConnManager, muxer: Muxer) {.raises: [CatchableError].} =
     if expectedConn != nil and not expectedConn.finished:
       expectedConn.complete(muxer)
     else:
-      debug "Too many connections for peer", conns = c.muxed.getOrDefault(peerId).len
+      debug "Too many connections for peer",
+        conns = c.muxed.getOrDefault(peerId).len, peerId, dir
 
       raise newTooManyConnectionsError()
 


### PR DESCRIPTION
Bring a bit more detail when the "Too many connections for peer" message is being logged. Particularly, we are adding the offending `peerId` and the stream direction