### PR TITLE
feat(transport): add memory transport

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -37,6 +37,8 @@ import services/wildcardresolverservice
 
 export switch, peerid, peerinfo, connection, multiaddress, crypto, errors
 
+const MemoryAutoAddress* = memorytransport.MemoryAutoAddress
+
 type
   TransportProvider* {.public.} =
     proc(upgr: Upgrade, privateKey: PrivateKey): Transport {.gcsafe, raises: [].}

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -23,7 +23,7 @@ import
   stream/connection,
   multiaddress,
   crypto/crypto,
-  transports/[transport, tcptransport, quictransport],
+  transports/[transport, tcptransport, quictransport, memorytransport],
   muxers/[muxer, mplex/mplex, yamux/yamux],
   protocols/[identify, secure/secure, secure/noise, rendezvous],
   protocols/connectivity/[autonat/server, relay/relay, relay/client, relay/rtransport],
@@ -171,6 +171,12 @@ proc withQuicTransport*(b: SwitchBuilder): SwitchBuilder {.public.} =
   b.withTransport(
     proc(upgr: Upgrade, privateKey: PrivateKey): Transport =
       QuicTransport.new(upgr, privateKey)
+  )
+
+proc withMemoryTransport*(b: SwitchBuilder): SwitchBuilder {.public.} =
+  b.withTransport(
+    proc(upgr: Upgrade, privateKey: PrivateKey): Transport =
+      MemoryTransport.new(upgr)
   )
 
 proc withRng*(b: SwitchBuilder, rng: ref HmacDrbgContext): SwitchBuilder {.public.} =

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -171,6 +171,18 @@ proc ip6zoneVB(vb: var VBuffer): bool =
   ## IPv6 validateBuffer() implementation.
   pathValidateBufferNoSlash(vb)
 
+proc memoryStB(s: string, vb: var VBuffer): bool =
+  ## Memory stringToBuffer() implementation.
+  pathStringToBuffer(s, vb)
+
+proc memoryBtS(vb: var VBuffer, s: var string): bool =
+  ## Memory bufferToString() implementation.
+  pathBufferToString(vb, s)
+
+proc memoryVB(vb: var VBuffer): bool =
+  ## Memory validateBuffer() implementation.
+  pathValidateBuffer(vb)
+
 proc portStB(s: string, vb: var VBuffer): bool =
   ## Port number stringToBuffer() implementation.
   var port: array[2, byte]
@@ -355,6 +367,10 @@ const
   )
   TranscoderDNS* =
     Transcoder(stringToBuffer: dnsStB, bufferToString: dnsBtS, validateBuffer: dnsVB)
+  TranscoderMemory* = Transcoder(
+    stringToBuffer: memoryStB, bufferToString: memoryBtS, validateBuffer: memoryVB
+  )
+
   ProtocolsList = [
     MAProtocol(mcodec: multiCodec("ip4"), kind: Fixed, size: 4, coder: TranscoderIP4),
     MAProtocol(mcodec: multiCodec("tcp"), kind: Fixed, size: 2, coder: TranscoderPort),
@@ -393,6 +409,9 @@ const
     MAProtocol(mcodec: multiCodec("p2p-websocket-star"), kind: Marker, size: 0),
     MAProtocol(mcodec: multiCodec("p2p-webrtc-star"), kind: Marker, size: 0),
     MAProtocol(mcodec: multiCodec("p2p-webrtc-direct"), kind: Marker, size: 0),
+    MAProtocol(
+      mcodec: multiCodec("memory"), kind: Path, size: 0, coder: TranscoderMemory
+    ),
   ]
 
   DNSANY* = mapEq("dns")
@@ -452,6 +471,8 @@ const
   )
 
   CircuitRelay* = mapEq("p2p-circuit")
+
+  Memory* = mapEq("memory")
 
 proc initMultiAddressCodeTable(): Table[MultiCodec, MAProtocol] {.compileTime.} =
   for item in ProtocolsList:

--- a/libp2p/multicodec.nim
+++ b/libp2p/multicodec.nim
@@ -396,6 +396,7 @@ const MultiCodecList = [
   ("onion3", 0x01BD),
   ("p2p-circuit", 0x0122),
   ("libp2p-peer-record", 0x0301),
+  ("memory", 0x0309),
   ("dns", 0x35),
   ("dns4", 0x36),
   ("dns6", 0x37),

--- a/libp2p/stream/bridgestream.nim
+++ b/libp2p/stream/bridgestream.nim
@@ -1,0 +1,60 @@
+# Nim-LibP2P
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import pkg/chronos
+import connection, bufferstream
+
+export connection
+
+type
+  WriteHandler = proc(data: seq[byte]): Future[void] {.
+    async: (raises: [CancelledError, LPStreamError])
+  .}
+
+  BridgeStream* = ref object of BufferStream
+    writeHandler: WriteHandler
+    closeHandler: proc(): Future[void] {.async: (raises: []).}
+
+method write*(
+    s: BridgeStream, msg: seq[byte]
+): Future[void] {.public, async: (raises: [CancelledError, LPStreamError], raw: true).} =
+  s.writeHandler(msg)
+
+method closeImpl*(s: BridgeStream): Future[void] {.async: (raises: [], raw: true).} =
+  if not isNil(s.closeHandler):
+    discard s.closeHandler()
+
+  procCall BufferStream(s).closeImpl()
+
+method getWrapped*(s: BridgeStream): Connection =
+  nil
+
+proc bridgedConnections*(): (BridgeStream, BridgeStream) =
+  let connA = BridgeStream()
+  let connB = BridgeStream()
+  connA.dir = Direction.In
+  connB.dir = Direction.In
+  connA.initStream()
+  connB.initStream()
+
+  connA.writeHandler = proc(
+      data: seq[byte]
+  ) {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
+    connB.pushData(data)
+  connA.closeHandler = proc(): Future[void] {.async: (raises: []).} =
+    await noCancel connB.close()
+
+  connB.writeHandler = proc(
+      data: seq[byte]
+  ) {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
+    connA.pushData(data)
+  connB.closeHandler = proc(): Future[void] {.async: (raises: []).} =
+    await noCancel connA.close()
+
+  return (connA, connB)

--- a/libp2p/transports/memorymanager.nim
+++ b/libp2p/transports/memorymanager.nim
@@ -1,0 +1,126 @@
+# Nim-LibP2P
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import locks
+import tables
+import std/sequtils
+import stew/byteutils
+import pkg/chronos
+import pkg/chronicles
+import ./transport
+import ../multiaddress
+import ../stream/connection
+import ../stream/bridgestream
+import ../muxers/muxer
+
+type
+  MemoryTransportError* = object of transport.TransportError
+  MemoryTransportAcceptStopped* = object of MemoryTransportError
+
+type MemoryListener* = object
+  address: string
+  accept: Future[Connection]
+  onListenerEnd: proc(address: string) {.closure, gcsafe, raises: [].}
+
+proc init(
+    _: type[MemoryListener],
+    address: string,
+    onListenerEnd: proc(address: string) {.closure, gcsafe, raises: [].},
+): MemoryListener =
+  return MemoryListener(
+    accept: newFuture[Connection]("MemoryListener.accept"),
+    address: address,
+    onListenerEnd: onListenerEnd,
+  )
+
+proc close*(self: MemoryListener) =
+  if not (self.accept.finished):
+    self.accept.fail(newException(MemoryTransportAcceptStopped, "Listener closed"))
+    self.onListenerEnd(self.address)
+
+proc accept*(
+    self: MemoryListener
+): Future[Connection] {.gcsafe, raises: [CatchableError].} =
+  return self.accept
+
+proc dial*(
+    self: MemoryListener
+): Future[Connection] {.gcsafe, raises: [CatchableError].} =
+  let (connA, connB) = bridgedConnections()
+
+  self.onListenerEnd(self.address)
+  self.accept.complete(connA)
+
+  let dFut = newFuture[Connection]("MemoryListener.dial")
+  dFut.complete(connB)
+
+  return dFut
+
+type memoryConnManager = ref object
+  listeners: Table[string, MemoryListener]
+  connections: Table[string, Connection]
+  lock: Lock
+
+proc init(_: type[memoryConnManager]): memoryConnManager =
+  var m = memoryConnManager()
+  initLock(m.lock)
+  return m
+
+proc onListenerEnd(
+    self: memoryConnManager
+): proc(address: string) {.closure, gcsafe, raises: [].} =
+  proc cb(address: string) {.closure, gcsafe, raises: [].} =
+    acquire(self.lock)
+    defer:
+      release(self.lock)
+
+    try:
+      if address in self.listeners:
+        self.listeners.del(address)
+    except KeyError:
+      raiseAssert "checked with if"
+
+  return cb
+
+proc accept*(
+    self: memoryConnManager, address: string
+): MemoryListener {.raises: [MemoryTransportError].} =
+  acquire(self.lock)
+  defer:
+    release(self.lock)
+
+  if address in self.listeners:
+    raise newException(MemoryTransportError, "Memory address already in use")
+
+  let listener = MemoryListener.init(address, self.onListenerEnd())
+  self.listeners[address] = listener
+
+  return listener
+
+proc dial*(
+    self: memoryConnManager, address: string
+): MemoryListener {.raises: [MemoryTransportError].} =
+  acquire(self.lock)
+  defer:
+    release(self.lock)
+
+  if address notin self.listeners:
+    raise newException(MemoryTransportError, "No memory listener found")
+
+  try:
+    let listener = self.listeners[address]
+    return listener
+  except KeyError:
+    raiseAssert "checked with if"
+
+let instance: memoryConnManager = memoryConnManager.init()
+
+proc getInstance*(): memoryConnManager {.gcsafe.} =
+  {.gcsafe.}:
+    instance

--- a/libp2p/transports/memorymanager.nim
+++ b/libp2p/transports/memorymanager.nim
@@ -114,8 +114,7 @@ proc dial*(
     raise newException(MemoryTransportError, "No memory listener found")
 
   try:
-    let listener = self.listeners[address]
-    return listener
+    return self.listeners[address]
   except KeyError:
     raiseAssert "checked with if"
 

--- a/libp2p/transports/memorytransport.nim
+++ b/libp2p/transports/memorytransport.nim
@@ -67,9 +67,9 @@ method stop*(self: MemoryTransport) {.async: (raises: []).} =
   trace "stopping memory transport", address = $self.addrs
   self.running = false
 
-  await noCancel allFutures(self.connections.mapIt(it.close()))
   if self.listener.isSome:
     self.listener.get().close()
+  await noCancel allFutures(self.connections.mapIt(it.close()))
 
 method accept*(
     self: MemoryTransport

--- a/libp2p/transports/memorytransport.nim
+++ b/libp2p/transports/memorytransport.nim
@@ -1,0 +1,120 @@
+# Nim-LibP2P
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+## Memory transport implementation
+
+import std/sequtils
+import pkg/chronos
+import pkg/chronicles
+import ./transport
+import ../multiaddress
+import ../stream/connection
+import ../crypto/crypto
+import ../upgrademngrs/upgrade
+import ../muxers/muxer
+import ./memorymanager
+
+export connection
+export MemoryTransportError, MemoryTransportAcceptStopped
+
+logScope:
+  topics = "libp2p memorytransport"
+
+type MemoryTransport* = ref object of Transport
+  rng: ref HmacDrbgContext
+  connections: seq[Connection]
+  listener: Opt[MemoryListener]
+
+proc new*(
+    T: typedesc[MemoryTransport],
+    upgrade: Upgrade = Upgrade(),
+    rng: ref HmacDrbgContext = newRng(),
+): T =
+  T(upgrader: upgrade, rng: rng)
+
+proc listenAddress(self: MemoryTransport, ma: MultiAddress): string =
+  let address = $ma
+  if address != "/memory/0":
+    return address
+
+  var randomBuf: array[20, byte]
+  hmacDrbgGenerate(self.rng[], randomBuf)
+
+  return "/memory/" & toHex(randomBuf)
+
+method start*(
+    self: MemoryTransport, addrs: seq[MultiAddress]
+) {.async: (raises: [LPError, transport.TransportError]).} =
+  if self.running:
+    return
+
+  trace "starting memory transport on addrs", address = $addrs
+
+  self.addrs =
+    addrs.mapIt(self.listenAddress(it)).mapIt(MultiAddress.init(it)).mapIt(it.get())
+  self.running = true
+
+method stop*(self: MemoryTransport) {.async: (raises: []).} =
+  if not self.running:
+    return
+
+  trace "stopping memory transport", address = $self.addrs
+  self.running = false
+
+  await noCancel allFutures(self.connections.mapIt(it.close()))
+  if self.listener.isSome:
+    self.listener.get().close()
+
+method accept*(
+    self: MemoryTransport
+): Future[Connection] {.async: (raises: [transport.TransportError, CancelledError]).} =
+  if not self.running:
+    raise newException(MemoryTransportError, "Transport closed, no more connections!")
+
+  try:
+    let listener = getInstance().accept($self.addrs[0])
+    self.listener = Opt.some(listener)
+    let conn = await listener.accept()
+    self.connections.add(conn)
+    self.listener = Opt.none(MemoryListener)
+    return conn
+  except CancelledError as e:
+    raise e
+  except MemoryTransportError as e:
+    raise e
+  except CatchableError:
+    raiseAssert "should never happen"
+
+method dial*(
+    self: MemoryTransport,
+    hostname: string,
+    ma: MultiAddress,
+    peerId: Opt[PeerId] = Opt.none(PeerId),
+): Future[Connection] {.async: (raises: [transport.TransportError, CancelledError]).} =
+  try:
+    let listener = getInstance().dial($ma)
+    let conn = await listener.dial()
+    self.connections.add(conn)
+    return conn
+  except CancelledError as e:
+    raise e
+  except MemoryTransportError as e:
+    raise e
+  except CatchableError:
+    raiseAssert "should never happen"
+
+proc dial*(
+    self: MemoryTransport, ma: MultiAddress, peerId: Opt[PeerId] = Opt.none(PeerId)
+): Future[Connection] {.gcsafe.} =
+  self.dial("", ma)
+
+method handles*(self: MemoryTransport, ma: MultiAddress): bool {.gcsafe, raises: [].} =
+  if procCall Transport(self).handles(ma):
+    if ma.protocols.isOk:
+      return Memory.match(ma)

--- a/libp2p/transports/memorytransport.nim
+++ b/libp2p/transports/memorytransport.nim
@@ -23,6 +23,8 @@ import ./memorymanager
 export connection
 export MemoryTransportError, MemoryTransportAcceptStopped
 
+const MemoryAutoAddress* = "/memory/*"
+
 logScope:
   topics = "libp2p memorytransport"
 
@@ -39,7 +41,7 @@ proc new*(
   T(upgrader: upgrade, rng: rng)
 
 proc listenAddress(self: MemoryTransport, ma: MultiAddress): MultiAddress =
-  if $ma != "/memory/*":
+  if $ma != MemoryAutoAddress:
     return ma
 
   # when special address is used `/memory/*` use any free address. 

--- a/tests/testbridgestream.nim
+++ b/tests/testbridgestream.nim
@@ -1,0 +1,45 @@
+{.used.}
+
+# Nim-LibP2P
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import ./helpers
+import stew/byteutils
+import ../libp2p/stream/bridgestream
+
+suite "BridgeStream":
+  asyncTest "send-receive":
+    let (c1, c2) = bridgestream.bridgedConnections()
+    var msg: array[8, byte]
+
+    # c1 -> c2
+    await c1.write("hello c2")
+    await c2.readExactly(addr msg, msg.len)
+    check string.fromBytes(msg) == "hello c2"
+
+    # c2 -> c1
+    await c2.write("hello c1")
+    await c1.readExactly(addr msg, msg.len)
+    check string.fromBytes(msg) == "hello c1"
+
+    await c1.close()
+    await c2.close()
+
+  asyncTest "closing":
+    # closing c1, should also close c2
+    var (c1, c2) = bridgestream.bridgedConnections()
+    await c1.close()
+    expect LPStreamEOFError:
+      await c2.write("hello c1")
+
+    # closing c2, should also close c1
+    (c1, c2) = bridgestream.bridgedConnections()
+    await c2.close()
+    expect LPStreamEOFError:
+      await c1.write("hello c2")

--- a/tests/testdiscovery.nim
+++ b/tests/testdiscovery.nim
@@ -24,7 +24,7 @@ proc createSwitch(rdv: RendezVous = RendezVous.new()): Switch =
   SwitchBuilder
   .new()
   .withRng(newRng())
-  .withAddresses(@[MultiAddress.init("/memory/0").tryGet()])
+  .withAddresses(@[MultiAddress.init("/memory/*").tryGet()])
   .withMemoryTransport()
   .withMplex()
   .withNoise()

--- a/tests/testdiscovery.nim
+++ b/tests/testdiscovery.nim
@@ -24,8 +24,8 @@ proc createSwitch(rdv: RendezVous = RendezVous.new()): Switch =
   SwitchBuilder
   .new()
   .withRng(newRng())
-  .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
-  .withTcpTransport()
+  .withAddresses(@[MultiAddress.init("/memory/0").tryGet()])
+  .withMemoryTransport()
   .withMplex()
   .withNoise()
   .withRendezVous(rdv)

--- a/tests/testdiscovery.nim
+++ b/tests/testdiscovery.nim
@@ -24,7 +24,7 @@ proc createSwitch(rdv: RendezVous = RendezVous.new()): Switch =
   SwitchBuilder
   .new()
   .withRng(newRng())
-  .withAddresses(@[MultiAddress.init("/memory/*").tryGet()])
+  .withAddresses(@[MultiAddress.init(MemoryAutoAddress).tryGet()])
   .withMemoryTransport()
   .withMplex()
   .withNoise()

--- a/tests/testmemorytransport.nim
+++ b/tests/testmemorytransport.nim
@@ -1,0 +1,149 @@
+{.used.}
+
+# Nim-LibP2P
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [].}
+
+import stew/byteutils
+import ../libp2p/[transports/memorytransport, multiaddress]
+import ./helpers
+
+suite "Memory transport":
+  teardown:
+    checkTrackers()
+
+  asyncTest "memory multiaddress":
+    let ma = MultiAddress.init("/memory/addr-1").get()
+    check $ma == "/memory/addr-1"
+
+  asyncTest "can handle local address":
+    let ma = @[MultiAddress.init("/memory/addr-1").get()]
+    let transport: MemoryTransport = MemoryTransport.new()
+    await transport.start(ma)
+    check transport.handles(transport.addrs[0])
+    await transport.stop()
+
+  asyncTest "send receive":
+    let ma = @[MultiAddress.init("/memory/addr-1").get()]
+    let server = MemoryTransport.new()
+    await server.start(ma)
+
+    proc runClient() {.async.} =
+      let client = MemoryTransport.new()
+      let conn = await client.dial("", ma[0])
+
+      await conn.write("client")
+      var resp: array[6, byte]
+      await conn.readExactly(addr resp, resp.len)
+      await conn.close()
+
+      check string.fromBytes(resp) == "server"
+      await client.stop()
+
+    proc serverAcceptHandler() {.async.} =
+      let conn = await server.accept()
+      var resp: array[6, byte]
+      await conn.readExactly(addr resp, resp.len)
+      check string.fromBytes(resp) == "client"
+
+      await conn.write("server")
+      await conn.close()
+      await server.stop()
+
+    asyncSpawn serverAcceptHandler()
+    await runClient()
+
+  asyncTest "server already started":
+    let ma = @[MultiAddress.init("/memory/addr-1").get()]
+    let server = MemoryTransport.new()
+    await server.start(ma)
+
+    proc serverAcceptHandler() {.async.} =
+      let conn = await server.accept()
+      await conn.close()
+
+    asyncSpawn serverAcceptHandler()
+
+    # accept by server2 should not succeed
+    let server2 = MemoryTransport.new()
+    await server2.start(ma)
+    expect MemoryTransportError:
+      discard await server2.accept()
+
+    # dial to pass through server.accept()
+    let conn = await server2.dial("", ma[0])
+    await conn.close()
+
+    await server.stop()
+    await server2.stop()
+
+  asyncTest "server stopping - should drop accept":
+    let ma = @[MultiAddress.init("/memory/addr-1").get()]
+    let server = MemoryTransport.new()
+    await server.start(ma)
+
+    proc serverAcceptHandler() {.async.} =
+      # should throw error when stopped
+      expect MemoryTransportAcceptStopped:
+        discard await server.accept()
+
+    asyncSpawn serverAcceptHandler()
+    await server.stop()
+
+  asyncTest "server conn close propagated to client":
+    let ma = @[MultiAddress.init("/memory/addr-1").get()]
+    let server = MemoryTransport.new()
+    await server.start(ma)
+
+    proc serverAcceptHandler() {.async.} =
+      let conn = await server.accept()
+      var resp: array[6, byte]
+      await conn.readExactly(addr resp, resp.len)
+      check string.fromBytes(resp) == "client"
+
+      await conn.close()
+      await server.stop()
+
+    proc runClient() {.async.} =
+      let client = MemoryTransport.new()
+      let conn = await client.dial("", ma[0])
+
+      await conn.write("client")
+      var resp: array[6, byte]
+      expect LPStreamEOFError:
+        await conn.readExactly(addr resp, resp.len)
+
+      await conn.close() # already closed
+      await client.stop()
+
+    asyncSpawn serverAcceptHandler()
+    await runClient()
+
+  asyncTest "client conn close propagated to server":
+    let ma = @[MultiAddress.init("/memory/addr-1").get()]
+    let server = MemoryTransport.new()
+    await server.start(ma)
+
+    proc serverAcceptHandler() {.async.} =
+      let conn = await server.accept()
+      expect LPStreamEOFError:
+        await conn.write("server") # already closed
+
+      await conn.close()
+      await server.stop()
+
+    proc runClient() {.async.} =
+      let client = MemoryTransport.new()
+      let conn = await client.dial("", ma[0])
+      await conn.close()
+      await client.stop()
+
+    asyncSpawn serverAcceptHandler()
+    await runClient()

--- a/tests/testnative.nim
+++ b/tests/testnative.nim
@@ -10,8 +10,8 @@
 # those terms.
 
 import
-  testvarint, testconnection, testminprotobuf, teststreamseq, testsemaphore,
-  testheartbeat, testfuture
+  testvarint, testconnection, testbridgestream, testminprotobuf, teststreamseq,
+  testsemaphore, testheartbeat, testfuture
 
 import testminasn1, testrsa, testecnist, tested25519, testsecp256k1, testcrypto
 
@@ -20,11 +20,16 @@ import
   testsigned_envelope, testrouting_record
 
 import
-  testtcptransport, testtortransport, testnameresolve, testwstransport, testmultistream,
-  testbufferstream, testidentify, testobservedaddrmanager, testconnmngr, testswitch,
-  testnoise, testpeerinfo, testpeerstore, testping, testmplex, testrelayv1, testrelayv2,
-  testrendezvous, testdiscovery, testyamux, testautonat, testautonatservice,
-  testautorelay, testdcutr, testhpservice, testutility, testhelpers,
-  testwildcardresolverservice
+  testtcptransport,
+  testtortransport,
+  testwstransport,
+  # testquic TODO
+  testmemorytransport,
+  transports/tls/testcertificate
 
-import transports/tls/testcertificate
+import
+  testnameresolve, testmultistream, testbufferstream, testidentify,
+  testobservedaddrmanager, testconnmngr, testswitch, testnoise, testpeerinfo,
+  testpeerstore, testping, testmplex, testrelayv1, testrelayv2, testrendezvous,
+  testdiscovery, testyamux, testautonat, testautonatservice, testautorelay, testdcutr,
+  testhpservice, testutility, testhelpers, testwildcardresolverservice


### PR DESCRIPTION
this pr add `memory` transports that can be used as drop in replacement for other transports in case if users don't need to go into network stack. memory transport only works in scope of same process.