### PR TITLE
feat: idontwant on publish

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -154,6 +154,9 @@ type
     # Max number of elements allowed in the non-priority queue. When this limit has been reached, the peer will be disconnected.
     maxNumElementsInNonPriorityQueue*: int
 
+    # Broadcast an IDONTWANT message automatically when the message exceeds the IDONTWANT message size threshold
+    sendIDontWantOnPublish*: bool
+
   BackoffTable* = Table[string, Table[PeerId, Moment]]
   ValidationSeenTable* = Table[SaltedId, HashSet[PubSubPeer]]
 

--- a/libp2p/utility.nim
+++ b/libp2p/utility.nim
@@ -149,3 +149,11 @@ template exclIfIt*[T](set: var HashSet[T], condition: untyped) =
       if condition:
         toExcl.incl(it)
     set.excl(toExcl)
+
+template filterIt*[T](set: HashSet[T], condition: untyped): HashSet[T] =
+  var filtered = HashSet[T]()
+  if set.len != 0:
+    for it {.inject.} in set:
+      if condition:
+        filtered.incl(it)
+  filtered

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -940,7 +940,12 @@ suite "GossipSub":
     func dumbMsgIdProvider(m: Message): Result[MessageId, ValidationResult] =
       ok(newSeq[byte](10))
     let
-      nodes = generateNodes(2, gossip = true, msgIdProvider = dumbMsgIdProvider)
+      nodes = generateNodes(
+        2,
+        gossip = true,
+        msgIdProvider = dumbMsgIdProvider,
+        sendIDontWantOnPublish = true,
+      )
 
       nodesFut = await allFinished(nodes[0].switch.start(), nodes[1].switch.start())
 
@@ -948,10 +953,10 @@ suite "GossipSub":
       nodes[1].switch.peerInfo.peerId, nodes[1].switch.peerInfo.addrs
     )
 
-    proc handlerA(topic: string, data: seq[byte]) {.async.} =
+    proc handlerA(topic: string, data: seq[byte]) {.async: (raises: []).} =
       discard
 
-    proc handlerB(topic: string, data: seq[byte]) {.async.} =
+    proc handlerB(topic: string, data: seq[byte]) {.async: (raises: []).} =
       discard
 
     nodes[0].subscribe("foobar", handlerA)

--- a/tests/pubsub/utils.nim
+++ b/tests/pubsub/utils.nim
@@ -74,6 +74,7 @@ proc generateNodes*(
     overheadRateLimit: Opt[tuple[bytes: int, interval: Duration]] =
       Opt.none(tuple[bytes: int, interval: Duration]),
     gossipSubVersion: string = "",
+    sendIDontWantOnPublish: bool = false,
 ): seq[PubSub] =
   for i in 0 ..< num:
     let switch = newStandardSwitch(
@@ -97,6 +98,7 @@ proc generateNodes*(
             p.unsubscribeBackoff = unsubscribeBackoff
             p.enablePX = enablePX
             p.overheadRateLimit = overheadRateLimit
+            p.sendIDontWantOnPublish = sendIDontWantOnPublish
             p
           ),
         )


### PR DESCRIPTION
Closes #1224 

The following changes were done:
1. Once a message is broadcasted, if it exceeds the threeshold to consider it a large message it will send an IDONTWANT message before publishing the message
https://github.com/vacp2p/nim-libp2p/blob/4f9c21f6999a58dff0fde2d4f031086bc846c9f7/libp2p/protocols/pubsub/gossipsub.nim#L800-L801
2. Extracts the logic to broadcast an IDONTWANT message and to verify the size of a message into separate functions
3. Adds a template to filter values of a hashset without modifying the original