### PR TITLE
fix:missing raises pragma for one of RendezVous.new

### DIFF
--- a/libp2p/protocols/rendezvous.nim
+++ b/libp2p/protocols/rendezvous.nim
@@ -750,7 +750,7 @@ proc new*(
     rng: ref HmacDrbgContext = newRng(),
     minDuration = MinimumDuration,
     maxDuration = MaximumDuration,
-): T =
+): T {.raises: [RendezVousError].} =
   let rdv = T.new(rng, minDuration, maxDuration)
   rdv.setup(switch)
   return rdv


### PR DESCRIPTION
Small issue arose in nwaku while bumping to v1.7 of nim-libp2p. 
There is a missing pragma preventing compilation while using RendezVous.new(switch).
Seems only nwaku is using that version, hence it overlooked. 


Issue: https://github.com/vacp2p/nim-libp2p/issues/1221
