### PR TITLE
chore: rendezvous improvements

### DIFF
--- a/libp2p/discovery/rendezvousinterface.nim
+++ b/libp2p/discovery/rendezvousinterface.nim
@@ -26,14 +26,14 @@ proc `==`*(a, b: RdvNamespace): bool {.borrow.}
 method request*(
     self: RendezVousInterface, pa: PeerAttributes
 ) {.async: (raises: [DiscoveryError, CancelledError]).} =
-  var namespace = ""
+  var namespace = Opt.none(string)
   for attr in pa:
     if attr.ofType(RdvNamespace):
-      namespace = string attr.to(RdvNamespace)
+      namespace = Opt.some(string attr.to(RdvNamespace))
     elif attr.ofType(DiscoveryService):
-      namespace = string attr.to(DiscoveryService)
+      namespace = Opt.some(string attr.to(DiscoveryService))
     elif attr.ofType(PeerId):
-      namespace = $attr.to(PeerId)
+      namespace = Opt.some($attr.to(PeerId))
     else:
       # unhandled type
       return
@@ -44,8 +44,8 @@ method request*(
       for address in pr.addresses:
         peer.add(address.address)
 
-      peer.add(DiscoveryService(namespace))
-      peer.add(RdvNamespace(namespace))
+      peer.add(DiscoveryService(namespace.get()))
+      peer.add(RdvNamespace(namespace.get()))
       self.onPeerFound(peer)
 
     await sleepAsync(self.timeToRequest)

--- a/tests/testrendezvous.nim
+++ b/tests/testrendezvous.nim
@@ -58,18 +58,22 @@ suite "RendezVous":
     await client.start()
     await remoteSwitch.start()
     await client.connect(remoteSwitch.peerInfo.peerId, remoteSwitch.peerInfo.addrs)
-    let res0 = await rdv.request("empty")
+    let res0 = await rdv.request(Opt.some("empty"))
     check res0.len == 0
+
     await rdv.advertise("foo")
-    let res1 = await rdv.request("foo")
+    let res1 = await rdv.request(Opt.some("foo"))
     check:
       res1.len == 1
       res1[0] == client.peerInfo.signedPeerRecord.data
-    let res2 = await rdv.request("bar")
+
+    let res2 = await rdv.request(Opt.some("bar"))
     check res2.len == 0
+
     await rdv.unsubscribe("foo")
-    let res3 = await rdv.request("foo")
+    let res3 = await rdv.request(Opt.some("foo"))
     check res3.len == 0
+
     await allFutures(client.stop(), remoteSwitch.stop())
 
   asyncTest "Harder remote test":
@@ -88,17 +92,21 @@ suite "RendezVous":
     )
     await allFutures(rdvSeq.mapIt(it.advertise("foo")))
     var data = clientSeq.mapIt(it.peerInfo.signedPeerRecord.data)
-    let res1 = await rdvSeq[0].request("foo", 5)
+    let res1 = await rdvSeq[0].request(Opt.some("foo"), 5)
     check res1.len == 5
     for d in res1:
       check d in data
     data.keepItIf(it notin res1)
-    let res2 = await rdvSeq[0].request("foo")
+    let res2 = await rdvSeq[0].request(Opt.some("foo"))
     check res2.len == 5
     for d in res2:
       check d in data
-    let res3 = await rdvSeq[0].request("foo")
+    let res3 = await rdvSeq[0].request(Opt.some("foo"))
     check res3.len == 0
+    let res4 = await rdvSeq[0].request()
+    check res4.len == 11
+    let res5 = await rdvSeq[0].request(Opt.none(string))
+    check res5.len == 11
     await remoteSwitch.stop()
     await allFutures(clientSeq.mapIt(it.stop()))
 
@@ -116,9 +124,9 @@ suite "RendezVous":
     await clientA.connect(remoteSwitch.peerInfo.peerId, remoteSwitch.peerInfo.addrs)
     await clientB.connect(remoteSwitch.peerInfo.peerId, remoteSwitch.peerInfo.addrs)
     await rdvA.advertise("foo")
-    let res1 = await rdvA.request("foo")
+    let res1 = await rdvA.request(Opt.some("foo"))
     await rdvB.advertise("foo")
-    let res2 = await rdvA.request("foo")
+    let res2 = await rdvA.request(Opt.some("foo"))
     check:
       res2.len == 1
       res2[0] == clientB.peerInfo.signedPeerRecord.data
@@ -129,11 +137,11 @@ suite "RendezVous":
       rdv = RendezVous.new(minDuration = 1.minutes, maxDuration = 72.hours)
       switch = createSwitch(rdv)
     expect AdvertiseError:
-      discard await rdv.request("A".repeat(300))
+      discard await rdv.request(Opt.some("A".repeat(300)))
     expect AdvertiseError:
-      discard await rdv.request("A", -1)
+      discard await rdv.request(Opt.some("A"), -1)
     expect AdvertiseError:
-      discard await rdv.request("A", 3000)
+      discard await rdv.request(Opt.some("A"), 3000)
     expect AdvertiseError:
       await rdv.advertise("A".repeat(300))
     expect AdvertiseError:


### PR DESCRIPTION
Fixes (most of) #1307 

1. Uses `Opt[string]` for `namespace` fields on `Cookie` and `request` (which does `Discover`s). You can now do `rdv.request()` or `rdv.request(Opt.none(string))` to get all namespaces.
2. Functions that timeout now get `timeout` as a parameter instead of hardcoded values
3.  Add `MaximumMessageLen` (4MB) as a safe max read size for `readLp`, similar to [go-libp2p's implementation](https://github.com/libp2p/go-libp2p/blob/v0.41.1/core/network/network.go#L19C1-L23C39)