### PR TITLE
chore: enhanced error propagation from publish + enable fast path send even observeres are added

### DIFF
--- a/libp2p/protocols/pubsub.nim
+++ b/libp2p/protocols/pubsub.nim
@@ -1,8 +1,8 @@
-import ./pubsub/[pubsub, floodsub, gossipsub]
+import ./pubsub/[pubsub, floodsub, gossipsub, errors]
 
 ## Home of PubSub & it's implementations:
 ## | **pubsub**: base interface for pubsub implementations
 ## | **floodsub**: simple flood-based publishing
 ## | **gossipsub**: more sophisticated gossip based publishing
 
-export pubsub, floodsub, gossipsub
+export pubsub, floodsub, gossipsub, errors

--- a/libp2p/protocols/pubsub/errors.nim
+++ b/libp2p/protocols/pubsub/errors.nim
@@ -1,9 +1,19 @@
 # this module will be further extended in PR
 # https://github.com/status-im/nim-libp2p/pull/107/
 
-import ../../utility
+import ../../utility, ../../errors
 
 type ValidationResult* {.pure, public.} = enum
   Accept
   Reject
   Ignore
+
+type
+  PublishingError* = object of LPError
+
+  NoTopicSpecifiedError* = object of PublishingError
+  PayloadIsEmptyError* = object of PublishingError
+  DuplicateMessageError* = object of PublishingError
+  NotSubscribedToTopicError* = object of PublishingError
+  NoPeersToPublishError* = object of PublishingError
+  GeneratingMessageIdError* = object of PublishingError

--- a/libp2p/protocols/pubsub/errors.nim
+++ b/libp2p/protocols/pubsub/errors.nim
@@ -13,16 +13,3 @@ type PublishOutcome* {.pure, public.} = enum
   DuplicateMessage
   NoPeersToPublish
   CannotGenerateMessageId
-
-proc `$`*(publishOutcome: PublishOutcome): string =
-  case publishOutcome
-  of NoTopicSpecified:
-    return "NoTopicSpecified"
-  of DuplicateMessage:
-    return "DuplicateMessage"
-  of NoPeersToPublish:
-    return "NoPeersToPublish"
-  of CannotGenerateMessageId:
-    return "CannotGenerateMessageId"
-  else:
-    return "unknown"

--- a/libp2p/protocols/pubsub/errors.nim
+++ b/libp2p/protocols/pubsub/errors.nim
@@ -8,12 +8,21 @@ type ValidationResult* {.pure, public.} = enum
   Reject
   Ignore
 
-type
-  PublishingError* = object of LPError
+type PublishOutcome* {.pure, public.} = enum
+  NoTopicSpecified
+  DuplicateMessage
+  NoPeersToPublish
+  CannotGenerateMessageId
 
-  NoTopicSpecifiedError* = object of PublishingError
-  PayloadIsEmptyError* = object of PublishingError
-  DuplicateMessageError* = object of PublishingError
-  NotSubscribedToTopicError* = object of PublishingError
-  NoPeersToPublishError* = object of PublishingError
-  GeneratingMessageIdError* = object of PublishingError
+proc `$`*(publishOutcome: PublishOutcome): string =
+  case publishOutcome
+  of NoTopicSpecified:
+    return "NoTopicSpecified"
+  of DuplicateMessage:
+    return "DuplicateMessage"
+  of NoPeersToPublish:
+    return "NoPeersToPublish"
+  of CannotGenerateMessageId:
+    return "CannotGenerateMessageId"
+  else:
+    return "unknown"

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -24,6 +24,7 @@ import
   ../../peerinfo,
   ../../utility
 
+export pubsub
 ## Simple flood-based publishing.
 
 logScope:
@@ -192,11 +193,11 @@ method init*(f: FloodSub) =
   f.handler = handler
   f.codec = FloodSubCodec
 
-method publish*(
+method doPublish*(
     f: FloodSub, topic: string, data: seq[byte]
 ): Future[int] {.async: (raises: []).} =
   # base returns always 0
-  discard await procCall PubSub(f).publish(topic, data)
+  discard await procCall PubSub(f).doPublish(topic, data)
 
   trace "Publishing message on topic", data = data.shortLog, topic
 

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -195,7 +195,7 @@ method init*(f: FloodSub) =
 
 method doPublish*(
     f: FloodSub, topic: string, data: seq[byte]
-): Future[Result[int, PublishOutcome]] {.async: (raises: []).} =
+): Future[PublishResult] {.async: (raises: []).} =
   # base returns always 0
   discard await procCall PubSub(f).doPublish(topic, data)
 
@@ -212,7 +212,7 @@ method doPublish*(
     return err(NoPeersToPublish)
 
   let (msg, msgId) = f.createMessage(topic, data).valueOr:
-    trace "Error generating message id, skipping publish", error = error
+    trace "Error creating message, skipping publish", error = error
     return err(CannotGenerateMessageId)
 
   trace "Created new message", payload = shortLog(msg), peers = peers.len, topic, msgId

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -765,7 +765,7 @@ proc collectPeersForPublish(
 
 method doPublish*(
     g: GossipSub, topic: string, data: seq[byte]
-): Future[Result[int, PublishOutcome]] {.async: (raises: []).} =
+): Future[PublishResult] {.async: (raises: []).} =
   logScope:
     topic
 
@@ -788,7 +788,7 @@ method doPublish*(
     return err(NoPeersToPublish)
 
   let (msg, msgId) = g.createMessage(topic, data).valueOr:
-    trace "Error generating message id, skipping publish", error = error
+    error "Error creating message, skipping publish", error = error
     return err(CannotGenerateMessageId)
 
   logScope:

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -553,12 +553,26 @@ proc subscribe*(p: PubSub, topic: string, handler: TopicHandler) {.public.} =
 
   p.updateTopicMetrics(topic)
 
+method createMessage*(
+    p: PubSub, topic: string, data: seq[byte]
+): Result[(Message, MessageId), ValidationResult] {.base, gcsafe, raises: [].} =
+  let
+    msg =
+      if p.anonymize:
+        Message.init(none(PeerInfo), data, topic, none(uint64), false)
+      else:
+        inc p.msgSeqno
+        Message.init(some(p.peerInfo), data, topic, some(p.msgSeqno), p.sign)
+    msgId = ?p.msgIdProvider(msg)
+
+  return ok((msg, msgId))
+
 # `Non-public` overridable interface for publshing messages.
 # Although it must be exported, this not intended to call from outside by class users, 
-# but call `publish` or `publishEx` interfaces.
+# but call `publish`.
 method doPublish*(
     p: PubSub, topic: string, data: seq[byte]
-): Future[int] {.base, async: (raises: []).} =
+): Future[Result[int, PublishOutcome]] {.base, async: (raises: []).} =
   ## publish to a ``topic``
   ##
   ## The return value is the number of neighbours that we attempted to send the
@@ -568,28 +582,13 @@ method doPublish*(
   if p.triggerSelf:
     await handleData(p, topic, data)
 
-  return 0
+  return ok(0)
 
 proc publish*(
     p: PubSub, topic: string, data: seq[byte]
 ): Future[int] {.async: (raises: []), public.} =
-  try:
-    return await p.doPublish(topic, data)
-  except LPError:
-    # won't let exception propagate further from this interface.
-    # keep original behavior for unprepared users, any error results that 
-    # message relayed to no - 0 - peers 
-    # Assuming errors logged in place they occured.
+  return (await p.doPublish(topic, data)).valueOr:
     return 0
-
-# Extended publish interface: it will raise exceptions in case any issue happaned
-# while publishing message, even found if no peers to relay it.
-# Will effectively return the number of peers the message is successfully try-send.
-# Notice: interface may change in future for better support heavy users like waku.
-proc publishEx*(
-    p: PubSub, topic: string, data: seq[byte]
-): Future[int] {.async: (raises: [LPError]), public.} =
-  return await p.doPublish(topic, data)
 
 method initPubSub*(p: PubSub) {.base, raises: [InitializationError].} =
   ## perform pubsub initialization

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -179,34 +179,31 @@ proc hasBeforeSendObservers*(p: PubSubPeer): bool =
 
 proc recvObservers*(p: PubSubPeer, msg: var RPCMsg) =
   # trigger hooks
-  if not (isNil(p.observers)) and p.observers[].len > 0:
+  if not (isNil(p.observers)):
     for obs in p.observers[]:
-      if not (isNil(obs)): # TODO: should never be nil, but...
-        if not (isNil(obs.onRecv)):
-          obs.onRecv(p, msg)
+      if not (isNil(obs)) and not (isNil(obs.onRecv)):
+        obs.onRecv(p, msg)
 
 proc validatedObservers*(p: PubSubPeer, msg: Message, msgId: MessageId) =
   # trigger hooks
-  if not (isNil(p.observers)) and p.observers[].len > 0:
+  if not (isNil(p.observers)):
     for obs in p.observers[]:
-      if not (isNil(obs.onValidated)):
+      if not (isNil(obs)) and not (isNil(obs.onValidated)):
         obs.onValidated(p, msg, msgId)
 
 proc beforeSendObservers(p: PubSubPeer, msg: var RPCMsg) =
   # trigger hooks
-  if not (isNil(p.observers)) and p.observers[].len > 0:
+  if not (isNil(p.observers)):
     for obs in p.observers[]:
-      if not (isNil(obs)): # TODO: should never be nil, but...
-        if not (isNil(obs.onBeforeSend)):
-          obs.onBeforeSend(p, msg)
+      if not (isNil(obs)) and not (isNil(obs.onBeforeSend)):
+        obs.onBeforeSend(p, msg)
 
 proc afterSentObservers(p: PubSubPeer, msg: RPCMsg) =
   # trigger hooks
-  if not (isNil(p.observers)) and p.observers[].len > 0:
+  if not (isNil(p.observers)):
     for obs in p.observers[]:
-      if not (isNil(obs)): # TODO: should never be nil, but...
-        if not (isNil(obs.onAfterSent)):
-          obs.onAfterSent(p, msg)
+      if not (isNil(obs)) and not (isNil(obs.onAfterSent)):
+        obs.onAfterSent(p, msg)
 
 proc handle*(p: PubSubPeer, conn: Connection) {.async: (raises: []).} =
   debug "starting pubsub read loop", conn, peer = p, closed = conn.closed


### PR DESCRIPTION
# Update!
I have updated the PR description after a bit of redesign after the first round of review discussions!

# Description 

Nwaku new lightpush protocol enriches the information sent back to its clients in case a problem occurs during relaying messages. This implies enhancing pubsub/gossipsub publish method.
publish method is now separated from the overridable doPublish to give a bit greater flexibility for later extenders.
doPublish returns some descriptive outcome in case publishing did not happen.

## Disclaimer about the interface change.
No breaking change in interface is made and current behavior to the outside world is kept.

## Optimizing message observers
Another shortcoming found and enhanced within this PR. While using any kind of observer on pubsub message relaying forces messages to be encoded as many peers it sends to. It is useless if the observer does not want to modify the message. While keeping the option to add an invasive observer before message-send, it is extended to having a view-only after-send observer. This allows fast path send whenever possible.   

