### PR TITLE
chore: add support to merge queues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -2,6 +2,7 @@ name: Interoperability Tests
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - master

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -2,6 +2,7 @@ name: Linters
 
 on:
   pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
This change is necessary before enabling merge queues.  The `merge_group` event is needed to trigger the GitHub Actions workflow when a pull request is added to a merge queue.

The merge queue provides the same benefits as the Require branches to be up to date before merging branch protection but does not require a pull request author to update their pull request branch and wait for status checks to finish before trying to merge. More info on https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue.