### PR TITLE
Large message handling combined

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -473,7 +473,7 @@ proc validateAndRelay(
     var seenPeers: HashSet[PubSubPeer]
     discard g.validationSeen.pop(saltedId, seenPeers)
     libp2p_gossipsub_duplicate_during_validation.inc(seenPeers.len.int64)
-    lma_dup_during_validation.atomicInc()
+    lma_dup_during_validation.atomicInc(seenPeers.len.uint32)
     libp2p_gossipsub_saved_bytes.inc(
       (msg.data.len * seenPeers.len).int64, labelValues = ["validation_duplicate"]
     )

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -252,6 +252,7 @@ method init*(g: GossipSub) =
   g.codecs &= GossipSubCodec_12
   g.codecs &= GossipSubCodec_11
   g.codecs &= GossipSubCodec_10
+  g.iwantsRequested = initHashSet[MessageId]()
 
 method onNewPeer*(g: GossipSub, peer: PubSubPeer) =
   g.withPeerStats(peer.peerId) do(stats: var PeerStats):

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -546,7 +546,7 @@ proc validateAndRelay(
 
     proc sendToOne(p: PubSubPeer) {.async.} =
       g.broadcast(@[p], RPCMsg(control: some(ControlMessage(
-          preamble: @[ControlIWant(messageIDs: @[msgId])]
+          preamble: @[ControlIHave(topicID: topic, messageIDs: @[msgId])]
         ))), isHighPriority = true)
       
       await sem.acquire()
@@ -873,6 +873,10 @@ method publish*(g: GossipSub, topic: string, data: seq[byte]): Future[int] {.asy
   g.rng.shuffle(staggerPeers)
 
   proc sendToOne(p: PubSubPeer) {.async.} =
+    g.broadcast(@[p], RPCMsg(control: some(ControlMessage(
+        preamble: @[ControlIHave(topicID: topic, messageIDs: @[msgId])]
+      ))), isHighPriority = true)
+
     await sem.acquire()
     defer: sem.release()
 

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -375,6 +375,7 @@ proc handleControl(g: GossipSub, peer: PubSubPeer, control: ControlMessage) =
 
   var respControl: ControlMessage
   g.handleIDontWant(peer, control.idontwant)
+  g.handlePreamble(peer, control.preamble)  
   g.handleIMReceiving(peer, control.imreceiving)
   let iwant = g.handleIHave(peer, control.ihave)
   if iwant.messageIDs.len > 0:
@@ -544,6 +545,10 @@ proc validateAndRelay(
     g.rng.shuffle(staggerPeers)
 
     proc sendToOne(p: PubSubPeer) {.async.} =
+      g.broadcast(@[p], RPCMsg(control: some(ControlMessage(
+          preamble: @[ControlIWant(messageIDs: @[msgId])]
+        ))), isHighPriority = true)
+      
       await sem.acquire()
       defer: sem.release()
 

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -540,7 +540,7 @@ proc validateAndRelay(
     #g.broadcast(toSendPeers, RPCMsg(messages: @[msg]), isHighPriority = false)
     trace "forwarded message to peers", peers = toSendPeers.len, msgId, peer
 
-    let sem = newAsyncSemaphore(2)
+    let sem = newAsyncSemaphore(1)
     var staggerPeers = toSeq(toSendPeers)
     g.rng.shuffle(staggerPeers)
 
@@ -868,7 +868,7 @@ method publish*(g: GossipSub, topic: string, data: seq[byte]): Future[int] {.asy
   g.mcache.put(msgId, msg)
 
   #g.broadcast(peers, RPCMsg(messages: @[msg]), isHighPriority = true)
-  let sem = newAsyncSemaphore(2)
+  let sem = newAsyncSemaphore(1)
   var staggerPeers = toSeq(peers)
   g.rng.shuffle(staggerPeers)
 

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -327,7 +327,7 @@ proc handleIDontWant*(g: GossipSub, peer: PubSubPeer, iDontWants: seq[ControlIWa
         break
       peer.iDontWants[^1].incl(g.salt(messageId))
   
-proc handlePreamble*(g: GossipSub, peer: PubSubPeer, preambles: seq[ControlIWant]) =
+proc handlePreamble*(g: GossipSub, peer: PubSubPeer, preambles: seq[ControlIHave]) =
   for preamble in preambles:
     for messageId in preamble.messageIDs:
       #Idealy a peer should a maximum of peer_preamble_announcements preambles for unfinished downloads
@@ -343,11 +343,11 @@ proc handlePreamble*(g: GossipSub, peer: PubSubPeer, preambles: seq[ControlIWant
         3) Better solution is to send Message detail in a message preamble, That can be used for IMReceiving
       ]#
       var toSendPeers = HashSet[PubSubPeer]()
-      g.floodsub.withValue("test", peers): toSendPeers.incl(peers[])
-      g.mesh.withValue("test", peers): toSendPeers.incl(peers[])
+      g.floodsub.withValue(preamble.topicID, peers): toSendPeers.incl(peers[])
+      g.mesh.withValue(preamble.topicID, peers): toSendPeers.incl(peers[])
 
       # add direct peers
-      toSendPeers.incl(g.subscribedDirectPeers.getOrDefault("test"))
+      toSendPeers.incl(g.subscribedDirectPeers.getOrDefault(preamble.topicID))
 
       g.broadcast(toSendPeers, RPCMsg(control: some(ControlMessage(
           imreceiving: @[ControlIWant(messageIDs: @[messageId])]

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -327,6 +327,14 @@ proc handleIDontWant*(g: GossipSub, peer: PubSubPeer, iDontWants: seq[ControlIWa
         break
       peer.iDontWants[^1].incl(g.salt(messageId))
   
+proc handlePreamble*(g: GossipSub, peer: PubSubPeer, preambles: seq[ControlIWant]) =
+  for preamble in preambles:
+    for messageId in preamble.messageIDs:
+      #Idealy a peer should a maximum of peer_preamble_announcements preambles for unfinished downloads
+      #A peer violating this should be pnalized through P4???
+      if peer.heIsSendings[^1].len > 1000:
+        break
+      peer.heIsSendings[^1].incl(messageId)
       #Experimental change for quick performance evaluation only (Ideally for very large messages):
       #[
         1) IDontWant is followed by the message. IMReceiving informs peers that we are receiving this message
@@ -344,7 +352,6 @@ proc handleIDontWant*(g: GossipSub, peer: PubSubPeer, iDontWants: seq[ControlIWa
       g.broadcast(toSendPeers, RPCMsg(control: some(ControlMessage(
           imreceiving: @[ControlIWant(messageIDs: @[messageId])]
         ))), isHighPriority = true)
-  
 
 
 proc handleIMReceiving*(g: GossipSub,

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -299,6 +299,8 @@ proc handleIHave*(
           if not g.hasSeen(g.salt(msgId)):
             if peer.iHaveBudget <= 0:
               break
+            elif msgId in g.iwantsRequested:
+              break
             elif msgId notin res.messageIDs:
               #dont send IWANT if we have received (N number of) IDontWant(s) for a msgID
               let saltedID = g.salt(msgId)
@@ -311,6 +313,7 @@ proc handleIHave*(
               if numFinds == 0:  #We currently wait for 1 IDontWants  
                 res.messageIDs.add(msgId)
                 dec peer.iHaveBudget
+                g.iwantsRequested.incl(msgId)
                 trace "requested message via ihave", messageID = msgId
     # shuffling res.messageIDs before sending it out to increase the likelihood
     # of getting an answer if the peer truncates the list due to internal size restrictions.

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -309,6 +309,35 @@ proc handleIDontWant*(g: GossipSub, peer: PubSubPeer, iDontWants: seq[ControlIWa
       if peer.iDontWants[^1].len > 1000:
         break
       peer.iDontWants[^1].incl(g.salt(messageId))
+  
+      #Experimental change for quick performance evaluation only (Ideally for very large messages):
+      #[
+        1) IDontWant is followed by the message. IMReceiving informs peers that we are receiving this message
+        2) Prototype implementation for a single topic ("test"). Need topic ID in IDontWant
+
+        3) Better solution is to send Message detail in a message preamble, That can be used for IMReceiving
+      ]#
+      var toSendPeers = HashSet[PubSubPeer]()
+      g.floodsub.withValue("test", peers): toSendPeers.incl(peers[])
+      g.mesh.withValue("test", peers): toSendPeers.incl(peers[])
+
+      # add direct peers
+      toSendPeers.incl(g.subscribedDirectPeers.getOrDefault("test"))
+
+      g.broadcast(toSendPeers, RPCMsg(control: some(ControlMessage(
+          imreceiving: @[ControlIWant(messageIDs: @[messageId])]
+        ))), isHighPriority = true)
+  
+
+
+proc handleIMReceiving*(g: GossipSub,
+                      peer: PubSubPeer,
+                      imreceivings: seq[ControlIWant]) =
+  for imreceiving in imreceivings:
+    for messageId in imreceiving.messageIDs:
+      if peer.heIsReceivings[^1].len > 1000: break
+      if messageId.len > 100: continue
+      peer.heIsReceivings[^1].incl(messageId)
 
 proc handleIWant*(
     g: GossipSub, peer: PubSubPeer, iwants: seq[ControlIWant]

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -293,6 +293,7 @@ proc handleIHave*(
         #look here for receieved idontwants for the same message
         var meshPeers: HashSet[PubSubPeer]
         g.mesh.withValue(ihave.topicID, peers): meshPeers.incl(peers[])
+        g.subscribedDirectPeers.withValue(ihave.topicID, peers): meshPeers.incl(peers[])
 
         for msgId in ihave.messageIDs:
           if not g.hasSeen(g.salt(msgId)):
@@ -307,7 +308,7 @@ proc handleIHave*(
                   if saltedID in heDontWant: 
                     numFinds = numFinds + 1
                     #break;
-              if numFinds <= 1:  #We currently wait for 2 IDontWants  
+              if numFinds == 0:  #We currently wait for 1 IDontWants  
                 res.messageIDs.add(msgId)
                 dec peer.iHaveBudget
                 trace "requested message via ihave", messageID = msgId

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -290,14 +290,27 @@ proc handleIHave*(
     for ihave in ihaves:
       trace "peer sent ihave", peer, topicID = ihave.topicID, msgs = ihave.messageIDs
       if ihave.topicID in g.topics:
+        #look here for receieved idontwants for the same message
+        var meshPeers: HashSet[PubSubPeer]
+        g.mesh.withValue(ihave.topicID, peers): meshPeers.incl(peers[])
+
         for msgId in ihave.messageIDs:
           if not g.hasSeen(g.salt(msgId)):
             if peer.iHaveBudget <= 0:
               break
             elif msgId notin res.messageIDs:
-              res.messageIDs.add(msgId)
-              dec peer.iHaveBudget
-              trace "requested message via ihave", messageID = msgId
+              #dont send IWANT if we have received (N number of) IDontWant(s) for a msgID
+              let saltedID = g.salt(msgId)
+              var numFinds: int = 0
+              for meshPeer in meshPeers:
+                for heDontWant in meshPeer.iDontWants:
+                  if saltedID in heDontWant: 
+                    numFinds = numFinds + 1
+                    #break;
+              if numFinds <= 1:  #We currently wait for 2 IDontWants  
+                res.messageIDs.add(msgId)
+                dec peer.iHaveBudget
+                trace "requested message via ihave", messageID = msgId
     # shuffling res.messageIDs before sending it out to increase the likelihood
     # of getting an answer if the peer truncates the list due to internal size restrictions.
     g.rng.shuffle(res.messageIDs)

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -188,6 +188,8 @@ type
 
     heartbeatEvents*: seq[AsyncEvent]
 
+    iwantsRequested*: HashSet[MessageId]
+
   MeshMetrics* = object # scratch buffers for metrics
     otherPeersPerTopicMesh*: int64
     otherPeersPerTopicFanout*: int64

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -109,6 +109,7 @@ type
       ## IDONTWANT contains unvalidated message id:s which may be long and/or
       ## expensive to look up, so we apply the same salting to them as during
       ## unvalidated message processing
+    heIsSendings*:Deque[HashSet[MessageId]]
     heIsReceivings*:Deque[HashSet[MessageId]]
     iHaveBudget*: int
     pingBudget*: int
@@ -558,5 +559,6 @@ proc new*(
   )
   result.sentIHaves.addFirst(default(HashSet[MessageId]))
   result.iDontWants.addFirst(default(HashSet[SaltedId]))
+  result.heIsSendings.addFirst(default(HashSet[MessageId]) )
   result.heIsReceivings.addFirst(default(HashSet[MessageId]))
   result.startSendNonPriorityTask()

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -109,6 +109,7 @@ type
       ## IDONTWANT contains unvalidated message id:s which may be long and/or
       ## expensive to look up, so we apply the same salting to them as during
       ## unvalidated message processing
+    heIsReceivings*:Deque[HashSet[MessageId]]
     iHaveBudget*: int
     pingBudget*: int
     maxMessageSize: int
@@ -557,4 +558,5 @@ proc new*(
   )
   result.sentIHaves.addFirst(default(HashSet[MessageId]))
   result.iDontWants.addFirst(default(HashSet[SaltedId]))
+  result.heIsReceivings.addFirst(default(HashSet[MessageId]))
   result.startSendNonPriorityTask()

--- a/libp2p/protocols/pubsub/rpc/messages.nim
+++ b/libp2p/protocols/pubsub/rpc/messages.nim
@@ -63,6 +63,7 @@ type
     graft*: seq[ControlGraft]
     prune*: seq[ControlPrune]
     idontwant*: seq[ControlIWant]
+    preamble*: seq[ControlIWant]
     imreceiving*: seq[ControlIWant]
 
   ControlIHave* = object
@@ -174,11 +175,12 @@ proc byteSize(controlPrune: ControlPrune): int =
     # 8 bytes for uint64
 
 static:
-  expectedFields(ControlMessage, @["ihave", "iwant", "graft", "prune", "idontwant", "imreceiving"])
+  expectedFields(ControlMessage, @["ihave", "iwant", "graft", "prune", "idontwant", "preamble", "imreceiving"])
 proc byteSize(control: ControlMessage): int =
   control.ihave.foldl(a + b.byteSize, 0) + control.iwant.foldl(a + b.byteSize, 0) +
     control.graft.foldl(a + b.byteSize, 0) + control.prune.foldl(a + b.byteSize, 0) +
     control.idontwant.foldl(a + b.byteSize, 0) +
+    control.preamble.foldl(a + b.byteSize, 0) +
     control.imreceiving.foldl(a + b.byteSize, 0)
 
 static:

--- a/libp2p/protocols/pubsub/rpc/messages.nim
+++ b/libp2p/protocols/pubsub/rpc/messages.nim
@@ -63,6 +63,7 @@ type
     graft*: seq[ControlGraft]
     prune*: seq[ControlPrune]
     idontwant*: seq[ControlIWant]
+    imreceiving*: seq[ControlIWant]
 
   ControlIHave* = object
     topicID*: string
@@ -173,11 +174,12 @@ proc byteSize(controlPrune: ControlPrune): int =
     # 8 bytes for uint64
 
 static:
-  expectedFields(ControlMessage, @["ihave", "iwant", "graft", "prune", "idontwant"])
+  expectedFields(ControlMessage, @["ihave", "iwant", "graft", "prune", "idontwant", "imreceiving"])
 proc byteSize(control: ControlMessage): int =
   control.ihave.foldl(a + b.byteSize, 0) + control.iwant.foldl(a + b.byteSize, 0) +
     control.graft.foldl(a + b.byteSize, 0) + control.prune.foldl(a + b.byteSize, 0) +
-    control.idontwant.foldl(a + b.byteSize, 0)
+    control.idontwant.foldl(a + b.byteSize, 0) +
+    control.imreceiving.foldl(a + b.byteSize, 0)
 
 static:
   expectedFields(RPCMsg, @["subscriptions", "messages", "control", "ping", "pong"])

--- a/libp2p/protocols/pubsub/rpc/messages.nim
+++ b/libp2p/protocols/pubsub/rpc/messages.nim
@@ -63,7 +63,7 @@ type
     graft*: seq[ControlGraft]
     prune*: seq[ControlPrune]
     idontwant*: seq[ControlIWant]
-    preamble*: seq[ControlIWant]
+    preamble*: seq[ControlIHave]
     imreceiving*: seq[ControlIWant]
 
   ControlIHave* = object

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -89,6 +89,8 @@ proc write*(pb: var ProtoBuffer, field: int, control: ControlMessage) =
     ipb.write(4, prune)
   for idontwant in control.idontwant:
     ipb.write(5, idontwant)
+  for imreceiving in control.imreceiving:
+    ipb.write(6, imreceiving)
   if len(ipb.buffer) > 0:
     ipb.finish()
     pb.write(field, ipb)
@@ -208,6 +210,7 @@ proc decodeControl*(pb: ProtoBuffer): ProtoResult[Option[ControlMessage]] {.inli
     var graftpbs: seq[seq[byte]]
     var prunepbs: seq[seq[byte]]
     var idontwant: seq[seq[byte]]
+    var imreceiving: seq[seq[byte]]
     if ?cpb.getRepeatedField(1, ihavepbs):
       for item in ihavepbs:
         control.ihave.add(?decodeIHave(initProtoBuffer(item)))
@@ -223,6 +226,9 @@ proc decodeControl*(pb: ProtoBuffer): ProtoResult[Option[ControlMessage]] {.inli
     if ?cpb.getRepeatedField(5, idontwant):
       for item in idontwant:
         control.idontwant.add(?decodeIWant(initProtoBuffer(item)))
+    if ? cpb.getRepeatedField(6, imreceiving):
+      for item in imreceiving:
+        control.imreceiving.add(?decodeIWant(initProtoBuffer(item)))
     trace "decodeControl: message statistics",
       graft_count = len(control.graft),
       prune_count = len(control.prune),

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -89,8 +89,10 @@ proc write*(pb: var ProtoBuffer, field: int, control: ControlMessage) =
     ipb.write(4, prune)
   for idontwant in control.idontwant:
     ipb.write(5, idontwant)
+  for preamble in control.preamble:
+    ipb.write(6, preamble)
   for imreceiving in control.imreceiving:
-    ipb.write(6, imreceiving)
+    ipb.write(7, imreceiving)
   if len(ipb.buffer) > 0:
     ipb.finish()
     pb.write(field, ipb)
@@ -210,6 +212,7 @@ proc decodeControl*(pb: ProtoBuffer): ProtoResult[Option[ControlMessage]] {.inli
     var graftpbs: seq[seq[byte]]
     var prunepbs: seq[seq[byte]]
     var idontwant: seq[seq[byte]]
+    var preamble:  seq[seq[byte]]
     var imreceiving: seq[seq[byte]]
     if ?cpb.getRepeatedField(1, ihavepbs):
       for item in ihavepbs:
@@ -226,7 +229,10 @@ proc decodeControl*(pb: ProtoBuffer): ProtoResult[Option[ControlMessage]] {.inli
     if ?cpb.getRepeatedField(5, idontwant):
       for item in idontwant:
         control.idontwant.add(?decodeIWant(initProtoBuffer(item)))
-    if ? cpb.getRepeatedField(6, imreceiving):
+    if ? cpb.getRepeatedField(6, preamble):
+      for item in preamble:
+        control.preamble.add(?decodeIWant(initProtoBuffer(item)))
+    if ? cpb.getRepeatedField(7, imreceiving):
       for item in imreceiving:
         control.imreceiving.add(?decodeIWant(initProtoBuffer(item)))
     trace "decodeControl: message statistics",

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -231,7 +231,7 @@ proc decodeControl*(pb: ProtoBuffer): ProtoResult[Option[ControlMessage]] {.inli
         control.idontwant.add(?decodeIWant(initProtoBuffer(item)))
     if ? cpb.getRepeatedField(6, preamble):
       for item in preamble:
-        control.preamble.add(?decodeIWant(initProtoBuffer(item)))
+        control.preamble.add(?decodeIHave(initProtoBuffer(item)))
     if ? cpb.getRepeatedField(7, imreceiving):
       for item in imreceiving:
         control.imreceiving.add(?decodeIWant(initProtoBuffer(item)))


### PR DESCRIPTION
We use message preamble to detect incoming messages. This information is used to:
-  Announce the messages we are receiving to full-message mesh using IMReceiving messages.
-  Make IWANT requests only if we are not already receiving the same message
-  Limit outstanding IWANT requests for a message to 1
-  Stagger (only add small delay) mesh transmissions

PoC implementation for shadow simulation. Not intended for merging
Reduces duplicates to less than 1.5 for large messages

[More details here](https://github.com/libp2p/specs/pull/654)