### PR TITLE
chore: specifing raising exceptions in root files

### DIFF
--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -123,7 +123,9 @@ proc removeConnEventHandler*(
 ) =
   c.connEvents[kind].excl(handler)
 
-proc triggerConnEvent*(c: ConnManager, peerId: PeerId, event: ConnEvent) {.async.} =
+proc triggerConnEvent*(
+    c: ConnManager, peerId: PeerId, event: ConnEvent
+) {.async: (raises: [CancelledError]).} =
   try:
     trace "About to trigger connection events", peer = peerId
     if c.connEvents[event.kind].len() > 0:
@@ -154,7 +156,9 @@ proc removePeerEventHandler*(
 ) =
   c.peerEvents[kind].excl(handler)
 
-proc triggerPeerEvents*(c: ConnManager, peerId: PeerId, event: PeerEvent) {.async.} =
+proc triggerPeerEvents*(
+    c: ConnManager, peerId: PeerId, event: PeerEvent
+) {.async: (raises: [CancelledError]).} =
   trace "About to trigger peer events", peer = peerId
   if c.peerEvents[event.kind].len == 0:
     return
@@ -174,7 +178,7 @@ proc triggerPeerEvents*(c: ConnManager, peerId: PeerId, event: PeerEvent) {.asyn
 
 proc expectConnection*(
     c: ConnManager, p: PeerId, dir: Direction
-): Future[Muxer] {.async.} =
+): Future[Muxer] {.async: (raises: [AlreadyExpectingConnectionError, CatchableError]).} =
   ## Wait for a peer to connect to us. This will bypass the `MaxConnectionsPerPeer`
   let key = (p, dir)
   if key in c.expectedConnectionsOverLimit:
@@ -205,7 +209,7 @@ proc contains*(c: ConnManager, muxer: Muxer): bool =
   let conn = muxer.connection
   return muxer in c.muxed.getOrDefault(conn.peerId)
 
-proc closeMuxer(muxer: Muxer) {.async.} =
+proc closeMuxer(muxer: Muxer) {.async: (raises: []).} =
   trace "Cleaning up muxer", m = muxer
 
   await muxer.close()
@@ -216,7 +220,7 @@ proc closeMuxer(muxer: Muxer) {.async.} =
       trace "Exception in close muxer handler", description = exc.msg
   trace "Cleaned up muxer", m = muxer
 
-proc muxCleanup(c: ConnManager, mux: Muxer) {.async.} =
+proc muxCleanup(c: ConnManager, mux: Muxer) {.async: (raises: []).} =
   try:
     trace "Triggering disconnect events", mux
     let peerId = mux.connection.peerId
@@ -238,7 +242,7 @@ proc muxCleanup(c: ConnManager, mux: Muxer) {.async.} =
     # do not need to propagate CancelledError and should handle other errors
     warn "Unexpected exception peer cleanup handler", mux, description = exc.msg
 
-proc onClose(c: ConnManager, mux: Muxer) {.async.} =
+proc onClose(c: ConnManager, mux: Muxer) {.async: (raises: []).} =
   ## connection close even handler
   ##
   ## triggers the connections resource cleanup
@@ -272,7 +276,7 @@ proc selectMuxer*(c: ConnManager, peerId: PeerId): Muxer =
     trace "connection not found", peerId
   return mux
 
-proc storeMuxer*(c: ConnManager, muxer: Muxer) {.raises: [CatchableError].} =
+proc storeMuxer*(c: ConnManager, muxer: Muxer) {.raises: [LPError].} =
   ## store the connection and muxer
   ##
 
@@ -324,7 +328,9 @@ proc storeMuxer*(c: ConnManager, muxer: Muxer) {.raises: [CatchableError].} =
 
   trace "Stored muxer", muxer, direction = $muxer.connection.dir, peers = c.muxed.len
 
-proc getIncomingSlot*(c: ConnManager): Future[ConnectionSlot] {.async.} =
+proc getIncomingSlot*(
+    c: ConnManager
+): Future[ConnectionSlot] {.async: (raises: [CatchableError]).} =
   await c.inSema.acquire()
   return ConnectionSlot(connManager: c, direction: In)
 
@@ -357,7 +363,7 @@ proc trackConnection*(cs: ConnectionSlot, conn: Connection) =
     cs.release()
     return
 
-  proc semaphoreMonitor() {.async.} =
+  proc semaphoreMonitor() {.async: (raises: []).} =
     try:
       await conn.join()
     except CatchableError as exc:
@@ -373,14 +379,18 @@ proc trackMuxer*(cs: ConnectionSlot, mux: Muxer) =
     return
   cs.trackConnection(mux.connection)
 
-proc getStream*(c: ConnManager, muxer: Muxer): Future[Connection] {.async.} =
+proc getStream*(
+    c: ConnManager, muxer: Muxer
+): Future[Connection] {.async: (raises: [CancelledError, LPStreamError, MuxerError]).} =
   ## get a muxed stream for the passed muxer
   ##
 
   if not (isNil(muxer)):
     return await muxer.newStream()
 
-proc getStream*(c: ConnManager, peerId: PeerId): Future[Connection] {.async.} =
+proc getStream*(
+    c: ConnManager, peerId: PeerId
+): Future[Connection] {.async: (raises: [CancelledError, LPStreamError, MuxerError]).} =
   ## get a muxed stream for the passed peer from any connection
   ##
 
@@ -388,13 +398,13 @@ proc getStream*(c: ConnManager, peerId: PeerId): Future[Connection] {.async.} =
 
 proc getStream*(
     c: ConnManager, peerId: PeerId, dir: Direction
-): Future[Connection] {.async.} =
+): Future[Connection] {.async: (raises: [CancelledError, LPStreamError, MuxerError]).} =
   ## get a muxed stream for the passed peer from a connection with `dir`
   ##
 
   return await c.getStream(c.selectMuxer(peerId, dir))
 
-proc dropPeer*(c: ConnManager, peerId: PeerId) {.async.} =
+proc dropPeer*(c: ConnManager, peerId: PeerId) {.async: (raises: []).} =
   ## drop connections and cleanup resources for peer
   ##
   trace "Dropping peer", peerId
@@ -405,7 +415,7 @@ proc dropPeer*(c: ConnManager, peerId: PeerId) {.async.} =
 
   trace "Peer dropped", peerId
 
-proc close*(c: ConnManager) {.async.} =
+proc close*(c: ConnManager) {.async: (raises: []).} =
   ## cleanup resources for the connection
   ## manager
   ##

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -52,7 +52,7 @@ func shortLog*(p: PeerInfo): auto =
 chronicles.formatIt(PeerInfo):
   shortLog(it)
 
-proc update*(p: PeerInfo) {.async.} =
+proc update*(p: PeerInfo) {.async: (raises: [CatchableError]).} =
   # p.addrs.len == 0 overrides addrs only if it is the first time update is being executed or if the field is empty.
   # p.addressMappers.len == 0 is for when all addressMappers have been removed,
   # and we wish to have addrs in its initial state, i.e., a copy of listenAddrs.

--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -188,7 +188,16 @@ proc cleanup*(peerStore: PeerStore, peerId: PeerId) =
     peerStore.del(peerStore.toClean[0])
     peerStore.toClean.delete(0)
 
-proc identify*(peerStore: PeerStore, muxer: Muxer) {.async.} =
+proc identify*(
+    peerStore: PeerStore, muxer: Muxer
+) {.
+    async: (
+      raises: [
+        CancelledError, LPStreamError, MultiStreamError, MuxerError,
+        IdentityInvalidMsgError, IdentityNoMatchError,
+      ]
+    )
+.} =
   # new stream for identify
   var stream = await muxer.newStream()
   if stream == nil:

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -166,7 +166,12 @@ method init*(p: Identify) =
 
 proc identify*(
     self: Identify, conn: Connection, remotePeerId: PeerId
-): Future[IdentifyInfo] {.async.} =
+): Future[IdentifyInfo] {.
+    async: (
+      raises:
+        [CancelledError, LPStreamError, IdentityInvalidMsgError, IdentityNoMatchError]
+    )
+.} =
   trace "initiating identify", conn
   var message = await conn.readLp(64 * 1024)
   if len(message) == 0:

--- a/libp2p/wire.nim
+++ b/libp2p/wire.nim
@@ -67,7 +67,9 @@ proc connect*(
     child: StreamTransport = nil,
     flags = default(set[SocketFlags]),
     localAddress: Opt[MultiAddress] = Opt.none(MultiAddress),
-): Future[StreamTransport] {.async.} =
+): Future[StreamTransport] {.
+    async: (raises: [MaInvalidAddress, CancelledError, TransportError, LPError])
+.} =
   ## Open new connection to remote peer with address ``ma`` and create
   ## new transport object ``StreamTransport`` for established connection.
   ## ``bufferSize`` is size of internal buffer for transport.


### PR DESCRIPTION
Specifying raising exceptions in root files of library. On some places there `CatchableError` is raised - please let me know if these could be avoided?

Part of: #962
