### PR TITLE
chore: fix warnings

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -4,7 +4,6 @@ if dirExists("nimbledeps/pkgs"):
 if dirExists("nimbledeps/pkgs2"):
   switch("NimblePath", "nimbledeps/pkgs2")
 
-switch("warningAsError", "UnusedImport:on")
 switch("warning", "CaseTransition:off")
 switch("warning", "ObservableStores:off")
 switch("warning", "LockLevel:off")

--- a/config.nims
+++ b/config.nims
@@ -4,6 +4,7 @@ if dirExists("nimbledeps/pkgs"):
 if dirExists("nimbledeps/pkgs2"):
   switch("NimblePath", "nimbledeps/pkgs2")
 
+switch("warningAsError", "UnusedImport:on")
 switch("warning", "CaseTransition:off")
 switch("warning", "ObservableStores:off")
 switch("warning", "LockLevel:off")

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -10,7 +10,7 @@ skipDirs = @["tests", "examples", "Nim", "tools", "scripts", "docs"]
 requires "nim >= 1.6.0",
   "nimcrypto >= 0.6.0 & < 0.7.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.5",
   "chronicles >= 0.10.2", "chronos >= 4.0.3", "metrics", "secp256k1", "stew#head",
-  "websock", "unittest2",
+  "websock", "unittest2", "results",
   "https://github.com/status-im/nim-quic.git#d54e8f0f2e454604b767fadeae243d95c30c383f"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use

--- a/libp2p/cid.nim
+++ b/libp2p/cid.nim
@@ -12,8 +12,8 @@
 {.push raises: [].}
 
 import tables, hashes
-import multibase, multicodec, multihash, vbuffer, varint
-import stew/[base58, results]
+import multibase, multicodec, multihash, vbuffer, varint, results
+import stew/base58
 
 export results
 

--- a/libp2p/crypto/crypto.nim
+++ b/libp2p/crypto/crypto.nim
@@ -76,7 +76,7 @@ import nimcrypto/[rijndael, twofish, sha2, hash, hmac]
 # We use `ncrutils` for constant-time hexadecimal encoding/decoding procedures.
 import nimcrypto/utils as ncrutils
 import ../utility
-import stew/results
+import results
 export results, utility
 
 # This is workaround for Nim's `import` bug

--- a/libp2p/crypto/curve25519.nim
+++ b/libp2p/crypto/curve25519.nim
@@ -18,7 +18,7 @@
 {.push raises: [].}
 
 import bearssl/[ec, rand]
-import stew/results
+import results
 from stew/assign2 import assign
 export results
 

--- a/libp2p/crypto/ecnist.nim
+++ b/libp2p/crypto/ecnist.nim
@@ -21,7 +21,8 @@ import bearssl/[ec, rand, hash]
 import nimcrypto/utils as ncrutils
 import minasn1
 export minasn1.Asn1Error
-import stew/[results, ctops]
+import stew/ctops
+import results
 
 import ../utility
 

--- a/libp2p/crypto/ed25519/ed25519.nim
+++ b/libp2p/crypto/ed25519/ed25519.nim
@@ -18,7 +18,8 @@ import constants
 import nimcrypto/[hash, sha2]
 # We use `ncrutils` for constant-time hexadecimal encoding/decoding procedures.
 import nimcrypto/utils as ncrutils
-import stew/[results, ctops]
+import results
+import stew/ctops
 
 import ../../utility
 

--- a/libp2p/crypto/minasn1.nim
+++ b/libp2p/crypto/minasn1.nim
@@ -644,7 +644,6 @@ proc read*(ab: var Asn1Buffer): Asn1Result[Asn1Field] =
         return ok(field)
       else:
         return err(Asn1Error.NoSupport)
-
     else:
       return err(Asn1Error.NoSupport)
 

--- a/libp2p/crypto/minasn1.nim
+++ b/libp2p/crypto/minasn1.nim
@@ -292,28 +292,6 @@ proc asn1EncodeBitString*(
       dest[2 + lenlen + bytelen - 1] = lastbyte and mask
   res
 
-proc asn1EncodeTag[T: SomeUnsignedInt](dest: var openArray[byte], value: T): int =
-  var v = value
-  if value <= cast[T](0x7F):
-    if len(dest) >= 1:
-      dest[0] = cast[byte](value)
-    1
-  else:
-    var s = 0
-    var res = 0
-    while v != 0:
-      v = v shr 7
-      s += 7
-      inc(res)
-    if len(dest) >= res:
-      var k = 0
-      while s != 0:
-        s -= 7
-        dest[k] = cast[byte](((value shr s) and cast[T](0x7F)) or cast[T](0x80))
-        inc(k)
-      dest[k - 1] = dest[k - 1] and 0x7F'u8
-    res
-
 proc asn1EncodeOid*(dest: var openArray[byte], value: openArray[byte]): int =
   ## Encode array of bytes ``value`` as ASN.1 DER `OBJECT IDENTIFIER` and return
   ## number of bytes (octets) used.
@@ -667,8 +645,6 @@ proc read*(ab: var Asn1Buffer): Asn1Result[Asn1Field] =
       else:
         return err(Asn1Error.NoSupport)
 
-      inclass = false
-      ttag = 0
     else:
       return err(Asn1Error.NoSupport)
 

--- a/libp2p/crypto/minasn1.nim
+++ b/libp2p/crypto/minasn1.nim
@@ -11,7 +11,8 @@
 
 {.push raises: [].}
 
-import stew/[endians2, results, ctops]
+import stew/[endians2, ctops]
+import results
 export results
 # We use `ncrutils` for constant-time hexadecimal encoding/decoding procedures.
 import nimcrypto/utils as ncrutils

--- a/libp2p/crypto/rsa.nim
+++ b/libp2p/crypto/rsa.nim
@@ -17,7 +17,8 @@
 
 import bearssl/[rsa, rand, hash]
 import minasn1
-import stew/[results, ctops]
+import results
+import stew/ctops
 # We use `ncrutils` for constant-time hexadecimal encoding/decoding procedures.
 import nimcrypto/utils as ncrutils
 

--- a/libp2p/crypto/secp.nim
+++ b/libp2p/crypto/secp.nim
@@ -10,7 +10,7 @@
 {.push raises: [].}
 
 import bearssl/rand
-import secp256k1, stew/[byteutils, results], nimcrypto/[hash, sha2]
+import secp256k1, results, stew/byteutils, nimcrypto/[hash, sha2]
 
 export sha2, results, rand
 

--- a/libp2p/dial.nim
+++ b/libp2p/dial.nim
@@ -10,7 +10,7 @@
 {.push raises: [].}
 
 import chronos
-import stew/results
+import results
 import peerid, stream/connection, transports/transport
 
 export results

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -9,8 +9,7 @@
 
 import std/tables
 
-import stew/results
-import pkg/[chronos, chronicles, metrics]
+import pkg/[chronos, chronicles, metrics, results]
 
 import
   dial,

--- a/libp2p/discovery/discoverymngr.nim
+++ b/libp2p/discovery/discoverymngr.nim
@@ -10,7 +10,7 @@
 {.push raises: [].}
 
 import std/sequtils
-import chronos, chronicles, stew/results
+import chronos, chronicles, results
 import ../errors
 
 type

--- a/libp2p/multibase.nim
+++ b/libp2p/multibase.nim
@@ -16,7 +16,8 @@
 {.push raises: [].}
 
 import tables
-import stew/[base32, base58, base64, results]
+import results
+import stew/[base32, base58, base64]
 
 type
   MultiBaseStatus* {.pure.} = enum

--- a/libp2p/multicodec.nim
+++ b/libp2p/multicodec.nim
@@ -13,7 +13,7 @@
 
 import tables, hashes
 import vbuffer
-import stew/results
+import results
 export results
 
 ## List of officially supported codecs can BE found here

--- a/libp2p/multihash.nim
+++ b/libp2p/multihash.nim
@@ -27,7 +27,7 @@ import tables
 import nimcrypto/[sha, sha2, keccak, blake2, hash, utils]
 import varint, vbuffer, multicodec, multibase
 import stew/base58
-import stew/results
+import results
 export results
 # This is workaround for Nim `import` bug.
 export sha, sha2, keccak, blake2, hash, utils

--- a/libp2p/peerid.nim
+++ b/libp2p/peerid.nim
@@ -14,7 +14,8 @@
 
 import
   std/[hashes, strutils],
-  stew/[base58, results],
+  stew/base58,
+  results,
   chronicles,
   nimcrypto/utils,
   utility,

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -11,7 +11,7 @@
 {.push public.}
 
 import std/sequtils
-import pkg/[chronos, chronicles, stew/results]
+import pkg/[chronos, chronicles, results]
 import peerid, multiaddress, multicodec, crypto/crypto, routing_record, errors, utility
 
 export peerid, multiaddress, crypto, routing_record, errors, results

--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -160,10 +160,10 @@ proc updatePeerInfo*(
     peerStore[KeyBook][info.peerId] = pubkey
 
   info.agentVersion.withValue(agentVersion):
-    peerStore[AgentBook][info.peerId] = agentVersion.string
+    peerStore[AgentBook][info.peerId] = agentVersion
 
   info.protoVersion.withValue(protoVersion):
-    peerStore[ProtoVersionBook][info.peerId] = protoVersion.string
+    peerStore[ProtoVersionBook][info.peerId] = protoVersion
 
   if info.protos.len > 0:
     peerStore[ProtoBook][info.peerId] = info.protos

--- a/libp2p/protobuf/minprotobuf.nim
+++ b/libp2p/protobuf/minprotobuf.nim
@@ -11,7 +11,7 @@
 
 {.push raises: [].}
 
-import ../varint, ../utility, stew/[endians2, results]
+import ../varint, ../utility, stew/endians2, results
 export results, utility
 
 {.push public.}

--- a/libp2p/protocols/connectivity/autonat/core.nim
+++ b/libp2p/protocols/connectivity/autonat/core.nim
@@ -9,8 +9,8 @@
 
 {.push raises: [].}
 
-import stew/[results, objects]
-import chronos, chronicles
+import stew/objects
+import results, chronos, chronicles
 import ../../../multiaddress, ../../../peerid, ../../../errors
 import ../../../protobuf/minprotobuf
 

--- a/libp2p/protocols/connectivity/autonat/server.nim
+++ b/libp2p/protocols/connectivity/autonat/server.nim
@@ -10,7 +10,7 @@
 {.push raises: [].}
 
 import std/[sets, sequtils]
-import stew/results
+import results
 import chronos, chronicles
 import
   ../../protocol,

--- a/libp2p/protocols/connectivity/relay/messages.nim
+++ b/libp2p/protocols/connectivity/relay/messages.nim
@@ -10,7 +10,8 @@
 {.push raises: [].}
 
 import macros
-import stew/[objects, results]
+import stew/objects
+import results
 import ../../../peerinfo, ../../../signed_envelope
 import ../../../protobuf/minprotobuf
 

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -13,8 +13,7 @@
 {.push raises: [].}
 
 import std/[sequtils, options, strutils, sugar]
-import stew/results
-import chronos, chronicles
+import results, chronos, chronicles
 import
   ../protobuf/minprotobuf,
   ../peerinfo,

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -9,7 +9,7 @@
 
 {.push raises: [].}
 
-import chronos, stew/results
+import chronos, results
 import ../stream/connection
 
 export results

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -20,7 +20,6 @@ import ../../peerid
 import ../../peerinfo
 import ../../protobuf/minprotobuf
 import ../../utility
-import ../../errors
 
 import secure, ../../crypto/[crypto, chacha20poly1305, curve25519, hkdf]
 

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -11,7 +11,7 @@
 {.push raises: [].}
 
 import std/[strformat]
-import stew/results
+import results
 import chronos, chronicles
 import
   ../protocol,

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -18,8 +18,7 @@ import
   ../../stream/streamseq,
   ../../stream/connection,
   ../../multiaddress,
-  ../../peerinfo,
-  ../../errors
+  ../../peerinfo
 
 export protocol, results
 

--- a/libp2p/routing_record.nim
+++ b/libp2p/routing_record.nim
@@ -12,7 +12,7 @@
 {.push raises: [].}
 
 import std/[sequtils, times]
-import pkg/stew/results
+import pkg/results
 import multiaddress, multicodec, peerid, protobuf/minprotobuf, signed_envelope
 
 export peerid, multiaddress, signed_envelope

--- a/libp2p/services/wildcardresolverservice.nim
+++ b/libp2p/services/wildcardresolverservice.nim
@@ -10,8 +10,8 @@
 {.push raises: [].}
 
 import std/sequtils
-import stew/[byteutils, results, endians2]
-import chronos, chronos/transports/[osnet, ipnet], chronicles
+import stew/endians2
+import chronos, chronos/transports/[osnet, ipnet], chronicles, results
 import ../[multiaddress, multicodec]
 import ../switch
 
@@ -73,7 +73,6 @@ proc new*(
   return T(networkInterfaceProvider: networkInterfaceProvider)
 
 proc getProtocolArgument*(ma: MultiAddress, codec: MultiCodec): MaResult[seq[byte]] =
-  var buffer: seq[byte]
   for item in ma:
     let
       ritem = ?item

--- a/libp2p/signed_envelope.nim
+++ b/libp2p/signed_envelope.nim
@@ -12,7 +12,7 @@
 {.push raises: [].}
 
 import std/sugar
-import pkg/stew/[results, byteutils]
+import pkg/stew/byteutils, pkg/results
 import multicodec, crypto/crypto, protobuf/minprotobuf, vbuffer
 
 export crypto

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -10,7 +10,7 @@
 {.push raises: [].}
 
 import std/[strformat]
-import stew/results
+import results
 import chronos, chronicles, metrics
 import connection
 import ../utility

--- a/libp2p/stream/connection.nim
+++ b/libp2p/stream/connection.nim
@@ -10,7 +10,7 @@
 {.push raises: [].}
 
 import std/[hashes, oids, strformat]
-import stew/results
+import results
 import chronicles, chronos, metrics
 import lpstream, ../multiaddress, ../peerinfo, ../errors
 

--- a/libp2p/transports/memorymanager.nim
+++ b/libp2p/transports/memorymanager.nim
@@ -9,15 +9,12 @@
 
 import locks
 import tables
-import std/sequtils
-import stew/byteutils
 import pkg/chronos
 import pkg/chronicles
 import ./transport
 import ../multiaddress
 import ../stream/connection
 import ../stream/bridgestream
-import ../muxers/muxer
 
 type
   MemoryTransportError* = object of transport.TransportError

--- a/libp2p/transports/memorytransport.nim
+++ b/libp2p/transports/memorytransport.nim
@@ -17,7 +17,6 @@ import ../multiaddress
 import ../stream/connection
 import ../crypto/crypto
 import ../upgrademngrs/upgrade
-import ../muxers/muxer
 import ./memorymanager
 
 export connection

--- a/libp2p/transports/tortransport.nim
+++ b/libp2p/transports/tortransport.nim
@@ -11,9 +11,8 @@
 
 {.push raises: [].}
 
-import std/strformat
-import chronos, chronicles, strutils
-import stew/[byteutils, endians2, results, objects]
+import chronos, chronicles, strutils, results
+import stew/[byteutils, endians2, objects]
 import ../multicodec
 import
   transport,

--- a/libp2p/utility.nim
+++ b/libp2p/utility.nim
@@ -10,7 +10,8 @@
 {.push raises: [].}
 
 import std/[sets, options, macros]
-import stew/[byteutils, results]
+import stew/byteutils
+import results
 
 export results
 

--- a/libp2p/varint.nim
+++ b/libp2p/varint.nim
@@ -18,7 +18,8 @@
 
 {.push raises: [].}
 
-import stew/[byteutils, leb128, results]
+import stew/[byteutils, leb128]
+import results
 export leb128, results
 
 type

--- a/tests/commontransport.nim
+++ b/tests/commontransport.nim
@@ -1,6 +1,6 @@
 {.used.}
 
-import chronos, stew/[byteutils, results]
+import chronos, results, stew/byteutils
 import
   ../libp2p/
     [
@@ -8,7 +8,6 @@ import
       transports/transport,
       upgrademngrs/upgrade,
       multiaddress,
-      errors,
     ]
 
 import ./helpers

--- a/tests/commontransport.nim
+++ b/tests/commontransport.nim
@@ -2,13 +2,7 @@
 
 import chronos, results, stew/byteutils
 import
-  ../libp2p/
-    [
-      stream/connection,
-      transports/transport,
-      upgrademngrs/upgrade,
-      multiaddress,
-    ]
+  ../libp2p/[stream/connection, transports/transport, upgrademngrs/upgrade, multiaddress]
 
 import ./helpers
 

--- a/tests/commontransport.nim
+++ b/tests/commontransport.nim
@@ -2,7 +2,8 @@
 
 import chronos, results, stew/byteutils
 import
-  ../libp2p/[stream/connection, transports/transport, upgrademngrs/upgrade, multiaddress]
+  ../libp2p/
+    [stream/connection, transports/transport, upgrademngrs/upgrade, multiaddress]
 
 import ./helpers
 

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -12,7 +12,7 @@ import ../libp2p/stream/chronosstream
 import ../libp2p/muxers/mplex/lpchannel
 import ../libp2p/protocols/secure/secure
 import ../libp2p/switch
-import ../libp2p/nameresolving/[nameresolver, mockresolver]
+import ../libp2p/nameresolving/mockresolver
 
 import errorhelpers
 import utils/async_tests

--- a/tests/testecnist.nim
+++ b/tests/testecnist.nim
@@ -12,7 +12,7 @@
 import unittest2
 import nimcrypto/utils
 import ../libp2p/crypto/[crypto, ecnist]
-import stew/results
+import results
 
 const
   TestsCount = 10 # number of random tests

--- a/tests/testminprotobuf.nim
+++ b/tests/testminprotobuf.nim
@@ -12,7 +12,7 @@
 import unittest2
 import ../libp2p/protobuf/minprotobuf
 import ../libp2p/varint
-import stew/byteutils, strutils, sequtils
+import stew/byteutils, strutils
 
 suite "MinProtobuf test suite":
   const VarintVectors = [

--- a/tests/testmultibase.nim
+++ b/tests/testmultibase.nim
@@ -11,7 +11,7 @@
 
 import unittest2
 import ../libp2p/multibase
-import stew/results
+import results
 
 const GoTestVectors = [
   ["identity", "\x00Decentralize everything!!!", "Decentralize everything!!!"],


### PR DESCRIPTION
Two warnings are "left as an exercise to the reader":

- _Warning: Please use cancelSoon() or cancelAndWait() instead; cancel is deprecated [Deprecated]_
- not using `stew/shims/net`, which is removed from the latest version of `stew`