### PR TITLE
fix(CI): free disk space on interop transport job

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -17,6 +17,12 @@ jobs:
     name: Run transport interoperability tests
     runs-on: ubuntu-22.04
     steps:
+      - name: Free Disk Space
+        # For some reason the original job (libp2p/test-plans) has enough disk space, but this one doesn't.
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
       - name: Build image
@@ -35,6 +41,12 @@ jobs:
     name: Run hole-punching interoperability tests
     runs-on: ubuntu-22.04
     steps:
+      - name: Free Disk Space
+        # For some reason the original job (libp2p/test-plans) has enough disk space, but this one doesn't.
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
       - name: Build image

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -42,13 +42,6 @@ jobs:
     name: Run hole-punching interoperability tests
     runs-on: ubuntu-22.04
     steps:
-      - name: Free Disk Space
-        # For some reason we have space issues while running this action. Likely while building the image.
-        # This action will free up some space to avoid the issue.
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: true
-
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
       - name: Build image

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -18,7 +18,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Free Disk Space
-        # For some reason the original job (libp2p/test-plans) has enough disk space, but this one doesn't.
+        # For some reason we have space issues while running this action. Likely while building the image.
+        # This action will free up some space to avoid the issue.
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: true
@@ -42,7 +43,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Free Disk Space
-        # For some reason the original job (libp2p/test-plans) has enough disk space, but this one doesn't.
+        # For some reason we have space issues while running this action. Likely while building the image.
+        # This action will free up some space to avoid the issue.
         uses: jlumbroso/free-disk-space@v1.3.1
         with:
           tool-cache: true


### PR DESCRIPTION
Readd the free disk space job, as space issues still happen when building images.