### PR TITLE
fix: do not use while loop for quic transport errors

### DIFF
--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -283,22 +283,19 @@ method accept*(
 .} =
   doAssert not self.listener.isNil, "call start() before calling accept()"
 
-  while true:
-    if not self.running:
-      # stop accept only when transport is stopped (not when error occurs)
-      raise newException(QuicTransportAcceptStopped, "Quic transport stopped")
+  if not self.running:
+    # stop accept only when transport is stopped (not when error occurs)
+    raise newException(QuicTransportAcceptStopped, "Quic transport stopped")
 
-    try:
-      let connection = await self.listener.accept()
-      return self.wrapConnection(connection)
-    except CancelledError as e:
-      raise e
-    except QuicError as e:
-      trace "Quic accept connection error", msg = e.msg
-      # swallow all errors and continue accepting until connection is established
-      continue
-    except CatchableError as e:
-      raise (ref QuicTransportError)(msg: e.msg, parent: e)
+  try:
+    let connection = await self.listener.accept()
+    return self.wrapConnection(connection)
+  except CancelledError as e:
+    raise e
+  except QuicError as e:
+    raise (ref QuicTransportError)(msg: e.msg, parent: e)
+  except CatchableError as e:
+    raise (ref QuicTransportError)(msg: e.msg, parent: e)
 
 method dial*(
     self: QuicTransport,

--- a/tests/testquic.nim
+++ b/tests/testquic.nim
@@ -12,7 +12,6 @@ import
     errors,
     wire,
   ]
-import quic
 import ./helpers
 
 proc createServerAcceptConn(
@@ -25,6 +24,9 @@ proc createServerAcceptConn(
   .} =
     try:
       let conn = await server.accept()
+      if conn == nil:
+        return
+
       let stream = await getStream(QuicSession(conn), Direction.In)
       var resp: array[6, byte]
       await stream.readExactly(addr resp, 6)
@@ -32,8 +34,6 @@ proc createServerAcceptConn(
 
       await stream.write("server")
       await stream.close()
-    except QuicTransportError:
-      discard # Transport failed (maybe dial error / handshake err, etc)
     except QuicTransportAcceptStopped:
       discard # Transport is stopped
 

--- a/tests/testquic.nim
+++ b/tests/testquic.nim
@@ -12,6 +12,7 @@ import
     errors,
     wire,
   ]
+import quic
 import ./helpers
 
 proc createServerAcceptConn(
@@ -31,6 +32,8 @@ proc createServerAcceptConn(
 
       await stream.write("server")
       await stream.close()
+    except QuicTransportError:
+      discard # Transport failed (maybe dial error / handshake err, etc)
     except QuicTransportAcceptStopped:
       discard # Transport is stopped
 


### PR DESCRIPTION
While reviewing code in more detail I saw that instead of having a `while true` and `continue` in the quic transport, we should instead return nil. This is gonna be later handled in here https://github.com/vacp2p/nim-libp2p/blob/master/libp2p/switch.nim#L273-L283 where we check whether the returned connection is nil or not. Since in this PR, when there's a QuicError, no connection will be returned, then we'll enter this condition https://github.com/vacp2p/nim-libp2p/blob/master/libp2p/switch.nim#L281-L283 . Do note that this code is already inside a `while transport.isRunning`. https://github.com/vacp2p/nim-libp2p/blob/master/libp2p/switch.nim#L264 so it will try to `accept` again in the next iteration

This should be refactored later in all transports to not return nil, but an option instead since it's semantically better