### PR TITLE
feature(mixnet): enable transport adapter

### DIFF
--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -52,7 +52,9 @@ proc select*(
 ): Future[string] {.async: (raises: [CancelledError, LPStreamError, MultiStreamError]).} =
   trace "initiating handshake", conn, codec = Codec
   ## select a remote protocol
+  echo "> MultiStreamSelect::select"
   await conn.writeLp(Codec & "\n") # write handshake
+  echo "> MultiStreamSelect::select - 0"
   if proto.len() > 0:
     trace "selecting proto", conn, proto = proto[0]
     await conn.writeLp((proto[0] & "\n")) # select proto
@@ -67,6 +69,7 @@ proc select*(
     trace "multistream handshake success", conn
 
   if proto.len() == 0: # no protocols, must be a handshake call
+    echo "< MultiStreamSelect::select - Handshake"
     return Codec
   else:
     s = string.fromBytes(await conn.readLp(MsgSize)) # read the first proto
@@ -75,6 +78,7 @@ proc select*(
     if s == proto[0]:
       trace "successfully selected ", conn, proto = proto[0]
       conn.protocol = proto[0]
+      echo "< MultiStreamSelect::select - ", proto[0]
       return proto[0]
     elif proto.len > 1:
       # Try to negotiate alternatives

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -148,6 +148,7 @@ method init*(s: Secure) =
     try:
       # We don't need the result but we
       # definitely need to await the handshake
+      echo "Secure::handle"
       discard await s.handleConn(conn, false, Opt.none(PeerId))
       trace "connection secured", conn
     except CancelledError as exc:
@@ -165,6 +166,7 @@ method secure*(
 ): Future[Connection] {.
     async: (raises: [CancelledError, LPStreamError], raw: true), base
 .} =
+  echo "> Secure::secure"
   s.handleConn(conn, conn.dir == Direction.Out, peerId)
 
 method readOnce*(

--- a/libp2p/stream/connection.nim
+++ b/libp2p/stream/connection.nim
@@ -40,14 +40,11 @@ type
 
 proc timeoutMonitor(s: Connection) {.async: (raises: []).}
 
-func shortLog*(conn: Connection): string =
-  try:
-    if conn == nil:
-      "Connection(nil)"
-    else:
-      &"{shortLog(conn.peerId)}:{conn.oid}"
-  except ValueError as exc:
-    raiseAssert(exc.msg)
+method shortLog*(conn: Connection): string {.raises: [].} =
+  if conn == nil:
+    "Connection(nil)"
+  else:
+    &"{shortLog(conn.peerId)}:{conn.oid}:{conn.protocol}"
 
 chronicles.formatIt(Connection):
   shortLog(it)

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -112,7 +112,7 @@ method initStream*(s: LPStream) {.base.} =
   trackCounter(s.objName)
   trace "Stream created", s, objName = s.objName, dir = $s.dir
 
-proc join*(
+method join*(
     s: LPStream
 ): Future[void] {.async: (raises: [CancelledError], raw: true), public.} =
   ## Wait for the stream to be closed
@@ -134,9 +134,10 @@ method readOnce*(
   ## available
   raiseAssert("Not implemented!")
 
-proc readExactly*(
+method readExactly*(
     s: LPStream, pbytes: pointer, nbytes: int
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError]), public.} =
+  # echo "readExactly. Is conn closed? ", s.isClosed
   ## Waits for `nbytes` to be available, then read
   ## them and return them
   if s.atEof:
@@ -159,9 +160,9 @@ proc readExactly*(
 
   if read == 0:
     doAssert s.atEof()
-    trace "couldn't read all bytes, stream EOF", s, nbytes, read
     # Re-readOnce to raise a more specific error than EOF
     # Raise EOF if it doesn't raise anything(shouldn't happen)
+    # echo "readExactly3. Is conn closed? ", s.isClosed
     discard await s.readOnce(addr pbuffer[read], nbytes - read)
     warn "Read twice while at EOF"
     raise newLPStreamEOFError()
@@ -170,7 +171,7 @@ proc readExactly*(
     trace "couldn't read all bytes, incomplete data", s, nbytes, read
     raise newLPStreamIncompleteError()
 
-proc readLine*(
+method readLine*(
     s: LPStream, limit = 0, sep = "\r\n"
 ): Future[string] {.async: (raises: [CancelledError, LPStreamError]), public.} =
   ## Reads up to `limit` bytes are read, or a `sep` is found
@@ -198,7 +199,7 @@ proc readLine*(
       if len(result) == lim:
         break
 
-proc readVarint*(
+method readVarint*(
     conn: LPStream
 ): Future[uint64] {.async: (raises: [CancelledError, LPStreamError]), public.} =
   var buffer: array[10, byte]
@@ -217,7 +218,7 @@ proc readVarint*(
   if true: # can't end with a raise apparently
     raise (ref InvalidVarintError)(msg: "Cannot parse varint")
 
-proc readLp*(
+method readLp*(
     s: LPStream, maxSize: int
 ): Future[seq[byte]] {.async: (raises: [CancelledError, LPStreamError]), public.} =
   ## read length prefixed msg, with the length encoded as a varint
@@ -243,7 +244,7 @@ method write*(
   # Write `msg` to stream, waiting for the write to be finished
   raiseAssert("Not implemented!")
 
-proc writeLp*(
+method writeLp*(
     s: LPStream, msg: openArray[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true), public.} =
   ## Write `msg` with a varint-encoded length prefix
@@ -253,7 +254,7 @@ proc writeLp*(
   buf[vbytes.len ..< buf.len] = msg
   s.write(buf)
 
-proc writeLp*(
+method writeLp*(
     s: LPStream, msg: string
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true), public.} =
   writeLp(s, msg.toOpenArrayByte(0, msg.high))
@@ -305,6 +306,7 @@ proc closeWithEOF*(s: LPStream): Future[void] {.async: (raises: []), public.} =
   ##
 
   trace "Closing with EOF", s
+  echo "> Closing with EOF: ", s.shortLog()
   if s.closedWithEOF:
     trace "Already closed"
     return

--- a/libp2p/transports/transport.nim
+++ b/libp2p/transports/transport.nim
@@ -36,6 +36,9 @@ type
     upgrader*: Upgrade
     networkReachability*: NetworkReachability
 
+method log*(self: Transport): string {.base, gcsafe.} =
+  "<Transport>"
+
 proc newTransportClosedError*(parent: ref Exception = nil): ref TransportError =
   newException(TransportClosedError, "Transport closed, no more connections!", parent)
 
@@ -69,10 +72,10 @@ method dial*(
 ): Future[Connection] {.base, gcsafe.} =
   ## dial a peer
   ##
-
+  echo "Transport::dial"
   doAssert(false, "Not implemented!")
 
-proc dial*(
+method dial*(
     self: Transport, address: MultiAddress, peerId: Opt[PeerId] = Opt.none(PeerId)
 ): Future[Connection] {.gcsafe.} =
   self.dial("", address)
@@ -83,6 +86,7 @@ method upgrade*(
   ## base upgrade method that the transport uses to perform
   ## transport specific upgrades
   ##
+  echo "> Transport::upgrade"
   self.upgrader.upgrade(conn, peerId)
 
 method handles*(self: Transport, address: MultiAddress): bool {.base, gcsafe.} =

--- a/libp2p/upgrademngrs/muxedupgrade.nim
+++ b/libp2p/upgrademngrs/muxedupgrade.nim
@@ -68,6 +68,8 @@ method upgrade*(
 ): Future[Muxer] {.async: (raises: [CancelledError, LPError]).} =
   trace "Upgrading connection", conn, direction = conn.dir
 
+  echo "> MuxedUpgrade::upgrade"
+  echo "-----"
   let sconn = await self.secure(conn, peerId) # secure the connection
   if sconn == nil:
     raise (ref UpgradeFailedError)(msg: "unable to secure connection, stopping upgrade")

--- a/libp2p/upgrademngrs/upgrade.nim
+++ b/libp2p/upgrademngrs/upgrade.nim
@@ -47,9 +47,10 @@ method upgrade*(
 ): Future[Muxer] {.async: (raises: [CancelledError, LPError], raw: true), base.} =
   raiseAssert("Not implemented!")
 
-proc secure*(
+method secure*(
     self: Upgrade, conn: Connection, peerId: Opt[PeerId]
 ): Future[Connection] {.async: (raises: [CancelledError, LPError]).} =
+  echo "> Upgrade::secure"
   if self.secureManagers.len <= 0:
     raise (ref UpgradeFailedError)(msg: "No secure managers registered!")
 
@@ -68,4 +69,5 @@ proc secure*(
   # let's avoid duplicating checks but detect if it fails to do it properly
   doAssert(secureProtocol.len > 0)
 
+  echo "> Upgrade::secure - 0"
   await secureProtocol[0].secure(conn, peerId)


### PR DESCRIPTION
# Description
This PR adds some changes that enable building a Transport/Connection/Muxer/Upgrade adapter, intended to build a seamless mixnet module.

This is very much a work in progress, partly because it contains a lot debug code that requires cleanup. But more importantly, because the impact of these changes hasn't been thoroughly assessed. That is, whether they might inadvertedly alter the behaviour of other parts of the codebase.

This branch will be used as a development dependency for now, and the PR will remain in draft status during this period.