### PR TITLE
chore: add trace log to analyse remote stream reset

### DIFF
--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -169,6 +169,7 @@ method readOnce*(
   ## channel must not be done from within a callback / read handler of another
   ## or the reads will lock each other.
   if s.remoteReset:
+    trace "reset stream in readOnce", s
     raise newLPStreamResetError()
   if s.localReset:
     raise newLPStreamClosedError()
@@ -201,6 +202,7 @@ proc prepareWrite(
   # prepareWrite is the slow path of writing a message - see conditions in
   # write
   if s.remoteReset:
+    trace "stream is reset when prepareWrite", s
     raise newLPStreamResetError()
   if s.closedLocal:
     raise newLPStreamClosedError()

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -269,10 +269,13 @@ method readOnce*(
   if channel.isReset:
     raise
       if channel.remoteReset:
+        trace "stream is remote reset when readOnce", channel = $channel
         newLPStreamResetError()
       elif channel.closedLocally:
+        trace "stream is closed locally when readOnce", channel = $channel
         newLPStreamClosedError()
       else:
+        trace "stream is down when readOnce", channel = $channel
         newLPStreamConnDownError()
   if channel.isEof:
     raise newLPStreamRemoteClosedError()
@@ -396,6 +399,7 @@ method write*(
   ##
   result = newFuture[void]("Yamux Send")
   if channel.remoteReset:
+    trace "stream is reset when write", channel = $channel
     result.fail(newLPStreamResetError())
     return result
   if channel.closedLocally or channel.isReset:


### PR DESCRIPTION
Add more debug logs. Interesting to analyse an issue discovered by @AlbertoSoutullo 