### PR TITLE
chore(CI): rollback nph change

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -29,4 +29,5 @@ jobs:
       - name: Check style
         run: |
           shopt -s extglob  # Enable extended globbing
-          ./nph --check examples libp2p tests tools *.@(nim|nims|nimble)
+          ./nph examples libp2p tests tools *.@(nim|nims|nimble)
+          git diff --exit-code


### PR DESCRIPTION
Rollbacks to the previous `nph` command that shows what files aren't formatted.