### PR TITLE
fix(ci): nim 2.0 dependency failure

### DIFF
--- a/.github/actions/install_nim/action.yml
+++ b/.github/actions/install_nim/action.yml
@@ -6,7 +6,7 @@ inputs:
   cpu:
     description: "CPU to build for"
     default: "amd64"
-  nim_branch:
+  nim_ref:
     description: "Nim version"
     default: "version-1-6"
   shell:
@@ -117,7 +117,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: '${{ github.workspace }}/nim'
-        key: ${{ inputs.os }}-${{ inputs.cpu }}-nim-${{ inputs.nim_branch }}-cache-${{ env.cache_nonce }}
+        key: ${{ inputs.os }}-${{ inputs.cpu }}-nim-${{ inputs.nim_ref }}-cache-${{ env.cache_nonce }}
 
     - name: Build Nim and Nimble
       shell: ${{ inputs.shell }}
@@ -126,6 +126,6 @@ runs:
         # We don't want partial matches of the cache restored
         rm -rf nim
         curl -O -L -s -S https://raw.githubusercontent.com/status-im/nimbus-build-system/master/scripts/build_nim.sh
-        env MAKE="${MAKE_CMD} -j${ncpu}" ARCH_OVERRIDE=${PLATFORM} NIM_COMMIT=${{ inputs.nim_branch }} \
+        env MAKE="${MAKE_CMD} -j${ncpu}" ARCH_OVERRIDE=${PLATFORM} NIM_COMMIT=${{ inputs.nim_ref }} \
           QUICK_AND_DIRTY_COMPILER=1 QUICK_AND_DIRTY_NIMBLE=1 CC=gcc \
           bash build_nim.sh nim csources dist/nimble NimBinaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,12 @@ jobs:
           - os: windows
             cpu: amd64
         nim: 
-          - branch: version-1-6
+          - ref: version-1-6
             memory_management: refc
-          - branch: version-2-0
+          # The ref below corresponds to the branch "version-2-0".
+          # Right before an update from Nimble 0.16.1 to 0.16.2.
+          # That update breaks our dependency resolution.
+          - ref: 8754469f4947844c5938f56e1fba846c349354b5
             memory_management: refc
         include:
           - platform:
@@ -56,7 +59,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
 
-    name: '${{ matrix.platform.os }}-${{ matrix.platform.cpu }} (Nim ${{ matrix.nim.branch }})'
+    name: '${{ matrix.platform.os }}-${{ matrix.platform.cpu }} (Nim ${{ matrix.nim.ref }})'
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout
@@ -70,7 +73,7 @@ jobs:
           os: ${{ matrix.platform.os }}
           cpu: ${{ matrix.platform.cpu }}
           shell: ${{ matrix.shell }}
-          nim_branch: ${{ matrix.nim.branch }}
+          nim_ref: ${{ matrix.nim.ref }}
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -86,9 +89,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: nimbledeps
-          # Using nim.branch as a simple way to differentiate between nimble using the "pkgs" or "pkgs2" directories.
+          # Using nim.ref as a simple way to differentiate between nimble using the "pkgs" or "pkgs2" directories.
           # The change happened on Nimble v0.14.0.
-          key: nimbledeps-${{ matrix.nim.branch }}-${{ hashFiles('.pinned') }} # hashFiles returns a different value on windows
+          key: nimbledeps-${{ matrix.nim.ref }}-${{ hashFiles('.pinned') }} # hashFiles returns a different value on windows
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/daily_amd64.yml
+++ b/.github/workflows/daily_amd64.yml
@@ -10,5 +10,5 @@ jobs:
     name: Daily amd64
     uses: ./.github/workflows/daily_common.yml
     with:
-      nim: "[{'branch': 'version-1-6', 'memory_management': 'refc'}, {'branch': 'version-2-0', 'memory_management': 'refc'}]"
+      nim: "[{'ref': 'version-1-6', 'memory_management': 'refc'}, {'ref': '8754469f4947844c5938f56e1fba846c349354b5', 'memory_management': 'refc'}]"
       cpu: "['amd64']"

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -7,7 +7,7 @@ on:
       nim:
         description: 'Nim Configuration'
         required: true
-        type: string # Following this format: [{"branch": ..., "memory_management": ...}, ...]
+        type: string # Following this format: [{"ref": ..., "memory_management": ...}, ...]
       cpu:
         description: 'CPU'
         required: true
@@ -58,7 +58,7 @@ jobs:
       run:
         shell: ${{ matrix.platform.shell }}
 
-    name: '${{ matrix.platform.os }}-${{ matrix.cpu }} (Nim ${{ matrix.nim.branch }})'
+    name: '${{ matrix.platform.os }}-${{ matrix.cpu }} (Nim ${{ matrix.nim.ref }})'
     runs-on: ${{ matrix.platform.builder }}
     steps:
       - name: Checkout
@@ -69,7 +69,7 @@ jobs:
         with:
           os: ${{ matrix.platform.os }}
           shell: ${{ matrix.platform.shell }}
-          nim_branch: ${{ matrix.nim.branch }}
+          nim_ref: ${{ matrix.nim.ref }}
           cpu: ${{ matrix.cpu }}
 
       - name: Setup Go

--- a/.github/workflows/daily_devel.yml
+++ b/.github/workflows/daily_devel.yml
@@ -10,5 +10,5 @@ jobs:
     name: Daily Nim Devel
     uses: ./.github/workflows/daily_common.yml
     with:
-      nim: "[{'branch': 'devel', 'memory_management': 'orc'}]"
+      nim: "[{'ref': 'devel', 'memory_management': 'orc'}]"
       cpu: "['amd64']"

--- a/.github/workflows/daily_i386.yml
+++ b/.github/workflows/daily_i386.yml
@@ -10,6 +10,6 @@ jobs:
     name: Daily i386 (Linux)
     uses: ./.github/workflows/daily_common.yml
     with:
-      nim: "[{'branch': 'version-1-6', 'memory_management': 'refc'}, {'branch': 'version-2-0', 'memory_management': 'refc'}, {'branch': 'devel', 'memory_management': 'orc'}]"
+      nim: "[{'ref': 'version-1-6', 'memory_management': 'refc'}, {'ref': '8754469f4947844c5938f56e1fba846c349354b5', 'memory_management': 'refc'}, {'ref': 'devel', 'memory_management': 'orc'}]"
       cpu: "['i386']"
       exclude: "[{'platform': {'os':'macos'}}, {'platform': {'os':'windows'}}]"

--- a/.github/workflows/daily_sat.yml
+++ b/.github/workflows/daily_sat.yml
@@ -10,6 +10,6 @@ jobs:
     name: Daily SAT
     uses: ./.github/workflows/daily_common.yml
     with:
-      nim: "[{'branch': 'version-2-0', 'memory_management': 'refc'}]"
+      nim: "[{'ref': '8754469f4947844c5938f56e1fba846c349354b5', 'memory_management': 'refc'}]"
       cpu: "['amd64']"
       use_sat_solver: true


### PR DESCRIPTION
Broken due to an update to Nimble 0.16.2 for the `version-2-0` branch. This PR sets the ref to the previous commit. Also, updates the key naming so it fits better.

Nim's commit list: https://github.com/nim-lang/Nim/commits/version-2-0/