### PR TITLE
chore(ci): add arm64 for macOS

### DIFF
--- a/.github/actions/install_nim/action.yml
+++ b/.github/actions/install_nim/action.yml
@@ -88,6 +88,8 @@ runs:
       run: |
         if [[ '${{ inputs.cpu }}' == 'amd64' ]]; then
           PLATFORM=x64
+        elif [[ '${{ inputs.cpu }}' == 'arm64' ]]; then
+          PLATFORM=arm64
         else
           PLATFORM=x86
         fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
             cpu: amd64
           - os: macos
             cpu: amd64
+          - os: macos-14
+            cpu: arm64
           - os: windows
             cpu: amd64
         nim:
@@ -46,6 +48,10 @@ jobs:
           - platform:
               os: macos
             builder: macos-13
+            shell: bash
+          - platform:
+              os: macos-14
+            builder: macos-14
             shell: bash
           - platform:
               os: windows
@@ -75,7 +81,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.15.5'
+          go-version: '~1.16.0' # That's the minimum Go version that works with arm.
 
       - name: Install p2pd
         run: |
@@ -87,8 +93,8 @@ jobs:
         with:
           path: nimbledeps
           # Using nim.ref as a simple way to differentiate between nimble using the "pkgs" or "pkgs2" directories.
-          # The change happened on Nimble v0.14.0.
-          key: nimbledeps-${{ matrix.nim.ref }}-${{ hashFiles('.pinned') }} # hashFiles returns a different value on windows
+          # The change happened on Nimble v0.14.0. Also forcing the deps to be reinstalled on each os and cpu.
+          key: nimbledeps-${{ matrix.nim.ref }}-${{ matrix.builder }}-${{ matrix.platform.cpu }}-${{ hashFiles('.pinned') }} # hashFiles returns a different value on windows
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.15.5'
+          go-version: '~1.16.0'
           cache: false
 
       - name: Install p2pd

--- a/examples/go-daemon/daemonapi.md
+++ b/examples/go-daemon/daemonapi.md
@@ -13,7 +13,7 @@ For more information about the go daemon, check out [this repository](https://gi
 > **Required only** for running the tests.
 
 # Prerequisites
-Go with version `1.15.15`.
+Go with version `1.16.0`.
 > You will *likely* be able to build `go-libp2p-daemon` with different Go versions, but **they haven't been tested**.
 
 # Installation
@@ -21,7 +21,7 @@ Follow one of the methods below:
 
 ## Script
 Run the build script while having the `go` command pointing to the correct Go version.
-We recommend using `1.15.15`, as previously stated.
+We recommend using `1.16.0`, as previously stated.
 ```sh
 ./scripts/build_p2pd.sh
 ```


### PR DESCRIPTION
This PR adds the macOS 14 GitHub runner that uses the arm64 cpu.