### PR TITLE
test: combine tests

### DIFF
--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -68,7 +68,7 @@ task testfilter, "Run PKI filter test":
   runTest("testpkifilter", moreoptions = "-d:libp2p_pki_schemes=")
 
 task test, "Runs the test suite":
-  runTest("testall", moreoptions = "--parallelBuild:0")
+  runTest("testall")
   exec "nimble testfilter"
 
 task test_slim, "Runs the (slimmed down) test suite":

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -68,10 +68,7 @@ task testfilter, "Run PKI filter test":
   runTest("testpkifilter", moreoptions = "-d:libp2p_pki_schemes=")
 
 task test, "Runs the test suite":
-  exec "nimble testnative"
-  exec "nimble testpubsub"
-  exec "nimble testdaemon"
-  exec "nimble testinterop"
+  runTest("testall", moreoptions = "--parallelBuild:0")
   exec "nimble testfilter"
 
 task test_slim, "Runs the (slimmed down) test suite":

--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -1,0 +1,3 @@
+{.used.}
+
+import testnative, testdaemon, ./pubsub/testpubsub, testinterop


### PR DESCRIPTION
Changes:
- combine all tests (beside `testfilter`) to limit compilations and further improve Unit Tests execution time

Note: order of the imports matter: `testnative, testdaemon, ./pubsub/testpubsub, testinterop`. When I tried to run `testpubsub` last, a lot of tests failed, probably due to: https://github.com/vacp2p/nim-libp2p/issues/1330.