### PR TITLE
style: fix code style with nph

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -22,7 +22,7 @@ jobs:
         # Pin nph to a specific version to avoid sudden style differences.
         # Updating nph version should be accompanied with running the new version on the fluffy directory.
         run: |
-          VERSION="v0.5.1"
+          VERSION="v0.6.1"
           ARCHIVE="nph-linux_x64.tar.gz"
           curl -L "https://github.com/arnetheduck/nph/releases/download/${VERSION}/${ARCHIVE}" -o ${ARCHIVE}
           tar -xzf ${ARCHIVE}

--- a/examples/tutorial_4_gossipsub.nim
+++ b/examples/tutorial_4_gossipsub.nim
@@ -79,8 +79,7 @@ proc oneNode(node: Node, rng: ref HmacDrbgContext) {.async.} =
       let decoded = MetricList.decode(message.data)
       if decoded.isErr:
         return ValidationResult.Reject
-      return ValidationResult.Accept
-    ,
+      return ValidationResult.Accept,
   )
   # This "validator" will attach to the `metrics` topic and make sure
   # that every message in this topic is valid. This allows us to stop

--- a/examples/tutorial_6_game.nim
+++ b/examples/tutorial_6_game.nim
@@ -214,8 +214,7 @@ proc networking(g: Game) {.async.} =
         # We are "player 2"
         swap(g.localPlayer, g.remotePlayer)
       except CatchableError as exc:
-        discard
-    ,
+        discard,
   )
 
   await switch.start()
@@ -268,14 +267,11 @@ nico.init("Status", "Tron")
 nico.createWindow("Tron", mapSize * 4, mapSize * 4, 4, false)
 nico.run(
   proc() =
-    discard
-  ,
+    discard,
   proc(dt: float32) =
-    game.update(dt)
-  ,
+    game.update(dt),
   proc() =
-    game.draw()
-  ,
+    game.draw(),
 )
 waitFor(netFut.cancelAndWait())
 

--- a/libp2p/crypto/hkdf.nim
+++ b/libp2p/crypto/hkdf.nim
@@ -28,8 +28,7 @@ proc hkdf*[T: sha256, len: static int](
     if salt.len > 0:
       unsafeAddr salt[0]
     else:
-      nil
-    ,
+      nil,
     csize_t(salt.len),
   )
   hkdfInject(
@@ -37,8 +36,7 @@ proc hkdf*[T: sha256, len: static int](
     if ikm.len > 0:
       unsafeAddr ikm[0]
     else:
-      nil
-    ,
+      nil,
     csize_t(ikm.len),
   )
   hkdfFlip(ctx)
@@ -48,8 +46,7 @@ proc hkdf*[T: sha256, len: static int](
       if info.len > 0:
         unsafeAddr info[0]
       else:
-        nil
-      ,
+        nil,
       csize_t(info.len),
       addr outputs[i][0],
       csize_t(outputs[i].len),

--- a/libp2p/discovery/discoverymngr.nim
+++ b/libp2p/discovery/discoverymngr.nim
@@ -38,8 +38,7 @@ proc add*[T](pa: var PeerAttributes, value: T) =
     Attribute[T](
       value: value,
       comparator: proc(f: BaseAttr, c: BaseAttr): bool =
-        f.ofType(T) and c.ofType(T) and f.to(T) == c.to(T)
-      ,
+        f.ofType(T) and c.ofType(T) and f.to(T) == c.to(T),
     )
   )
 

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -82,8 +82,7 @@ proc `$`(header: YamuxHeader): string =
       if a != "":
         a & ", " & $b
       else:
-        $b
-      ,
+        $b,
       "",
     ) & "}, " & "streamId: " & $header.streamId & ", " & "length: " & $header.length &
     "}"
@@ -176,8 +175,7 @@ proc `$`(channel: YamuxChannel): string =
         if a != "":
           a & ", " & b
         else:
-          b
-        ,
+          b,
         "",
       ) & "}"
 

--- a/libp2p/protocols/connectivity/autonat/server.nim
+++ b/libp2p/protocols/connectivity/autonat/server.nim
@@ -47,8 +47,7 @@ proc sendResponseError(
       if text == "":
         Opt.none(string)
       else:
-        Opt.some(text)
-    ,
+        Opt.some(text),
     ma: Opt.none(MultiAddress),
   ).encode()
   await conn.writeLp(pb.buffer)

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -334,8 +334,7 @@ proc setup*(r: Relay, switch: Switch) =
   r.switch = switch
   r.switch.addPeerEventHandler(
     proc(peerId: PeerId, event: PeerEvent) {.async.} =
-      r.rsvp.del(peerId)
-    ,
+      r.rsvp.del(peerId),
     Left,
   )
 

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -92,8 +92,7 @@ proc new*(
       when maxIncomingStreams is int:
         Opt.some(maxIncomingStreams)
       else:
-        maxIncomingStreams
-    ,
+        maxIncomingStreams,
   )
 
 proc new*[E](

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -126,8 +126,7 @@ proc peerExchangeList*(g: GossipSub, topic: string): seq[PeerInfoMsg] =
         if x.peerId in sprBook:
           sprBook[x.peerId].encode().get(default(seq[byte]))
         else:
-          default(seq[byte])
-      ,
+          default(seq[byte]),
     )
 
 proc handleGraft*(

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -44,8 +44,7 @@ chronicles.formatIt(BufferStream):
 
 proc len*(s: BufferStream): int =
   s.readBuf.len + (if s.readQueue.len > 0: s.readQueue[0].len()
-  else: 0
-  )
+  else: 0)
 
 method initStream*(s: BufferStream) =
   if s.objName.len == 0:

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -99,8 +99,7 @@ proc new*(
       if ServerFlags.TcpNoDelay in flags:
         {SocketFlags.TcpNoDelay}
       else:
-        default(set[SocketFlags])
-    ,
+        default(set[SocketFlags]),
     upgrader: upgrade,
     networkReachability: NetworkReachability.Unknown,
     connectionsTimeout: connectionsTimeout,

--- a/libp2p/wire.nim
+++ b/libp2p/wire.nim
@@ -86,8 +86,7 @@ proc connect*(
       if localAddress.isSome():
         initTAddress(localAddress.expect("just checked")).tryGet()
       else:
-        TransportAddress()
-      ,
+        TransportAddress(),
       flags,
     )
   do:

--- a/tests/commoninterop.nim
+++ b/tests/commoninterop.nim
@@ -9,8 +9,7 @@ type
   SwitchCreator = proc(
     ma: MultiAddress = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet(),
     prov: TransportProvider = proc(upgr: Upgrade): Transport =
-      TcpTransport.new({}, upgr)
-    ,
+      TcpTransport.new({}, upgr),
     relay: Relay = Relay.new(circuitRelayV1 = true),
   ): Switch {.gcsafe, raises: [LPError].}
   DaemonPeerInfo = daemonapi.PeerInfo
@@ -301,8 +300,7 @@ proc commonInteropTests*(name: string, swCreator: SwitchCreator) =
       let nativeNode = swCreator(
         ma = wsAddress,
         prov = proc(upgr: Upgrade): Transport =
-          WsTransport.new(upgr)
-        ,
+          WsTransport.new(upgr),
       )
 
       nativeNode.mount(proto)

--- a/tests/testinterop.nim
+++ b/tests/testinterop.nim
@@ -5,8 +5,7 @@ import ../libp2p/crypto/crypto, ../libp2p/protocols/connectivity/relay/[relay, c
 proc switchMplexCreator(
     ma: MultiAddress = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet(),
     prov: TransportProvider = proc(upgr: Upgrade): Transport =
-      TcpTransport.new({}, upgr)
-    ,
+      TcpTransport.new({}, upgr),
     relay: Relay = Relay.new(circuitRelayV1 = true),
 ): Switch {.raises: [LPError].} =
   SwitchBuilder
@@ -29,8 +28,7 @@ proc switchMplexCreator(
 proc switchYamuxCreator(
     ma: MultiAddress = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet(),
     prov: TransportProvider = proc(upgr: Upgrade): Transport =
-      TcpTransport.new({}, upgr)
-    ,
+      TcpTransport.new({}, upgr),
     relay: Relay = Relay.new(circuitRelayV1 = true),
 ): Switch {.raises: [LPError].} =
   SwitchBuilder


### PR DESCRIPTION
- CI was failing because code style was not up to the `nph` guidelines. This PR just fixes code style to conform to `nph`.
- Updated `nph` version to 0.6.1