### PR TITLE
feat(certificate): set distinguishable issuer name with peer id

### DIFF
--- a/tests/transports/tls/testcertificate.nim
+++ b/tests/transports/tls/testcertificate.nim
@@ -4,12 +4,6 @@ import ../../../libp2p/transports/tls/certificate
 import ../../../libp2p/crypto/crypto
 import ../../../libp2p/peerid
 
-func publicKey*(cert: P2pCertificate): PublicKey =
-  return PublicKey.init(cert.extension.publicKey).get()
-
-func peerId*(cert: P2pCertificate): PeerId =
-  return PeerId.init(cert.publicKey()).tryGet()
-
 suite "Certificate roundtrip tests":
   test "generate then parse with DER ecoding":
     let schemes = @[Ed25519, Secp256k1, ECDSA]


### PR DESCRIPTION
- setting distinguishable issuer name for certificate. each peer id is like organization that issues self signed certificates for themself, so it makes sense to have peer id as CN. other implementations like [go-libp2p](https://github.com/vladopajic/go-libp2p/blob/tls-certificate-test-vector/p2p/security/tls/crypto.go#L284) are also setting unique issuer for each certificate (but generating random id seems unnecessary when we can use peer id).

- moved utilities from test since `certificate.nim` now imports `peerid.nim`