### PR TITLE
fix: use target repository branch as suffix for `nim-libp2p-auto-bump-`

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -44,7 +44,7 @@ jobs:
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
           git config --global user.name = "${{ github.actor }}"
           git commit --allow-empty -a -m "auto-bump nim-libp2p"
-          git branch -D nim-libp2p-auto-bump-${GITHUB_REF##*/} || true
-          git switch -c nim-libp2p-auto-bump-${GITHUB_REF##*/}
-          git push -f origin nim-libp2p-auto-bump-${GITHUB_REF##*/}
+          git branch -D nim-libp2p-auto-bump-${{ matrix.target.ref }} || true
+          git switch -c nim-libp2p-auto-bump-${{ matrix.target.ref }}
+          git push -f origin nim-libp2p-auto-bump-${{ matrix.target.ref }}
 


### PR DESCRIPTION
The branch `nim-libp2p-auto-bump-unstable` was not getting autobumped because at one point of time in nim-libp2p `unstable` branch was renamed to `master` branch. Since the workflow file depended on `GITHUB_REF`, it was instead updating `nim-libp2p-auto-bump-master` instead of `nim-libp2p-auto-bump-unstable`