### PR TITLE
test(gossipsub): block5 protobuf test cases

### DIFF
--- a/tests/pubsub/testgossipsubmessagehandling.nim
+++ b/tests/pubsub/testgossipsubmessagehandling.nim
@@ -842,3 +842,57 @@ suite "GossipSub Message Handling":
       publishResult == 0
       results[0].isPending()
       results[1].isPending()
+
+  # test cases for block 5 gossibsub test plan 
+  # check correctly parsed ihave/iwant/graft/prune/idontwant messages
+  # check value before & after decoding equal using protoc cmd tool for reference
+  asyncTest "Check RPCMsg encoding":
+    let backofftime = 10.uint64
+    var id: seq[byte] = @[123]
+    let rpcMsg = RPCMsg(
+      control: some(
+        ControlMessage(
+          ihave: @[ControlIHave(topicID: "foobar", messageIDs: @[id])],
+          iwant: @[ControlIWant(messageIDs: @[id])],
+          graft: @[ControlGraft(topicID: "foobar")],
+          prune: @[ControlPrune(topicID: "foobar", backoff: backofftime)],
+          idontwant: @[ControlIWant(messageIDs: @[id])],
+        )
+      )
+    )
+    let encodedExpected: seq[byte] =
+      @[
+        26, 51, 10, 10, 6, 102, 111, 111, 98, 97, 114, 18, 3, 49, 50, 51, 18, 5, 10, 3,
+        49, 50, 51, 26, 8, 10, 6, 102, 111, 111, 98, 97, 114, 34, 10, 10, 6, 102, 111,
+        111, 98, 97, 114, 16, 10, 42, 5, 10, 3, 49, 50, 51,
+      ] #encoded using protoc cmd tool
+
+    let encodedMsg = encodeRpcMsg(rpcMsg, true)
+    check:
+      encodedExpected == encodedMsg
+
+  asyncTest "Check RPCMsg decoding":
+    let backofftime = 12.uint64
+    let id: seq[byte] = @[1]
+    let originMessage = RPCMsg(
+      control: some(
+        ControlMessage(
+          ihave: @[ControlIHave(topicID: "foobar", messageIDs: @[id])],
+          iwant: @[ControlIWant(messageIDs: @[id])],
+          graft: @[ControlGraft(topicID: "topic")],
+          prune: @[ControlPrune(topicID: "new", backoff: backofftime)],
+          idontwant: @[ControlIWant(messageIDs: @[id])],
+        )
+      )
+    )
+    #data encoded using protoc cmd tool
+    let encodedMsg: seq[byte] =
+      @[
+        26, 41, 10, 11, 10, 6, 102, 111, 111, 98, 97, 114, 18, 1, 49, 18, 3, 10, 1, 49,
+        26, 7, 10, 5, 116, 111, 112, 105, 99, 34, 7, 10, 3, 110, 101, 119, 16, 12, 42,
+        3, 10, 1, 49,
+      ]
+
+    var rpcMsg = decodeRpcMsg(encodedMsg).value
+    check:
+      rpcMsg == originMessage

--- a/tests/pubsub/testgossipsubmessagehandling.nim
+++ b/tests/pubsub/testgossipsubmessagehandling.nim
@@ -845,9 +845,9 @@ suite "GossipSub Message Handling":
 
   # check correctly parsed ihave/iwant/graft/prune/idontwant messages
   # check value before & after decoding equal using protoc cmd tool for reference
-  asyncTest "ControlMessage RPCMsg encoding":
-    var id: seq[byte] = @[123]
-    let rpcMsg = RPCMsg(
+  asyncTest "ControlMessage RPCMsg encoding and decoding":
+    let id: seq[byte] = @[123]
+    let message = RPCMsg(
       control: some(
         ControlMessage(
           ihave: @[ControlIHave(topicID: "foobar", messageIDs: @[id])],
@@ -859,38 +859,17 @@ suite "GossipSub Message Handling":
       )
     )
     #data encoded using protoc cmd tool
-    let encodedExpected: seq[byte] =
+    let expectedEncoded: seq[byte] =
       @[
         26, 45, 10, 11, 10, 6, 102, 111, 111, 98, 97, 114, 18, 1, 123, 18, 3, 10, 1,
         123, 26, 8, 10, 6, 102, 111, 111, 98, 97, 114, 34, 10, 10, 6, 102, 111, 111, 98,
         97, 114, 24, 10, 42, 3, 10, 1, 123,
       ]
 
-    let encodedMsg = encodeRpcMsg(rpcMsg, true)
+    let actualEncoded = encodeRpcMsg(message, true)
     check:
-      encodedExpected == encodedMsg
+      actualEncoded == expectedEncoded
 
-  asyncTest "ControlMessage RPCMsg decoding":
-    let id: seq[byte] = @[1]
-    let rpcMsg = RPCMsg(
-      control: some(
-        ControlMessage(
-          ihave: @[ControlIHave(topicID: "foobar", messageIDs: @[id])],
-          iwant: @[ControlIWant(messageIDs: @[id])],
-          graft: @[ControlGraft(topicID: "topic")],
-          prune: @[ControlPrune(topicID: "new", backoff: 12.uint64)],
-          idontwant: @[ControlIWant(messageIDs: @[id])],
-        )
-      )
-    )
-    #data encoded using protoc cmd tool
-    let encodedMsg: seq[byte] =
-      @[
-        26, 41, 10, 11, 10, 6, 102, 111, 111, 98, 97, 114, 18, 1, 1, 18, 3, 10, 1, 1,
-        26, 7, 10, 5, 116, 111, 112, 105, 99, 34, 7, 10, 3, 110, 101, 119, 24, 12, 42,
-        3, 10, 1, 1,
-      ]
-
-    var decodedExpected = decodeRpcMsg(encodedMsg).value
+    let actualDecoded = decodeRpcMsg(expectedEncoded).value
     check:
-      decodedExpected == rpcMsg
+      actualDecoded == message


### PR DESCRIPTION
**Note the 2 tests failed and issue #1208 is opened accordingly**
**Note:**  PR ready for review
test cases written according to test plan [here](https://www.notion.so/Gossipsub-651e02d4d7894bb2ac1e4edb55f3192d)

**Test "Check RPCMsg encoding"**  

1. create rpcMessage and encode it using encodeRpcMsg
2.  compare encoded message to encoded message generated from protoc cmd tool  version "libprotoc 3.21.12"


**Test "Check RPCMsg decoding"**

1. Use RPC message & encoded version of it generated from protoc cmd tool  version "libprotoc 3.21.12" as a reference
2. Check that decodeRpcMsg will decode the refernce RPC message successfully to the original version 

