### PR TITLE
test(gossipsub): Part 2 Test cases covering JOIN and LEAVE Events

### DIFF
--- a/tests/pubsub/testgossipmembership.nim
+++ b/tests/pubsub/testgossipmembership.nim
@@ -237,7 +237,7 @@ suite "GossipSub Topic Membership Tests":
     var peersToUnsubscribe = gossipSub.mesh[topic].toSeq()[0 .. 2]
     for peer in peersToUnsubscribe:
       echo "Unsubscribing peer: ", peer.peerId
-      gossipSub.PubSub.unsubscribe(topic, dummyHandler)
+      gossipSub.unsubscribe(topic, dummyHandler)
 
     # Now assert that 6 peers still remain in the mesh because the mesh retains peers
     doAssert gossipSub.mesh[topic].len == 6,


### PR DESCRIPTION
Test Plan: https://www.notion.so/Gossipsub-651e02d4d7894bb2ac1e4edb55f3192d

Test Scenario: Block 6
Topic Membership Tests:

**Part 2:**

1.  **TC6.1**: Verify that peers can correctly join a topic using `JOIN(topic)`.
2. **TC6.2**: Ensure that peers can correctly leave a topic using `LEAVE(topic)`.
3. **TC6.5**:  Multiple peers join and leave topic simultaneously
