### PR TITLE
chore: add gcsafe pragma to removeValidator

### DIFF
--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -589,7 +589,7 @@ method addValidator*(
 
 method removeValidator*(
     p: PubSub, topic: varargs[string], hook: ValidatorHandler
-) {.base, public.} =
+) {.base, public, gcsafe.} =
   for t in topic:
     p.validators.withValue(t, validators):
       validators[].excl(hook)


### PR DESCRIPTION
This is needed for consistency with `addValidator` and also I came across compilation issue when using `removeValidator` from nwaku code base (`Error: 'scenario' is not GC-safe as it calls 'unsubscribe'`.)