### PR TITLE
fix(ci): nim 2.0 dependency failure

### DIFF
--- a/.github/actions/install_nim/action.yml
+++ b/.github/actions/install_nim/action.yml
@@ -6,7 +6,7 @@ inputs:
   cpu:
     description: "CPU to build for"
     default: "amd64"
-  nim_branch:
+  nim_ref:
     description: "Nim version"
     default: "version-1-6"
   shell:
@@ -117,7 +117,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: '${{ github.workspace }}/nim'
-        key: ${{ inputs.os }}-${{ inputs.cpu }}-nim-${{ inputs.nim_branch }}-cache-${{ env.cache_nonce }}
+        key: ${{ inputs.os }}-${{ inputs.cpu }}-nim-${{ inputs.nim_ref }}-cache-${{ env.cache_nonce }}
 
     - name: Build Nim and Nimble
       shell: ${{ inputs.shell }}
@@ -126,6 +126,6 @@ runs:
         # We don't want partial matches of the cache restored
         rm -rf nim
         curl -O -L -s -S https://raw.githubusercontent.com/status-im/nimbus-build-system/master/scripts/build_nim.sh
-        env MAKE="${MAKE_CMD} -j${ncpu}" ARCH_OVERRIDE=${PLATFORM} NIM_COMMIT=${{ inputs.nim_branch }} \
+        env MAKE="${MAKE_CMD} -j${ncpu}" ARCH_OVERRIDE=${PLATFORM} NIM_COMMIT=${{ inputs.nim_ref }} \
           QUICK_AND_DIRTY_COMPILER=1 QUICK_AND_DIRTY_NIMBLE=1 CC=gcc \
           bash build_nim.sh nim csources dist/nimble NimBinaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,13 @@ jobs:
             cpu: amd64
           - os: windows
             cpu: amd64
-        nim: 
+        nim:
           - ref: version-1-6
             memory_management: refc
           # The ref below corresponds to the branch "version-2-0".
           # Right before an update from Nimble 0.16.1 to 0.16.2.
           # That update breaks our dependency resolution.
-          - ref: 8754469f4947844c5938f56e1fba846c349354b5
+          - ref: cc4c9251f0fbf5e2c93e6815db402a0e27e1110d
             memory_management: refc
         include:
           - platform:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,11 @@ jobs:
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
         # The reason for using solver:legacy is to avoid an error in Nimble 0.16.2 where SAT is not able to check the dependencies.
         run: |
-          nimble --nimbleDir:nimbledeps --solver:legacy install_pinned
+          if [[ "${{ matrix.nim.ref }}" == "version-2-0" ]]; then
+            nimble --solver:legacy install_pinned
+          else
+            nimble install
+          fi
 
       - name: Use gcc 14
         if : ${{ matrix.platform.os == 'linux-gcc-14'}}
@@ -114,5 +118,10 @@ jobs:
           nim --version
           nimble --version
           gcc --version
-          NIMFLAGS="${NIMFLAGS} --mm:${{ matrix.nim.memory_management }} --solver:legacy"
+
+          NIMFLAGS="${NIMFLAGS} --mm:${{ matrix.nim.memory_management }}"
+          if [[ "${{ matrix.nim.ref }}" == "version-2-0" ]]; then
+            NIMFLAGS="${NIMFLAGS} --solver:legacy"
+          fi
+
           nimble test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,12 @@ jobs:
           - os: windows
             cpu: amd64
         nim: 
-          - branch: version-1-6
+          - ref: version-1-6
             memory_management: refc
-          - branch: version-2-0
+          # The ref below corresponds to the branch "version-2-0".
+          # Right before an update from Nimble 0.16.1 to 0.16.2.
+          # That update breaks our dependency resolution.
+          - ref: 8754469f4947844c5938f56e1fba846c349354b5
             memory_management: refc
         include:
           - platform:
@@ -56,7 +59,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
 
-    name: '${{ matrix.platform.os }}-${{ matrix.platform.cpu }} (Nim ${{ matrix.nim.branch }})'
+    name: '${{ matrix.platform.os }}-${{ matrix.platform.cpu }} (Nim ${{ matrix.nim.ref }})'
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout
@@ -70,7 +73,7 @@ jobs:
           os: ${{ matrix.platform.os }}
           cpu: ${{ matrix.platform.cpu }}
           shell: ${{ matrix.shell }}
-          nim_branch: ${{ matrix.nim.branch }}
+          nim_ref: ${{ matrix.nim.ref }}
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -86,9 +89,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: nimbledeps
-          # Using nim.branch as a simple way to differentiate between nimble using the "pkgs" or "pkgs2" directories.
+          # Using nim.ref as a simple way to differentiate between nimble using the "pkgs" or "pkgs2" directories.
           # The change happened on Nimble v0.14.0.
-          key: nimbledeps-${{ matrix.nim.branch }}-${{ hashFiles('.pinned') }} # hashFiles returns a different value on windows
+          key: nimbledeps-${{ matrix.nim.ref }}-${{ hashFiles('.pinned') }} # hashFiles returns a different value on windows
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,13 +95,8 @@ jobs:
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
-        # The reason for using solver:legacy is to avoid an error in Nimble 0.16.2 where SAT is not able to check the dependencies.
         run: |
-          if [[ "${{ matrix.nim.ref }}" == "8754469f4947844c5938f56e1fba846c349354b5" ]]; then
-            nimble --solver:legacy install_pinned
-          else
-            nimble install_pinned
-          fi
+          nimble install_pinned
 
       - name: Use gcc 14
         if : ${{ matrix.platform.os == 'linux-gcc-14'}}
@@ -113,15 +108,10 @@ jobs:
           sudo update-alternatives --set gcc /usr/bin/gcc-14
 
       - name: Run tests
-        # The reason for using solver:legacy is to avoid an error in Nimble 0.16.2 where SAT is not able to check the dependencies.
         run: |
           nim --version
           nimble --version
           gcc --version
 
           NIMFLAGS="${NIMFLAGS} --mm:${{ matrix.nim.memory_management }}"
-          if [[ "${{ matrix.nim.ref }}" == "8754469f4947844c5938f56e1fba846c349354b5" ]]; then
-            NIMFLAGS="${NIMFLAGS} --solver:legacy"
-          fi
-
           nimble test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
-        # The reason for using solver:legacy is to avoid an error in Nimble 0.16.2 where SAT is not able to check the dependencies. 
+        # The reason for using solver:legacy is to avoid an error in Nimble 0.16.2 where SAT is not able to check the dependencies.
         run: |
           nimble --nimbleDir:nimbledeps --solver:legacy install_pinned
 
@@ -109,9 +109,10 @@ jobs:
           sudo update-alternatives --set gcc /usr/bin/gcc-14
 
       - name: Run tests
+        # The reason for using solver:legacy is to avoid an error in Nimble 0.16.2 where SAT is not able to check the dependencies.
         run: |
           nim --version
           nimble --version
           gcc --version
-          NIMFLAGS="${NIMFLAGS} --mm:${{ matrix.nim.memory_management }}"
+          NIMFLAGS="${NIMFLAGS} --mm:${{ matrix.nim.memory_management }} --solver:legacy"
           nimble test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           # The ref below corresponds to the branch "version-2-0".
           # Right before an update from Nimble 0.16.1 to 0.16.2.
           # That update breaks our dependency resolution.
-          - ref: 8754469f4947844c5938f56e1fba846c349354b5
+          - ref: version-2-0
             memory_management: refc
         include:
           - platform:
@@ -95,8 +95,9 @@ jobs:
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
+        # The reason for using solver:legacy is to avoid an error in Nimble 0.16.2 where SAT is not able to check the dependencies. 
         run: |
-          nimble install_pinned
+          nimble --nimbleDir:nimbledeps --solver:legacy install_pinned
 
       - name: Use gcc 14
         if : ${{ matrix.platform.os == 'linux-gcc-14'}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
           if [[ "${{ matrix.nim.ref }}" == "version-2-0" ]]; then
             nimble --solver:legacy install_pinned
           else
-            nimble install
+            nimble install_pinned
           fi
 
       - name: Use gcc 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           # The ref below corresponds to the branch "version-2-0".
           # Right before an update from Nimble 0.16.1 to 0.16.2.
           # That update breaks our dependency resolution.
-          - ref: cc4c9251f0fbf5e2c93e6815db402a0e27e1110d
+          - ref: 8754469f4947844c5938f56e1fba846c349354b5
             memory_management: refc
         include:
           - platform:
@@ -97,7 +97,7 @@ jobs:
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
         # The reason for using solver:legacy is to avoid an error in Nimble 0.16.2 where SAT is not able to check the dependencies.
         run: |
-          if [[ "${{ matrix.nim.ref }}" == "cc4c9251f0fbf5e2c93e6815db402a0e27e1110d" ]]; then
+          if [[ "${{ matrix.nim.ref }}" == "8754469f4947844c5938f56e1fba846c349354b5" ]]; then
             nimble --solver:legacy install_pinned
           else
             nimble install_pinned
@@ -120,7 +120,7 @@ jobs:
           gcc --version
 
           NIMFLAGS="${NIMFLAGS} --mm:${{ matrix.nim.memory_management }}"
-          if [[ "${{ matrix.nim.ref }}" == "cc4c9251f0fbf5e2c93e6815db402a0e27e1110d" ]]; then
+          if [[ "${{ matrix.nim.ref }}" == "8754469f4947844c5938f56e1fba846c349354b5" ]]; then
             NIMFLAGS="${NIMFLAGS} --solver:legacy"
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           # The ref below corresponds to the branch "version-2-0".
           # Right before an update from Nimble 0.16.1 to 0.16.2.
           # That update breaks our dependency resolution.
-          - ref: version-2-0
+          - ref: 8754469f4947844c5938f56e1fba846c349354b5
             memory_management: refc
         include:
           - platform:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
         # The reason for using solver:legacy is to avoid an error in Nimble 0.16.2 where SAT is not able to check the dependencies.
         run: |
-          if [[ "${{ matrix.nim.ref }}" == "version-2-0" ]]; then
+          if [[ "${{ matrix.nim.ref }}" == "cc4c9251f0fbf5e2c93e6815db402a0e27e1110d" ]]; then
             nimble --solver:legacy install_pinned
           else
             nimble install_pinned
@@ -120,7 +120,7 @@ jobs:
           gcc --version
 
           NIMFLAGS="${NIMFLAGS} --mm:${{ matrix.nim.memory_management }}"
-          if [[ "${{ matrix.nim.ref }}" == "version-2-0" ]]; then
+          if [[ "${{ matrix.nim.ref }}" == "cc4c9251f0fbf5e2c93e6815db402a0e27e1110d" ]]; then
             NIMFLAGS="${NIMFLAGS} --solver:legacy"
           fi
 

--- a/.github/workflows/daily_amd64.yml
+++ b/.github/workflows/daily_amd64.yml
@@ -10,5 +10,5 @@ jobs:
     name: Daily amd64
     uses: ./.github/workflows/daily_common.yml
     with:
-      nim: "[{'branch': 'version-1-6', 'memory_management': 'refc'}, {'branch': 'version-2-0', 'memory_management': 'refc'}]"
+      nim: "[{'ref': 'version-1-6', 'memory_management': 'refc'}, {'ref': '8754469f4947844c5938f56e1fba846c349354b5', 'memory_management': 'refc'}]"
       cpu: "['amd64']"

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -7,7 +7,7 @@ on:
       nim:
         description: 'Nim Configuration'
         required: true
-        type: string # Following this format: [{"branch": ..., "memory_management": ...}, ...]
+        type: string # Following this format: [{"ref": ..., "memory_management": ...}, ...]
       cpu:
         description: 'CPU'
         required: true
@@ -58,7 +58,7 @@ jobs:
       run:
         shell: ${{ matrix.platform.shell }}
 
-    name: '${{ matrix.platform.os }}-${{ matrix.cpu }} (Nim ${{ matrix.nim.branch }})'
+    name: '${{ matrix.platform.os }}-${{ matrix.cpu }} (Nim ${{ matrix.nim.ref }})'
     runs-on: ${{ matrix.platform.builder }}
     steps:
       - name: Checkout
@@ -69,7 +69,7 @@ jobs:
         with:
           os: ${{ matrix.platform.os }}
           shell: ${{ matrix.platform.shell }}
-          nim_branch: ${{ matrix.nim.branch }}
+          nim_ref: ${{ matrix.nim.ref }}
           cpu: ${{ matrix.cpu }}
 
       - name: Setup Go

--- a/.github/workflows/daily_devel.yml
+++ b/.github/workflows/daily_devel.yml
@@ -10,5 +10,5 @@ jobs:
     name: Daily Nim Devel
     uses: ./.github/workflows/daily_common.yml
     with:
-      nim: "[{'branch': 'devel', 'memory_management': 'orc'}]"
+      nim: "[{'ref': 'devel', 'memory_management': 'orc'}]"
       cpu: "['amd64']"

--- a/.github/workflows/daily_i386.yml
+++ b/.github/workflows/daily_i386.yml
@@ -10,6 +10,6 @@ jobs:
     name: Daily i386 (Linux)
     uses: ./.github/workflows/daily_common.yml
     with:
-      nim: "[{'branch': 'version-1-6', 'memory_management': 'refc'}, {'branch': 'version-2-0', 'memory_management': 'refc'}, {'branch': 'devel', 'memory_management': 'orc'}]"
+      nim: "[{'ref': 'version-1-6', 'memory_management': 'refc'}, {'ref': '8754469f4947844c5938f56e1fba846c349354b5', 'memory_management': 'refc'}, {'ref': 'devel', 'memory_management': 'orc'}]"
       cpu: "['i386']"
       exclude: "[{'platform': {'os':'macos'}}, {'platform': {'os':'windows'}}]"

--- a/.github/workflows/daily_sat.yml
+++ b/.github/workflows/daily_sat.yml
@@ -10,6 +10,6 @@ jobs:
     name: Daily SAT
     uses: ./.github/workflows/daily_common.yml
     with:
-      nim: "[{'branch': 'version-2-0', 'memory_management': 'refc'}]"
+      nim: "[{'ref': '8754469f4947844c5938f56e1fba846c349354b5', 'memory_management': 'refc'}]"
       cpu: "['amd64']"
       use_sat_solver: true

--- a/.pinned
+++ b/.pinned
@@ -13,7 +13,7 @@ results;https://github.com/arnetheduck/nim-results@#f3c666a272c69d70cb41e7245e7f
 secp256k1;https://github.com/status-im/nim-secp256k1@#7246d91c667f4cc3759fdd50339caa45a2ecd8be
 serialization;https://github.com/status-im/nim-serialization@#4bdbc29e54fe54049950e352bb969aab97173b35
 stew;https://github.com/status-im/nim-stew@#3159137d9a3110edb4024145ce0ba778975de40e
-testutils;https://github.com/status-im/nim-testutils@#4d37244f9f5e1acd8592a4ceb5c3fc47bc160181
-unittest2;https://github.com/status-im/nim-unittest2@#845b6af28b9f68f02d320e03ad18eccccea7ddb9
+testutils;https://github.com/status-im/nim-testutils@#dfc4c1b39f9ded9baf6365014de2b4bfb4dafc34
+unittest2;https://github.com/status-im/nim-unittest2@#2300fa9924a76e6c96bc4ea79d043e3a0f27120c
 websock;https://github.com/status-im/nim-websock@#f8ed9b40a5ff27ad02a3c237c4905b0924e3f982
 zlib;https://github.com/status-im/nim-zlib@#38b72eda9d70067df4a953f56b5ed59630f2a17b

--- a/.pinned
+++ b/.pinned
@@ -13,7 +13,7 @@ results;https://github.com/arnetheduck/nim-results@#f3c666a272c69d70cb41e7245e7f
 secp256k1;https://github.com/status-im/nim-secp256k1@#7246d91c667f4cc3759fdd50339caa45a2ecd8be
 serialization;https://github.com/status-im/nim-serialization@#4bdbc29e54fe54049950e352bb969aab97173b35
 stew;https://github.com/status-im/nim-stew@#3159137d9a3110edb4024145ce0ba778975de40e
-testutils;https://github.com/status-im/nim-testutils@#dfc4c1b39f9ded9baf6365014de2b4bfb4dafc34
-unittest2;https://github.com/status-im/nim-unittest2@#2300fa9924a76e6c96bc4ea79d043e3a0f27120c
+testutils;https://github.com/status-im/nim-testutils@#4d37244f9f5e1acd8592a4ceb5c3fc47bc160181
+unittest2;https://github.com/status-im/nim-unittest2@#845b6af28b9f68f02d320e03ad18eccccea7ddb9
 websock;https://github.com/status-im/nim-websock@#f8ed9b40a5ff27ad02a3c237c4905b0924e3f982
 zlib;https://github.com/status-im/nim-zlib@#38b72eda9d70067df4a953f56b5ed59630f2a17b


### PR DESCRIPTION
Broken due to an update to Nimble 0.16.2 for the version-2-0 branch. This PR sets the ref to the previous commit. Also, updates the key naming so it fits better.

Nim's commit list: https://github.com/nim-lang/Nim/commits/version-2-0/

# Important Note
In this PR some required job's names were changed. They need to be updated at repo-level so this PR can be merged.