### PR TITLE
fix: set peerId on incoming Quic connection

### DIFF
--- a/.pinned
+++ b/.pinned
@@ -8,7 +8,7 @@ json_serialization;https://github.com/status-im/nim-json-serialization@#85b7ea09
 metrics;https://github.com/status-im/nim-metrics@#6142e433fc8ea9b73379770a788017ac528d46ff
 ngtcp2;https://github.com/status-im/nim-ngtcp2@#9456daa178c655bccd4a3c78ad3b8cce1f0add73
 nimcrypto;https://github.com/cheatfate/nimcrypto@#1c8d6e3caf3abc572136ae9a1da81730c4eb4288
-quic;https://github.com/status-im/nim-quic.git@#fb8cbf0e4af3e1ccc2949c11855313ffd294b6c9
+quic;https://github.com/status-im/nim-quic.git@#c80a963d055add75cca6bd376d8f1093f124d33d
 results;https://github.com/arnetheduck/nim-results@#f3c666a272c69d70cb41e7245e7f6844797303ad
 secp256k1;https://github.com/status-im/nim-secp256k1@#7246d91c667f4cc3759fdd50339caa45a2ecd8be
 serialization;https://github.com/status-im/nim-serialization@#4bdbc29e54fe54049950e352bb969aab97173b35

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -11,7 +11,7 @@ requires "nim >= 1.6.0",
   "nimcrypto >= 0.6.0 & < 0.7.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.5",
   "chronicles >= 0.10.2", "chronos >= 4.0.3", "metrics", "secp256k1", "stew#head",
   "websock", "unittest2",
-  "https://github.com/status-im/nim-quic.git#fb8cbf0e4af3e1ccc2949c11855313ffd294b6c9"
+  "https://github.com/status-im/nim-quic.git#c80a963d055add75cca6bd376d8f1093f124d33d"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use
 let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)

--- a/libp2p/transports/tls/certificate.c
+++ b/libp2p/transports/tls/certificate.c
@@ -491,6 +491,7 @@ cert_error_t cert_generate(cert_context_t ctx, cert_key_t key,
     goto cleanup;
   }
 
+  /*
   // Add Key Usage extension
   usage = ASN1_BIT_STRING_new();
   if (!usage) {
@@ -504,9 +505,10 @@ cert_error_t cert_generate(cert_context_t ctx, cert_key_t key,
     ret_code = CERT_ERROR_EXTENSION_DATA;
     goto cleanup;
   }
+  */
 
   // Create Key Usage extension
-  ku_ex = X509_EXTENSION_create_by_NID(NULL, NID_key_usage, 1,
+  /*ku_ex = X509_EXTENSION_create_by_NID(NULL, NID_key_usage, 1,
                                        usage); // 1 for  critical
   if (!ku_ex) {
     ret_code = CERT_ERROR_EXTENSION_GEN;
@@ -517,7 +519,7 @@ cert_error_t cert_generate(cert_context_t ctx, cert_key_t key,
   if (!X509_add_ext(x509, ku_ex, -1)) {
     ret_code = CERT_ERROR_EXTENSION_ADD;
     goto cleanup;
-  }
+  }*/
 
   // Sign the certificate with SHA256
   if (!X509_sign(x509, pkey, EVP_sha256())) {
@@ -557,8 +559,8 @@ cleanup:
     BIO_free(bio);
   if (ex)
     X509_EXTENSION_free(ex);
-  if (usage)
-    ASN1_BIT_STRING_free(usage);
+  // if (usage)
+  //  ASN1_BIT_STRING_free(usage);
   if (ku_ex)
     X509_EXTENSION_free(ku_ex);
   if (oct_sign)

--- a/tests/transport-interop/Dockerfile
+++ b/tests/transport-interop/Dockerfile
@@ -3,7 +3,7 @@ FROM nimlang/nim:1.6.16 as builder
 
 WORKDIR /app
 
-COPY .pinned libp2p.nimble nim-libp2p/
+COPY .pinned libp2p.nimble nim-libp2p/ 
 
 RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y libssl-dev
 


### PR DESCRIPTION
While manually testing interop between diff implementations, i noticed that I forgot to set the peerId on incoming connections. This PR fixes that. Do notice that I had no easy way to obtain the peerId hence why I re-parse the certificate again.

Also, some impl did not understand the certificate usage, so I commented it in the meantime, and will fix it on subsequent PR tomorrow

Requires:
- https://github.com/vacp2p/nim-quic/pull/65