### PR TITLE
chore(protocol): handler to propagate CancelledError

### DIFF
--- a/examples/directchat.nim
+++ b/examples/directchat.nim
@@ -43,14 +43,16 @@ proc new(T: typedesc[ChatProto], c: Chat): T =
   let chatproto = T()
 
   # create handler for incoming connection
-  proc handle(stream: Connection, proto: string) {.async: (raises: []).} =
+  proc handle(stream: Connection, proto: string) {.async: (raises: [CancelledError]).} =
     try:
       if c.connected and not c.conn.closed:
         c.writeStdout "a chat session is already in progress - refusing incoming peer!"
       else:
         await c.handlePeer(stream)
-    except:
-      echo "exception in handler", getCurrentException().msg
+    except CancelledError as e:
+      raise e
+    except CatchableError as e:
+      echo "exception in handler", e.msg
     finally:
       await stream.close()
 

--- a/examples/helloworld.nim
+++ b/examples/helloworld.nim
@@ -11,12 +11,14 @@ type TestProto = ref object of LPProtocol # declare a custom protocol
 
 proc new(T: typedesc[TestProto]): T =
   # every incoming connections will be in handled in this closure
-  proc handle(conn: Connection, proto: string) {.async: (raises: []).} =
+  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
     try:
       echo "Got from remote - ", string.fromBytes(await conn.readLp(1024))
       await conn.writeLp("Roger p2p!")
-    except:
-      echo "exception in handler", getCurrentException().msg
+    except CancelledError as e:
+      raise e
+    except CatchableError as e:
+      echo "exception in handler", e.msg
     finally:
       # We must close the connections ourselves when we're done with it
       await conn.close()

--- a/examples/tutorial_2_customproto.nim
+++ b/examples/tutorial_2_customproto.nim
@@ -25,13 +25,15 @@ type TestProto = ref object of LPProtocol
 
 proc new(T: typedesc[TestProto]): T =
   # every incoming connections will in be handled in this closure
-  proc handle(conn: Connection, proto: string) {.async: (raises: []).} =
+  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
     # Read up to 1024 bytes from this connection, and transform them into
     # a string
     try:
       echo "Got from remote - ", string.fromBytes(await conn.readLp(1024))
-    except:
-      echo "exception in handler", getCurrentException().msg
+    except CancelledError as e:
+      raise e
+    except CatchableError as e:
+      echo "exception in handler", e.msg
     finally:
       await conn.close()
 

--- a/examples/tutorial_5_discovery.nim
+++ b/examples/tutorial_5_discovery.nim
@@ -34,11 +34,13 @@ proc createSwitch(rdv: RendezVous = RendezVous.new()): Switch =
 const DumbCodec = "/dumb/proto/1.0.0"
 type DumbProto = ref object of LPProtocol
 proc new(T: typedesc[DumbProto], nodeNumber: int): T =
-  proc handle(conn: Connection, proto: string) {.async: (raises: []).} =
+  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
     try:
       echo "Node", nodeNumber, " received: ", string.fromBytes(await conn.readLp(1024))
-    except:
-      echo "exception in handler", getCurrentException().msg
+    except CancelledError as e:
+      raise e
+    except CatchableError as e:
+      echo "exception in handler", e.msg
     finally:
       await conn.close()
 

--- a/libp2p/protocols/connectivity/dcutr/server.nim
+++ b/libp2p/protocols/connectivity/dcutr/server.nim
@@ -30,7 +30,9 @@ proc new*(
     connectTimeout = 15.seconds,
     maxDialableAddrs = 8,
 ): T =
-  proc handleStream(stream: Connection, proto: string) {.async: (raises: []).} =
+  proc handleStream(
+      stream: Connection, proto: string
+  ) {.async: (raises: [CancelledError]).} =
     var peerDialableAddrs: seq[MultiAddress]
     try:
       let connectMsg = DcutrMsg.decode(await stream.readLp(1024))
@@ -78,6 +80,7 @@ proc new*(
           fut.cancel()
     except CancelledError as err:
       trace "cancelled Dcutr receiver"
+      raise err
     except AllFuturesFailedError as err:
       debug "Dcutr receiver could not connect to the remote peer, " &
         "all connect attempts failed", peerDialableAddrs, description = err.msg

--- a/libp2p/protocols/connectivity/relay/client.nim
+++ b/libp2p/protocols/connectivity/relay/client.nim
@@ -304,7 +304,9 @@ proc new*(
     msgSize: msgSize,
     isCircuitRelayV1: circuitRelayV1,
   )
-  proc handleStream(conn: Connection, proto: string) {.async: (raises: []).} =
+  proc handleStream(
+      conn: Connection, proto: string
+  ) {.async: (raises: [CancelledError]).} =
     try:
       case proto
       of RelayV1Codec:
@@ -315,6 +317,7 @@ proc new*(
         await cl.handleHopStreamV2(conn)
     except CancelledError as exc:
       trace "cancelled client handler"
+      raise exc
     except CatchableError as exc:
       trace "exception in client handler", description = exc.msg, conn
     finally:

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -369,15 +369,18 @@ proc new*(
     isCircuitRelayV1: circuitRelayV1,
   )
 
-  proc handleStream(conn: Connection, proto: string) {.async: (raises: []).} =
+  proc handleStream(
+      conn: Connection, proto: string
+  ) {.async: (raises: [CancelledError]).} =
     try:
       case proto
       of RelayV2HopCodec:
         await r.handleHopStreamV2(conn)
       of RelayV1Codec:
         await r.handleStreamV1(conn)
-    except CancelledError:
+    except CancelledError as exc:
       trace "cancelled relayv2 handler"
+      raise exc
     except CatchableError as exc:
       debug "exception in relayv2 handler", description = exc.msg, conn
     finally:

--- a/libp2p/protocols/perf/server.nim
+++ b/libp2p/protocols/perf/server.nim
@@ -24,7 +24,7 @@ type Perf* = ref object of LPProtocol
 
 proc new*(T: typedesc[Perf]): T {.public.} =
   var p = T()
-  proc handle(conn: Connection, proto: string) {.async: (raises: []).} =
+  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
     var bytesRead = 0
     try:
       trace "Received benchmark performance check", conn
@@ -48,6 +48,7 @@ proc new*(T: typedesc[Perf]): T {.public.} =
         size -= toWrite
     except CancelledError as exc:
       trace "cancelled perf handler"
+      raise exc
     except CatchableError as exc:
       trace "exception in perf handler", description = exc.msg, conn
     finally:

--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -51,7 +51,7 @@ proc new*(
   ping
 
 method init*(p: Ping) =
-  proc handle(conn: Connection, proto: string) {.async: (raises: []).} =
+  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
     try:
       trace "handling ping", conn
       var buf: array[PingSize, byte]
@@ -62,6 +62,7 @@ method init*(p: Ping) =
         await p.pingHandler(conn.peerId)
     except CancelledError as exc:
       trace "cancelled ping handler"
+      raise exc
     except CatchableError as exc:
       trace "exception in ping handler", description = exc.msg, conn
 

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -177,17 +177,16 @@ method rpcHandler*(
   f.updateMetrics(rpcMsg)
 
 method init*(f: FloodSub) =
-  proc handler(conn: Connection, proto: string) {.async: (raises: []).} =
+  proc handler(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
     ## main protocol handler that gets triggered on every
     ## connection for a protocol string
     ## e.g. ``/floodsub/1.0.0``, etc...
     ##
     try:
       await f.handleConn(conn, proto)
-    except CancelledError:
-      # This is top-level procedure which will work as separate task, so it
-      # do not need to propagate CancelledError.
+    except CancelledError as exc:
       trace "Unexpected cancellation in floodsub handler", conn
+      raise exc
 
   f.handler = handler
   f.codec = FloodSubCodec

--- a/libp2p/protocols/rendezvous.nim
+++ b/libp2p/protocols/rendezvous.nim
@@ -741,7 +741,9 @@ proc new*(
   )
   logScope:
     topics = "libp2p discovery rendezvous"
-  proc handleStream(conn: Connection, proto: string) {.async: (raises: []).} =
+  proc handleStream(
+      conn: Connection, proto: string
+  ) {.async: (raises: [CancelledError]).} =
     try:
       let
         buf = await conn.readLp(4096)
@@ -757,8 +759,9 @@ proc new*(
         await rdv.discover(conn, msg.discover.tryGet())
       of MessageType.DiscoverResponse:
         trace "Got an unexpected Discover Response", response = msg.discoverResponse
-    except CancelledError:
+    except CancelledError as exc:
       trace "cancelled rendezvous handler"
+      raise exc
     except CatchableError as exc:
       trace "exception in rendezvous handler", description = exc.msg
     finally:

--- a/libp2p/protocols/secure/plaintext.nim
+++ b/libp2p/protocols/secure/plaintext.nim
@@ -17,7 +17,7 @@ const PlainTextCodec* = "/plaintext/1.0.0"
 type PlainText* = ref object of Secure
 
 method init(p: PlainText) {.gcsafe.} =
-  proc handle(conn: Connection, proto: string) {.async: (raises: []).} =
+  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
     ## plain text doesn't do anything
     discard
 

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -143,15 +143,16 @@ proc handleConn(
 method init*(s: Secure) =
   procCall LPProtocol(s).init()
 
-  proc handle(conn: Connection, proto: string) {.async: (raises: []).} =
+  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
     trace "handling connection upgrade", proto, conn
     try:
       # We don't need the result but we
       # definitely need to await the handshake
       discard await s.handleConn(conn, false, Opt.none(PeerId))
       trace "connection secured", conn
-    except CancelledError:
+    except CancelledError as exc:
       warn "securing connection canceled", conn
+      raise exc
     except LPStreamError as exc:
       warn "securing connection failed", description = exc.msg, conn
     finally:

--- a/tests/commoninterop.nim
+++ b/tests/commoninterop.nim
@@ -253,12 +253,16 @@ proc commonInteropTests*(name: string, swCreator: SwitchCreator) =
       var test = "TEST STRING"
 
       var testFuture = newFuture[string]("test.future")
-      proc nativeHandler(conn: Connection, proto: string) {.async: (raises: []).} =
+      proc nativeHandler(
+          conn: Connection, proto: string
+      ) {.async: (raises: [CancelledError]).} =
         try:
           var line = string.fromBytes(await conn.readLp(1024))
           check line == test
           testFuture.complete(line)
-        except:
+        except CancelledError as e:
+          raise e
+        except CatchableError:
           check false # should not be here
         finally:
           await conn.close()
@@ -292,12 +296,16 @@ proc commonInteropTests*(name: string, swCreator: SwitchCreator) =
       var test = "TEST STRING"
 
       var testFuture = newFuture[string]("test.future")
-      proc nativeHandler(conn: Connection, proto: string) {.async: (raises: []).} =
+      proc nativeHandler(
+          conn: Connection, proto: string
+      ) {.async: (raises: [CancelledError]).} =
         try:
           var line = string.fromBytes(await conn.readLp(1024))
           check line == test
           testFuture.complete(line)
-        except:
+        except CancelledError as e:
+          raise e
+        except CatchableError:
           check false # should not be here
         finally:
           await conn.close()
@@ -386,7 +394,9 @@ proc commonInteropTests*(name: string, swCreator: SwitchCreator) =
       var protos = @["/test-stream"]
 
       var testFuture = newFuture[void]("test.future")
-      proc nativeHandler(conn: Connection, proto: string) {.async: (raises: []).} =
+      proc nativeHandler(
+          conn: Connection, proto: string
+      ) {.async: (raises: [CancelledError]).} =
         try:
           check "test 1" == string.fromBytes(await conn.readLp(1024))
           await conn.writeLp("test 2".toBytes())
@@ -395,7 +405,9 @@ proc commonInteropTests*(name: string, swCreator: SwitchCreator) =
           await conn.writeLp("test 4".toBytes())
 
           testFuture.complete()
-        except:
+        except CancelledError as e:
+          raise e
+        except CatchableError:
           check false # should not be here
         finally:
           await conn.close()
@@ -434,7 +446,9 @@ proc commonInteropTests*(name: string, swCreator: SwitchCreator) =
 
       var count = 0
       var testFuture = newFuture[int]("test.future")
-      proc nativeHandler(conn: Connection, proto: string) {.async: (raises: []).} =
+      proc nativeHandler(
+          conn: Connection, proto: string
+      ) {.async: (raises: [CancelledError]).} =
         try:
           while count < 10:
             var line = string.fromBytes(await conn.readLp(1024))
@@ -443,7 +457,9 @@ proc commonInteropTests*(name: string, swCreator: SwitchCreator) =
             count.inc()
 
           testFuture.complete(count)
-        except:
+        except CancelledError as e:
+          raise e
+        except CatchableError:
           check false # should not be here
         finally:
           await conn.close()
@@ -548,13 +564,17 @@ proc relayInteropTests*(name: string, relayCreator: SwitchCreator) =
       await daemonNode.close()
 
     asyncTest "DaemonSrc -> NativeRelay -> NativeDst":
-      proc customHandler(conn: Connection, proto: string) {.async: (raises: []).} =
+      proc customHandler(
+          conn: Connection, proto: string
+      ) {.async: (raises: [CancelledError]).} =
         try:
           check "line1" == string.fromBytes(await conn.readLp(1024))
           await conn.writeLp("line2")
           check "line3" == string.fromBytes(await conn.readLp(1024))
           await conn.writeLp("line4")
-        except:
+        except CancelledError as e:
+          raise e
+        except CatchableError:
           check false # should not be here
         finally:
           await conn.close()
@@ -591,13 +611,17 @@ proc relayInteropTests*(name: string, relayCreator: SwitchCreator) =
       await daemonNode.close()
 
     asyncTest "NativeSrc -> DaemonRelay -> NativeDst":
-      proc customHandler(conn: Connection, proto: string) {.async: (raises: []).} =
+      proc customHandler(
+          conn: Connection, proto: string
+      ) {.async: (raises: [CancelledError]).} =
         try:
           check "line1" == string.fromBytes(await conn.readLp(1024))
           await conn.writeLp("line2")
           check "line3" == string.fromBytes(await conn.readLp(1024))
           await conn.writeLp("line4")
-        except:
+        except CancelledError as e:
+          raise e
+        except CatchableError:
           check false # should not be here
         finally:
           await conn.close()

--- a/tests/testautonat.nim
+++ b/tests/testautonat.nim
@@ -42,7 +42,7 @@ proc makeAutonatServicePrivate(): Switch =
   var autonatProtocol = new LPProtocol
   autonatProtocol.handler = proc(
       conn: Connection, proto: string
-  ) {.async: (raises: []).} =
+  ) {.async: (raises: [CancelledError]).} =
     try:
       discard await conn.readLp(1024)
       await conn.writeLp(
@@ -50,7 +50,9 @@ proc makeAutonatServicePrivate(): Switch =
           status: DialError, text: Opt.some("dial failed"), ma: Opt.none(MultiAddress)
         ).encode().buffer
       )
-    except:
+    except CancelledError as e:
+      raise e
+    except CatchableError:
       check false # should not be here
     finally:
       await conn.close()

--- a/tests/testmultistream.nim
+++ b/tests/testmultistream.nim
@@ -225,7 +225,7 @@ suite "Multistream select":
     var protocol: LPProtocol = new LPProtocol
     proc testHandler(
         conn: Connection, proto: string
-    ): Future[void] {.async: (raises: []).} =
+    ): Future[void] {.async: (raises: [CancelledError]).} =
       check proto == "/test/proto/1.0.0"
       await conn.close()
 
@@ -250,7 +250,7 @@ suite "Multistream select":
 
     proc testHandler(
         conn: Connection, proto: string
-    ): Future[void] {.async: (raises: []).} =
+    ): Future[void] {.async: (raises: [CancelledError]).} =
       discard
 
     var protocol: LPProtocol = new LPProtocol
@@ -275,7 +275,7 @@ suite "Multistream select":
     var protocol: LPProtocol = new LPProtocol
     proc testHandler(
         conn: Connection, proto: string
-    ): Future[void] {.async: (raises: []).} =
+    ): Future[void] {.async: (raises: [CancelledError]).} =
       discard
 
     protocol.handler = testHandler
@@ -289,11 +289,13 @@ suite "Multistream select":
     var protocol: LPProtocol = new LPProtocol
     proc testHandler(
         conn: Connection, proto: string
-    ): Future[void] {.async: (raises: []).} =
+    ): Future[void] {.async: (raises: [CancelledError]).} =
       check proto == "/test/proto/1.0.0"
       try:
         await conn.writeLp("Hello!")
-      except:
+      except CancelledError as e:
+        raise e
+      except CatchableError:
         check false # should not be here
       finally:
         await conn.close()
@@ -336,11 +338,13 @@ suite "Multistream select":
     # Unblock the 5 streams, check that we can open a new one
     proc testHandler(
         conn: Connection, proto: string
-    ): Future[void] {.async: (raises: []).} =
+    ): Future[void] {.async: (raises: [CancelledError]).} =
       try:
         await blocker
         await conn.writeLp("Hello!")
-      except:
+      except CancelledError as e:
+        raise e
+      except CatchableError:
         check false # should not be here
       finally:
         await conn.close()
@@ -410,13 +414,15 @@ suite "Multistream select":
 
     let msListen = MultistreamSelect.new()
     var protocol: LPProtocol = new LPProtocol
-    protocol.handler = proc(conn: Connection, proto: string) {.async: (raises: []).} =
+    protocol.handler = proc(
+        conn: Connection, proto: string
+    ) {.async: (raises: [CancelledError]).} =
       # never reached
       discard
 
     proc testHandler(
         conn: Connection, proto: string
-    ): Future[void] {.async: (raises: []).} =
+    ): Future[void] {.async: (raises: [CancelledError]).} =
       # never reached
       discard
 
@@ -460,11 +466,13 @@ suite "Multistream select":
     var protocol: LPProtocol = new LPProtocol
     proc testHandler(
         conn: Connection, proto: string
-    ): Future[void] {.async: (raises: []).} =
+    ): Future[void] {.async: (raises: [CancelledError]).} =
       check proto == "/test/proto/1.0.0"
       try:
         await conn.writeLp("Hello!")
-      except:
+      except CancelledError as e:
+        raise e
+      except CatchableError:
         check false # should not be here
       finally:
         await conn.close()
@@ -502,10 +510,12 @@ suite "Multistream select":
     var protocol: LPProtocol = new LPProtocol
     proc testHandler(
         conn: Connection, proto: string
-    ): Future[void] {.async: (raises: []).} =
+    ): Future[void] {.async: (raises: [CancelledError]).} =
       try:
         await conn.writeLp(&"Hello from {proto}!")
-      except:
+      except CancelledError as e:
+        raise e
+      except CatchableError:
         check false # should not be here
       finally:
         await conn.close()

--- a/tests/testnoise.nim
+++ b/tests/testnoise.nim
@@ -42,12 +42,14 @@ type TestProto = ref object of LPProtocol
 {.push raises: [].}
 
 method init(p: TestProto) {.gcsafe.} =
-  proc handle(conn: Connection, proto: string) {.async: (raises: []).} =
+  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
     try:
       let msg = string.fromBytes(await conn.readLp(1024))
       check "Hello!" == msg
       await conn.writeLp("Hello!")
-    except:
+    except CancelledError as e:
+      raise e
+    except CatchableError:
       check false # should not be here
     finally:
       await conn.close()

--- a/tests/testping.nim
+++ b/tests/testping.nim
@@ -96,14 +96,18 @@ suite "Ping":
   asyncTest "bad ping data ack":
     type FakePing = ref object of LPProtocol
     let fakePingProto = FakePing()
-    proc fakeHandle(conn: Connection, proto: string) {.async: (raises: []).} =
+    proc fakeHandle(
+        conn: Connection, proto: string
+    ) {.async: (raises: [CancelledError]).} =
       try:
         var
           buf: array[32, byte]
           fakebuf: array[32, byte]
         await conn.readExactly(addr buf[0], 32)
         await conn.write(@fakebuf)
-      except:
+      except CancelledError as e:
+        raise e
+      except CatchableError as e:
         check false # should not be here
 
     fakePingProto.codec = PingCodec

--- a/tests/testrelayv1.nim
+++ b/tests/testrelayv1.nim
@@ -81,13 +81,17 @@ suite "Circuit Relay":
     check:
       m.dstPeer == dst
 
-  proc customHandler(conn: Connection, proto: string) {.async: (raises: []).} =
+  proc customHandler(
+      conn: Connection, proto: string
+  ) {.async: (raises: [CancelledError]).} =
     try:
       check "line1" == string.fromBytes(await conn.readLp(1024))
       await conn.writeLp("line2")
       check "line3" == string.fromBytes(await conn.readLp(1024))
       await conn.writeLp("line4")
-    except:
+    except CancelledError as e:
+      raise e
+    except CatchableError:
       check false # should not be here
     finally:
       await conn.close()

--- a/tests/testrelayv2.nim
+++ b/tests/testrelayv2.nim
@@ -173,7 +173,9 @@ suite "Circuit Relay V2":
         rel = createSwitch(nil, useYamux)
 
       asyncTest "Connection succeed":
-        proto.handler = proc(conn: Connection, proto: string) {.async: (raises: []).} =
+        proto.handler = proc(
+            conn: Connection, proto: string
+        ) {.async: (raises: [CancelledError]).} =
           try:
             check:
               "test1" == string.fromBytes(await conn.readLp(1024))
@@ -181,7 +183,9 @@ suite "Circuit Relay V2":
             check:
               "test3" == string.fromBytes(await conn.readLp(1024))
             await conn.writeLp("test4")
-          except:
+          except CancelledError as e:
+            raise e
+          except CatchableError:
             check false # should not be here
           finally:
             await conn.close()
@@ -221,7 +225,9 @@ suite "Circuit Relay V2":
 
       asyncTest "Connection duration exceeded":
         ldur = 3
-        proto.handler = proc(conn: Connection, proto: string) {.async: (raises: []).} =
+        proto.handler = proc(
+            conn: Connection, proto: string
+        ) {.async: (raises: [CancelledError]).} =
           try:
             check "wanna sleep?" == string.fromBytes(await conn.readLp(1024))
             await conn.writeLp("yeah!")
@@ -229,6 +235,8 @@ suite "Circuit Relay V2":
             await sleepAsync(chronos.timer.seconds(ldur + 1))
             await conn.writeLp("that was a cool power nap")
             check false # must not be here - should timeout
+          except CancelledError as e:
+            raise e
           except CatchableError:
             discard # will get here after timeout
           finally:
@@ -268,7 +276,9 @@ suite "Circuit Relay V2":
 
       asyncTest "Connection data exceeded":
         ldata = 1000
-        proto.handler = proc(conn: Connection, proto: string) {.async: (raises: []).} =
+        proto.handler = proc(
+            conn: Connection, proto: string
+        ) {.async: (raises: [CancelledError]).} =
           try:
             check "count me the better story you know" ==
               string.fromBytes(await conn.readLp(1024))
@@ -291,6 +301,8 @@ suite "Circuit Relay V2":
     philosophical flourish Cato throws himself upon his sword; I quietly
     take to the ship."""
             )
+          except CancelledError as e:
+            raise e
           except CatchableError:
             discard # will get here after data exceeded
           finally:
@@ -331,7 +343,9 @@ suite "Circuit Relay V2":
 
       asyncTest "Reservation ttl expire during connection":
         ttl = 3
-        proto.handler = proc(conn: Connection, proto: string) {.async: (raises: []).} =
+        proto.handler = proc(
+            conn: Connection, proto: string
+        ) {.async: (raises: [CancelledError]).} =
           try:
             check:
               "test1" == string.fromBytes(await conn.readLp(1024))
@@ -339,7 +353,9 @@ suite "Circuit Relay V2":
             check:
               "test3" == string.fromBytes(await conn.readLp(1024))
             await conn.writeLp("test4")
-          except:
+          except CancelledError as e:
+            raise e
+          except CatchableError:
             check false # should not be here
           finally:
             await conn.close()
@@ -388,7 +404,9 @@ suite "Circuit Relay V2":
         # rel2 reserve rel
         # dst reserve rel2
         # src try to connect with dst
-        proto.handler = proc(conn: Connection, proto: string) {.async: (raises: []).} =
+        proto.handler = proc(
+            conn: Connection, proto: string
+        ) {.async: (raises: [CancelledError]).} =
           check false # should not be here
 
         let
@@ -435,7 +453,7 @@ suite "Circuit Relay V2":
         protoABC.codec = "/abctest"
         protoABC.handler = proc(
             conn: Connection, proto: string
-        ) {.async: (raises: []).} =
+        ) {.async: (raises: [CancelledError]).} =
           try:
             check:
               "testABC1" == string.fromBytes(await conn.readLp(1024))
@@ -443,14 +461,16 @@ suite "Circuit Relay V2":
             check:
               "testABC3" == string.fromBytes(await conn.readLp(1024))
             await conn.writeLp("testABC4")
-          except:
+          except CancelledError as e:
+            raise e
+          except CatchableError:
             check false # should not be here
           finally:
             await conn.close()
         protoBCA.codec = "/bcatest"
         protoBCA.handler = proc(
             conn: Connection, proto: string
-        ) {.async: (raises: []).} =
+        ) {.async: (raises: [CancelledError]).} =
           try:
             check:
               "testBCA1" == string.fromBytes(await conn.readLp(1024))
@@ -458,14 +478,16 @@ suite "Circuit Relay V2":
             check:
               "testBCA3" == string.fromBytes(await conn.readLp(1024))
             await conn.writeLp("testBCA4")
-          except:
+          except CancelledError as e:
+            raise e
+          except CatchableError:
             check false # should not be here
           finally:
             await conn.close()
         protoCAB.codec = "/cabtest"
         protoCAB.handler = proc(
             conn: Connection, proto: string
-        ) {.async: (raises: []).} =
+        ) {.async: (raises: [CancelledError]).} =
           try:
             check:
               "testCAB1" == string.fromBytes(await conn.readLp(1024))
@@ -473,7 +495,9 @@ suite "Circuit Relay V2":
             check:
               "testCAB3" == string.fromBytes(await conn.readLp(1024))
             await conn.writeLp("testCAB4")
-          except:
+          except CancelledError as e:
+            raise e
+          except CatchableError:
             check false # should not be here
           finally:
             await conn.close()

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -49,12 +49,14 @@ suite "Switch":
 
   asyncTest "e2e use switch dial proto string":
     let done = newFuture[void]()
-    proc handle(conn: Connection, proto: string) {.async: (raises: []).} =
+    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
       try:
         let msg = string.fromBytes(await conn.readLp(1024))
         check "Hello!" == msg
         await conn.writeLp("Hello!")
-      except:
+      except CancelledError as e:
+        raise e
+      except CatchableError:
         check false # should not be here
       finally:
         await conn.close()
@@ -89,12 +91,14 @@ suite "Switch":
 
   asyncTest "e2e use switch dial proto string with custom matcher":
     let done = newFuture[void]()
-    proc handle(conn: Connection, proto: string) {.async: (raises: []).} =
+    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
       try:
         let msg = string.fromBytes(await conn.readLp(1024))
         check "Hello!" == msg
         await conn.writeLp("Hello!")
-      except:
+      except CancelledError as e:
+        raise e
+      except CatchableError:
         check false # should not be here
       finally:
         await conn.close()
@@ -134,12 +138,14 @@ suite "Switch":
 
   asyncTest "e2e should not leak bufferstreams and connections on channel close":
     let done = newFuture[void]()
-    proc handle(conn: Connection, proto: string) {.async: (raises: []).} =
+    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
       try:
         let msg = string.fromBytes(await conn.readLp(1024))
         check "Hello!" == msg
         await conn.writeLp("Hello!")
-      except:
+      except CancelledError as e:
+        raise e
+      except CatchableError:
         check false # should not be here
       finally:
         await conn.close()
@@ -173,12 +179,14 @@ suite "Switch":
     check not switch2.isConnected(switch1.peerInfo.peerId)
 
   asyncTest "e2e use connect then dial":
-    proc handle(conn: Connection, proto: string) {.async: (raises: []).} =
+    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
       try:
         let msg = string.fromBytes(await conn.readLp(1024))
         check "Hello!" == msg
         await conn.writeLp("Hello!")
-      except:
+      except CancelledError as e:
+        raise e
+      except CatchableError:
         check false # should not be here
       finally:
         await conn.close()
@@ -664,9 +672,11 @@ suite "Switch":
     await allFuturesThrowing(transport.stop(), switch.stop())
 
   asyncTest "e2e calling closeWithEOF on the same stream should not assert":
-    proc handle(conn: Connection, proto: string) {.async: (raises: []).} =
+    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
       try:
         discard await conn.readLp(100)
+      except CancelledError as e:
+        raise e
       except CatchableError:
         check true # should be here
 
@@ -820,12 +830,14 @@ suite "Switch":
 
   asyncTest "e2e peer store":
     let done = newFuture[void]()
-    proc handle(conn: Connection, proto: string) {.async: (raises: []).} =
+    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
       try:
         let msg = string.fromBytes(await conn.readLp(1024))
         check "Hello!" == msg
         await conn.writeLp("Hello!")
-      except:
+      except CancelledError as e:
+        raise e
+      except CatchableError:
         check false # should not be here
       finally:
         await conn.close()
@@ -872,12 +884,14 @@ suite "Switch":
       # this randomly locks the Windows CI job
       skip()
       return
-    proc handle(conn: Connection, proto: string) {.async: (raises: []).} =
+    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
       try:
         let msg = string.fromBytes(await conn.readLp(1024))
         check "Hello!" == msg
         await conn.writeLp("Hello!")
-      except:
+      except CancelledError as e:
+        raise e
+      except CatchableError:
         check false # should not be here
       finally:
         await conn.close()
@@ -1050,11 +1064,13 @@ suite "Switch":
     await srcSwitch.stop()
 
   asyncTest "mount unstarted protocol":
-    proc handle(conn: Connection, proto: string) {.async: (raises: []).} =
+    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
       try:
         check "test123" == string.fromBytes(await conn.readLp(1024))
         await conn.writeLp("test456")
-      except:
+      except CancelledError as e:
+        raise e
+      except CatchableError:
         check false # should not be here
       finally:
         await conn.close()


### PR DESCRIPTION
initially `LPProtoHandler` has specified zero raised exceptions. this PR is adding `CancelledError` as only exception to the list.

part of https://github.com/vacp2p/nim-libp2p/issues/1270 effort.