### PR TITLE
test: include missing tests in testall

### DIFF
--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -71,11 +71,6 @@ task test, "Runs the test suite":
   runTest("testall")
   exec "nimble testfilter"
 
-task test_slim, "Runs the (slimmed down) test suite":
-  exec "nimble testnative"
-  exec "nimble testpubsub"
-  exec "nimble testfilter"
-
 task website, "Build the website":
   tutorialToMd("examples/tutorial_1_connect.nim")
   tutorialToMd("examples/tutorial_2_customproto.nim")

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -60,11 +60,7 @@ task testpubsub, "Runs pubsub tests":
   runTest("pubsub/testpubsub")
 
 task testfilter, "Run PKI filter test":
-  runTest("testpkifilter", moreoptions = "-d:libp2p_pki_schemes=\"secp256k1\"")
-  runTest("testpkifilter", moreoptions = "-d:libp2p_pki_schemes=\"secp256k1;ed25519\"")
-  runTest(
-    "testpkifilter", moreoptions = "-d:libp2p_pki_schemes=\"secp256k1;ed25519;ecnist\""
-  )
+  runTest("testpkifilter")
   runTest("testpkifilter", moreoptions = "-d:libp2p_pki_schemes=")
 
 task test, "Runs the test suite":

--- a/tests/testall.nim
+++ b/tests/testall.nim
@@ -1,3 +1,4 @@
 {.used.}
 
-import testnative, testdaemon, ./pubsub/testpubsub, testinterop
+import
+  testnative, testdaemon, ./pubsub/testgossipinternal, ./pubsub/testpubsub, testinterop


### PR DESCRIPTION
Changes:
- include `pubsub/testgossipinternal` in `testall`
- simplify `testfilter`, keep 2 cases:
    - all schemes supported
    - no scheme supported
- delete `test_slim`