### PR TITLE
chore: move mm:refc config and remove skipParentCfg 

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -12,6 +12,9 @@ switch("warning", "LockLevel:off")
 switch("warningAsError", "UseBase:on")
 --styleCheck:
   error
+--mm:
+  refc
+  # reconsider when there's a version-2-2 branch worth testing with as we might switch to orc
 
 # Avoid some rare stack corruption while using exceptions with a SEH-enabled
 # toolchain: https://github.com/status-im/nimbus-eth2/issues/3121

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -19,8 +19,8 @@ let verbose = getEnv("V", "") notin ["", "0"]
 
 let cfg =
   " --styleCheck:usages --styleCheck:error" &
-  (if verbose: "" else: " --verbosity:0 --hints:off") &
-  " --skipParentCfg --skipUserCfg -f" & " --threads:on --opt:speed"
+  (if verbose: "" else: " --verbosity:0 --hints:off") & " --skipUserCfg -f" &
+  " --threads:on --opt:speed"
 
 import hashes, strutils
 

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -17,7 +17,6 @@ import strutils, os
   libp2p_mplex_metrics
 --d:
   unittestPrintTime
---skipParentCfg
 
 # Only add chronicles param if the
 # user didn't specify any

--- a/tests/config.nims
+++ b/tests/config.nims
@@ -18,9 +18,6 @@ import strutils, os
 --d:
   unittestPrintTime
 --skipParentCfg
---mm:
-  refc
-  # reconsider when there's a version-2-2 branch worth testing with as we might switch to orc
 
 # Only add chronicles param if the
 # user didn't specify any


### PR DESCRIPTION
- Moving the `mm:refc` configuration to the main `config.nims` file makes it be used in tests and tasks that build examples.
- It's not clear why `skipParentCfg`was being used and it doesn't seem to be necessary.