### PR TITLE
feat(autotls): add autotls support

### DIFF
--- a/.pinned
+++ b/.pinned
@@ -17,3 +17,6 @@ testutils;https://github.com/status-im/nim-testutils@#9e842bd58420d23044bc55e160
 unittest2;https://github.com/status-im/nim-unittest2@#8b51e99b4a57fcfb31689230e75595f024543024
 websock;https://github.com/status-im/nim-websock@#d5cd89062cd2d168ef35193c7d29d2102921d97e
 zlib;https://github.com/status-im/nim-zlib@#daa8723fd32299d4ca621c837430c29a5a11e19a
+jwt;https://github.com/yglukhov/nim-jwt@#7da158687b86640da42639845f7144ac53b15c87
+bearssl_pkey_decoder;https://github.com/yglukhov/bearssl_pkey_decoder@#546f8d9bb887ae1d8a23f62155c583acb0358046
+bio;https://github.com/xzeshen/bio@#0f5ed58b31c678920b6b4f7c1783984e6660be97

--- a/.pinned
+++ b/.pinned
@@ -17,6 +17,6 @@ testutils;https://github.com/status-im/nim-testutils@#9e842bd58420d23044bc55e160
 unittest2;https://github.com/status-im/nim-unittest2@#8b51e99b4a57fcfb31689230e75595f024543024
 websock;https://github.com/status-im/nim-websock@#d5cd89062cd2d168ef35193c7d29d2102921d97e
 zlib;https://github.com/status-im/nim-zlib@#daa8723fd32299d4ca621c837430c29a5a11e19a
-jwt;https://github.com/yglukhov/nim-jwt@#7da158687b86640da42639845f7144ac53b15c87
+jwt;https://github.com/vacp2p/nim-jwt@#baff57251ea4abc1f466511c3ce565a738ac1f77
 bearssl_pkey_decoder;https://github.com/yglukhov/bearssl_pkey_decoder@#546f8d9bb887ae1d8a23f62155c583acb0358046
 bio;https://github.com/xzeshen/bio@#0f5ed58b31c678920b6b4f7c1783984e6660be97

--- a/.pinned
+++ b/.pinned
@@ -17,6 +17,6 @@ testutils;https://github.com/status-im/nim-testutils@#9e842bd58420d23044bc55e160
 unittest2;https://github.com/status-im/nim-unittest2@#8b51e99b4a57fcfb31689230e75595f024543024
 websock;https://github.com/status-im/nim-websock@#d5cd89062cd2d168ef35193c7d29d2102921d97e
 zlib;https://github.com/status-im/nim-zlib@#daa8723fd32299d4ca621c837430c29a5a11e19a
-jwt;https://github.com/vacp2p/nim-jwt@#baff57251ea4abc1f466511c3ce565a738ac1f77
-bearssl_pkey_decoder;https://github.com/yglukhov/bearssl_pkey_decoder@#546f8d9bb887ae1d8a23f62155c583acb0358046
+jwt;https://github.com/vacp2p/nim-jwt@#18f8378de52b241f321c1f9ea905456e89b95c6f
+bearssl_pkey_decoder;https://github.com/vacp2p/bearssl_pkey_decoder@#21dd3710df9345ed2ad8bf8f882761e07863b8e0
 bio;https://github.com/xzeshen/bio@#0f5ed58b31c678920b6b4f7c1783984e6660be97

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -11,8 +11,7 @@ requires "nim >= 1.6.0",
   "nimcrypto >= 0.6.0 & < 0.7.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.5",
   "chronicles >= 0.10.3 & < 0.11.0", "chronos >= 4.0.4", "metrics", "secp256k1",
   "stew >= 0.4.0", "websock >= 0.2.0", "unittest2", "results", "quic >= 0.2.7", "bio",
-  "https://github.com/vacp2p/nim-jwt.git#18f8378de52b241f321c1f9ea905456e89b95c6f",
-  "https://github.com/status-im/nim-quic.git#892feade77cfd84692026f8123c8825d8f2273c8"
+  "https://github.com/vacp2p/nim-jwt.git#18f8378de52b241f321c1f9ea905456e89b95c6f"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use
 let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -10,7 +10,9 @@ skipDirs = @["tests", "examples", "Nim", "tools", "scripts", "docs"]
 requires "nim >= 1.6.0",
   "nimcrypto >= 0.6.0 & < 0.7.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.5",
   "chronicles >= 0.10.3 & < 0.11.0", "chronos >= 4.0.4", "metrics", "secp256k1",
-  "stew >= 0.4.0", "websock >= 0.2.0", "unittest2", "results", "quic >= 0.2.7"
+  "stew >= 0.4.0", "websock >= 0.2.0", "unittest2", "results", "quic >= 0.2.7", "bio",
+  "https://github.com/vacp2p/nim-jwt.git#baff57251ea4abc1f466511c3ce565a738ac1f77",
+  "https://github.com/status-im/nim-quic.git#892feade77cfd84692026f8123c8825d8f2273c8"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use
 let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -11,7 +11,7 @@ requires "nim >= 1.6.0",
   "nimcrypto >= 0.6.0 & < 0.7.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.5",
   "chronicles >= 0.10.3 & < 0.11.0", "chronos >= 4.0.4", "metrics", "secp256k1",
   "stew >= 0.4.0", "websock >= 0.2.0", "unittest2", "results", "quic >= 0.2.7", "bio",
-  "https://github.com/vacp2p/nim-jwt.git#baff57251ea4abc1f466511c3ce565a738ac1f77",
+  "https://github.com/vacp2p/nim-jwt.git#18f8378de52b241f321c1f9ea905456e89b95c6f",
   "https://github.com/status-im/nim-quic.git#892feade77cfd84692026f8123c8825d8f2273c8"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use

--- a/libp2p/autotls/acme.nim
+++ b/libp2p/autotls/acme.nim
@@ -10,8 +10,8 @@ import ../transports/tls/certificate
 
 # TODO: change staging to actual url
 const
-  LetsEncryptURL = "https://acme-v02.api.letsencrypt.org"
-  LetsEncryptURLStaging = "https://acme-staging-v02.api.letsencrypt.org"
+  LetsEncryptURL* = "https://acme-v02.api.letsencrypt.org"
+  LetsEncryptURLStaging* = "https://acme-staging-v02.api.letsencrypt.org"
   Alg = "RS256"
 
 type ACMEAccount* = object

--- a/libp2p/autotls/acme.nim
+++ b/libp2p/autotls/acme.nim
@@ -54,7 +54,7 @@ proc new*(
     raise newException(ACMEError, "Unable to parse JSON")
   except IOError:
     raise newException(ACMEError, "Unable to parse JSON")
-  except Exception as e:
+  except CatchableError as e:
     raise newException(
       ACMEError,
       "Unexpected error occurred while getting ACME server directory: " & e.msg,
@@ -103,7 +103,7 @@ proc signedAcmeRequest(
     let pemPrivKey: string = pemEncode(derPrivKey, "PRIVATE KEY")
     token.sign(pemPrivKey)
     body = token.toFlattenedJson()
-  except Exception as e:
+  except CatchableError as e:
     raise newException(ACMEError, "could not create JWT: " & e.msg)
   try:
     let response = await HttpClientRequestRef
@@ -162,7 +162,7 @@ proc requestChallenge*(
       let authzResponse =
         await HttpClientRequestRef.get(self.session, authzURL).get().send()
       await authzResponse.getParsedResponseBody()
-    except Exception as e:
+    except CatchableError as e:
       raise newException(ACMEError, "failed to request challenge: " & e.msg)
 
   let challenges = authzResponseBody.getJSONField("challenges")
@@ -190,7 +190,7 @@ proc notifyChallengeCompleted*(
       bytesToString(await completedResponse.getBodyBytes()).parseJson()
   except HttpError:
     raise newException(ACMEError, "Failed to connect to ACME server")
-  except Exception as e:
+  except CatchableError as e:
     raise newException(
       ACMEError, "Unexpected error while signaling challenge completion: " & e.msg
     )
@@ -205,7 +205,7 @@ proc notifyChallengeCompleted*(
       checkResponseBody = bytesToString(await checkResponse.getBodyBytes()).parseJson()
     except HttpError:
       raise newException(ACMEError, "Failed to connect to ACME server")
-    except Exception as e:
+    except CatchableError as e:
       raise newException(
         ACMEError, "Unexpected error while signaling challenge completion: " & e.msg
       )
@@ -262,7 +262,7 @@ proc finalizeCertificate*(
       let checkResponse =
         await HttpClientRequestRef.get(self.session, orderURL).get().send()
       checkResponseBody = bytesToString(await checkResponse.getBodyBytes()).parseJson()
-    except Exception as e:
+    except CatchableError as e:
       raise newException(
         ACMEError, "Unexpected error while finalizing certificate: " & e.msg
       )
@@ -303,7 +303,7 @@ proc downloadCertificate*(
     return (rawCertificate, certificateExpiry)
   except HttpError:
     raise newException(ACMEError, "Failed to connect to ACME server")
-  except Exception as e:
+  except CatchableError as e:
     raise newException(
       ACMEError, "Unexpected error while downloading certificate: " & e.msg
     )

--- a/libp2p/autotls/acme.nim
+++ b/libp2p/autotls/acme.nim
@@ -46,18 +46,17 @@ proc new*(
     acc.directory = directory
     acc.acmeServerURL = acmeServerURL
     return acc
-  except HttpError:
-    raise newException(ACMEError, "Failed to connect to ACME server")
-  except ValueError:
-    raise newException(ACMEError, "Unable to parse JSON")
-  except OSError:
-    raise newException(ACMEError, "Unable to parse JSON")
-  except IOError:
-    raise newException(ACMEError, "Unable to parse JSON")
-  except CatchableError as e:
+  except HttpError as exc:
+    raise newException(ACMEError, "Failed to connect to ACME server", exc)
+  except ValueError as exc:
+    raise newException(ACMEError, "Unable to parse JSON", exc)
+  except OSError as exc:
+    raise newException(ACMEError, "Unable to parse JSON", exc)
+  except IOError as exc:
+    raise newException(ACMEError, "Unable to parse JSON", exc)
+  except CatchableError as exc:
     raise newException(
-      ACMEError,
-      "Unexpected error occurred while getting ACME server directory: " & e.msg,
+      ACMEError, "Unexpected error occurred while getting ACME server directory: ", exc
     )
 
 proc newNonce(

--- a/libp2p/autotls/autotls.nim
+++ b/libp2p/autotls/autotls.nim
@@ -1,0 +1,114 @@
+import
+  results,
+  chronos,
+  chronicles,
+  bearssl/rand,
+  bio,
+  strformat,
+  json,
+  chronos/apps/http/httpclient
+
+import ./acme
+import ./peeridauth
+import ./utils
+import ../transports/tls/certificate
+import ../crypto/crypto
+import ../peerinfo
+
+logScope:
+  topics = "libp2p autotls"
+
+type SigParam = object
+  k: string
+  v: seq[byte]
+
+type AutoTLSManager* = ref object
+  rng: ref HmacDrbgContext
+  cert: Opt[CertificateX509]
+  acmeAccount*: ref ACMEAccount
+  bearerToken*: Opt[string]
+  running: bool
+
+proc new*(
+    T: typedesc[AutoTLSManager],
+    rng: ref HmacDrbgContext = newRng(),
+    acmeAccount: ref ACMEAccount = nil,
+): Future[T] {.async: (raises: [AutoTLSError, ACMEError, CancelledError]).} =
+  let account =
+    if acmeAccount.isNil:
+      let accountKey = KeyPair.random(PKScheme.RSA, rng[]).get() # TODO: check
+      (await ACMEAccount.new(accountKey))
+    else:
+      acmeAccount
+
+  T(
+    rng: rng,
+    cert: Opt.none(CertificateX509),
+    acmeAccount: account,
+    bearerToken: Opt.none(string),
+    running: false,
+  )
+
+method start*(
+    self: AutoTLSManager, peerInfo: PeerInfo
+): Future[void] {.base, async: (raises: [AutoTLSError, CancelledError]).} =
+  if self.running:
+    return
+  trace "starting AutoTLS manager"
+  self.running = true
+
+  trace "registering ACME account"
+  await self.acmeAccount.register()
+
+  # generate autotls domain
+  # *.{peerID}.libp2p.direct
+  let base36PeerId = encodePeerId(peerInfo.peerId)
+  let baseDomain = fmt"{base36PeerId}.{AutoTLSDNSServer}"
+  let domain = fmt"*.{baseDomain}"
+
+  trace "requesting ACME challenge"
+  let (dns01Challenge, finalizeURL, orderURL) =
+    await self.acmeAccount.requestChallenge(@[domain])
+  discard finalizeURL
+  discard orderURL
+
+  let keyAuthorization = base64UrlEncode(
+    @(
+      sha256.digest(
+        (
+          dns01Challenge.getJSONField("token").getStr & "." &
+          thumbprint(self.acmeAccount.key)
+        ).toByteSeq
+      ).data
+    )
+  )
+
+  var strMultiaddresses: seq[string] = @[]
+  for ma in peerInfo.addrs:
+    strMultiaddresses.add($ma)
+
+  let payload = %*{"value": keyAuthorization, "addresses": strMultiaddresses}
+  let registrationURL = fmt"{AutoTLSBroker}/v1/_acme-challenge"
+
+  trace "sending challenge to AutoTLS broker"
+  var response: HttpClientResponseRef
+  var bearerToken: string
+  if self.bearerToken.isSome:
+    (bearerToken, response) = await peerIdAuthSend(
+      registrationURL, peerInfo, payload, bearerToken = self.bearerToken
+    )
+    discard bearerToken
+  else:
+    # authenticate, send challenge and save bearerToken for future requests
+    (bearerToken, response) = await peerIdAuthSend(registrationURL, peerInfo, payload)
+    self.bearerToken = Opt.some(bearerToken)
+
+method stop*(self: AutoTLSManager): Future[void] {.base, async: (raises: []).} =
+  if not self.running:
+    return
+
+  trace "stopping AutoTLS manager"
+  self.running = false
+
+  # end all connections (TODO)
+  # await noCancel allFutures(self.connections.mapIt(it.close()))

--- a/libp2p/autotls/autotls.nim
+++ b/libp2p/autotls/autotls.nim
@@ -102,7 +102,7 @@ proc checkDNSRecords(
     try:
       ip4 = await self.dnsResolver.resolveIp(ip4Domain, 0.Port)
     except CatchableError as exc:
-      error "Failed to resolve IP" # retry
+      error "Failed to resolve IP", description = exc.msg # retry
     if txt.len > 0 and self.keyAuthorization.isSome and
         txt[0] == self.keyAuthorization.get() and ip4.len > 0:
       return true

--- a/libp2p/autotls/autotls.nim
+++ b/libp2p/autotls/autotls.nim
@@ -19,7 +19,6 @@ import
   bio,
   json,
   chronos/apps/http/httpclient
-from std/times import DateTime
 
 import ./acme
 import ./peeridauth

--- a/libp2p/autotls/autotls.nim
+++ b/libp2p/autotls/autotls.nim
@@ -103,6 +103,13 @@ method start*(
     (bearerToken, response) = await peerIdAuthSend(registrationURL, peerInfo, payload)
     self.bearerToken = Opt.some(bearerToken)
 
+  trace "waiting for DNS records to be set"
+  trace "notifying challenge completion to ACME server"
+  trace "waiting for certificate to be ready"
+  trace "downloading certificate"
+  trace "certificate installed"
+  trace "monitor for certificate renewals"
+
 method stop*(self: AutoTLSManager): Future[void] {.base, async: (raises: []).} =
   if not self.running:
     return

--- a/libp2p/autotls/autotls.nim
+++ b/libp2p/autotls/autotls.nim
@@ -5,7 +5,6 @@ import
   chronicles,
   bearssl/rand,
   bio,
-  strformat,
   json,
   chronos/apps/http/httpclient
 
@@ -97,8 +96,8 @@ method start*(
   # generate autotls domain
   # *.{peerID}.libp2p.direct
   let base36PeerId = encodePeerId(peerInfo.peerId)
-  let baseDomain = fmt"{base36PeerId}.{AutoTLSDNSServer}"
-  let domain = fmt"*.{baseDomain}"
+  let baseDomain = base36PeerId & "." & AutoTLSDNSServer
+  let domain = "*." & baseDomain
 
   trace "requesting ACME challenge"
   let (dns01Challenge, finalizeURL, orderURL) =
@@ -120,7 +119,7 @@ method start*(
     strMultiaddresses.add($ma)
 
   let payload = %*{"value": keyAuthorization, "addresses": strMultiaddresses}
-  let registrationURL = fmt"{AutoTLSBroker}/v1/_acme-challenge"
+  let registrationURL = AutoTLSBroker & "/v1/_acme-challenge"
 
   trace "sending challenge to AutoTLS broker"
   var response: HttpClientResponseRef
@@ -152,8 +151,8 @@ method start*(
   # and acme challenge TXT domain will be:
   #     _acme-challenge.{peerIdBase36}.libp2p.direct
   let dashedIpAddr = ($hostPrimaryIP).replace(".", "-")
-  let acmeChalDomain = fmt"_acme-challenge.{baseDomain}"
-  let ip4Domain = fmt"{dashedIpAddr}.{baseDomain}"
+  let acmeChalDomain = "_acme-challenge." & baseDomain
+  let ip4Domain = dashedIpAddr & "." & baseDomain
   if not await checkDNSRecords(ip4Domain, acmeChalDomain, retries = 3):
     raise newException(AutoTLSError, "DNS records not set")
 

--- a/libp2p/autotls/autotls.nim
+++ b/libp2p/autotls/autotls.nim
@@ -148,14 +148,20 @@ method issueCertificate(
       self.httpSession,
       peerInfo,
       payload,
+      self.rng,
       bearerToken = self.bearerToken,
     )
     discard bearerToken
   else:
     # authenticate, send challenge and save bearerToken for future requests
-    (bearerToken, response) =
-      await peerIdAuthSend(registrationURL, self.httpSession, peerInfo, payload)
+    (bearerToken, response) = await peerIdAuthSend(
+      registrationURL, self.httpSession, peerInfo, payload, self.rng
+    )
     self.bearerToken = Opt.some(bearerToken)
+  if response.status != 200:
+    raise newException(
+      AutoTLSError, "Failed to authenticate with AutoTLS Broker at " & AutoTLSBroker
+    )
 
   # no need to do anything from this point forward if there are not public ip addresses on host
   var hostPrimaryIP: IpAddress

--- a/libp2p/autotls/autotls.nim
+++ b/libp2p/autotls/autotls.nim
@@ -153,7 +153,7 @@ method issueCertificate(
   var response: HttpClientResponseRef
   var bearerToken: string
   if self.bearerToken.isSome:
-    (_, response) = await peerIdAuthSend(
+    (bearerToken, response) = await peerIdAuthSend(
       registrationURL,
       self.httpSession,
       peerInfo,

--- a/libp2p/autotls/autotls.nim
+++ b/libp2p/autotls/autotls.nim
@@ -211,7 +211,7 @@ proc manageCertificate(
     if self.cert.isNone or self.certExpiry.isNone:
       try:
         await self.issueCertificate()
-      except Exception as e:
+      except CatchableError as e:
         error "Failed to issue certificate", err = e.msg
         break
 
@@ -221,7 +221,7 @@ proc manageCertificate(
     if waitTime <= self.renewBufferTime:
       try:
         await self.issueCertificate()
-      except Exception as e:
+      except CatchableError as e:
         error "Failed to renew certificate", err = e.msg
         break
 

--- a/libp2p/autotls/peeridauth.nim
+++ b/libp2p/autotls/peeridauth.nim
@@ -1,0 +1,174 @@
+import
+  base64,
+  json,
+  random,
+  std/sysrand,
+  strformat # TODO: swap sysrand for bearssl functions?
+import chronos/apps/http/httpclient, results, chronicles, bio
+import ./utils, ../peerinfo, ../crypto/crypto
+
+logScope:
+  topics = "libp2p peerid auth"
+
+type SigParam = object
+  k: string
+  v: seq[byte]
+
+proc randomChallenge(): string =
+  randomize()
+  let charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+  result = ""
+  for _ in 0 ..< 48:
+    result.add sample(charset)
+
+proc extractField(data, key: string): string {.raises: [PeerIDAuthError].} =
+  # Helper to extract quoted value from key
+  for segment in data.split(","):
+    if key in segment:
+      return segment.split("=", 1)[1].strip(chars = {' ', '"'})
+  raise newException(PeerIDAuthError, fmt"Could not find {key} in {data}")
+
+proc encodeVarint(n: int): seq[byte] =
+  var varInt: seq[byte] = @[]
+  var x = uint64(n)
+  while x != 0:
+    var byteVal = byte(x and 0x7F)
+    x = x shr 7
+    if x != 0:
+      byteVal = byteVal or 0x80
+    varInt.add(byteVal)
+  return varInt
+
+proc genDataToSign(prefix: string, parts: seq[SigParam]): seq[byte] =
+  var buf: seq[byte] = prefix.toByteSeq()
+  for p in parts:
+    buf.add encodeVarint(p.k.len + p.v.len + 1)
+    buf.add (p.k & "=").toByteSeq
+    buf.add p.v
+  return buf
+
+proc peerIdSign(
+    privateKey: PrivateKey,
+    challenge: string,
+    publicKey: PublicKey,
+    hostname: string,
+    clientSender: bool = true,
+): string =
+  let prefix = "libp2p-PeerID"
+  let parts =
+    # parts need to be sorted alphabetically by key
+    if clientSender:
+      @[
+        SigParam(k: "challenge-client", v: challenge.toByteSeq()),
+        SigParam(k: "hostname", v: hostname.toByteSeq()),
+        SigParam(k: "server-public-key", v: publicKey.getBytes().get()),
+      ]
+    else:
+      @[
+        SigParam(k: "challenge-server", v: challenge.toByteSeq()),
+        SigParam(k: "client-public-key", v: publicKey.getBytes().get()),
+        SigParam(k: "hostname", v: hostname.toByteSeq),
+      ]
+  let bytesToSign = genDataToSign(prefix, parts)
+  return base64.encode(privateKey.sign(bytesToSign).get().getBytes(), safe = true)
+
+proc peerIdAuthenticate(
+    url: string, peerInfo: PeerInfo, payload: JsonNode
+): Future[(string, HttpClientResponseRef)] {.
+    async: (raises: [AutoTLSError, PeerIDAuthError, CancelledError])
+.} =
+  # Authenticate in three ways as per the PeerID Auth spec
+  # https://github.com/libp2p/specs/blob/master/http/peer-id-auth.md
+
+  # request authentication
+  let base36PeerId = encodePeerId(peerInfo.peerId)
+  var authStartResponse: HttpClientResponseRef
+  try:
+    authStartResponse =
+      await HttpClientRequestRef.get(HttpSessionRef.new(), url).get().send()
+  except HttpError:
+    raise newException(PeerIDAuthError, "Failed to start PeerID Auth")
+
+  # TODO: check server's signature
+  # www-authenticate
+  let wwwAuthenticate = authStartResponse.headers.getString("www-authenticate")
+  if wwwAuthenticate == "":
+    raise newException(PeerIDAuthError, "www-authenticate not present in response")
+  let challengeClient = extractField(wwwAuthenticate, "challenge-client")
+  var serverPublicKey: PublicKey
+  try:
+    serverPublicKey = PublicKey
+      .init(decode(extractField(wwwAuthenticate, "public-key")).toByteSeq)
+      .get()
+  except ValueError:
+    raise newException(PeerIDAuthError, "Could not decode public-key")
+  let opaque = extractField(wwwAuthenticate, "opaque")
+
+  let hostname = fmt"registration.{AutoTLSDNSServer}" # registration.libp2p.direct
+  let clientPubKeyB64 = base64.encode(peerInfo.publicKey.getBytes().get(), safe = true)
+  let challengeServer = randomChallenge()
+  let sig = peerIdSign(peerInfo.privateKey, challengeClient, serverPublicKey, hostname)
+  let authHeader =
+    "libp2p-PeerID public-key=\"" & clientPubKeyB64 & "\"" & ", opaque=\"" & opaque &
+    "\"" & ", challenge-server=\"" & challengeServer & "\"" & ", sig=\"" & sig & "\""
+
+  # Authorization
+  var authorizationResponse: HttpClientResponseRef
+  try:
+    authorizationResponse = await HttpClientRequestRef
+    .post(
+      HttpSessionRef.new(),
+      url,
+      body = $payload,
+      headers = [
+        ("Content-Type", "application/json"),
+        ("User-Agent", "nim-libp2p"),
+        ("authorization", authHeader),
+      ],
+    )
+    .get()
+    .send()
+  except HttpError:
+    raise newException(PeerIDAuthError, "Failed to send Authorization for PeerID Auth")
+
+  # Bearer token
+  return (
+    extractField(
+      authorizationResponse.headers.getString("authentication-info"), "bearer"
+    ),
+    authorizationResponse,
+  )
+
+proc peerIdAuthSend*(
+    url: string,
+    peerInfo: PeerInfo,
+    payload: JsonNode,
+    bearerToken: Opt[string] = Opt.none(string),
+): Future[(string, HttpClientResponseRef)] {.
+    async: (raises: [AutoTLSError, PeerIDAuthError, CancelledError])
+.} =
+  if bearerToken.isNone:
+    return await peerIdAuthenticate(url, peerInfo, payload)
+
+  let authHeader = "libp2p-PeerID bearer=\"" & bearerToken.get & "\""
+  var response: HttpClientResponseRef
+  try:
+    response = await HttpClientRequestRef
+    .post(
+      HttpSessionRef.new(),
+      url,
+      body = $payload,
+      headers = [
+        ("Content-Type", "application/json"),
+        ("User-Agent", "nim-libp2p"),
+        ("authorization", authHeader),
+      ],
+    )
+    .get()
+    .send()
+  except HttpError:
+    raise newException(
+      PeerIDAuthError, "Failed to send request with bearer token for PeerID Auth"
+    )
+
+  return (bearerToken.get, response)

--- a/libp2p/autotls/peeridauth.nim
+++ b/libp2p/autotls/peeridauth.nim
@@ -1,10 +1,4 @@
-import
-  base64,
-  json,
-  random,
-  std/sysrand,
-  strutils,
-  strformat # TODO: swap sysrand for bearssl functions?
+import base64, json, random, strutils
 import chronos/apps/http/httpclient, results, chronicles, bio
 import ./utils, ../peerinfo, ../crypto/crypto
 
@@ -27,7 +21,7 @@ proc extractField(data, key: string): string {.raises: [PeerIDAuthError].} =
   for segment in data.split(","):
     if key in segment:
       return segment.split("=", 1)[1].strip(chars = {' ', '"'})
-  raise newException(PeerIDAuthError, fmt"Could not find {key} in {data}")
+  raise newException(PeerIDAuthError, "Could not find " & key & " in " & data)
 
 proc encodeVarint(n: int): seq[byte] =
   var varInt: seq[byte] = @[]
@@ -131,7 +125,7 @@ proc peerIdAuthenticate(
     raise newException(PeerIDAuthError, "Could not decode public-key")
   let opaque = extractField(wwwAuthenticate, "opaque")
 
-  let hostname = fmt"registration.{AutoTLSDNSServer}" # registration.libp2p.direct
+  let hostname = "registration." & AutoTLSDNSServer # registration.libp2p.direct
   let clientPubKeyB64 = base64.encode(peerInfo.publicKey.getBytes().get(), safe = true)
   let challengeServer = randomChallenge()
   let sig = peerIdSign(peerInfo.privateKey, challengeClient, serverPublicKey, hostname)

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -3,10 +3,11 @@ import
 import
   ../errors, ../peerid, ../multihash, ../cid, ../multicodec, ../crypto/[crypto, rsa]
 
-type GetPrimaryIPError* = object of LPError
-type AutoTLSError* = object of LPError
-type ACMEError* = object of AutoTLSError
-type PeerIDAuthError* = object of AutoTLSError
+type
+  GetPrimaryIPError* = object of LPError
+  AutoTLSError* = object of LPError
+  ACMEError* = object of AutoTLSError
+  PeerIDAuthError* = object of AutoTLSError
 
 const
   AutoTLSBroker* = "registration.libp2p.direct"
@@ -96,7 +97,7 @@ proc getParsedResponseBody*(
       newException(ACMEError, "Unexpected error occurred while getting body bytes", exc)
 
 proc thumbprint*(key: KeyPair): string =
-  # TODO: check if scheme is RSA
+  doAssert key.seckey.scheme == PKScheme.RSA, "unsupported keytype"
   let pubkey = key.pubkey.rsakey
   let nArray = @(getArray(pubkey.buffer, pubkey.key.n, pubkey.key.nlen))
   let eArray = @(getArray(pubkey.buffer, pubkey.key.e, pubkey.key.elen))

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -16,8 +16,10 @@ type ACMEError* = object of AutoTLSError
 type PeerIDAuthError* = object of AutoTLSError
 
 const
-  AutoTLSBroker* = "https://registration.libp2p.direct"
+  AutoTLSBroker* = "registration.libp2p.direct"
   AutoTLSDNSServer* = "libp2p.direct"
+  HttpOk* = 200
+  HttpCreated* = 201
 
 proc sampleChar*(ctx: var HmacDrbgContext, choices: string): char =
   ## Samples a random character from the input string using the DRBG context

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -1,5 +1,13 @@
 import
-  base64, strutils, stew/base36, chronos/apps/http/httpclient, json, net, std/sysrand
+  base64,
+  strutils,
+  stew/base36,
+  chronos/apps/http/httpclient,
+  chronos,
+  json,
+  net,
+  std/sysrand,
+  times
 import
   ../errors, ../peerid, ../multihash, ../cid, ../multicodec, ../crypto/[crypto, rsa]
 
@@ -28,6 +36,10 @@ proc isPublicIPv4*(ip: IpAddress): bool =
       (ip.startsWith("172.") and parseInt(ip.split(".")[1]) in 16 .. 31) or
       ip.startsWith("192.168.") or ip.startsWith("127.") or ip.startsWith("169.254.")
     )
+
+proc asMoment*(dt: DateTime): Moment =
+  let unixTime: int64 = dt.toTime.toUnix
+  return Moment.init(unixTime, Second)
 
 proc encodePeerId*(peerId: PeerId): string {.raises: [AutoTLSError].} =
   var mh: MultiHash

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -19,6 +19,14 @@ const
   AutoTLSBroker* = "https://registration.libp2p.direct"
   AutoTLSDNSServer* = "libp2p.direct"
 
+proc sampleChar*(ctx: var HmacDrbgContext, choices: string): char =
+  ## Samples a random character from the input string using the DRBG context
+  if choices.len == 0:
+    raise newException(ValueError, "Cannot sample from an empty string")
+  var idx: uint32
+  ctx.generate(idx)
+  return choices[uint32(idx mod uint32(choices.len))]
+
 proc base64UrlEncode*(data: seq[byte]): string =
   ## Encodes data using base64url (RFC 4648 §5) — no padding, URL-safe
   var encoded = base64.encode(data, safe = true)

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -82,7 +82,6 @@ proc thumbprint*(key: KeyPair): string =
   let n = base64UrlEncode(nArray)
   let e = base64UrlEncode(eArray)
   let keyJson = %*{"e": e, "kty": "RSA", "n": n}
-  # TODO: https://www.rfc-editor.org/rfc/rfc7638
   let digest = sha256.digest($keyJson)
   return base64UrlEncode(@(digest.data))
 

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -62,7 +62,7 @@ proc getParsedResponseBody*(
     return responseBody
   except ValueError, OSError, IOError:
     raise newException(ACMEError, "Unable to parse JSON body")
-  except Exception as e:
+  except CatchableError as e:
     raise newException(
       ACMEError, "Unexpected error occurred while getting body bytes: " & e.msg
     )

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -1,0 +1,62 @@
+import base64, strutils, stew/base36, chronos/apps/http/httpclient, json, strformat
+import
+  ../errors, ../peerid, ../multihash, ../cid, ../multicodec, ../crypto/[crypto, rsa]
+
+type AutoTLSError* = object of LPError
+type ACMEError* = object of AutoTLSError
+type PeerIDAuthError* = object of AutoTLSError
+
+const
+  AutoTLSBroker* = "https://registration.libp2p.direct"
+  AutoTLSDNSServer* = "libp2p.direct"
+
+proc base64UrlEncode*(data: seq[byte]): string =
+  ## Encodes data using base64url (RFC 4648 §5) — no padding, URL-safe
+  var encoded = base64.encode(data, safe = true)
+  encoded.removeSuffix("=")
+  encoded.removeSuffix("=")
+  return encoded
+
+proc encodePeerId*(peerId: PeerId): string {.raises: [AutoTLSError].} =
+  var mh: MultiHash
+  let decodeResult = MultiHash.decode(peerId.data, mh)
+  if decodeResult.isErr or decodeResult.get() == -1:
+    raise
+      newException(AutoTLSError, "Failed to decode PeerId: invalid multihash format")
+
+  let cidResult = Cid.init(CIDv1, multiCodec("libp2p-key"), mh)
+  if cidResult.isErr:
+    raise newException(AutoTLSError, "Failed to initialize CID from multihash")
+
+  return Base36.encode(cidResult.get().data.buffer)
+
+proc getParsedResponseBody*(
+    response: HttpClientResponseRef
+): Future[JsonNode] {.async: (raises: [ACMEError]).} =
+  try:
+    let responseBody = bytesToString(await response.getBodyBytes()).parseJson()
+    return responseBody
+  except ValueError, OSError, IOError:
+    raise newException(ACMEError, "Unable to parse JSON body")
+  except Exception as e:
+    raise newException(
+      ACMEError, "Unexpected error occurred while getting body bytes: " & e.msg
+    )
+
+proc getJSONField*(node: JsonNode, field: string): JsonNode {.raises: [ACMEError].} =
+  if node{field} == nil:
+    raise newException(ACMEError, fmt"'{field}' field not found in JSON: " & $node)
+  return node{field}
+
+proc thumbprint*(key: KeyPair): string =
+  # TODO: check if scheme is RSA
+  let pubkey = key.pubkey.rsakey
+  let nArray = @(getArray(pubkey.buffer, pubkey.key.n, pubkey.key.nlen))
+  let eArray = @(getArray(pubkey.buffer, pubkey.key.e, pubkey.key.elen))
+
+  let n = base64UrlEncode(nArray)
+  let e = base64UrlEncode(eArray)
+  let keyJson = %*{"e": e, "kty": "RSA", "n": n}
+  # TODO: https://www.rfc-editor.org/rfc/rfc7638
+  let digest = sha256.digest($keyJson)
+  return base64UrlEncode(@(digest.data))

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -1,12 +1,5 @@
 import
-  base64,
-  strutils,
-  stew/base36,
-  chronos/apps/http/httpclient,
-  json,
-  strformat,
-  net,
-  std/sysrand
+  base64, strutils, stew/base36, chronos/apps/http/httpclient, json, net, std/sysrand
 import
   ../errors, ../peerid, ../multihash, ../cid, ../multicodec, ../crypto/[crypto, rsa]
 
@@ -66,7 +59,7 @@ proc getJSONField*(node: JsonNode, field: string): JsonNode {.raises: [ACMEError
   try:
     return node[field]
   except:
-    raise newException(ACMEError, fmt"'{field}' field not found in JSON: {node}")
+    raise newException(ACMEError, "'" & field & "' field not found in JSON")
 
 proc thumbprint*(key: KeyPair): string =
   # TODO: check if scheme is RSA

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -1,4 +1,4 @@
-import base64, strutils, stew/base36, chronos/apps/http/httpclient, json, strformat
+import base64, strutils, stew/base36, chronos/apps/http/httpclient, json, strformat, net
 import
   ../errors, ../peerid, ../multihash, ../cid, ../multicodec, ../crypto/[crypto, rsa]
 
@@ -16,6 +16,17 @@ proc base64UrlEncode*(data: seq[byte]): string =
   encoded.removeSuffix("=")
   encoded.removeSuffix("=")
   return encoded
+
+proc isPublicIPv4*(ip: IpAddress): bool =
+  if ip.family != IpAddressFamily.IPv4:
+    return false
+  let ip = $ip
+  return
+    not (
+      ip.startsWith("10.") or
+      (ip.startsWith("172.") and parseInt(ip.split(".")[1]) in 16 .. 31) or
+      ip.startsWith("192.168.") or ip.startsWith("127.") or ip.startsWith("169.254.")
+    )
 
 proc encodePeerId*(peerId: PeerId): string {.raises: [AutoTLSError].} =
   var mh: MultiHash

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -1,13 +1,5 @@
 import
-  base64,
-  strutils,
-  stew/base36,
-  chronos/apps/http/httpclient,
-  chronos,
-  json,
-  net,
-  std/sysrand,
-  times
+  base64, strutils, stew/base36, chronos/apps/http/httpclient, chronos, json, net, times
 import
   ../errors, ../peerid, ../multihash, ../cid, ../multicodec, ../crypto/[crypto, rsa]
 
@@ -72,10 +64,9 @@ proc getParsedResponseBody*(
     return responseBody
   except ValueError, OSError, IOError:
     raise newException(ACMEError, "Unable to parse JSON body")
-  except CatchableError as e:
-    raise newException(
-      ACMEError, "Unexpected error occurred while getting body bytes: " & e.msg
-    )
+  except Exception as exc:
+    raise
+      newException(ACMEError, "Unexpected error occurred while getting body bytes", exc)
 
 proc getJSONField*(node: JsonNode, field: string): JsonNode {.raises: [ACMEError].} =
   try:
@@ -94,10 +85,3 @@ proc thumbprint*(key: KeyPair): string =
   let keyJson = %*{"e": e, "kty": "RSA", "n": n}
   let digest = sha256.digest($keyJson)
   return base64UrlEncode(@(digest.data))
-
-proc urandomToCString*(size: int): cstring =
-  let randBytes = urandom(size)
-  result = cast[cstring](alloc(size + 1)) # +1 for null terminator
-  for i in 0 ..< size:
-    result[i] = char(randBytes[i])
-  result[size] = '\0' # Null-terminate

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -184,6 +184,10 @@ proc withMemoryTransport*(b: SwitchBuilder): SwitchBuilder {.public.} =
       MemoryTransport.new(upgr)
   )
 
+proc withAutoTLS*(b: SwitchBuilder): SwitchBuilder {.public.} =
+  b.autoTLSMgr = AutoTLSManager.new(b.rng) # TODO: configs
+  b
+
 proc withRng*(b: SwitchBuilder, rng: ref HmacDrbgContext): SwitchBuilder {.public.} =
   b.rng = rng
   b

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -30,6 +30,7 @@ import
   connmanager,
   upgrademngrs/muxedupgrade,
   observedaddrmanager,
+  autotls/autotls,
   nameresolving/nameresolver,
   errors,
   utility
@@ -63,6 +64,7 @@ type
     nameResolver: NameResolver
     peerStoreCapacity: Opt[int]
     autonat: bool
+    autoTLSMgr: AutoTLSManager
     circuitRelay: Relay
     rdv: RendezVous
     services: seq[Service]
@@ -185,8 +187,8 @@ proc withMemoryTransport*(b: SwitchBuilder): SwitchBuilder {.public.} =
   )
 
 proc withAutoTLS*(b: SwitchBuilder): SwitchBuilder {.public.} =
-  b.autoTLSMgr = AutoTLSManager.new(b.rng) # TODO: configs
-  b
+b.autoTLSMgr = AutoTLSManager.new(b.rng) # TODO: configs
+b
 
 proc withRng*(b: SwitchBuilder, rng: ref HmacDrbgContext): SwitchBuilder {.public.} =
   b.rng = rng
@@ -320,6 +322,7 @@ proc build*(b: SwitchBuilder): Switch {.raises: [LPError], public.} =
     secureManagers = secureManagerInstances,
     connManager = connManager,
     ms = ms,
+    autoTLSMgr = b.autoTLSMgr,
     nameResolver = b.nameResolver,
     peerStore = peerStore,
     services = b.services,

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -187,12 +187,12 @@ proc withMemoryTransport*(b: SwitchBuilder): SwitchBuilder {.public.} =
       MemoryTransport.new(upgr)
   )
 
-proc withAutoTLSManager*(
-    b: SwitchBuilder, acmeServerURL = LetsEncryptURL, ipAddress = Opt.none(IpAddress)
-): SwitchBuilder {.public.} =
-  b.autoTLSMgr =
-    AutoTLSManager.new(b.rng, acmeServerURL = acmeServerURL, ipAddress = ipAddress)
-  b
+# proc withAutoTLSManager*(
+#     b: SwitchBuilder, acmeServerURL = LetsEncryptURL, ipAddress = Opt.none(IpAddress)
+# ): SwitchBuilder {.public.} =
+#   b.autoTLSMgr =
+#     AutoTLSManager.new(b.rng, acmeServerURL = acmeServerURL, ipAddress = ipAddress)
+#   b
 
 proc withRng*(b: SwitchBuilder, rng: ref HmacDrbgContext): SwitchBuilder {.public.} =
   b.rng = rng

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -186,7 +186,7 @@ proc withMemoryTransport*(b: SwitchBuilder): SwitchBuilder {.public.} =
       MemoryTransport.new(upgr)
   )
 
-proc withAutoTLS*(b: SwitchBuilder): SwitchBuilder {.public.} =
+proc withAutoTLSManager*(b: SwitchBuilder): SwitchBuilder {.public.} =
   b.autoTLSMgr = AutoTLSManager.new(b.rng) # TODO: configs
   b
 

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -188,9 +188,10 @@ proc withMemoryTransport*(b: SwitchBuilder): SwitchBuilder {.public.} =
   )
 
 proc withAutoTLSManager*(
-    b: SwitchBuilder, acmeServerURL = LetsEncryptURL
+    b: SwitchBuilder, acmeServerURL = LetsEncryptURL, ipAddress = Opt.none(IpAddress)
 ): SwitchBuilder {.public.} =
-  b.autoTLSMgr = AutoTLSManager.new(b.rng, acmeServerURL = acmeServerURL)
+  b.autoTLSMgr =
+    AutoTLSManager.new(b.rng, acmeServerURL = acmeServerURL, ipAddress = ipAddress)
   b
 
 proc withRng*(b: SwitchBuilder, rng: ref HmacDrbgContext): SwitchBuilder {.public.} =

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -30,6 +30,7 @@ import
   connmanager,
   upgrademngrs/muxedupgrade,
   observedaddrmanager,
+  autotls/acme,
   autotls/autotls,
   nameresolving/nameresolver,
   errors,
@@ -186,8 +187,10 @@ proc withMemoryTransport*(b: SwitchBuilder): SwitchBuilder {.public.} =
       MemoryTransport.new(upgr)
   )
 
-proc withAutoTLSManager*(b: SwitchBuilder): SwitchBuilder {.public.} =
-  b.autoTLSMgr = AutoTLSManager.new(b.rng)
+proc withAutoTLSManager*(
+    b: SwitchBuilder, acmeServerURL = LetsEncryptURL
+): SwitchBuilder {.public.} =
+  b.autoTLSMgr = AutoTLSManager.new(b.rng, acmeServerURL = acmeServerURL)
   b
 
 proc withRng*(b: SwitchBuilder, rng: ref HmacDrbgContext): SwitchBuilder {.public.} =

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -187,8 +187,8 @@ proc withMemoryTransport*(b: SwitchBuilder): SwitchBuilder {.public.} =
   )
 
 proc withAutoTLS*(b: SwitchBuilder): SwitchBuilder {.public.} =
-b.autoTLSMgr = AutoTLSManager.new(b.rng) # TODO: configs
-b
+  b.autoTLSMgr = AutoTLSManager.new(b.rng) # TODO: configs
+  b
 
 proc withRng*(b: SwitchBuilder, rng: ref HmacDrbgContext): SwitchBuilder {.public.} =
   b.rng = rng

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -187,7 +187,7 @@ proc withMemoryTransport*(b: SwitchBuilder): SwitchBuilder {.public.} =
   )
 
 proc withAutoTLSManager*(b: SwitchBuilder): SwitchBuilder {.public.} =
-  b.autoTLSMgr = AutoTLSManager.new(b.rng) # TODO: configs
+  b.autoTLSMgr = AutoTLSManager.new(b.rng)
   b
 
 proc withRng*(b: SwitchBuilder, rng: ref HmacDrbgContext): SwitchBuilder {.public.} =

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -333,6 +333,9 @@ proc stop*(s: Switch) {.public, async: (raises: [CancelledError]).} =
     except CatchableError as exc:
       warn "error cleaning up transports", description = exc.msg
 
+  if not s.autoTLSMgr.isNil:
+    await s.autoTLSMgr.stop()
+
   await s.ms.stop()
 
   trace "Switch stopped"

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -371,8 +371,8 @@ proc start*(s: Switch) {.public, async: (raises: [CancelledError, LPError]).} =
 
   await s.peerInfo.update()
   await s.ms.start()
-  # if not s.autoTLSMgr.isNil:
-  #   await s.autoTLSMgr.start(s.peerInfo)
+  if not s.autoTLSMgr.isNil:
+    await s.autoTLSMgr.start(s.peerInfo)
   s.started = true
 
   debug "Started libp2p node", peer = s.peerInfo

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -369,6 +369,7 @@ proc start*(s: Switch) {.public, async: (raises: [CancelledError, LPError]).} =
 
   await s.peerInfo.update()
   await s.ms.start()
+  await s.autoTLSMgr.start(s.peerInfo)
   s.started = true
 
   debug "Started libp2p node", peer = s.peerInfo

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -369,7 +369,8 @@ proc start*(s: Switch) {.public, async: (raises: [CancelledError, LPError]).} =
 
   await s.peerInfo.update()
   await s.ms.start()
-  await s.autoTLSMgr.start(s.peerInfo)
+  if not s.autoTLSMgr.isNil:
+    await s.autoTLSMgr.start(s.peerInfo)
   s.started = true
 
   debug "Started libp2p node", peer = s.peerInfo

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -20,6 +20,7 @@ import chronos, chronicles, metrics
 import
   stream/connection,
   transports/transport,
+  autotls/autotls,
   upgrademngrs/upgrade,
   multistream,
   multiaddress,
@@ -58,6 +59,7 @@ type
     acceptFuts: seq[Future[void]]
     dialer*: Dial
     peerStore*: PeerStore
+    autoTLSMgr*: AutoTLSManager
     nameResolver*: NameResolver
     started: bool
     services*: seq[Service]
@@ -369,8 +371,8 @@ proc start*(s: Switch) {.public, async: (raises: [CancelledError, LPError]).} =
 
   await s.peerInfo.update()
   await s.ms.start()
-  if not s.autoTLSMgr.isNil:
-    await s.autoTLSMgr.start(s.peerInfo)
+  # if not s.autoTLSMgr.isNil:
+  #   await s.autoTLSMgr.start(s.peerInfo)
   s.started = true
 
   debug "Started libp2p node", peer = s.peerInfo
@@ -382,6 +384,7 @@ proc newSwitch*(
     connManager: ConnManager,
     ms: MultistreamSelect,
     peerStore: PeerStore,
+    autoTLSMgr: AutoTLSManager = nil,
     nameResolver: NameResolver = nil,
     services = newSeq[Service](),
 ): Switch {.raises: [LPError].} =
@@ -396,6 +399,7 @@ proc newSwitch*(
     peerStore: peerStore,
     dialer:
       Dialer.new(peerInfo.peerId, connManager, peerStore, transports, nameResolver),
+    autoTLSMgr: autoTLSMgr,
     nameResolver: nameResolver,
     services: services,
   )

--- a/tests/testautotls.nim
+++ b/tests/testautotls.nim
@@ -57,21 +57,6 @@ suite "AutoTLS":
       check finalizeURL.len > 0
       check orderURL.len > 0
 
-    asyncTest "test notify ACME challenge complete":
-      var hostPrimaryIP: IpAddress
-      try:
-        hostPrimaryIP = getPrimaryIPAddr()
-      except Exception:
-        check false # could not get primary address
-      if not isPublicIPv4(hostPrimaryIP):
-        skip()
-        return
-      await acc.register()
-      let (dns01Challenge, finalizeURL, orderURL) =
-        await acc.requestChallenge(@["some.dummy.domain.com"])
-      let chalURL = dns01Challenge["url"].getStr
-      check (await acc.notifyChallengeCompleted(chalURL))
-
   suite "AutoTLSManager":
     var autotlsMgr {.threadvar.}: AutoTLSManager
     var peerInfo {.threadvar.}: PeerInfo

--- a/tests/testautotls.nim
+++ b/tests/testautotls.nim
@@ -31,32 +31,32 @@ import
 import ./helpers
 
 suite "AutoTLS":
-  # suite "ACME communication":
-  #   var acc {.threadvar.}: ref ACMEAccount
-  #   var rng {.threadvar.}: ref HmacDrbgContext
+  suite "ACME communication":
+    var acc {.threadvar.}: ref ACMEAccount
+    var rng {.threadvar.}: ref HmacDrbgContext
 
-  #   asyncSetup:
-  #     rng = newRng()
-  #     let accountKey = KeyPair.random(PKScheme.RSA, rng[]).get()
-  #     acc = await ACMEAccount.new(accountKey)
+    asyncSetup:
+      rng = newRng()
+      let accountKey = KeyPair.random(PKScheme.RSA, rng[]).get()
+      acc = await ACMEAccount.new(accountKey)
 
-  #   asyncTeardown:
-  #     await noCancel(acc.session.closeWait())
-  #     checkTrackers()
+    asyncTeardown:
+      await noCancel(acc.session.closeWait())
+      checkTrackers()
 
-  #   asyncTest "test ACME account register":
-  #     await acc.register()
-  #     # account was registered (kid set)
-  #     check acc.kid.isSome
+    asyncTest "test ACME account register":
+      await acc.register()
+      # account was registered (kid set)
+      check acc.kid.isSome
 
-  #   asyncTest "test ACME challange request":
-  #     await acc.register()
-  #     # challenge requested
-  #     let (dns01Challenge, finalizeURL, orderURL) =
-  #       await acc.requestChallenge(@["some.dummy.domain.com"])
-  #     check dns01Challenge.isNil == false
-  #     check finalizeURL.len > 0
-  #     check orderURL.len > 0
+    asyncTest "test ACME challange request":
+      await acc.register()
+      # challenge requested
+      let (dns01Challenge, finalizeURL, orderURL) =
+        await acc.requestChallenge(@["some.dummy.domain.com"])
+      check dns01Challenge.isNil == false
+      check finalizeURL.len > 0
+      check orderURL.len > 0
 
   suite "AutoTLSManager":
     var switch {.threadvar.}: Switch

--- a/tests/testautotls.nim
+++ b/tests/testautotls.nim
@@ -24,20 +24,20 @@ import
 import ./helpers
 
 suite "AutoTLS":
-  suite "ACME communication":
-    asyncTest "test ACME challange request":
-      let rng = newRng()
-      let accountKey = KeyPair.random(PKScheme.RSA, rng[]).get()
-      let acc = await ACMEAccount.new(accountKey)
-      await acc.register()
-      # account was registered (kid set)
-      check acc.kid.isSome
-      # challenge requested
-      let (dns01Challenge, finalizeURL, orderURL) =
-        await acc.requestChallenge(@["some.dummy.domain.com"])
-      check dns01Challenge.isNil == false
-      check finalizeURL.len > 0
-      check orderURL.len > 0
+  # suite "ACME communication":
+  #   asyncTest "test ACME challange request":
+  #     let rng = newRng()
+  #     let accountKey = KeyPair.random(PKScheme.RSA, rng[]).get()
+  #     let acc = await ACMEAccount.new(accountKey)
+  #     await acc.register()
+  #     # account was registered (kid set)
+  #     check acc.kid.isSome
+  #     # challenge requested
+  #     let (dns01Challenge, finalizeURL, orderURL) =
+  #       await acc.requestChallenge(@["some.dummy.domain.com"])
+  #     check dns01Challenge.isNil == false
+  #     check finalizeURL.len > 0
+  #     check orderURL.len > 0
 
   suite "AutoTLS manager":
     asyncTest "test send challenge to AutoTLS broker":
@@ -49,14 +49,9 @@ suite "AutoTLS":
       let peerInfo = PeerInfo.new(seckey, multiAddresses)
 
       await autotlsMgr.start(peerInfo)
+
       # check if challenge was sent (bearer token from peer id auth was set)
       check autotlsMgr.bearerToken.isSome
 
-    # asyncTest "test notify ACME challenge completion":
-
-    # suite "AutoTLS broker handling":
-    #   asyncSetup:
-    #     rng = newRng()
-    #     autotlsMgr = AutoTLSManager.new()
-
-    #   asyncTest "test ACME account registration":
+      # TODO: check if DNS TXT and A records are set
+      check dnsSet() #TODO

--- a/tests/testautotls.nim
+++ b/tests/testautotls.nim
@@ -1,0 +1,62 @@
+{.used.}
+
+# Nim-Libp2p
+# Copyright (c) 2023 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import std/[strutils, sequtils, tables]
+import chronos
+import
+  ../libp2p/[
+    stream/connection,
+    transports/tcptransport,
+    upgrademngrs/upgrade,
+    multiaddress,
+    autotls/autotls,
+    autotls/acme,
+  ]
+
+import ./helpers
+
+suite "AutoTLS":
+  suite "ACME communication":
+    asyncTest "test ACME challange request":
+      let rng = newRng()
+      let accountKey = KeyPair.random(PKScheme.RSA, rng[]).get()
+      let acc = await ACMEAccount.new(accountKey)
+      await acc.register()
+      # account was registered (kid set)
+      check acc.kid.isSome
+      # challenge requested
+      let (dns01Challenge, finalizeURL, orderURL) =
+        await acc.requestChallenge(@["some.dummy.domain.com"])
+      check dns01Challenge.isNil == false
+      check finalizeURL.len > 0
+      check orderURL.len > 0
+
+  suite "AutoTLS manager":
+    asyncTest "test send challenge to AutoTLS broker":
+      let rng = newRng()
+      let autotlsMgr = await AutoTLSManager.new(rng)
+      let seckey = PrivateKey.random(rng[]).tryGet()
+      let peerId = PeerId.init(seckey).get()
+      let multiAddresses = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
+      let peerInfo = PeerInfo.new(seckey, multiAddresses)
+
+      await autotlsMgr.start(peerInfo)
+      # check if challenge was sent (bearer token from peer id auth was set)
+      check autotlsMgr.bearerToken.isSome
+
+    # asyncTest "test notify ACME challenge completion":
+
+    # suite "AutoTLS broker handling":
+    #   asyncSetup:
+    #     rng = newRng()
+    #     autotlsMgr = AutoTLSManager.new()
+
+    #   asyncTest "test ACME account registration":

--- a/tests/testautotls.nim
+++ b/tests/testautotls.nim
@@ -9,7 +9,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-import std/[strutils, sequtils, tables, strformat, net, json]
+import std/[strformat, net, json]
 import chronos
 import
   ../libp2p/[

--- a/tests/testautotls.nim
+++ b/tests/testautotls.nim
@@ -64,6 +64,9 @@ suite "AutoTLS":
     var autotlsMgr {.threadvar.}: AutoTLSManager
     var peerInfo {.threadvar.}: PeerInfo
 
+    teardown:
+      checkTrackers()
+
     asyncSetup:
       let rng = newRng()
       autotlsMgr = AutoTLSManager.new(rng)
@@ -79,26 +82,26 @@ suite "AutoTLS":
       # check if challenge was sent (bearer token from peer id auth was set)
       check autotlsMgr.bearerToken.isSome
 
-    asyncTest "test DNS TXT record set":
-      let hostPrimaryIP = getPrimaryIPAddr()
-      if not isPublicIPv4(hostPrimaryIP):
-        skip()
-        return
+    # asyncTest "test DNS TXT record set":
+    #   let hostPrimaryIP = getPrimaryIPAddr()
+    #   if not isPublicIPv4(hostPrimaryIP):
+    #     skip()
+    #     return
 
-      # check if DNS TXT record is set
-      let dnsResolver = DnsResolver.new(
-        @[
-          initTAddress("1.1.1.1:53"),
-          initTAddress("1.0.0.1:53"),
-          initTAddress("[2606:4700:4700::1111]:53"),
-        ]
-      )
-      let base36PeerId = encodePeerId(peerInfo.peerId)
-      let baseDomain = fmt"{base36PeerId}.{AutoTLSDNSServer}"
-      let acmeChalDomain = fmt"_acme-challenge.{baseDomain}"
-      let txt = await dnsResolver.resolveTxt(acmeChalDomain)
-      check txt.len > 0
-      check txt[0] != "not set yet"
+    #   # check if DNS TXT record is set
+    #   let dnsResolver = DnsResolver.new(
+    #     @[
+    #       initTAddress("1.1.1.1:53"),
+    #       initTAddress("1.0.0.1:53"),
+    #       initTAddress("[2606:4700:4700::1111]:53"),
+    #     ]
+    #   )
+    #   let base36PeerId = encodePeerId(peerInfo.peerId)
+    #   let baseDomain = fmt"{base36PeerId}.{AutoTLSDNSServer}"
+    #   let acmeChalDomain = fmt"_acme-challenge.{baseDomain}"
+    #   let txt = await dnsResolver.resolveTxt(acmeChalDomain)
+    #   check txt.len > 0
+    #   check txt[0] != "not set yet"
 
     asyncTest "test download certificate":
       let hostPrimaryIP = getPrimaryIPAddr()

--- a/tests/testautotls.nim
+++ b/tests/testautotls.nim
@@ -32,32 +32,33 @@ import
 import ./helpers
 
 suite "AutoTLS":
-  #  suite "ACME communication":
-  #    var acc {.threadvar.}: ref ACMEAccount
-  #    var rng {.threadvar.}: ref HmacDrbgContext
+  suite "ACME communication":
+    var acc {.threadvar.}: ref ACMEAccount
+    var rng {.threadvar.}: ref HmacDrbgContext
 
-  #    asyncSetup:
-  #      rng = newRng()
-  #      let accountKey = KeyPair.random(PKScheme.RSA, rng[]).get()
-  #      acc = await ACMEAccount.new(accountKey)
+    asyncSetup:
+      rng = newRng()
+      let accountKey = KeyPair.random(PKScheme.RSA, rng[]).get()
+      acc = await ACMEAccount.new(accountKey)
 
-  #    asyncTeardown:
-  #      await noCancel(acc.session.closeWait())
-  #      checkTrackers()
+    asyncTeardown:
+      await noCancel(acc.session.closeWait())
+      checkTrackers()
 
-  #    asyncTest "test ACME account register":
-  #      await acc.register()
-  #      # account was registered (kid set)
-  #      check acc.kid.isSome
+    asyncTest "test ACME account register":
+      await acc.register()
+      # account was registered (kid set)
+      check acc.kid.isSome
 
-  #    asyncTest "test ACME challange request":
-  #      await acc.register()
-  #      # challenge requested
-  #      let (dns01Challenge, finalizeURL, orderURL) =
-  #        await acc.requestChallenge(@["some.dummy.domain.com"])
-  #      check dns01Challenge.isNil == false
-  #      check finalizeURL.len > 0
-  #      check orderURL.len > 0
+    asyncTest "test ACME challange request":
+      await acc.register()
+      # challenge requested
+      let (dns01Challenge, finalizeURL, orderURL) =
+        await acc.requestChallenge(@["some.dummy.domain.com"])
+      check dns01Challenge.isNil == false
+      check finalizeURL.len > 0
+      check orderURL.len > 0
+
   suite "AutoTLSManager":
     var switch {.threadvar.}: Switch
 
@@ -103,5 +104,8 @@ suite "AutoTLS":
       check txt.len > 0
       check txt[0] != "not set yet"
 
-      # check if certificate was downloaded
+      # check if certificate was downloaded and parsed
       check switch.autoTLSMgr.cert.isSome
+
+      # TODO: invalidate certificate
+      # check if certificate was renewed

--- a/tests/testautotls.nim
+++ b/tests/testautotls.nim
@@ -20,6 +20,8 @@ import
     transports/tcptransport,
     upgrademngrs/upgrade,
     multiaddress,
+    switch,
+    builders,
     autotls/autotls,
     autotls/acme,
     autotls/utils,
@@ -30,66 +32,62 @@ import
 import ./helpers
 
 suite "AutoTLS":
-  suite "ACME communication":
-    var acc {.threadvar.}: ref ACMEAccount
-    var rng {.threadvar.}: ref HmacDrbgContext
+  #  suite "ACME communication":
+  #    var acc {.threadvar.}: ref ACMEAccount
+  #    var rng {.threadvar.}: ref HmacDrbgContext
 
-    asyncSetup:
-      rng = newRng()
-      let accountKey = KeyPair.random(PKScheme.RSA, rng[]).get()
-      acc = await ACMEAccount.new(accountKey)
+  #    asyncSetup:
+  #      rng = newRng()
+  #      let accountKey = KeyPair.random(PKScheme.RSA, rng[]).get()
+  #      acc = await ACMEAccount.new(accountKey)
 
-    asyncTeardown:
-      await noCancel(acc.session.closeWait())
-      checkTrackers()
+  #    asyncTeardown:
+  #      await noCancel(acc.session.closeWait())
+  #      checkTrackers()
 
-    asyncTest "test ACME account register":
-      await acc.register()
-      # account was registered (kid set)
-      check acc.kid.isSome
+  #    asyncTest "test ACME account register":
+  #      await acc.register()
+  #      # account was registered (kid set)
+  #      check acc.kid.isSome
 
-    asyncTest "test ACME challange request":
-      await acc.register()
-      # challenge requested
-      let (dns01Challenge, finalizeURL, orderURL) =
-        await acc.requestChallenge(@["some.dummy.domain.com"])
-      check dns01Challenge.isNil == false
-      check finalizeURL.len > 0
-      check orderURL.len > 0
-
+  #    asyncTest "test ACME challange request":
+  #      await acc.register()
+  #      # challenge requested
+  #      let (dns01Challenge, finalizeURL, orderURL) =
+  #        await acc.requestChallenge(@["some.dummy.domain.com"])
+  #      check dns01Challenge.isNil == false
+  #      check finalizeURL.len > 0
+  #      check orderURL.len > 0
   suite "AutoTLSManager":
-    var autotlsMgr {.threadvar.}: AutoTLSManager
-    var peerInfo {.threadvar.}: PeerInfo
+    var switch {.threadvar.}: Switch
 
     asyncSetup:
-      let rng = newRng()
-      autotlsMgr = AutoTLSManager.new(rng)
-      let seckey = PrivateKey.random(rng[]).tryGet()
-      let peerId = PeerId.init(seckey).get()
-      let multiAddresses = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
-      peerInfo = PeerInfo.new(seckey, multiAddresses)
+      switch = SwitchBuilder
+        .new()
+        .withRng(newRng())
+        .withAddress(MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet())
+        .withTcpTransport()
+        .withAutoTLSManager()
+        .withYamux()
+        .withNoise()
+        .build()
+      await switch.start()
 
     asyncTeardown:
-      await noCancel(autotlsMgr.stop())
+      await switch.stop()
       checkTrackers()
 
-    asyncTest "test send challenge to AutoTLS broker":
-      await autotlsMgr.start(peerInfo)
-
+    asyncTest "test AutoTLSManager start":
       # check if challenge was sent (bearer token from peer id auth was set)
-      check autotlsMgr.bearerToken.isSome
+      check switch.autoTLSMgr.bearerToken.isSome
 
-    asyncTest "test DNS TXT record set":
       var hostPrimaryIP: IpAddress
       try:
         hostPrimaryIP = getPrimaryIPAddr()
       except Exception:
         check false # could not get primary address
       if not isPublicIPv4(hostPrimaryIP):
-        skip()
         return
-
-      await autotlsMgr.start(peerInfo)
 
       # check if DNS TXT record is set
       let dnsResolver = DnsResolver.new(
@@ -99,21 +97,11 @@ suite "AutoTLS":
           initTAddress("[2606:4700:4700::1111]:53"),
         ]
       )
-      let base36PeerId = encodePeerId(peerInfo.peerId)
-      let baseDomain = fmt"{base36PeerId}.{AutoTLSDNSServer}"
-      let acmeChalDomain = fmt"_acme-challenge.{baseDomain}"
+      let base36PeerId = encodePeerId(switch.peerInfo.peerId)
+      let acmeChalDomain = fmt"_acme-challenge.{base36PeerId}.{AutoTLSDNSServer}"
       let txt = await dnsResolver.resolveTxt(acmeChalDomain)
       check txt.len > 0
       check txt[0] != "not set yet"
 
-    asyncTest "test download certificate":
-      var hostPrimaryIP: IpAddress
-      try:
-        hostPrimaryIP = getPrimaryIPAddr()
-      except Exception:
-        check false # could not get primary address
-      if not isPublicIPv4(hostPrimaryIP):
-        skip()
-        return
-      await autotlsMgr.start(peerInfo)
-      check autotlsMgr.cert.isSome
+      # check if certificate was downloaded
+      check switch.autoTLSMgr.cert.isSome

--- a/tests/testautotls.nim
+++ b/tests/testautotls.nim
@@ -33,7 +33,10 @@ import ./helpers
 
 suite "AutoTLS":
   asyncTest "test ACME":
-    let acc = await ACMEAccount.new(KeyPair.random(PKScheme.RSA, newRng()[]).get())
+    let acc = await ACMEAccount.new(
+      KeyPair.random(PKScheme.RSA, newRng()[]).get(),
+      acmeServerURL = LetsEncryptURLStaging,
+    )
     defer:
       checkTrackers()
 
@@ -55,7 +58,7 @@ suite "AutoTLS":
       .withRng(newRng())
       .withAddress(MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet())
       .withTcpTransport()
-      .withAutoTLSManager()
+      .withAutoTLSManager(acmeServerURL = LetsEncryptURLStaging)
       .withYamux()
       .withNoise()
       .build()

--- a/tests/testnative.nim
+++ b/tests/testnative.nim
@@ -9,27 +9,26 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-import
-  testvarint, testconnection, testbridgestream, testminprotobuf, teststreamseq,
-  testsemaphore, testheartbeat, testfuture
+# import
+#   testvarint, testconnection, testbridgestream, testminprotobuf, teststreamseq,
+#   testsemaphore, testheartbeat, testfuture
+# 
+# import testminasn1, testrsa, testecnist, tested25519, testsecp256k1, testcrypto
+# 
+# import
+#   testmultibase, testmultihash, testmultiaddress, testcid, testpeerid,
+#   testsigned_envelope, testrouting_record
+# 
+# import
+#   testtcptransport,
+#   testtortransport,
+#   testwstransport,
+#   testquic,
+#   testmemorytransport,
+#   transports/tls/testcertificate
 
-import testminasn1, testrsa, testecnist, tested25519, testsecp256k1, testcrypto
-
 import
-  testmultibase, testmultihash, testmultiaddress, testcid, testpeerid,
-  testsigned_envelope, testrouting_record
-
-import
-  testtcptransport,
-  testtortransport,
-  testwstransport,
-  testquic,
-  testmemorytransport,
-  transports/tls/testcertificate,
-  testautotls
-
-import
-  testnameresolve, testmultistream, testbufferstream, testidentify,
+  testautotls, testnameresolve, testmultistream, testbufferstream, testidentify,
   testobservedaddrmanager, testconnmngr, testswitch, testnoise, testpeerinfo,
   testpeerstore, testping, testmplex, testrelayv1, testrelayv2, testrendezvous,
   testdiscovery, testyamux, testautonat, testautonatservice, testautorelay, testdcutr,

--- a/tests/testnative.nim
+++ b/tests/testnative.nim
@@ -9,23 +9,23 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-# import
-#   testvarint, testconnection, testbridgestream, testminprotobuf, teststreamseq,
-#   testsemaphore, testheartbeat, testfuture
-# 
-# import testminasn1, testrsa, testecnist, tested25519, testsecp256k1, testcrypto
-# 
-# import
-#   testmultibase, testmultihash, testmultiaddress, testcid, testpeerid,
-#   testsigned_envelope, testrouting_record
-# 
-# import
-#   testtcptransport,
-#   testtortransport,
-#   testwstransport,
-#   testquic,
-#   testmemorytransport,
-#   transports/tls/testcertificate
+import
+  testvarint, testconnection, testbridgestream, testminprotobuf, teststreamseq,
+  testsemaphore, testheartbeat, testfuture
+
+import testminasn1, testrsa, testecnist, tested25519, testsecp256k1, testcrypto
+
+import
+  testmultibase, testmultihash, testmultiaddress, testcid, testpeerid,
+  testsigned_envelope, testrouting_record
+
+import
+  testtcptransport,
+  testtortransport,
+  testwstransport,
+  testquic,
+  testmemorytransport,
+  transports/tls/testcertificate
 
 import
   testautotls, testnameresolve, testmultistream, testbufferstream, testidentify,

--- a/tests/testnative.nim
+++ b/tests/testnative.nim
@@ -25,7 +25,8 @@ import
   testwstransport,
   testquic,
   testmemorytransport,
-  transports/tls/testcertificate
+  transports/tls/testcertificate,
+  testautotls
 
 import
   testnameresolve, testmultistream, testbufferstream, testidentify,


### PR DESCRIPTION
Adding [AutoTLS](https://blog.libp2p.io/autotls/) support (addresses #1325)
- `AutoTLSManager` is responsible for always keeping a valid certificate signed by [Let's Encrypt](https://letsencrypt.org/)
- ACME functionality (`libp2p/autotls/acme.nim`): send signed requests to ACME server to request and finalize challenges
- [PeerID Authentication](https://github.com/libp2p/specs/blob/master/http/peer-id-auth.md) (`libp2p/autotls/peeridauth.nim`): authenticate with AutoTLS broker and send challenge
- DNS: check for RRs (`TXT _acme-challenge.{peerID}.libp2p.direct` and `A {dashed-ip-addr}.{peerID}.libp2p.direct`) to appear
- Certificates (`libp2p/transports/tls/challenge{.c, .h, .nim, _ffi.nim}`): generate certificate singing requests (CSR) and encode them for sending to ACME server as `finalize` payload (this has been merged in https://github.com/vacp2p/nim-libp2p/pull/1355)