### PR TITLE
chore: fix broken old status-im links

### DIFF
--- a/examples/tutorial_4_gossipsub.nim
+++ b/examples/tutorial_4_gossipsub.nim
@@ -158,8 +158,8 @@ waitFor(main())
 ## This is John receiving & logging everyone's metrics.
 ##
 ## ## Going further
-## Building efficient & safe GossipSub networks is a tricky subject. By tweaking the [gossip params](https://status-im.github.io/nim-libp2p/master/libp2p/protocols/pubsub/gossipsub/types.html#GossipSubParams)
-## and [topic params](https://status-im.github.io/nim-libp2p/master/libp2p/protocols/pubsub/gossipsub/types.html#TopicParams),
+## Building efficient & safe GossipSub networks is a tricky subject. By tweaking the [gossip params](https://vacp2p.github.io/nim-libp2p/master/libp2p/protocols/pubsub/gossipsub/types.html#GossipSubParams)
+## and [topic params](https://vacp2p.github.io/nim-libp2p/master/libp2p/protocols/pubsub/gossipsub/types.html#TopicParams),
 ## you can achieve very different properties.
 ##
 ## Also see reports for [GossipSub v1.1](https://gateway.ipfs.io/ipfs/QmRAFP5DBnvNjdYSbWhEhVRJJDFCLpPyvew5GwCCB4VxM4)

--- a/libp2p.nim
+++ b/libp2p.nim
@@ -17,7 +17,7 @@ when defined(nimdoc):
   ## stay backward compatible during the Major version, whereas private ones can
   ## change at each new Minor version.
   ##
-  ## If you're new to nim-libp2p, you can find a tutorial `here<https://status-im.github.io/nim-libp2p/docs/tutorial_1_connect/>`_
+  ## If you're new to nim-libp2p, you can find a tutorial `here<https://vacp2p.github.io/nim-libp2p/docs/tutorial_1_connect/>`_
   ## that can help you get started.
 
   # Import stuff for doc

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: nim-libp2p
 
-repo_url: https://github.com/status-im/nim-libp2p
-repo_name: status-im/nim-libp2p
-site_url: https://status-im.github.io/nim-libp2p/docs
+repo_url: https://github.com/vacp2p/nim-libp2p
+repo_name: vacp2p/nim-libp2p
+site_url: https://vacp2p.github.io/nim-libp2p/docs
 # Can't find a way to point the edit to the .nim instead
 # of the .md
 edit_uri: ''


### PR DESCRIPTION
Some links refer back to the old `status-im` org, most of which redirect to corrected new repos, but a few of them don't. Fixed the ones that are broken. 