### PR TITLE
refactor: use openssl instead of mbedtls

### DIFF
--- a/.pinned
+++ b/.pinned
@@ -5,7 +5,6 @@ dnsclient;https://github.com/ba0f3/dnsclient.nim@#23214235d4784d24aceed99bbfe153
 faststreams;https://github.com/status-im/nim-faststreams@#720fc5e5c8e428d9d0af618e1e27c44b42350309
 httputils;https://github.com/status-im/nim-http-utils@#3b491a40c60aad9e8d3407443f46f62511e63b18
 json_serialization;https://github.com/status-im/nim-json-serialization@#85b7ea093cb85ee4f433a617b97571bd709d30df
-mbedtls;https://github.com/status-im/nim-mbedtls.git@#b9ee2b8cd8990d32afc227a4d64fb22441160704
 metrics;https://github.com/status-im/nim-metrics@#6142e433fc8ea9b73379770a788017ac528d46ff
 ngtcp2;https://github.com/status-im/nim-ngtcp2@#6834f4756b6af58356ac9c4fef3d71db3c3ae5fe
 nimcrypto;https://github.com/cheatfate/nimcrypto@#1c8d6e3caf3abc572136ae9a1da81730c4eb4288

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -11,8 +11,7 @@ requires "nim >= 1.6.0",
   "nimcrypto >= 0.6.0 & < 0.7.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.5",
   "chronicles >= 0.10.2", "chronos >= 4.0.3", "metrics", "secp256k1", "stew#head",
   "websock", "unittest2",
-  "https://github.com/status-im/nim-quic.git#ddcb31ffb74b5460ab37fd13547eca90594248bc",
-  "https://github.com/status-im/nim-mbedtls.git"
+  "https://github.com/status-im/nim-quic.git#ddcb31ffb74b5460ab37fd13547eca90594248bc"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use
 let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)

--- a/libp2p/transports/tls/certificate.c
+++ b/libp2p/transports/tls/certificate.c
@@ -1,0 +1,879 @@
+#include <openssl/bn.h>
+#include <openssl/core_names.h>
+#include <openssl/ec.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/objects.h>
+#include <openssl/param_build.h>
+#include <openssl/pem.h>
+#include <openssl/rand.h>
+#include <openssl/types.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "certificate.h"
+
+#define LIBP2P_OID "1.3.6.1.4.1.53594.1.1"
+
+struct cert_context_s {
+  OSSL_LIB_CTX *lib_ctx; /* OpenSSL library context */
+  EVP_RAND_CTX *drbg;    /* DRBG context */
+};
+
+struct cert_key_s {
+  EVP_PKEY *pkey; /* OpenSSL EVP_PKEY */
+};
+
+// Function to initialize CTR_DRBG
+cert_error_t cert_init_drbg(const char *seed, size_t seed_len,
+                            cert_context_t *ctx) {
+  if (!seed) {
+    return CERT_ERROR_NULL_PARAM;
+  }
+
+  // Allocate context
+  struct cert_context_s *c = calloc(1, sizeof(struct cert_context_s));
+  if (c == NULL) {
+    return CERT_ERROR_MEMORY;
+  }
+
+  EVP_RAND_CTX *drbg = NULL;
+  EVP_RAND *rand_algo = NULL;
+  OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new(); // Create a new library context
+
+  if (!libctx) {
+    return CERT_ERROR_MEMORY;
+  }
+
+  rand_algo = EVP_RAND_fetch(libctx, "CTR-DRBG", NULL);
+  if (!rand_algo) {
+    return CERT_ERROR_DRBG_INIT;
+  }
+
+  drbg = EVP_RAND_CTX_new(rand_algo, NULL);
+  EVP_RAND_free(rand_algo); // Free the algorithm object, no longer needed
+  if (!drbg) {
+    return CERT_ERROR_MEMORY;
+  }
+
+  OSSL_PARAM params[2];
+  params[0] = OSSL_PARAM_construct_utf8_string(OSSL_DRBG_PARAM_CIPHER,
+                                               "AES-256-CTR", 0);
+  params[1] = OSSL_PARAM_construct_end();
+
+  if (!EVP_RAND_CTX_set_params(drbg, params)) {
+    RANDerr(0, RAND_R_ERROR_INITIALISING_DRBG);
+    EVP_RAND_CTX_free(drbg);
+    return CERT_ERROR_DRBG_CONFIG;
+  }
+
+  int res = EVP_RAND_instantiate(drbg, 0, 0, (const unsigned char *)seed,
+                                 seed_len, NULL);
+  if (res != 1) {
+
+    EVP_RAND_CTX_free(drbg);
+    return CERT_ERROR_DRBG_SEED;
+  }
+
+  c->lib_ctx = libctx;
+  c->drbg = drbg;
+  *ctx = c;
+
+  return CERT_SUCCESS;
+}
+
+// Function to free CTR_DRBG context resources
+void cert_free_ctr_drbg(cert_context_t ctx) {
+  if (ctx == NULL)
+    return;
+
+  struct cert_context_s *c = (struct cert_context_s *)ctx;
+  EVP_RAND_CTX_free(c->drbg);
+  OSSL_LIB_CTX_free(c->lib_ctx);
+  free(c);
+}
+
+// Function to ensure the libp2p OID is registered
+int ensure_libp2p_oid() {
+  int nid = OBJ_txt2nid(LIBP2P_OID);
+  if (nid == NID_undef) {
+    // OID not yet registered, create it
+    nid = OBJ_create(LIBP2P_OID, "libp2p_tls", "libp2p TLS extension");
+    if (!nid) {
+      return 0;
+    }
+  }
+  return nid;
+}
+
+// Function to generate a key
+cert_error_t cert_generate_key(cert_context_t ctx, cert_key_t *out) {
+  unsigned char priv_key_bytes[32]; // 256 bits for secp256r1
+  EC_KEY *ec_key = NULL;
+  BIGNUM *priv_bn = NULL;
+  EVP_PKEY *pkey = NULL;
+  cert_error_t ret_code = CERT_SUCCESS;
+
+  if (ctx == NULL || out == NULL) {
+    return CERT_ERROR_NULL_PARAM;
+  }
+
+  // Allocate key structure
+  struct cert_key_s *key = calloc(1, sizeof(struct cert_key_s));
+  if (key == NULL) {
+    return CERT_ERROR_MEMORY;
+  }
+
+  // Generate random bytes for private key using our RNG
+  if (EVP_RAND_generate(ctx->drbg, priv_key_bytes, sizeof(priv_key_bytes), 0, 0,
+                        NULL, 0) <= 0) {
+    ret_code = CERT_ERROR_RAND;
+    goto cleanup;
+  }
+
+  // Create EC key from random bytes
+  ec_key = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);
+  if (!ec_key) {
+    ret_code = CERT_ERROR_ECKEY_GEN;
+    goto cleanup;
+  }
+
+  // Convert bytes to BIGNUM for private key
+  priv_bn = BN_bin2bn(priv_key_bytes, sizeof(priv_key_bytes), NULL);
+  if (!priv_bn) {
+    ret_code = CERT_ERROR_BIGNUM_CONV;
+    goto cleanup;
+  }
+
+  // Set private key and compute public key
+  if (!EC_KEY_set_private_key(ec_key, priv_bn)) {
+    ret_code = CERT_ERROR_SET_KEY;
+    goto cleanup;
+  }
+
+  // Generate the public key from the private key
+  if (!EC_KEY_generate_key(ec_key)) {
+    ret_code = CERT_ERROR_KEY_GEN;
+    goto cleanup;
+  }
+
+  // Convert EC_KEY to EVP_PKEY
+  pkey = EVP_PKEY_new();
+  if (!pkey || !EVP_PKEY_set1_EC_KEY(pkey, ec_key)) {
+    ret_code = CERT_ERROR_EVP_PKEY_EC_KEY;
+    goto cleanup;
+  }
+
+  key->pkey = pkey;
+  *out = key;
+
+cleanup:
+  OPENSSL_cleanse(priv_key_bytes, sizeof(priv_key_bytes));
+  if (ec_key)
+    EC_KEY_free(ec_key);
+  if (priv_bn)
+    BN_free(priv_bn);
+  if (ret_code != CERT_SUCCESS) {
+    if (pkey)
+      EVP_PKEY_free(pkey);
+    free(key);
+    *out = NULL;
+  }
+
+  return ret_code;
+}
+
+int init_cert_buffer(cert_buffer **buffer, const unsigned char *src_data,
+                     size_t data_len) {
+  if (!buffer) {
+    return CERT_ERROR_NULL_PARAM;
+  }
+
+  *buffer = (cert_buffer *)malloc(sizeof(cert_buffer));
+  if (!*buffer) {
+    return CERT_ERROR_MEMORY;
+  }
+  memset(*buffer, 0, sizeof(cert_buffer));
+
+  (*buffer)->data = (unsigned char *)malloc(data_len);
+  if (!(*buffer)->data) {
+    free(*buffer);
+    *buffer = NULL;
+    return CERT_ERROR_MEMORY;
+  }
+
+  memcpy((*buffer)->data, src_data, data_len);
+  (*buffer)->len = data_len;
+
+  return CERT_SUCCESS;
+}
+
+// Function to generate a self-signed X.509 certificate with custom extension
+cert_error_t cert_generate(cert_context_t ctx, cert_key_t key,
+                           cert_buffer **out, cert_buffer *signature,
+                           cert_buffer *ident_pubk, const char *cn,
+                           cert_format_t format) {
+  X509 *x509 = NULL;
+  BIO *bio = NULL;
+  BUF_MEM *bptr = NULL;
+  X509_EXTENSION *ex = NULL;
+  BIGNUM *serial_bn = NULL;
+  X509_NAME *name = NULL;
+  X509_EXTENSION *ku_ex = NULL;
+  ASN1_BIT_STRING *usage = NULL;
+  ASN1_OCTET_STRING *oct_sign = NULL;
+  ASN1_OCTET_STRING *oct_pubk = NULL;
+  ASN1_OCTET_STRING *ext_oct = NULL;
+  ASN1_TIME *start_time = NULL;
+  ASN1_TIME *end_time = NULL;
+  unsigned char *seq_der = NULL;
+  int ret = 0;
+
+  cert_error_t ret_code = CERT_SUCCESS;
+
+  if (ctx == NULL || key == NULL) {
+    ret_code = CERT_ERROR_NULL_PARAM;
+    goto cleanup;
+  }
+
+  // Get the EVP_PKEY from our opaque key structure
+  EVP_PKEY *pkey = ((struct cert_key_s *)key)->pkey;
+  if (pkey == NULL) {
+    ret_code = CERT_ERROR_NULL_PARAM;
+    goto cleanup;
+  }
+
+  // Allocate result structure
+  *out = (cert_buffer *)malloc(sizeof(cert_buffer));
+  if (!*out) {
+    ret_code = CERT_ERROR_MEMORY;
+    goto cleanup;
+  }
+  memset(*out, 0, sizeof(cert_buffer));
+
+  // Create X509 certificate
+  x509 = X509_new();
+  if (!x509) {
+    ret_code = CERT_ERROR_CERT_GEN;
+    goto cleanup;
+  }
+
+  // Set version to X509v3
+  if (!X509_set_version(x509, 2)) {
+    ret_code = CERT_ERROR_X509_VER;
+    goto cleanup;
+  }
+
+  // Set random serial number
+  serial_bn = BN_new();
+  if (!serial_bn) {
+    ret_code = CERT_ERROR_BIGNUM_GEN;
+    goto cleanup;
+  }
+
+  unsigned char serial_bytes[20]; // Adjust size as needed
+  if (EVP_RAND_generate(ctx->drbg, serial_bytes, sizeof(serial_bytes), 0, 0,
+                        NULL, 0) <= 0) {
+    ret_code = CERT_ERROR_RAND;
+    goto cleanup;
+  }
+  if (!BN_bin2bn(serial_bytes, sizeof(serial_bytes), serial_bn)) {
+    ret_code = CERT_ERROR_BIGNUM_CONV;
+    goto cleanup;
+  }
+
+  if (!BN_to_ASN1_INTEGER(serial_bn, X509_get_serialNumber(x509))) {
+    ret_code = CERT_ERROR_SERIAL_WRITE;
+    goto cleanup;
+  }
+
+  // Set subject and issuer using the provided cn
+  name = X509_NAME_new();
+  if (!name) {
+    ret_code = CERT_ERROR_X509_NAME;
+    goto cleanup;
+  }
+  if (!X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
+                                  (const unsigned char *)cn, -1, -1, 0)) {
+    ret_code = CERT_ERROR_X509_CN;
+    goto cleanup;
+  }
+  if (!X509_set_subject_name(x509, name)) {
+    ret_code = CERT_ERROR_X509_SUBJECT;
+    goto cleanup;
+  }
+  if (!X509_set_issuer_name(x509, name)) {
+    ret_code = CERT_ERROR_X509_ISSUER;
+    goto cleanup;
+  }
+
+  // Set validity period
+  start_time = ASN1_TIME_new();
+  end_time = ASN1_TIME_new();
+  if (!start_time || !end_time) {
+    ret_code = CERT_ERROR_AS1_TIME_GEN;
+    goto cleanup;
+  }
+  if (!ASN1_TIME_set_string(start_time, "19750101000000Z") ||
+      !ASN1_TIME_set_string(end_time, "40960101000000Z")) {
+    ret_code = CERT_ERROR_VALIDITY_PERIOD;
+    goto cleanup;
+  }
+  if (!X509_set1_notBefore(x509, start_time) ||
+      !X509_set1_notAfter(x509, end_time)) {
+    ret_code = CERT_ERROR_VALIDITY_PERIOD;
+    goto cleanup;
+  }
+
+  // Set public key
+  if (!X509_set_pubkey(x509, pkey)) {
+    ret_code = CERT_ERROR_PUBKEY_SET;
+    goto cleanup;
+  }
+
+  // Add custom extension
+  int nid = ensure_libp2p_oid();
+  if (!nid) {
+    goto cleanup;
+  }
+
+  unsigned char *p;
+  int seq_len, total_len;
+
+  // Allocate and initialize ASN1_OCTET_STRING objects
+  oct_pubk = ASN1_OCTET_STRING_new();
+  if (!oct_pubk) {
+    ret_code = CERT_ERROR_AS1_OCTET;
+    goto cleanup;
+  }
+
+  oct_sign = ASN1_OCTET_STRING_new();
+  if (!oct_sign) {
+    ret_code = CERT_ERROR_AS1_OCTET;
+    goto cleanup;
+  }
+
+  if (!ASN1_OCTET_STRING_set(oct_pubk, ident_pubk->data, ident_pubk->len)) {
+    ret_code = CERT_ERROR_EXTENSION_DATA;
+    goto cleanup;
+  }
+
+  if (!ASN1_OCTET_STRING_set(oct_sign, signature->data, signature->len)) {
+    ret_code = CERT_ERROR_EXTENSION_DATA;
+    goto cleanup;
+  }
+
+  // Calculate DER-encoded lengths of the OCTET STRINGs
+  int oct_pubk_len = i2d_ASN1_OCTET_STRING(oct_pubk, NULL);
+  int oct_sign_len = i2d_ASN1_OCTET_STRING(oct_sign, NULL);
+  seq_len = oct_pubk_len + oct_sign_len;
+
+  // Compute the exact required length for the SEQUENCE
+  total_len = ASN1_object_size(1, seq_len, V_ASN1_SEQUENCE);
+
+  // Allocate the exact required space
+  seq_der = OPENSSL_malloc(total_len);
+  if (!seq_der) {
+    ret_code = CERT_ERROR_MEMORY;
+    goto cleanup;
+  }
+
+  // Encode the sequence. p is moved fwd as it is written
+  p = seq_der;
+  ASN1_put_object(&p, 1, seq_len, V_ASN1_SEQUENCE, V_ASN1_UNIVERSAL);
+  i2d_ASN1_OCTET_STRING(oct_pubk, &p);
+  i2d_ASN1_OCTET_STRING(oct_sign, &p);
+
+  // Wrap the encoded sequence in an ASN1_OCTET_STRING
+  ext_oct = ASN1_OCTET_STRING_new();
+  if (!ext_oct) {
+    ret_code = CERT_ERROR_AS1_OCTET;
+    goto cleanup;
+  }
+
+  if (!ASN1_OCTET_STRING_set(ext_oct, seq_der, total_len)) {
+    ret_code = CERT_ERROR_EXTENSION_DATA;
+    goto cleanup;
+  }
+
+  // Create extension with the octet string
+  ex = X509_EXTENSION_create_by_NID(NULL, nid, 0, ext_oct);
+  if (!ex) {
+    ret_code = CERT_ERROR_EXTENSION_GEN;
+    goto cleanup;
+  }
+
+  // Add extension to certificate
+  if (!X509_add_ext(x509, ex, -1)) {
+    ret_code = CERT_ERROR_EXTENSION_ADD;
+    goto cleanup;
+  }
+
+  // Add Key Usage extension
+  usage = ASN1_BIT_STRING_new();
+  if (!usage) {
+    ret_code = CERT_ERROR_MEMORY;
+    goto cleanup;
+  }
+
+  // Set bits for DIGITAL_SIGNATURE (bit 0) and KEY_ENCIPHERMENT (bit 2)
+  if (!ASN1_BIT_STRING_set_bit(usage, 0, 1) ||
+      !ASN1_BIT_STRING_set_bit(usage, 2, 1)) {
+    ret_code = CERT_ERROR_EXTENSION_DATA;
+    goto cleanup;
+  }
+
+  // Create Key Usage extension
+  ku_ex = X509_EXTENSION_create_by_NID(NULL, NID_key_usage, 1,
+                                       usage); // 1 for  critical
+  if (!ku_ex) {
+    ret_code = CERT_ERROR_EXTENSION_GEN;
+    goto cleanup;
+  }
+
+  // Add extension to certificate
+  if (!X509_add_ext(x509, ku_ex, -1)) {
+    ret_code = CERT_ERROR_EXTENSION_ADD;
+    goto cleanup;
+  }
+
+  // Sign the certificate with SHA256
+  if (!X509_sign(x509, pkey, EVP_sha256())) {
+    ret_code = CERT_ERROR_SIGN;
+    goto cleanup;
+  }
+
+  // Convert to requested format (DER or PEM)
+  bio = BIO_new(BIO_s_mem());
+  if (!bio) {
+    ret_code = CERT_ERROR_BIO_GEN;
+    goto cleanup;
+  }
+
+  if (format == CERT_FORMAT_DER) {
+    ret = i2d_X509_bio(bio, x509);
+  } else { // PEM format
+    ret = PEM_write_bio_X509(bio, x509);
+  }
+
+  if (!ret) {
+    ret_code = CERT_ERROR_BIO_WRITE;
+    goto cleanup;
+  }
+
+  BIO_get_mem_ptr(bio, &bptr);
+  (*out)->data = (unsigned char *)malloc(bptr->length);
+  if (!(*out)->data) {
+    ret_code = CERT_ERROR_MEMORY;
+    goto cleanup;
+  }
+  memcpy((*out)->data, bptr->data, bptr->length);
+  (*out)->len = bptr->length;
+
+cleanup:
+  if (bio)
+    BIO_free(bio);
+  if (ex)
+    X509_EXTENSION_free(ex);
+  if (usage)
+    ASN1_BIT_STRING_free(usage);
+  if (ku_ex)
+    X509_EXTENSION_free(ku_ex);
+  if (oct_sign)
+    ASN1_OCTET_STRING_free(oct_sign);
+  if (oct_pubk)
+    ASN1_OCTET_STRING_free(oct_pubk);
+  if (ext_oct)
+    ASN1_OCTET_STRING_free(ext_oct);
+  if (seq_der)
+    OPENSSL_free(seq_der);
+  if (serial_bn)
+    BN_free(serial_bn);
+  if (name)
+    X509_NAME_free(name);
+  if (x509)
+    X509_free(x509);
+  if (start_time)
+    ASN1_TIME_free(start_time);
+  if (end_time)
+    ASN1_TIME_free(end_time);
+
+  if (ret_code != CERT_SUCCESS && (*out)) {
+    if ((*out)->data)
+      free((*out)->data);
+    free((*out));
+    *out = NULL;
+  }
+
+  return ret_code;
+}
+
+// Function to parse a certificate and extract custom extension and public key
+cert_error_t cert_parse(cert_buffer *cert, cert_format_t format,
+                        cert_parsed **out) {
+  X509 *x509 = NULL;
+  BIO *bio = NULL;
+  int extension_index;
+  X509_EXTENSION *ex = NULL;
+  ASN1_OCTET_STRING *ext_data = NULL;
+  ASN1_SEQUENCE_ANY *seq = NULL;
+  ASN1_OCTET_STRING *oct1 = NULL;
+  ASN1_OCTET_STRING *oct2 = NULL;
+  EVP_PKEY *pkey = NULL;
+  unsigned char *pubkey_buf = NULL;
+  cert_error_t ret_code;
+
+  // Allocate result structure
+  *out = (cert_parsed *)malloc(sizeof(cert_parsed));
+  if (!*out) {
+    ret_code = CERT_ERROR_MEMORY;
+    goto cleanup;
+  }
+  memset(*out, 0, sizeof(cert_parsed));
+
+  // Create BIO from memory
+  bio = BIO_new_mem_buf(cert->data, cert->len);
+  if (!bio) {
+    ret_code = CERT_ERROR_BIO_GEN;
+    goto cleanup;
+  }
+
+  // Parse certificate based on format
+  if (format == 0) { // DER format
+    x509 = d2i_X509_bio(bio, NULL);
+  } else { // PEM format
+    x509 = PEM_read_bio_X509(bio, NULL, NULL, NULL);
+  }
+
+  if (!x509) {
+    ret_code = CERT_ERROR_X509_READ;
+    goto cleanup;
+  }
+
+  // Find custom extension by OID - use the existing OID or create it if needed
+  int nid = ensure_libp2p_oid();
+  if (!nid) {
+    goto cleanup;
+  }
+
+  extension_index = X509_get_ext_by_NID(x509, nid, -1);
+  if (extension_index < 0) {
+    ret_code = CERT_ERROR_EXTENSION_NOT_FOUND;
+    goto cleanup;
+  }
+
+  // Get extension
+  ex = X509_get_ext(x509, extension_index);
+  if (!ex) {
+    ret_code = CERT_ERROR_EXTENSION_GET;
+    goto cleanup;
+  }
+
+  // Get extension data
+  ext_data = X509_EXTENSION_get_data(ex);
+  if (!ext_data) {
+    ret_code = CERT_ERROR_EXTENSION_DATA;
+    goto cleanup;
+  }
+
+  // Point to the data
+  const unsigned char *p;
+  p = ASN1_STRING_get0_data(ext_data);
+
+  // Decode the SEQUENCE
+  seq = d2i_ASN1_SEQUENCE_ANY(NULL, &p, ASN1_STRING_length(ext_data));
+  if (!seq) {
+    ret_code = CERT_ERROR_DECODE_SEQUENCE;
+    goto cleanup;
+  }
+
+  // Check if we have exactly two items in the sequence
+  if (sk_ASN1_TYPE_num(seq) != 2) {
+    printf("Expected 2 items in sequence, found %d\n", sk_ASN1_TYPE_num(seq));
+    ret_code = CERT_ERROR_NOT_ENOUGH_SEQ_ELEMS;
+    goto cleanup;
+  }
+
+  // Get the first octet string
+  ASN1_TYPE *type1 = sk_ASN1_TYPE_value(seq, 0);
+  if (type1->type != V_ASN1_OCTET_STRING) {
+    ret_code = CERT_ERROR_NOT_OCTET_STR;
+    goto cleanup;
+  }
+  oct1 = type1->value.octet_string;
+
+  // Get the second octet string
+  ASN1_TYPE *type2 = sk_ASN1_TYPE_value(seq, 1);
+  if (type2->type != V_ASN1_OCTET_STRING) {
+    ret_code = CERT_ERROR_NOT_OCTET_STR;
+    goto cleanup;
+  }
+  oct2 = type2->value.octet_string;
+
+  ret_code =
+      init_cert_buffer(&((*out)->ident_pubk), ASN1_STRING_get0_data(oct1),
+                       ASN1_STRING_length(oct1));
+  if (ret_code != 0) {
+    goto cleanup;
+  }
+
+  ret_code = init_cert_buffer(&((*out)->signature), ASN1_STRING_get0_data(oct2),
+                              ASN1_STRING_length(oct2));
+  if (ret_code != 0) {
+    goto cleanup;
+  }
+
+  // Get public key
+  pkey = X509_get_pubkey(x509);
+  if (!pkey) {
+    ret_code = CERT_ERROR_PUBKEY_GET;
+    goto cleanup;
+  }
+
+  // Get public key length
+  int pubkey_len = i2d_PUBKEY(pkey, NULL);
+  if (pubkey_len <= 0) {
+    fprintf(stderr, "Failed to determine public key length\n");
+    goto cleanup;
+  }
+
+  pubkey_buf = (unsigned char *)malloc(pubkey_len);
+  if (!pubkey_buf) {
+    ret_code = CERT_ERROR_MEMORY;
+    goto cleanup;
+  }
+
+  unsigned char *temp = pubkey_buf;
+  if (i2d_PUBKEY(pkey, &temp) <= 0) {
+    fprintf(stderr, "Failed to convert public key to DER\n");
+    goto cleanup;
+  }
+
+  ret_code = init_cert_buffer(&(*out)->cert_pubkey, pubkey_buf, pubkey_len);
+  if (ret_code != CERT_SUCCESS) {
+    goto cleanup;
+  }
+
+  const ASN1_TIME *not_before = X509_get0_notBefore(x509);
+  if (not_before) {
+    // Convert ASN1_TIME to a more usable format
+    char *not_before_str = NULL;
+    BIO *bio_nb = BIO_new(BIO_s_mem());
+    if (bio_nb) {
+      if (ASN1_TIME_print(bio_nb, not_before)) {
+        size_t len = BIO_ctrl_pending(bio_nb);
+        not_before_str = malloc(len + 1);
+        if (not_before_str) {
+          BIO_read(bio_nb, not_before_str, len);
+          not_before_str[len] = '\0';
+
+          // Store in the output structure
+          (*out)->valid_from = not_before_str;
+        }
+      }
+      BIO_free(bio_nb);
+    } else {
+      ret_code = CERT_ERROR_MEMORY;
+      goto cleanup;
+    }
+  }
+
+  const ASN1_TIME *not_after = X509_get0_notAfter(x509);
+  if (not_after) {
+    // Convert ASN1_TIME to a more usable format
+    char *not_after_str = NULL;
+    BIO *bio_na = BIO_new(BIO_s_mem());
+    if (bio_na) {
+      if (ASN1_TIME_print(bio_na, not_after)) {
+        size_t len = BIO_ctrl_pending(bio_na);
+        not_after_str = malloc(len + 1);
+        if (not_after_str) {
+          BIO_read(bio_na, not_after_str, len);
+          not_after_str[len] = '\0';
+
+          // Store in the output structure
+          (*out)->valid_to = not_after_str;
+        }
+      }
+      BIO_free(bio_na);
+    }
+  }
+
+  ret_code = CERT_SUCCESS;
+
+cleanup:
+  if (pkey)
+    EVP_PKEY_free(pkey);
+  if (x509)
+    X509_free(x509);
+  if (bio)
+    BIO_free(bio);
+  if (pubkey_buf)
+    free(pubkey_buf);
+  if (ret_code != CERT_SUCCESS && (*out)) {
+    cert_free_parsed(*out);
+    out = NULL;
+  }
+
+  return ret_code;
+}
+
+cert_error_t cert_serialize_privk(cert_key_t key, cert_buffer **out,
+                                  cert_format_t format) {
+  BIO *bio = NULL;
+  BUF_MEM *bptr = NULL;
+  int ret;
+  cert_error_t ret_code = CERT_SUCCESS;
+
+  if (key == NULL || out == NULL) {
+    return CERT_ERROR_NULL_PARAM;
+  }
+
+  // Get the EVP_PKEY from our opaque key structure
+  EVP_PKEY *pkey = ((struct cert_key_s *)key)->pkey;
+  if (!pkey) {
+    return CERT_ERROR_NULL_PARAM;
+  }
+
+  // Create memory BIO
+  bio = BIO_new(BIO_s_mem());
+  if (!bio) {
+    ret_code = CERT_ERROR_BIO_GEN;
+    goto cleanup;
+  }
+
+  if (format == CERT_FORMAT_DER) {
+    // Write key in DER format to BIO
+    ret = i2d_PrivateKey_bio(bio, pkey);
+    if (!ret) {
+      ret_code = CERT_ERROR_BIO_WRITE;
+      goto cleanup;
+    }
+  } else {
+    // No encryption is used (NULL cipher, NULL password)
+    ret = PEM_write_bio_PrivateKey(bio, pkey, NULL, NULL, 0, NULL, NULL);
+    if (!ret) {
+      ret_code = CERT_ERROR_BIO_WRITE;
+      goto cleanup;
+    }
+  }
+  // Get the data from BIO
+  BIO_get_mem_ptr(bio, &bptr);
+
+  ret = init_cert_buffer(out, (const unsigned char *)bptr->data, bptr->length);
+  if (ret != CERT_SUCCESS) {
+    goto cleanup;
+  }
+
+cleanup:
+  if (bio)
+    BIO_free(bio);
+
+  if (ret_code != CERT_SUCCESS && *out) {
+    if ((*out)->data)
+      free((*out)->data);
+    free(*out);
+    *out = NULL;
+  }
+
+  return ret_code;
+}
+
+cert_error_t cert_serialize_pubk(cert_key_t key, cert_buffer **out,
+                                 cert_format_t format) {
+  BIO *bio = NULL;
+  BUF_MEM *bptr = NULL;
+  int ret;
+  cert_error_t ret_code = CERT_SUCCESS;
+
+  if (key == NULL || out == NULL) {
+    return CERT_ERROR_NULL_PARAM;
+  }
+
+  // Get the EVP_PKEY from our opaque key structure
+  EVP_PKEY *pkey = ((struct cert_key_s *)key)->pkey;
+  if (!pkey) {
+    return CERT_ERROR_NULL_PARAM;
+  }
+
+  // Create memory BIO
+  bio = BIO_new(BIO_s_mem());
+  if (!bio) {
+    ret_code = CERT_ERROR_BIO_GEN;
+    goto cleanup;
+  }
+
+  if (format == CERT_FORMAT_DER) {
+    // Write key in DER format to BIO
+    ret = i2d_PUBKEY_bio(bio, pkey);
+    if (!ret) {
+      ret_code = CERT_ERROR_BIO_WRITE;
+      goto cleanup;
+    }
+  } else {
+    ret = PEM_write_bio_PUBKEY(bio, pkey);
+    if (!ret) {
+      ret_code = CERT_ERROR_BIO_WRITE;
+      goto cleanup;
+    }
+  }
+  // Get the data from BIO
+  BIO_get_mem_ptr(bio, &bptr);
+
+  ret = init_cert_buffer(out, (const unsigned char *)bptr->data, bptr->length);
+  if (ret != CERT_SUCCESS) {
+    goto cleanup;
+  }
+
+cleanup:
+  if (bio)
+    BIO_free(bio);
+
+  if (ret_code != CERT_SUCCESS && *out) {
+    if ((*out)->data)
+      free((*out)->data);
+    free(*out);
+    *out = NULL;
+  }
+
+  return ret_code;
+}
+
+void cert_free_buffer(cert_buffer *buffer) {
+  if (buffer) {
+    if (buffer->data)
+      free(buffer->data);
+    free(buffer);
+  }
+}
+
+// Function to free the parsed certificate struct
+void cert_free_parsed(cert_parsed *cert) {
+  if (cert) {
+    if (cert->cert_pubkey)
+      cert_free_buffer(cert->cert_pubkey);
+    if (cert->ident_pubk)
+      cert_free_buffer(cert->ident_pubk);
+    if (cert->signature)
+      cert_free_buffer(cert->signature);
+    if (cert->valid_from)
+      free(cert->valid_from);
+    if (cert->valid_to)
+      free(cert->valid_to);
+
+    free(cert);
+  }
+}
+
+// Function to free key resources
+void cert_free_key(cert_key_t key) {
+  if (key == NULL)
+    return;
+
+  struct cert_key_s *k = (struct cert_key_s *)key;
+  EVP_PKEY_free(k->pkey);
+  free(k);
+}

--- a/libp2p/transports/tls/certificate.h
+++ b/libp2p/transports/tls/certificate.h
@@ -49,6 +49,9 @@ typedef int32_t cert_error_t;
 #define CERT_ERROR_DECODE_SEQUENCE -36
 #define CERT_ERROR_NOT_ENOUGH_SEQ_ELEMS -37
 #define CERT_ERROR_NOT_OCTET_STR -38
+#define CERT_ERROR_NID -39
+#define CERT_ERROR_PUBKEY_DER_LEN -40
+#define CERT_ERROR_PUBKEY_DER_CONV -41
 
 typedef enum { CERT_FORMAT_DER = 0, CERT_FORMAT_PEM = 1 } cert_format_t;
 

--- a/libp2p/transports/tls/certificate.h
+++ b/libp2p/transports/tls/certificate.h
@@ -1,0 +1,179 @@
+#ifndef LIBP2P_CERT_H
+#define LIBP2P_CERT_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct cert_context_s *cert_context_t;
+
+typedef struct cert_key_s *cert_key_t;
+
+typedef int32_t cert_error_t;
+
+#define CERT_SUCCESS 0
+#define CERT_ERROR_NULL_PARAM -1
+#define CERT_ERROR_MEMORY -2
+#define CERT_ERROR_DRBG_INIT -3
+#define CERT_ERROR_DRBG_CONFIG -4
+#define CERT_ERROR_DRBG_SEED -5
+#define CERT_ERROR_KEY_GEN -6
+#define CERT_ERROR_CERT_GEN -7
+#define CERT_ERROR_EXTENSION_GEN -8
+#define CERT_ERROR_EXTENSION_ADD -9
+#define CERT_ERROR_EXTENSION_DATA -10
+#define CERT_ERROR_BIO_GEN -11
+#define CERT_ERROR_SIGN -12
+#define CERT_ERROR_ENCODING -13
+#define CERT_ERROR_PARSE -14
+#define CERT_ERROR_RAND -15
+#define CERT_ERROR_ECKEY_GEN -16
+#define CERT_ERROR_BIGNUM_CONV -17
+#define CERT_ERROR_SET_KEY -18
+#define CERT_ERROR_VALIDITY_PERIOD -19
+#define CERT_ERROR_BIO_WRITE -20
+#define CERT_ERROR_SERIAL_WRITE -21
+#define CERT_ERROR_EVP_PKEY_EC_KEY -22
+#define CERT_ERROR_X509_VER -23
+#define CERT_ERROR_BIGNUM_GEN -24
+#define CERT_ERROR_X509_NAME -25
+#define CERT_ERROR_X509_CN -26
+#define CERT_ERROR_X509_SUBJECT -27
+#define CERT_ERROR_X509_ISSUER -28
+#define CERT_ERROR_AS1_TIME_GEN -29
+#define CERT_ERROR_PUBKEY_SET -30
+#define CERT_ERROR_AS1_OCTET -31
+#define CERT_ERROR_X509_READ -32
+#define CERT_ERROR_PUBKEY_GET -33
+#define CERT_ERROR_EXTENSION_NOT_FOUND -34
+#define CERT_ERROR_EXTENSION_GET -35
+#define CERT_ERROR_DECODE_SEQUENCE -36
+#define CERT_ERROR_NOT_ENOUGH_SEQ_ELEMS -37
+#define CERT_ERROR_NOT_OCTET_STR -38
+
+typedef enum { CERT_FORMAT_DER = 0, CERT_FORMAT_PEM = 1 } cert_format_t;
+
+/* Buffer structure for raw key data */
+typedef struct {
+  unsigned char *data; /*  data buffer */
+  size_t len;          /* Length of data */
+} cert_buffer;
+
+/* Struct to hold the parsed certificate data */
+typedef struct {
+  cert_buffer *signature;
+  cert_buffer *ident_pubk;
+  cert_buffer *cert_pubkey;
+  char *valid_from;
+  char *valid_to;
+} cert_parsed;
+
+/**
+ * Initialize the CTR-DRBG for cryptographic operations
+ * This function creates and initializes a CTR-DRBG context using
+ * the provided seed for entropy. The DRBG is configured to use
+ * AES-256-CTR as the underlying cipher.
+ *
+ * @param seed A null-terminated string used to seed the DRBG. Must not be NULL.
+ * @param ctx Pointer to a context pointer that will be allocated and
+ * initialized. The caller is responsible for eventually freeing this context
+ * with the appropriate cleanup function.
+ *
+ * @return CERT_SUCCESS on successful initialization, an error code otherwise
+ */
+cert_error_t cert_init_drbg(const char *seed, size_t seed_len,
+                            cert_context_t *ctx);
+
+/**
+ * Generate an EC key pair for use with certificates
+ *
+ * @param ctx Context pointer obtained from `cert_init_drbg`
+ * @param out Pointer to store the generated key
+ *
+ * @return CERT_SUCCESS on successful execution, an error code otherwise
+ */
+cert_error_t cert_generate_key(cert_context_t ctx, cert_key_t *out);
+
+/**
+ * Serialize a key's private key to a format
+ *
+ * @param key The key to export
+ * @param out Pointer to a buffer structure that will be populated with the key
+ * @param format output format
+ *
+ * @return CERT_SUCCESS on successful execution, an error code otherwise
+ */
+cert_error_t cert_serialize_privk(cert_key_t key, cert_buffer **out,
+                                  cert_format_t format);
+
+/**
+ * Serialize a key's public key to a format
+ *
+ * @param key The key to export
+ * @param out Pointer to a buffer structure that will be populated with the key
+ * @param format output format
+ *
+ * @return CERT_SUCCESS on successful execution, an error code otherwise
+ */
+cert_error_t cert_serialize_pubk(cert_key_t key, cert_buffer **out,
+                                 cert_format_t format);
+
+/**
+ * Generate a self-signed X.509 certificate with libp2p extension
+ *
+ * @param ctx Context pointer obtained from `cert_init_drbg`
+ * @param key Key to use
+ * @param out Pointer to a buffer that will be populated with a certificate
+ * @param signature buffer that contains a signature
+ * @param ident_pubk buffer that contains the bytes of an identity pubk
+ * @param common_name Common name to use for the certificate subject/issuer
+ * @param format Certificate format
+ *
+ * @return CERT_SUCCESS on successful execution, an error code otherwise
+ */
+cert_error_t cert_generate(cert_context_t ctx, cert_key_t key,
+                           cert_buffer **out, cert_buffer *signature,
+                           cert_buffer *ident_pubk, const char *cn,
+                           cert_format_t format);
+
+/**
+ * Parse a certificate to extract the custom extension and public key
+ *
+ * @param cert            Buffer containing the certificate data
+ * @param format          Certificate format
+ * @param cert_parsed     Pointer to a structure containing the parsed
+ * certificate data.
+ *
+ * @return CERT_SUCCESS on successful execution, an error code otherwise
+ */
+cert_error_t cert_parse(cert_buffer *cert, cert_format_t format,
+                        cert_parsed **out);
+
+/**
+ * Free all resources associated with a CTR-DRBG context
+ *
+ * @param ctx The context to free
+ */
+void cert_free_ctr_drbg(cert_context_t ctx);
+
+/**
+ * Free memory allocated for a parsed certificate
+ *
+ * @param cert  Pointer to the parsed certificate structure
+ */
+void cert_free_parsed(cert_parsed *cert);
+
+/**
+ * Free all resources associated with a key
+ *
+ * @param key The key to free
+ */
+void cert_free_key(cert_key_t key);
+
+/**
+ * Free memory allocated for a buffer
+ *
+ * @param buffer Pointer to the buffer structure
+ */
+void cert_free_buffer(cert_buffer *buffer);
+
+#endif /* LIBP2P_CERT_H */

--- a/libp2p/transports/tls/certificate.nim
+++ b/libp2p/transports/tls/certificate.nim
@@ -7,47 +7,27 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-import std/[sequtils, strutils, exitprocs]
+import std/[sequtils, exitprocs]
 
 import stew/byteutils
 import chronicles
-
-import mbedtls/pk
-import mbedtls/ctr_drbg as ctr_drbg_module
-import mbedtls/entropy as entropy_module
-import mbedtls/ecp
-import mbedtls/sha256
-import mbedtls/md
-import mbedtls/asn1
-import mbedtls/asn1write
-import mbedtls/x509
-import mbedtls/x509_crt
-import mbedtls/oid
-import mbedtls/debug
-import mbedtls/error
-import nimcrypto/utils
 import ../../crypto/crypto
 import ../../errors
+import ./certificate_ffi
 import ../../../libp2p/peerid
 
 logScope:
   topics = "libp2p tls certificate"
 
 # Constants and OIDs
-const
-  P2P_SIGNING_PREFIX = "libp2p-tls-handshake:".toBytes()
-  SIGNATURE_ALG = MBEDTLS_MD_SHA256
-  EC_GROUP_ID = MBEDTLS_ECP_DP_SECP256R1
-  LIBP2P_EXT_OID_DER: array[10, byte] =
-    [0x2B, 0x06, 0x01, 0x04, 0x01, 0x83, 0xA2, 0x5A, 0x01, 0x01]
-    # "1.3.6.1.4.1.53594.1.1"
+const P2P_SIGNING_PREFIX = "libp2p-tls-handshake:".toBytes()
 
 # Exception types for TLS certificate errors
 type
   TLSCertificateError* = object of LPError
-  ASN1EncodingError* = object of TLSCertificateError
   KeyGenerationError* = object of TLSCertificateError
   CertificateCreationError* = object of TLSCertificateError
+  CertificatePubKeySerializationError* = object of TLSCertificateError
   CertificateParsingError* = object of TLSCertificateError
   IdentityPubKeySerializationError* = object of TLSCertificateError
   IdentitySigningError* = object of TLSCertificateError
@@ -66,14 +46,18 @@ type EncodingFormat* = enum
   DER
   PEM
 
-proc ptrInc*(p: ptr byte, n: uint): ptr byte =
-  ## Utility function to increment a pointer by n bytes.
-  cast[ptr byte](cast[uint](p) + n)
+proc cert_format_t(self: EncodingFormat): cert_format_t =
+  if self == EncodingFormat.DER: CERT_FORMAT_DER else: CERT_FORMAT_PEM
+
+proc toCertBuffer(self: seq[uint8]): cert_buffer =
+  cert_buffer(data: self[0].addr, length: self.len.csize_t)
+
+proc toSeq(self: ptr cert_buffer): seq[byte] =
+  toOpenArray(cast[ptr UncheckedArray[byte]](self.data), 0, self.length.int - 1).toSeq()
 
 # Initialize entropy and DRBG contexts at the module level
 var
-  entropy: mbedtls_entropy_context
-  ctrDrbg: mbedtls_ctr_drbg_context
+  cert_ctx: cert_context_t = nil
   drbgInitialized = false
 
 func publicKey*(cert: P2pCertificate): PublicKey =
@@ -85,97 +69,23 @@ func peerId*(cert: P2pCertificate): PeerId =
 proc initializeDRBG() {.raises: [KeyGenerationError].} =
   ## Function to initialize entropy and DRBG context if not already initialized.
   if not drbgInitialized:
-    mbedtls_entropy_init(addr entropy)
-    mbedtls_ctr_drbg_init(addr ctrDrbg)
-
     # Seed the random number generator
     let personalization = "libp2p_tls"
-    let ret = mbedtls_ctr_drbg_seed(
-      addr ctrDrbg,
-      mbedtls_entropy_func,
-      addr entropy,
-      cast[ptr byte](personalization.cstring),
-      personalization.len.uint,
+    let ret = cert_init_drbg(
+      personalization.cstring, personalization.len.csize_t, addr cert_ctx
     )
-    if ret != 0:
+    if ret != CERT_SUCCESS:
       raise newException(KeyGenerationError, "Failed to seed CTR_DRBG")
     drbgInitialized = true
 
 proc cleanupDRBG() =
   ## Function to free entropy and DRBG context.
   if drbgInitialized:
-    mbedtls_ctr_drbg_free(addr ctrDrbg)
-    mbedtls_entropy_free(addr entropy)
+    cert_free_ctr_drbg(cert_ctx)
     drbgInitialized = false
 
 # Register cleanup function to free entropy and DRBG context
 addExitProc(cleanupDRBG)
-
-proc generateSignedKey(
-    signature: seq[byte], pubKey: seq[byte]
-): seq[byte] {.raises: [ASN1EncodingError].} =
-  ## Generates the ASN.1-encoded SignedKey structure.
-  ##
-  ## The SignedKey structure contains the public key and its signature,
-  ## encoded as a SEQUENCE of two OCTET STRINGs.
-  ##
-  ## Parameters:
-  ## - `signature`: The signature bytes.
-  ## - `pubKey`: The public key bytes.
-  ##
-  ## Returns:
-  ## A sequence of bytes representing the ASN.1-encoded SignedKey.
-  ##
-  ## Raises:
-  ## - `ASN1EncodingError` if ASN.1 encoding fails.
-  const extValueSize = 256 # Buffer size for ASN.1 encoding
-  var
-    extValue: array[extValueSize, byte]
-    extPtr: ptr byte = addr extValue[extValueSize - 1]
-      # Start at the end of the buffer as mbedtls_asn1_write_octet_string works backwards in data buffer.
-    startPtr: ptr byte = addr extValue[0]
-    len = 0
-
-  # Write signature OCTET STRING
-  let retSig = mbedtls_asn1_write_octet_string(
-    addr extPtr, startPtr, unsafeAddr signature[0], signature.len.uint
-  )
-  if retSig < 0:
-    raise newException(ASN1EncodingError, "Failed to write signature OCTET STRING")
-  len += retSig
-
-  # Write publicKey OCTET STRING
-  let retPub = mbedtls_asn1_write_octet_string(
-    addr extPtr, startPtr, unsafeAddr pubKey[0], pubKey.len.uint
-  )
-  if retPub < 0:
-    raise newException(ASN1EncodingError, "Failed to write publicKey OCTET STRING")
-  len += retPub
-
-  # Total length of the SEQUENCE contents
-  let contentLen = retSig + retPub
-  # Write SEQUENCE length
-  let retLen = mbedtls_asn1_write_len(addr extPtr, startPtr, contentLen.uint)
-  if retLen < 0:
-    raise newException(ASN1EncodingError, "Failed to write SEQUENCE length")
-  len += retLen
-
-  # Write SEQUENCE tag
-  let retTag = mbedtls_asn1_write_tag(
-    addr extPtr, startPtr, MBEDTLS_ASN1_CONSTRUCTED or MBEDTLS_ASN1_SEQUENCE
-  )
-  if retTag < 0:
-    raise newException(ASN1EncodingError, "Failed to write SEQUENCE tag")
-  len += retTag
-
-  # Calculate dataOffset based on the accumulated length
-  let dataOffset = extValueSize - len - 1
-
-  # Extract the relevant portion of extValue as a seq[byte]
-  let extValueSeq = toSeq(extValue[dataOffset ..< extValueSize])
-
-  # Return the extension content
-  return extValueSeq
 
 func makeSignatureMessage(pubKey: seq[byte]): seq[byte] {.inline.} =
   ## Creates message used for certificate signature.
@@ -198,63 +108,38 @@ func makeIssuerDN(identityKeyPair: KeyPair): string {.inline.} =
 
   return issuerDN
 
-func parseCertificatePublicKey(
-    pk: mbedtls_pk_context
-): seq[byte] {.raises: [CertificateParsingError].} =
-  ## Parses public key from certificate encoded in DER format.
-  ## 
-
-  var certPubKeyDer: array[512, byte]
-
-  let certPubKeyDerLen = mbedtls_pk_write_pubkey_der(
-    unsafeAddr pk, addr certPubKeyDer[0], certPubKeyDer.len.uint
-  )
-  if certPubKeyDerLen < 0:
-    raise newException(
-      CertificateParsingError,
-      "Failed to parse certificate public key der, error code: " & $certPubKeyDerLen,
-    )
-
-  # Adjust pointer to the start of the data
-  let certPubKeyDerPtr = addr certPubKeyDer[certPubKeyDer.len - certPubKeyDerLen]
-
-  let pkDer = newSeq[byte](certPubKeyDerLen.int)
-  copyMem(pkDer[0].unsafeAddr, certPubKeyDerPtr, certPubKeyDerLen.int)
-
-  return pkDer
-
-proc makeLibp2pExtension(
-    identityKeypair: KeyPair, certificateKeypair: mbedtls_pk_context
-): seq[byte] {.
+proc makeExtValues(
+    identityKeypair: KeyPair, certKey: cert_key_t
+): tuple[signature: cert_buffer, pubkey: cert_buffer] {.
     raises: [
-      CertificateCreationError, IdentityPubKeySerializationError, IdentitySigningError,
-      ASN1EncodingError,
+      CertificatePubKeySerializationError, IdentitySigningError,
+      IdentityPubKeySerializationError,
     ]
 .} =
-  ## Creates the libp2p extension containing the SignedKey.
-  ##
-  ## The libp2p extension is an ASN.1-encoded structure that includes
-  ## the public key and its signature over the certificate's public key.
+  ## Creates the buffers to be used for writing the libp2p extension
   ##
   ## Parameters:
   ## - `identityKeypair`: The peer's identity key pair.
-  ## - `certificateKeypair`: The key pair used for the certificate.
+  ## - `certificateKey`: The key used for the certificate.
   ##
   ## Returns:
   ## A sequence of bytes representing the libp2p extension.
   ##
   ## Raises:
-  ## - `CertificateCreationError` if public key serialization fails.
-  ## - `IdentityPubKeySerializationError` if serialization of identity public key fails.
   ## - `IdentitySigningError` if signing the message fails.
-  ## - `ASN1EncodingError` if ASN.1 encoding fails.
+  ## - `CertificatePubKeySerializationError` if serialization of certificate public key fails
+  ## - `IdentityPubKeySerializationError` if serialization of identity public key fails.
 
-  let cerPubKeyDer =
-    try:
-      parseCertificatePublicKey(certificateKeypair)
-    except CertificateParsingError as e:
-      raise newException(CertificateCreationError, e.msg)
-  let msg = makeSignatureMessage(cerPubKeyDer)
+  var derCert: ptr cert_buffer = nil
+  let ret = cert_serialize_pubk(certKey, derCert.addr, DER.cert_format_t())
+  if ret != CERT_SUCCESS:
+    raise newException(
+      CertificatePubKeySerializationError, "Failed to serialize the certificate pubkey"
+    )
+
+  let certificatePubKeyDer = derCert.toSeq()
+
+  let msg = makeSignatureMessage(certificatePubKeyDer)
 
   # Sign the message with the Identity Key
   let signatureResult = identityKeypair.seckey.sign(msg)
@@ -272,15 +157,14 @@ proc makeLibp2pExtension(
     )
   let pubKeyBytes = pubKeyBytesResult.get()
 
-  # Generate the SignedKey ASN.1 structure
-  return generateSignedKey(signature, pubKeyBytes)
+  return (signature.toCertBuffer(), pubKeyBytes.toCertBuffer())
 
 proc generate*(
     identityKeyPair: KeyPair, encodingFormat: EncodingFormat = EncodingFormat.DER
 ): tuple[raw: seq[byte], privateKey: seq[byte]] {.
     raises: [
-      KeyGenerationError, CertificateCreationError, ASN1EncodingError,
-      IdentityPubKeySerializationError, IdentitySigningError,
+      KeyGenerationError, IdentitySigningError, IdentityPubKeySerializationError,
+      CertificateCreationError, CertificatePubKeySerializationError,
     ]
 .} =
   ## Generates a self-signed X.509 certificate with the libp2p extension.
@@ -297,262 +181,41 @@ proc generate*(
   ## Raises:
   ## - `KeyGenerationError` if key generation fails.
   ## - `CertificateCreationError` if certificate creation fails.
-  ## - `ASN1EncodingError` if encoding fails.
+
   # Ensure DRBG contexts are initialized
   initializeDRBG()
-  var
-    crt: mbedtls_x509write_cert
-    certKey: mbedtls_pk_context
-    ret: cint
 
-  mbedtls_entropy_init(addr entropy)
-  mbedtls_ctr_drbg_init(addr ctrDrbg)
-  mbedtls_x509write_crt_init(addr crt)
-  mbedtls_pk_init(addr certKey)
-
-  defer:
-    mbedtls_entropy_free(addr entropy)
-    mbedtls_ctr_drbg_free(addr ctrDrbg)
-    mbedtls_pk_free(addr certKey)
-    mbedtls_x509write_crt_free(addr crt)
-
-  # Seed the random number generator
-  let personalization = "libp2p_tls"
-  ret = mbedtls_ctr_drbg_seed(
-    addr ctrDrbg,
-    mbedtls_entropy_func,
-    addr entropy,
-    cast[ptr byte](personalization.cstring),
-    personalization.len.uint,
-  )
-  if ret != 0:
-    raise newException(KeyGenerationError, "Failed to seed CTR_DRBG")
-
-  # Initialize certificate key
-  ret = mbedtls_pk_setup(addr certKey, mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY))
-  if ret != 0:
-    raise newException(KeyGenerationError, "Failed to set up certificate key context")
-
-  # Generate key pair for the certificate
-  let G =
-    try:
-      mb_pk_ec(certKey)
-    except MbedTLSError as e:
-      raise newException(KeyGenerationError, e.msg)
-  ret = mbedtls_ecp_gen_key(EC_GROUP_ID, G, mbedtls_ctr_drbg_random, addr ctrDrbg)
-  if ret != 0:
+  var certKey: cert_key_t
+  var ret = cert_generate_key(cert_ctx, certKey.addr)
+  if ret != CERT_SUCCESS:
     raise
-      newException(KeyGenerationError, "Failed to generate EC key pair for certificate")
+      newException(KeyGenerationError, "Failed to generate certificate key - " & $ret)
 
-  ## Initialize libp2p extension
-  let libp2pExtension = makeLibp2pExtension(identityKeyPair, certKey)
-
-  # Set the Subject and Issuer Name (self-signed)
   let issuerDN = makeIssuerDN(identityKeyPair)
-  ret = mbedtls_x509write_crt_set_subject_name(addr crt, issuerDN)
-  if ret != 0:
-    raise newException(CertificateCreationError, "Failed to set subject name")
+  let libp2pExtension = makeExtValues(identityKeyPair, certKey)
+  var certificate: ptr cert_buffer = nil
 
-  ret = mbedtls_x509write_crt_set_issuer_name(addr crt, issuerDN)
-  if ret != 0:
-    raise newException(CertificateCreationError, "Failed to set issuer name")
-
-  # Set Validity Period
-  let notBefore = "19750101000000"
-  let notAfter = "40960101000000"
-  ret =
-    mbedtls_x509write_crt_set_validity(addr crt, notBefore.cstring, notAfter.cstring)
-  if ret != 0:
-    raise newException(
-      CertificateCreationError, "Failed to set certificate validity period"
-    )
-
-  # Assign the Public Key to the Certificate
-  mbedtls_x509write_crt_set_subject_key(addr crt, addr certKey)
-  mbedtls_x509write_crt_set_issuer_key(addr crt, addr certKey) # Self-signed
-
-  # Add the libp2p Extension
-  let oid = string.fromBytes(LIBP2P_EXT_OID_DER)
-  ret = mbedtls_x509write_crt_set_extension(
-    addr crt,
-    oid, # OID
-    oid.len.uint, # OID length
-    0, # Critical flag
-    unsafeAddr libp2pExtension[0], # Extension data
-    libp2pExtension.len.uint, # Extension data length
+  ret = cert_generate(
+    cert_ctx, certKey, certificate.addr, libp2pExtension.signature.addr,
+    libp2pExtension.pubkey.addr, issuerDN.cstring, encodingFormat.cert_format_t,
   )
-  if ret != 0:
-    raise newException(
-      CertificateCreationError, "Failed to set libp2p extension in certificate"
-    )
+  if ret != CERT_SUCCESS:
+    raise
+      newException(CertificateCreationError, "Failed to generate certificate - " & $ret)
 
-  # Set Basic Constraints (optional, e.g., CA:FALSE)
-  ret = mbedtls_x509write_crt_set_basic_constraints(
-    addr crt,
-    0, # is_ca
-    -1, # max_pathlen (-1 for no limit)
-  )
-  if ret != 0:
-    raise newException(CertificateCreationError, "Failed to set basic constraints")
+  var privKDer: ptr cert_buffer = nil
+  ret = cert_serialize_privk(certKey, privKDer.addr, encodingFormat.cert_format_t)
+  if ret != CERT_SUCCESS:
+    raise newException(KeyGenerationError, "Failed to serialize privK - " & $ret)
 
-  # Set Key Usage
-  ret = mbedtls_x509write_crt_set_key_usage(
-    addr crt, MBEDTLS_X509_KU_DIGITAL_SIGNATURE or MBEDTLS_X509_KU_KEY_ENCIPHERMENT
-  )
-  if ret != 0:
-    raise newException(CertificateCreationError, "Failed to set key usage")
+  let outputCertificate = certificate.toSeq()
+  let outputPrivateKey = privKDer.toSeq()
 
-  # Set the MD algorithm
-  mbedtls_x509write_crt_set_md_alg(addr crt, SIGNATURE_ALG)
-
-  # Generate a random serial number
-  const SERIAL_LEN = 20
-  var serialBuffer: array[SERIAL_LEN, byte]
-  ret = mbedtls_ctr_drbg_random(addr ctrDrbg, addr serialBuffer[0], SERIAL_LEN)
-  if ret != 0:
-    raise newException(CertificateCreationError, "Failed to generate serial number")
-
-  # Set the serial number
-  ret = mbedtls_x509write_crt_set_serial_raw(addr crt, addr serialBuffer[0], SERIAL_LEN)
-  if ret != 0:
-    raise newException(CertificateCreationError, "Failed to set serial number")
-
-  # Prepare Buffer for Certificate Serialization
-  const CERT_BUFFER_SIZE = 4096
-  var certBuffer: array[CERT_BUFFER_SIZE, byte]
-  var outputCertificate: seq[byte]
-
-  if encodingFormat == EncodingFormat.DER:
-    let certLen: cint = mbedtls_x509write_crt_der(
-      addr crt,
-      addr certBuffer[0],
-      CERT_BUFFER_SIZE.uint,
-      mbedtls_ctr_drbg_random,
-      addr ctrDrbg,
-    )
-    if certLen < 0:
-      raise newException(
-        CertificateCreationError, "Failed to write certificate in DER format"
-      )
-    # Adjust the buffer to contain only the data
-    outputCertificate =
-      toSeq(certBuffer[(CERT_BUFFER_SIZE - certLen) ..< CERT_BUFFER_SIZE])
-  else:
-    let ret = mbedtls_x509write_crt_pem(
-      addr crt,
-      addr certBuffer[0],
-      CERT_BUFFER_SIZE.uint,
-      mbedtls_ctr_drbg_random,
-      addr ctrDrbg,
-    )
-    if ret != 0:
-      raise newException(
-        CertificateCreationError, "Failed to write certificate in PEM format"
-      )
-    let n = certBuffer.find(0'u8) # Find the index of the first null byte
-    outputCertificate = certBuffer[0 .. n - 1].toSeq()
-
-  # Serialize the Private Key 
-  var privKeyBuffer: array[2048, byte]
-  var outputPrivateKey: seq[byte]
-
-  if encodingFormat == EncodingFormat.DER:
-    let privKeyLen = mbedtls_pk_write_key_der(
-      addr certKey, addr privKeyBuffer[0], privKeyBuffer.len.uint
-    )
-    if privKeyLen < 0:
-      raise newException(
-        CertificateCreationError, "Failed to write private key in DER format"
-      )
-    # Adjust the buffer to contain only the data
-    outputPrivateKey =
-      toSeq(privKeyBuffer[(privKeyBuffer.len - privKeyLen) ..< privKeyBuffer.len])
-  else:
-    let ret = mbedtls_pk_write_key_pem(
-      addr certKey, addr privKeyBuffer[0], privKeyBuffer.len.uint
-    )
-    if ret != 0:
-      raise newException(
-        CertificateCreationError, "Failed to write private key in PEM format"
-      )
-    let n = privKeyBuffer.find(0'u8) # Find the index of the first null byte
-    outputPrivateKey = privKeyBuffer[0 .. n - 1].toSeq()
+  cert_free_buffer(certificate)
+  cert_free_buffer(privKDer)
 
   # Return the Serialized Certificate and Private Key
   return (outputCertificate, outputPrivateKey)
-
-proc libp2pext(
-    p_ctx: pointer,
-    crt: ptr mbedtls_x509_crt,
-    oid: ptr mbedtls_x509_buf,
-    critical: cint,
-    p: ptr byte,
-    endPtr: ptr byte,
-): cint {.cdecl.} =
-  ## Callback function to parse the libp2p extension.
-  ##
-  ## This function is used as a callback by mbedtls during certificate parsing
-  ## to extract the libp2p extension containing the SignedKey.
-  ##
-  ## Parameters:
-  ## - `p_ctx`: Pointer to the P2pExtension object to store the parsed data.
-  ## - `crt`: Pointer to the certificate being parsed.
-  ## - `oid`: Pointer to the OID of the extension.
-  ## - `critical`: Critical flag of the extension.
-  ## - `p`: Pointer to the start of the extension data.
-  ## - `endPtr`: Pointer to the end of the extension data.
-  ##
-  ## Returns:
-  ## - 0 on success, or a negative error code on failure.
-
-  # Check if the OID matches the libp2p extension
-  if oid.len != LIBP2P_EXT_OID_DER.len:
-    return MBEDTLS_ERR_OID_NOT_FOUND # Extension not handled by this callback
-  for i in 0 ..< LIBP2P_EXT_OID_DER.len:
-    if ptrInc(oid.p, i.uint)[] != LIBP2P_EXT_OID_DER[i]:
-      return MBEDTLS_ERR_OID_NOT_FOUND # Extension not handled by this callback
-
-  var parsePtr = p
-
-  # Parse SEQUENCE tag and length
-  var len: uint
-  if mbedtls_asn1_get_tag(
-    addr parsePtr, endPtr, addr len, MBEDTLS_ASN1_CONSTRUCTED or MBEDTLS_ASN1_SEQUENCE
-  ) != 0:
-    debug "Failed to parse SEQUENCE in libp2p extension"
-    return MBEDTLS_ERR_ASN1_UNEXPECTED_TAG
-
-  # Parse publicKey OCTET STRING
-  var pubKeyLen: uint
-  if mbedtls_asn1_get_tag(
-    addr parsePtr, endPtr, addr pubKeyLen, MBEDTLS_ASN1_OCTET_STRING
-  ) != 0:
-    debug "Failed to parse publicKey OCTET STRING in libp2p extension"
-    return MBEDTLS_ERR_ASN1_UNEXPECTED_TAG
-
-  # Extract publicKey
-  var publicKey = newSeq[byte](int(pubKeyLen))
-  copyMem(addr publicKey[0], parsePtr, int(pubKeyLen))
-  parsePtr = ptrInc(parsePtr, pubKeyLen)
-
-  # Parse signature OCTET STRING
-  var signatureLen: uint
-  if mbedtls_asn1_get_tag(
-    addr parsePtr, endPtr, addr signatureLen, MBEDTLS_ASN1_OCTET_STRING
-  ) != 0:
-    debug "Failed to parse signature OCTET STRING in libp2p extension"
-    return MBEDTLS_ERR_ASN1_UNEXPECTED_TAG
-
-  # Extract signature
-  var signature = newSeq[byte](int(signatureLen))
-  copyMem(addr signature[0], parsePtr, int(signatureLen))
-
-  # Store the publicKey and signature in the P2pExtension
-  let extension = cast[ptr P2pExtension](p_ctx)
-  extension[].publicKey = publicKey
-  extension[].signature = signature
-
-  return 0 # Success
 
 proc parse*(
     certificateDer: seq[byte]
@@ -567,28 +230,24 @@ proc parse*(
   ##
   ## Raises:
   ## - `CertificateParsingError` if certificate parsing fails.
-  var crt: mbedtls_x509_crt
-  mbedtls_x509_crt_init(addr crt)
-  defer:
-    mbedtls_x509_crt_free(addr crt)
 
-  var extension = P2pExtension()
-  let ret = mbedtls_x509_crt_parse_der_with_ext_cb(
-    addr crt,
-    unsafeAddr certificateDer[0],
-    certificateDer.len.uint,
-    0,
-    libp2pext,
-    addr extension,
-  )
-  if ret != 0:
+  let certDerBuffer = certificateDer.toCertBuffer()
+  let certParsed: ptr cert_parsed = nil
+  defer:
+    cert_free_parsed(certParsed)
+
+  let ret = cert_parse(certDerBuffer.addr, DER.cert_format_t(), certParsed.addr)
+  if ret != CERT_SUCCESS:
     raise newException(
       CertificateParsingError, "Failed to parse certificate, error code: " & $ret
     )
 
-  let pkDer = parseCertificatePublicKey(crt.pk)
-
-  return P2pCertificate(extension: extension, pubKeyDer: pkDer)
+  P2pCertificate(
+    extension: P2pExtension(
+      signature: certParsed.signature.toSeq(), publicKey: certParsed.ident_pubk.toSeq()
+    ),
+    pubKeyDer: certParsed.cert_pbuk.toSeq(),
+  )
 
 proc verify*(self: P2pCertificate): bool =
   ## Verifies that P2pCertificate has signature that was signed by owner of the certificate.
@@ -601,6 +260,8 @@ proc verify*(self: P2pCertificate): bool =
 
   var sig: Signature
   var key: PublicKey
+
+  # TODO: validate dates
 
   if sig.init(self.extension.signature) and key.init(self.extension.publicKey):
     let msg = makeSignatureMessage(self.pubKeyDer)

--- a/libp2p/transports/tls/certificate.nim
+++ b/libp2p/transports/tls/certificate.nim
@@ -184,8 +184,8 @@ func makeSignatureMessage(pubKey: seq[byte]): seq[byte] {.inline.} =
   let prefixLen = P2P_SIGNING_PREFIX.len.int
   let msg = newSeq[byte](prefixLen + pubKey.len)
 
-  copyMem(addr msg[0], addr P2P_SIGNING_PREFIX[0], prefixLen)
-  copyMem(addr msg[prefixLen], addr pubKey[0], pubKey.len.int)
+  copyMem(msg[0].unsafeAddr, P2P_SIGNING_PREFIX[0].unsafeAddr, prefixLen)
+  copyMem(msg[prefixLen].unsafeAddr, pubKey[0].unsafeAddr, pubKey.len.int)
 
   return msg
 
@@ -219,7 +219,7 @@ func parseCertificatePublicKey(
   let certPubKeyDerPtr = addr certPubKeyDer[certPubKeyDer.len - certPubKeyDerLen]
 
   let pkDer = newSeq[byte](certPubKeyDerLen.int)
-  copyMem(addr pkDer[0], certPubKeyDerPtr, certPubKeyDerLen.int)
+  copyMem(pkDer[0].unsafeAddr, certPubKeyDerPtr, certPubKeyDerLen.int)
 
   return pkDer
 

--- a/libp2p/transports/tls/certificate_ffi.nim
+++ b/libp2p/transports/tls/certificate_ffi.nim
@@ -1,0 +1,79 @@
+when defined(macosx):
+  {.passl: "-L/opt/homebrew/opt/openssl@3/lib -lcrypto".}
+  {.passc: "-I/opt/homebrew/opt/openssl@3/include".}
+else:
+  {.passl: "-lcrypto".}
+
+{.compile: "./certificate.c".}
+
+type
+  cert_error_t* = int32
+
+  cert_format_t* {.size: sizeof(cuint).} = enum
+    CERT_FORMAT_DER = 0
+    CERT_FORMAT_PEM = 1
+
+  cert_buffer* {.pure, inheritable, bycopy.} = object
+    data*: ptr uint8
+    length*: csize_t
+
+  cert_parsed* {.pure, inheritable, bycopy.} = object
+    signature*: ptr cert_buffer
+    ident_pubk*: ptr cert_buffer
+    cert_pbuk*: ptr cert_buffer
+    valid_from*: cstring
+    valid_to*: cstring
+
+  cert_context_s* = object
+
+  cert_key_s* = object
+
+  cert_context_t* = ptr cert_context_s
+
+  cert_key_t* = ptr cert_key_s
+
+const CERT_SUCCESS* = 0
+
+proc cert_init_drbg*(
+  seed: cstring, seed_len: csize_t, ctx: ptr cert_context_t
+): cert_error_t {.cdecl, importc: "cert_init_drbg".}
+
+proc cert_generate_key*(
+  ctx: cert_context_t, out_arg: ptr cert_key_t
+): cert_error_t {.cdecl, importc: "cert_generate_key".}
+
+proc cert_serialize_privk*(
+  key: cert_key_t, out_arg: ptr ptr cert_buffer, format: cert_format_t
+): cert_error_t {.cdecl, importc: "cert_serialize_privk".}
+
+proc cert_serialize_pubk*(
+  key: cert_key_t, out_arg: ptr ptr cert_buffer, format: cert_format_t
+): cert_error_t {.cdecl, importc: "cert_serialize_pubk".}
+
+proc cert_generate*(
+  ctx: cert_context_t,
+  key: cert_key_t,
+  out_arg: ptr ptr cert_buffer,
+  signature: ptr cert_buffer,
+  ident_pubk: ptr cert_buffer,
+  cn: cstring,
+  format: cert_format_t,
+): cert_error_t {.cdecl, importc: "cert_generate".}
+
+proc cert_parse*(
+  cert: ptr cert_buffer, format: cert_format_t, out_arg: ptr ptr cert_parsed
+): cert_error_t {.cdecl, importc: "cert_parse".}
+
+proc cert_free_ctr_drbg*(
+  ctx: cert_context_t
+): void {.cdecl, importc: "cert_free_ctr_drbg".}
+
+proc cert_free_key*(key: cert_key_t): void {.cdecl, importc: "cert_free_key".}
+
+proc cert_free_buffer*(
+  buffer: ptr cert_buffer
+): void {.cdecl, importc: "cert_free_buffer".}
+
+proc cert_free_parsed*(
+  cert: ptr cert_parsed
+): void {.cdecl, importc: "cert_free_parsed".}

--- a/tests/testnative.nim
+++ b/tests/testnative.nim
@@ -26,3 +26,5 @@ import
   testrendezvous, testdiscovery, testyamux, testautonat, testautonatservice,
   testautorelay, testdcutr, testhpservice, testutility, testhelpers,
   testwildcardresolverservice
+
+import transports/tls/testcertificate


### PR DESCRIPTION
@vladopajic, @kaiserd 

I attempted to fix the compilation errors occuring in Linux i386 and macOS ARM64 (as seen in [this PR](https://github.com/vacp2p/nim-libp2p/pull/1278)), but I was not successful. There's an open issue related to [missing symbols in ARM64](https://github.com/Mbed-TLS/mbedtls/issues/9895) so it's probably the same problem affecting us. Something similar likely happens with Linux i386.

To prevent this from becoming a blocker, I quickly translated the certificate generation code to use OpenSSL instead of MbedTLS, (which I think might even make sense, given that we're already using OpenSSL via ngtcp2 + picoTLS), and Iwould suggest to use this instead of MbedTLS until the ARM64 compilation issues are resolved; and even consider to continue using OpenSSL until we can full remove OpenSSL once https://github.com/Mbed-TLS/mbedtls/issues/4731 is fixed and compilation on the previously mentioned architectures is possible.