### PR TITLE
chore: specify raising exceptions in `daemon` module

### DIFF
--- a/libp2p/daemon/daemonapi.nim
+++ b/libp2p/daemon/daemonapi.nim
@@ -626,8 +626,10 @@ proc newDaemonApi*(
     logLevel = IpfsLogLevel.Debug,
 ): Future[DaemonAPI] {.
     async: (
-      raises:
-        [ValueError, DaemonLocalError, CancelledError, LPError, OSError, IOError, CatchableError]
+      raises: [
+        ValueError, DaemonLocalError, CancelledError, LPError, OSError, IOError,
+        CatchableError,
+      ]
     )
 .} =
   ## Initialize connection to `go-libp2p-daemon` control socket.

--- a/libp2p/daemon/daemonapi.nim
+++ b/libp2p/daemon/daemonapi.nim
@@ -158,7 +158,7 @@ type
     key*: PublicKey
 
   P2PStreamCallback* = proc(api: DaemonAPI, stream: P2PStream): Future[void] {.
-    gcsafe, raises: [CatchableError]
+    gcsafe, async: (raises: [CatchableError])
   .}
   P2PPubSubCallback* = proc(
     api: DaemonAPI, ticket: PubsubTicket, message: PubSubMessage

--- a/libp2p/daemon/daemonapi.nim
+++ b/libp2p/daemon/daemonapi.nim
@@ -512,7 +512,11 @@ proc recvMessage(
 
   result = buffer
 
-proc newConnection*(api: DaemonAPI): Future[StreamTransport] {.raises: [LPError].} =
+proc newConnection*(
+    api: DaemonAPI
+): Future[StreamTransport] {.
+    raises: [MaInvalidAddress, TransportError, CancelledError, LPError]
+.} =
   result = connect(api.address)
 
 proc closeConnection*(api: DaemonAPI, transp: StreamTransport): Future[void] =
@@ -571,8 +575,12 @@ proc getSocket(
 proc listPeers*(
   api: DaemonAPI
 ): Future[seq[PeerInfo]] {.
-  async:
-    (raises: [ValueError, DaemonLocalError, CancelledError, OSError, CatchableError])
+  async: (
+    raises: [
+      ValueError, DaemonLocalError, OSError, MaInvalidAddress, TransportError,
+      CancelledError, LPError, CatchableError,
+    ]
+  )
 .}
 
 proc copyEnv(): StringTableRef =
@@ -867,7 +875,12 @@ proc getPeerInfo(pb: ProtoBuffer): PeerInfo {.raises: [DaemonLocalError].} =
 
 proc identity*(
     api: DaemonAPI
-): Future[PeerInfo] {.async: (raises: [LPError, CancelledError, CatchableError]).} =
+): Future[PeerInfo] {.
+    async: (
+      raises:
+        [MaInvalidAddress, TransportError, CancelledError, LPError, CatchableError]
+    )
+.} =
   ## Get Node identity information
   var transp = await api.newConnection()
   try:
@@ -882,7 +895,12 @@ proc identity*(
 
 proc connect*(
     api: DaemonAPI, peer: PeerId, addresses: seq[MultiAddress], timeout = 0
-) {.async: (raises: [LPError, CatchableError]).} =
+) {.
+    async: (
+      raises:
+        [MaInvalidAddress, TransportError, CancelledError, LPError, CatchableError]
+    )
+.} =
   ## Connect to remote peer with id ``peer`` and addresses ``addresses``.
   var transp = await api.newConnection()
   try:
@@ -894,7 +912,12 @@ proc connect*(
 
 proc disconnect*(
     api: DaemonAPI, peer: PeerId
-) {.async: (raises: [LPError, CatchableError, TransportError]).} =
+) {.
+    async: (
+      raises:
+        [MaInvalidAddress, TransportError, CancelledError, LPError, CatchableError]
+    )
+.} =
   ## Disconnect from remote peer with id ``peer``.
   var transp = await api.newConnection()
   try:
@@ -906,7 +929,12 @@ proc disconnect*(
 
 proc openStream*(
     api: DaemonAPI, peer: PeerId, protocols: seq[string], timeout = 0
-): Future[P2PStream] {.async: (raises: [LPError, CatchableError]).} =
+): Future[P2PStream] {.
+    async: (
+      raises:
+        [MaInvalidAddress, TransportError, CancelledError, LPError, CatchableError]
+    )
+.} =
   ## Open new stream to peer ``peer`` using one of the protocols in
   ## ``protocols``. Returns ``StreamTransport`` for the stream.
   var transp = await api.newConnection()
@@ -951,7 +979,10 @@ proc streamHandler(server: StreamServer, transp: StreamTransport) {.async.} =
 
 proc addHandler*(
     api: DaemonAPI, protocols: seq[string], handler: P2PStreamCallback
-) {.async, raises: [LPError].} =
+) {.
+    async,
+    raises: [MaInvalidAddress, TransportError, CancelledError, LPError, CatchableError]
+.} =
   ## Add stream handler ``handler`` for set of protocols ``protocols``.
   var transp = await api.newConnection()
   let maddress = await getSocket(api.pattern, addr api.ucounter)
@@ -976,8 +1007,12 @@ proc addHandler*(
 proc listPeers*(
     api: DaemonAPI
 ): Future[seq[PeerInfo]] {.
-    async:
-      (raises: [ValueError, DaemonLocalError, CancelledError, OSError, CatchableError])
+    async: (
+      raises: [
+        ValueError, DaemonLocalError, OSError, MaInvalidAddress, TransportError,
+        CancelledError, LPError, CatchableError,
+      ]
+    )
 .} =
   ## Get list of remote peers to which we are currently connected.
   var transp = await api.newConnection()
@@ -997,8 +1032,10 @@ proc cmTagPeer*(
     api: DaemonAPI, peer: PeerId, tag: string, weight: int
 ) {.
     async: (
-      raises:
-        [LPError, DaemonLocalError, TransportError, CancelledError, CatchableError]
+      raises: [
+        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
+        CatchableError,
+      ]
     )
 .} =
   ## Tag peer with id ``peer`` using ``tag`` and ``weight``.
@@ -1014,8 +1051,10 @@ proc cmUntagPeer*(
     api: DaemonAPI, peer: PeerId, tag: string
 ) {.
     async: (
-      raises:
-        [LPError, DaemonLocalError, TransportError, CancelledError, CatchableError]
+      raises: [
+        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
+        CatchableError,
+      ]
     )
 .} =
   ## Remove tag ``tag`` from peer with id ``peer``.
@@ -1031,8 +1070,10 @@ proc cmTrimPeers*(
     api: DaemonAPI
 ) {.
     async: (
-      raises:
-        [LPError, DaemonLocalError, TransportError, CancelledError, CatchableError]
+      raises: [
+        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
+        CatchableError,
+      ]
     )
 .} =
   ## Trim all connections.
@@ -1110,8 +1151,10 @@ proc dhtFindPeer*(
     api: DaemonAPI, peer: PeerId, timeout = 0
 ): Future[PeerInfo] {.
     async: (
-      raises:
-        [LPError, DaemonLocalError, TransportError, CancelledError, CatchableError]
+      raises: [
+        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
+        CatchableError,
+      ]
     )
 .} =
   ## Find peer with id ``peer`` and return peer information ``PeerInfo``.
@@ -1130,8 +1173,10 @@ proc dhtGetPublicKey*(
     api: DaemonAPI, peer: PeerId, timeout = 0
 ): Future[PublicKey] {.
     async: (
-      raises:
-        [LPError, DaemonLocalError, TransportError, CancelledError, CatchableError]
+      raises: [
+        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
+        CatchableError,
+      ]
     )
 .} =
   ## Get peer's public key from peer with id ``peer``.
@@ -1150,8 +1195,10 @@ proc dhtGetValue*(
     api: DaemonAPI, key: string, timeout = 0
 ): Future[seq[byte]] {.
     async: (
-      raises:
-        [LPError, DaemonLocalError, TransportError, CancelledError, CatchableError]
+      raises: [
+        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
+        CatchableError,
+      ]
     )
 .} =
   ## Get value associated with ``key``.
@@ -1170,8 +1217,10 @@ proc dhtPutValue*(
     api: DaemonAPI, key: string, value: seq[byte], timeout = 0
 ) {.
     async: (
-      raises:
-        [LPError, DaemonLocalError, TransportError, CancelledError, CatchableError]
+      raises: [
+        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
+        CatchableError,
+      ]
     )
 .} =
   ## Associate ``value`` with ``key``.
@@ -1190,8 +1239,10 @@ proc dhtProvide*(
     api: DaemonAPI, cid: Cid, timeout = 0
 ) {.
     async: (
-      raises:
-        [LPError, DaemonLocalError, TransportError, CancelledError, CatchableError]
+      raises: [
+        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
+        CatchableError,
+      ]
     )
 .} =
   ## Provide content with id ``cid``.
@@ -1210,8 +1261,10 @@ proc dhtFindPeersConnectedToPeer*(
     api: DaemonAPI, peer: PeerId, timeout = 0
 ): Future[seq[PeerInfo]] {.
     async: (
-      raises:
-        [LPError, DaemonLocalError, TransportError, CancelledError, CatchableError]
+      raises: [
+        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
+        CatchableError,
+      ]
     )
 .} =
   ## Find peers which are connected to peer with id ``peer``.
@@ -1241,8 +1294,10 @@ proc dhtGetClosestPeers*(
     api: DaemonAPI, key: string, timeout = 0
 ): Future[seq[PeerId]] {.
     async: (
-      raises:
-        [LPError, DaemonLocalError, TransportError, CancelledError, CatchableError]
+      raises: [
+        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
+        CatchableError,
+      ]
     )
 .} =
   ## Get closest peers for ``key``.
@@ -1272,8 +1327,10 @@ proc dhtFindProviders*(
     api: DaemonAPI, cid: Cid, count: uint32, timeout = 0
 ): Future[seq[PeerInfo]] {.
     async: (
-      raises:
-        [LPError, DaemonLocalError, TransportError, CancelledError, CatchableError]
+      raises: [
+        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
+        CatchableError,
+      ]
     )
 .} =
   ## Get ``count`` providers for content with id ``cid``.
@@ -1303,8 +1360,10 @@ proc dhtSearchValue*(
     api: DaemonAPI, key: string, timeout = 0
 ): Future[seq[seq[byte]]] {.
     async: (
-      raises:
-        [LPError, DaemonLocalError, TransportError, CancelledError, CatchableError]
+      raises: [
+        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
+        CatchableError,
+      ]
     )
 .} =
   ## Search for value with ``key``, return list of values found.
@@ -1333,8 +1392,10 @@ proc pubsubGetTopics*(
     api: DaemonAPI
 ): Future[seq[string]] {.
     async: (
-      raises:
-        [LPError, DaemonLocalError, TransportError, CancelledError, CatchableError]
+      raises: [
+        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
+        CatchableError,
+      ]
     )
 .} =
   ## Get list of topics this node is subscribed to.
@@ -1353,8 +1414,10 @@ proc pubsubListPeers*(
     api: DaemonAPI, topic: string
 ): Future[seq[PeerId]] {.
     async: (
-      raises:
-        [LPError, DaemonLocalError, TransportError, CancelledError, CatchableError]
+      raises: [
+        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
+        CatchableError,
+      ]
     )
 .} =
   ## Get list of peers we are connected to and which also subscribed to topic
@@ -1375,8 +1438,10 @@ proc pubsubPublish*(
     api: DaemonAPI, topic: string, value: seq[byte]
 ) {.
     async: (
-      raises:
-        [LPError, DaemonLocalError, TransportError, CancelledError, CatchableError]
+      raises: [
+        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
+        CatchableError,
+      ]
     )
 .} =
   ## Get list of peer identifiers which are subscribed to topic ``topic``.

--- a/libp2p/daemon/daemonapi.nim
+++ b/libp2p/daemon/daemonapi.nim
@@ -515,12 +515,14 @@ proc recvMessage(
 proc newConnection*(
     api: DaemonAPI
 ): Future[StreamTransport] {.
-    raises: [MaInvalidAddress, TransportError, CancelledError, LPError]
+    async: (raises: [MaInvalidAddress, TransportError, CancelledError, LPError])
 .} =
-  result = connect(api.address)
+  await connect(api.address)
 
-proc closeConnection*(api: DaemonAPI, transp: StreamTransport): Future[void] =
-  result = transp.closeWait()
+proc closeConnection*(
+    api: DaemonAPI, transp: StreamTransport
+): Future[void] {.async: (raises: [CancelledError]).} =
+  await transp.closeWait()
 
 proc socketExists(address: MultiAddress): Future[bool] {.async: (raises: []).} =
   try:
@@ -578,7 +580,7 @@ proc listPeers*(
   async: (
     raises: [
       ValueError, DaemonLocalError, OSError, MaInvalidAddress, TransportError,
-      CancelledError, LPError, CatchableError,
+      CancelledError, LPError,
     ]
   )
 .}
@@ -628,7 +630,7 @@ proc newDaemonApi*(
     async: (
       raises: [
         ValueError, DaemonLocalError, CancelledError, LPError, OSError, IOError,
-        CatchableError,
+        AsyncError,
       ]
     )
 .} =
@@ -897,10 +899,7 @@ proc getPeerInfo(pb: ProtoBuffer): PeerInfo {.raises: [DaemonLocalError].} =
 proc identity*(
     api: DaemonAPI
 ): Future[PeerInfo] {.
-    async: (
-      raises:
-        [MaInvalidAddress, TransportError, CancelledError, LPError, CatchableError]
-    )
+    async: (raises: [MaInvalidAddress, TransportError, CancelledError, LPError])
 .} =
   ## Get Node identity information
   var transp = await api.newConnection()
@@ -916,12 +915,7 @@ proc identity*(
 
 proc connect*(
     api: DaemonAPI, peer: PeerId, addresses: seq[MultiAddress], timeout = 0
-) {.
-    async: (
-      raises:
-        [MaInvalidAddress, TransportError, CancelledError, LPError, CatchableError]
-    )
-.} =
+) {.async: (raises: [MaInvalidAddress, TransportError, CancelledError, LPError]).} =
   ## Connect to remote peer with id ``peer`` and addresses ``addresses``.
   var transp = await api.newConnection()
   try:
@@ -933,12 +927,7 @@ proc connect*(
 
 proc disconnect*(
     api: DaemonAPI, peer: PeerId
-) {.
-    async: (
-      raises:
-        [MaInvalidAddress, TransportError, CancelledError, LPError, CatchableError]
-    )
-.} =
+) {.async: (raises: [MaInvalidAddress, TransportError, CancelledError, LPError]).} =
   ## Disconnect from remote peer with id ``peer``.
   var transp = await api.newConnection()
   try:
@@ -1031,7 +1020,7 @@ proc listPeers*(
     async: (
       raises: [
         ValueError, DaemonLocalError, OSError, MaInvalidAddress, TransportError,
-        CancelledError, LPError, CatchableError,
+        CancelledError, LPError,
       ]
     )
 .} =
@@ -1053,10 +1042,8 @@ proc cmTagPeer*(
     api: DaemonAPI, peer: PeerId, tag: string, weight: int
 ) {.
     async: (
-      raises: [
-        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
-        CatchableError,
-      ]
+      raises:
+        [DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError]
     )
 .} =
   ## Tag peer with id ``peer`` using ``tag`` and ``weight``.
@@ -1072,10 +1059,8 @@ proc cmUntagPeer*(
     api: DaemonAPI, peer: PeerId, tag: string
 ) {.
     async: (
-      raises: [
-        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
-        CatchableError,
-      ]
+      raises:
+        [DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError]
     )
 .} =
   ## Remove tag ``tag`` from peer with id ``peer``.
@@ -1091,10 +1076,8 @@ proc cmTrimPeers*(
     api: DaemonAPI
 ) {.
     async: (
-      raises: [
-        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
-        CatchableError,
-      ]
+      raises:
+        [DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError]
     )
 .} =
   ## Trim all connections.
@@ -1172,10 +1155,8 @@ proc dhtFindPeer*(
     api: DaemonAPI, peer: PeerId, timeout = 0
 ): Future[PeerInfo] {.
     async: (
-      raises: [
-        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
-        CatchableError,
-      ]
+      raises:
+        [DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError]
     )
 .} =
   ## Find peer with id ``peer`` and return peer information ``PeerInfo``.
@@ -1194,10 +1175,8 @@ proc dhtGetPublicKey*(
     api: DaemonAPI, peer: PeerId, timeout = 0
 ): Future[PublicKey] {.
     async: (
-      raises: [
-        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
-        CatchableError,
-      ]
+      raises:
+        [DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError]
     )
 .} =
   ## Get peer's public key from peer with id ``peer``.
@@ -1216,10 +1195,8 @@ proc dhtGetValue*(
     api: DaemonAPI, key: string, timeout = 0
 ): Future[seq[byte]] {.
     async: (
-      raises: [
-        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
-        CatchableError,
-      ]
+      raises:
+        [DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError]
     )
 .} =
   ## Get value associated with ``key``.
@@ -1238,10 +1215,8 @@ proc dhtPutValue*(
     api: DaemonAPI, key: string, value: seq[byte], timeout = 0
 ) {.
     async: (
-      raises: [
-        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
-        CatchableError,
-      ]
+      raises:
+        [DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError]
     )
 .} =
   ## Associate ``value`` with ``key``.
@@ -1260,10 +1235,8 @@ proc dhtProvide*(
     api: DaemonAPI, cid: Cid, timeout = 0
 ) {.
     async: (
-      raises: [
-        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
-        CatchableError,
-      ]
+      raises:
+        [DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError]
     )
 .} =
   ## Provide content with id ``cid``.
@@ -1282,10 +1255,8 @@ proc dhtFindPeersConnectedToPeer*(
     api: DaemonAPI, peer: PeerId, timeout = 0
 ): Future[seq[PeerInfo]] {.
     async: (
-      raises: [
-        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
-        CatchableError,
-      ]
+      raises:
+        [DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError]
     )
 .} =
   ## Find peers which are connected to peer with id ``peer``.
@@ -1315,10 +1286,8 @@ proc dhtGetClosestPeers*(
     api: DaemonAPI, key: string, timeout = 0
 ): Future[seq[PeerId]] {.
     async: (
-      raises: [
-        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
-        CatchableError,
-      ]
+      raises:
+        [DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError]
     )
 .} =
   ## Get closest peers for ``key``.
@@ -1348,10 +1317,8 @@ proc dhtFindProviders*(
     api: DaemonAPI, cid: Cid, count: uint32, timeout = 0
 ): Future[seq[PeerInfo]] {.
     async: (
-      raises: [
-        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
-        CatchableError,
-      ]
+      raises:
+        [DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError]
     )
 .} =
   ## Get ``count`` providers for content with id ``cid``.
@@ -1381,10 +1348,8 @@ proc dhtSearchValue*(
     api: DaemonAPI, key: string, timeout = 0
 ): Future[seq[seq[byte]]] {.
     async: (
-      raises: [
-        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
-        CatchableError,
-      ]
+      raises:
+        [DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError]
     )
 .} =
   ## Search for value with ``key``, return list of values found.
@@ -1413,10 +1378,8 @@ proc pubsubGetTopics*(
     api: DaemonAPI
 ): Future[seq[string]] {.
     async: (
-      raises: [
-        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
-        CatchableError,
-      ]
+      raises:
+        [DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError]
     )
 .} =
   ## Get list of topics this node is subscribed to.
@@ -1435,10 +1398,8 @@ proc pubsubListPeers*(
     api: DaemonAPI, topic: string
 ): Future[seq[PeerId]] {.
     async: (
-      raises: [
-        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
-        CatchableError,
-      ]
+      raises:
+        [DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError]
     )
 .} =
   ## Get list of peers we are connected to and which also subscribed to topic
@@ -1459,10 +1420,8 @@ proc pubsubPublish*(
     api: DaemonAPI, topic: string, value: seq[byte]
 ) {.
     async: (
-      raises: [
-        DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError,
-        CatchableError,
-      ]
+      raises:
+        [DaemonLocalError, MaInvalidAddress, TransportError, CancelledError, LPError]
     )
 .} =
   ## Get list of peer identifiers which are subscribed to topic ``topic``.

--- a/libp2p/daemon/transpool.nim
+++ b/libp2p/daemon/transpool.nim
@@ -55,7 +55,7 @@ proc newPool*(
     address: TransportAddress,
     poolsize: int = DefaultPoolSize,
     bufferSize = DefaultStreamBufferSize,
-): Future[TransportPool] {.async: (raises: [CatchableError]).} =
+): Future[TransportPool] {.async: (raises: [CancelledError]).} =
   ## Establish pool of connections to address ``address`` with size
   ## ``poolsize``.
   var pool = new TransportPool
@@ -138,7 +138,7 @@ proc join*(
 
 proc close*(
     pool: TransportPool
-) {.async: (raises: [TransportPoolError, CatchableError]).} =
+) {.async: (raises: [TransportPoolError, CancelledError]).} =
   ## Closes transports pool ``pool`` and release all resources.
   if pool.state == Connected:
     pool.state = Closing

--- a/libp2p/utility.nim
+++ b/libp2p/utility.nim
@@ -71,23 +71,6 @@ proc capLen*[T](s: var seq[T], length: Natural) =
   if s.len > length:
     s.setLen(length)
 
-template exceptionToAssert*(body: untyped): untyped =
-  block:
-    var res: type(body)
-    when defined(nimHasWarnBareExcept):
-      {.push warning[BareExcept]: off.}
-    try:
-      res = body
-    except CatchableError as exc:
-      raise exc
-    except Defect as exc:
-      raise exc
-    except Exception as exc:
-      raiseAssert exc.msg
-    when defined(nimHasWarnBareExcept):
-      {.pop.}
-    res
-
 template withValue*[T](self: Opt[T] | Option[T], value, body: untyped): untyped =
   ## This template provides a convenient way to work with `Option` types in Nim.
   ## It allows you to execute a block of code (`body`) only when the `Option` is not empty.

--- a/libp2p/wire.nim
+++ b/libp2p/wire.nim
@@ -67,7 +67,9 @@ proc connect*(
     child: StreamTransport = nil,
     flags = default(set[SocketFlags]),
     localAddress: Opt[MultiAddress] = Opt.none(MultiAddress),
-): Future[StreamTransport] {.async.} =
+): Future[StreamTransport] {.
+    async: (raises: [MaInvalidAddress, TransportError, CancelledError, LPError])
+.} =
   ## Open new connection to remote peer with address ``ma`` and create
   ## new transport object ``StreamTransport`` for established connection.
   ## ``bufferSize`` is size of internal buffer for transport.

--- a/tests/commoninterop.nim
+++ b/tests/commoninterop.nim
@@ -185,7 +185,9 @@ proc commonInteropTests*(name: string, swCreator: SwitchCreator) =
       let daemonPeer = await daemonNode.identity()
 
       var testFuture = newFuture[void]("test.future")
-      proc daemonHandler(api: DaemonAPI, stream: P2PStream) {.async.} =
+      proc daemonHandler(
+          api: DaemonAPI, stream: P2PStream
+      ) {.async: (raises: [CatchableError]).} =
         check string.fromBytes(await stream.transp.readLp()) == "test 1"
         discard await stream.transp.writeLp("test 2")
         check string.fromBytes(await stream.transp.readLp()) == "test 3"
@@ -227,7 +229,9 @@ proc commonInteropTests*(name: string, swCreator: SwitchCreator) =
       let daemonPeer = await daemonNode.identity()
 
       var testFuture = newFuture[string]("test.future")
-      proc daemonHandler(api: DaemonAPI, stream: P2PStream) {.async.} =
+      proc daemonHandler(
+          api: DaemonAPI, stream: P2PStream
+      ) {.async: (raises: [CatchableError]).} =
         # We should perform `readLp()` instead of `readLine()`. `readLine()`
         # here reads actually length prefixed string.
         var line = await stream.transp.readLine()
@@ -351,7 +355,9 @@ proc commonInteropTests*(name: string, swCreator: SwitchCreator) =
       let daemonPeer = await daemonNode.identity()
 
       var testFuture = newFuture[string]("test.future")
-      proc daemonHandler(api: DaemonAPI, stream: P2PStream) {.async.} =
+      proc daemonHandler(
+          api: DaemonAPI, stream: P2PStream
+      ) {.async: (raises: [CatchableError]).} =
         # We should perform `readLp()` instead of `readLine()`. `readLine()`
         # here reads actually length prefixed string.
         var line = await stream.transp.readLine()
@@ -485,7 +491,9 @@ proc relayInteropTests*(name: string, relayCreator: SwitchCreator) =
       # TODO: This Future blocks the daemonHandler after sending the last message.
       # It exists because there's a strange behavior where stream.close sends
       # a Rst instead of Fin. We should investigate this at some point.
-      proc daemonHandler(api: DaemonAPI, stream: P2PStream) {.async.} =
+      proc daemonHandler(
+          api: DaemonAPI, stream: P2PStream
+      ) {.async: (raises: [CatchableError]).} =
         check "line1" == string.fromBytes(await stream.transp.readLp())
         discard await stream.transp.writeLp("line2")
         check "line3" == string.fromBytes(await stream.transp.readLp())

--- a/tests/testdaemon.nim
+++ b/tests/testdaemon.nim
@@ -28,7 +28,9 @@ proc connectStreamTest(): Future[bool] {.async.} =
 
   var testFuture = newFuture[string]("test.future")
 
-  proc streamHandler(api: DaemonAPI, stream: P2PStream) {.async.} =
+  proc streamHandler(
+      api: DaemonAPI, stream: P2PStream
+  ) {.async: (raises: [CatchableError]).} =
     var line = await stream.transp.readLine()
     testFuture.complete(line)
 


### PR DESCRIPTION
`CatchableError` in this PR where listed because `P2PStreamCallback` had it listed before in https://github.com/vacp2p/nim-libp2p/pull/1233 effort.

part of https://github.com/vacp2p/nim-libp2p/issues/962 effort.