### PR TITLE
chore(version): update libp2p.nimble to 1.6.0

### DIFF
--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName = "libp2p"
-version = "1.5.0"
+version = "1.6.0"
 author = "Status Research & Development GmbH"
 description = "LibP2P implementation"
 license = "MIT"


### PR DESCRIPTION
Updating libp2p.nimble to 1.6.0.
This commit is planned to be tagged with 1.6.0.

The only new feature in this version is the highly experimental Quick transport. Still, it is a feature and justifies a minor version upgrade.
It also contains a few fixes and improvements (see commit history).