### PR TITLE
chore(ci): Enable S3 caching for interop

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -13,32 +13,43 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run-interop-tests:
-    name: Run ${{ matrix.test-type }} Tests
+  run-transport-interop:
+    name: Run transport interoperability tests
     runs-on: ubuntu-22.04
-    if: success() || failure()
-    strategy:
-      matrix:
-        test-type: 
-          - transport-interop
-          - hole-punching-interop
-    
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v4
+      - name: Free Disk Space (Ubuntu)
+        # For some reason the original job (libp2p/test-plans) has enough disk space, but this one doesn't.
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build Docker Image
-        run: |
-          docker buildx build --load -t nim-libp2p-head -f tests/${{ matrix.test-type }}/Dockerfile .
-
-      - name: Run Tests
-        uses: libp2p/test-plans/.github/actions/run-${{ matrix.test-type == 'transport-interop' && 'transport-interop-test' || 'interop-hole-punch-test' }}@master
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image
+        run: docker buildx build --load -t nim-libp2p-head -f tests/transport-interop/Dockerfile .
+      - name: Run tests
+        uses: libp2p/test-plans/.github/actions/run-transport-interop-test@master
         with:
           test-filter: nim-libp2p-head
-          extra-versions: ${{ github.workspace }}/tests/${{ matrix.test-type }}/version.json
+          extra-versions: ${{ github.workspace }}/tests/transport-interop/version.json
+          s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
+          s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
+          s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_REGION }}
+
+  run-hole-punching-interop:
+    name: Run hole-punching interoperability tests
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build image
+        run: docker buildx build --load -t nim-libp2p-head -f tests/hole-punching-interop/Dockerfile .
+      - name: Run tests
+        uses: libp2p/test-plans/.github/actions/run-interop-hole-punch-test@master
+        with:
+          test-filter: nim-libp2p-head
+          extra-versions: ${{ github.workspace }}/tests/hole-punching-interop/version.json
           s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
           s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
           s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -17,12 +17,6 @@ jobs:
     name: Run transport interoperability tests
     runs-on: ubuntu-22.04
     steps:
-      - name: Free Disk Space (Ubuntu)
-        # For some reason the original job (libp2p/test-plans) has enough disk space, but this one doesn't.
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: true
-
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
       - name: Build image

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           test-filter: nim-libp2p-head
           extra-versions: ${{ github.workspace }}/tests/transport-interop/version.json
+        with:
+          s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
+          s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
+          s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_REGION }}
 
   run-hole-punching-interop:
     name: Run hole-punching interoperability tests
@@ -46,3 +51,8 @@ jobs:
         with:
           test-filter: nim-libp2p-head
           extra-versions: ${{ github.workspace }}/tests/hole-punching-interop/version.json
+        with:
+          s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
+          s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
+          s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_REGION }}

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -20,10 +20,8 @@ jobs:
     strategy:
       matrix:
         test-type: 
-          - folder: transport-interop
-            action: run-transport-interop-test
-          - folder: hole-punching-interop
-            action: run-interop-hole-punch-test
+          - transport-interop
+          - hole-punching-interop
     
     steps:
       - name: Checkout Code
@@ -34,10 +32,10 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          docker buildx build --load -t nim-libp2p-head -f tests/${{ matrix.test-type.folder }}/Dockerfile .
+          docker buildx build --load -t nim-libp2p-head -f tests/${{ matrix.test-type }}/Dockerfile .
 
       - name: Run Tests
-        uses: libp2p/test-plans/.github/actions/${{ matrix.test-type.action }}@master
+        uses: libp2p/test-plans/.github/actions/run-${{ matrix.test-type == 'transport-interop' && 'transport-interop-test' || 'interop-hole-punch-test' }}@master
         with:
           test-filter: nim-libp2p-head
           extra-versions: ${{ github.workspace }}/tests/${{ matrix.test-type }}/version.json

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -20,8 +20,10 @@ jobs:
     strategy:
       matrix:
         test-type: 
-          - transport-interop
-          - hole-punching-interop
+          - folder: transport-interop
+            action: run-transport-interop-test
+          - folder: hole-punching-interop
+            action: run-interop-hole-punch-test
     
     steps:
       - name: Checkout Code
@@ -32,10 +34,10 @@ jobs:
 
       - name: Build Docker Image
         run: |
-          docker buildx build --load -t nim-libp2p-head -f tests/${{ matrix.test-type }}/Dockerfile .
+          docker buildx build --load -t nim-libp2p-head -f tests/${{ matrix.test-type.folder }}/Dockerfile .
 
       - name: Run Tests
-        uses: libp2p/test-plans/.github/actions/run-${{ matrix.test-type == 'transport-interop' && 'transport-interop-test' || 'interop-hole-punch-test' }}@master
+        uses: libp2p/test-plans/.github/actions/${{ matrix.test-type.action }}@master
         with:
           test-filter: nim-libp2p-head
           extra-versions: ${{ github.workspace }}/tests/${{ matrix.test-type }}/version.json

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           test-filter: nim-libp2p-head
           extra-versions: ${{ github.workspace }}/tests/transport-interop/version.json
-        with:
           s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
           s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
           s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
@@ -51,7 +50,6 @@ jobs:
         with:
           test-filter: nim-libp2p-head
           extra-versions: ${{ github.workspace }}/tests/hole-punching-interop/version.json
-        with:
           s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
           s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
           s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -13,43 +13,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run-transport-interop:
-    name: Run transport interoperability tests
+  run-interop-tests:
+    name: Run ${{ matrix.test-type }} Tests
     runs-on: ubuntu-22.04
+    if: success() || failure()
+    strategy:
+      matrix:
+        test-type: 
+          - transport-interop
+          - hole-punching-interop
+    
     steps:
-      - name: Free Disk Space (Ubuntu)
-        # For some reason the original job (libp2p/test-plans) has enough disk space, but this one doesn't.
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: true
+      - name: Checkout Code
+        uses: actions/checkout@v4
 
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - name: Build image
-        run: docker buildx build --load -t nim-libp2p-head -f tests/transport-interop/Dockerfile .
-      - name: Run tests
-        uses: libp2p/test-plans/.github/actions/run-transport-interop-test@master
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker Image
+        run: |
+          docker buildx build --load -t nim-libp2p-head -f tests/${{ matrix.test-type }}/Dockerfile .
+
+      - name: Run Tests
+        uses: libp2p/test-plans/.github/actions/run-${{ matrix.test-type == 'transport-interop' && 'transport-interop-test' || 'interop-hole-punch-test' }}@master
         with:
           test-filter: nim-libp2p-head
-          extra-versions: ${{ github.workspace }}/tests/transport-interop/version.json
-          s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
-          s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
-          s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_REGION }}
-
-  run-hole-punching-interop:
-    name: Run hole-punching interoperability tests
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - name: Build image
-        run: docker buildx build --load -t nim-libp2p-head -f tests/hole-punching-interop/Dockerfile .
-      - name: Run tests
-        uses: libp2p/test-plans/.github/actions/run-interop-hole-punch-test@master
-        with:
-          test-filter: nim-libp2p-head
-          extra-versions: ${{ github.workspace }}/tests/hole-punching-interop/version.json
+          extra-versions: ${{ github.workspace }}/tests/${{ matrix.test-type }}/version.json
           s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
           s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
           s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
- Adds our S3 bucket for caching docker images as Protocol Labs shut down their shared one.
- Remove the free disk space workaround that prevented the jobs from failing for using too much space for the images.