### PR TITLE
refactor(pubsub): do not raise exceptions on publish

### DIFF
--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -194,7 +194,7 @@ method init*(f: FloodSub) =
 
 method publish*(
     f: FloodSub, topic: string, data: seq[byte]
-): Future[int] {.async: (raises: [LPError]).} =
+): Future[int] {.async: (raises: []).} =
   # base returns always 0
   discard await procCall PubSub(f).publish(topic, data)
 

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -705,7 +705,7 @@ method onTopicSubscription*(g: GossipSub, topic: string, subscribed: bool) =
 
 method publish*(
     g: GossipSub, topic: string, data: seq[byte]
-): Future[int] {.async: (raises: [LPError]).} =
+): Future[int] {.async: (raises: []).} =
   logScope:
     topic
 

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -555,7 +555,7 @@ proc subscribe*(p: PubSub, topic: string, handler: TopicHandler) {.public.} =
 
 method publish*(
     p: PubSub, topic: string, data: seq[byte]
-): Future[int] {.base, async: (raises: [LPError]), public.} =
+): Future[int] {.base, async: (raises: []), public.} =
   ## publish to a ``topic``
   ##
   ## The return value is the number of neighbours that we attempted to send the

--- a/libp2p/protocols/pubsub/rpc/message.nim
+++ b/libp2p/protocols/pubsub/rpc/message.nim
@@ -65,7 +65,10 @@ proc init*(
     topic: string,
     seqno: Option[uint64],
     sign: bool = true,
-): Message {.gcsafe, raises: [LPError].} =
+): Message {.gcsafe, raises: [].} =
+  if sign and peer.isNone():
+    doAssert(false, "Cannot sign message without peer info")
+
   var msg = Message(data: data, topic: topic)
 
   # order matters, we want to include seqno in the signature
@@ -81,9 +84,6 @@ proc init*(
         .expect("Invalid private key!")
         .getBytes()
         .expect("Couldn't get public key bytes!")
-  else:
-    if sign:
-      raise (ref LPError)(msg: "Cannot sign message without peer info")
 
   msg
 


### PR DESCRIPTION
As commented on https://github.com/vacp2p/nim-libp2p/pull/1243#issuecomment-2639659840 the only scenario in which is it possible to have this exception being raised is due to a misconfig when initializing a message in 
- https://github.com/vacp2p/nim-libp2p/blob/master/libp2p/protocols/pubsub/floodsub.nim#L215-L219
- https://github.com/vacp2p/nim-libp2p/blob/master/libp2p/protocols/pubsub/gossipsub.nim#L784-L788

Since `Message.init` is used only in these places and it's not expected for a consumer of nim-libp2p to create a `Message` themselves, adding this assertion is safe as it will immediatly indicate that the message is being initialized incorrectly.