### PR TITLE
chore: change nim-stew dep tagging

### DIFF
--- a/.pinned
+++ b/.pinned
@@ -4,7 +4,7 @@ chronos;https://github.com/status-im/nim-chronos@#c04576d829b8a0a1b12baaa8bc9203
 dnsclient;https://github.com/ba0f3/dnsclient.nim@#23214235d4784d24aceed99bbfe153379ea557c8
 faststreams;https://github.com/status-im/nim-faststreams@#720fc5e5c8e428d9d0af618e1e27c44b42350309
 httputils;https://github.com/status-im/nim-http-utils@#3b491a40c60aad9e8d3407443f46f62511e63b18
-json_serialization;https://github.com/status-im/nim-json-serialization@#85b7ea093cb85ee4f433a617b97571bd709d30df
+json_serialization;https://github.com/status-im/nim-json-serialization@#6eadb6e939ffa7882ff5437033c11a9464d3385c
 metrics;https://github.com/status-im/nim-metrics@#6142e433fc8ea9b73379770a788017ac528d46ff
 ngtcp2;https://github.com/status-im/nim-ngtcp2@#9456daa178c655bccd4a3c78ad3b8cce1f0add73
 nimcrypto;https://github.com/cheatfate/nimcrypto@#1c8d6e3caf3abc572136ae9a1da81730c4eb4288

--- a/.pinned
+++ b/.pinned
@@ -12,7 +12,7 @@ quic;https://github.com/status-im/nim-quic.git@#d54e8f0f2e454604b767fadeae243d95
 results;https://github.com/arnetheduck/nim-results@#f3c666a272c69d70cb41e7245e7f6844797303ad
 secp256k1;https://github.com/status-im/nim-secp256k1@#7246d91c667f4cc3759fdd50339caa45a2ecd8be
 serialization;https://github.com/status-im/nim-serialization@#4bdbc29e54fe54049950e352bb969aab97173b35
-stew;https://github.com/status-im/nim-stew@#3159137d9a3110edb4024145ce0ba778975de40e
+stew;https://github.com/status-im/nim-stew@#0db179256cf98eb9ce9ee7b9bc939f219e621f77
 testutils;https://github.com/status-im/nim-testutils@#dfc4c1b39f9ded9baf6365014de2b4bfb4dafc34
 unittest2;https://github.com/status-im/nim-unittest2@#2300fa9924a76e6c96bc4ea79d043e3a0f27120c
 websock;https://github.com/status-im/nim-websock@#f8ed9b40a5ff27ad02a3c237c4905b0924e3f982

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -9,7 +9,7 @@ skipDirs = @["tests", "examples", "Nim", "tools", "scripts", "docs"]
 
 requires "nim >= 1.6.0",
   "nimcrypto >= 0.6.0 & < 0.7.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.5",
-  "chronicles >= 0.10.2", "chronos >= 4.0.3", "metrics", "secp256k1", "stew#head",
+  "chronicles >= 0.10.2", "chronos >= 4.0.3", "metrics", "secp256k1", "stew >= 0.4.0",
   "websock", "unittest2", "results",
   "https://github.com/status-im/nim-quic.git#d54e8f0f2e454604b767fadeae243d95c30c383f"
 

--- a/tests/stubs/torstub.nim
+++ b/tests/stubs/torstub.nim
@@ -11,8 +11,9 @@
 
 {.push raises: [].}
 
+import std/net
 import tables
-import chronos, stew/[byteutils, endians2, shims/net]
+import chronos, stew/[byteutils, endians2]
 import
   ../../libp2p/[
     stream/connection,
@@ -62,7 +63,8 @@ proc start*(self: TorServerStub, address: TransportAddress) {.async.} =
         var ip: array[4, byte]
         for i, e in msg[0 ..^ 3]:
           ip[i] = e
-        $(ipv4(ip)) & ":" & $(Port(fromBytesBE(uint16, msg[^2 ..^ 1])))
+        $(IpAddress(family: IPv4, address_v4: ip)) & ":" &
+          $(Port(fromBytesBE(uint16, msg[^2 ..^ 1])))
       of Socks5AddressType.IPv6.byte:
         let n = 16 + 2 # +2 bytes for the port
         msg = newSeq[byte](n) # +2 bytes for the port
@@ -70,7 +72,8 @@ proc start*(self: TorServerStub, address: TransportAddress) {.async.} =
         var ip: array[16, byte]
         for i, e in msg[0 ..^ 3]:
           ip[i] = e
-        $(ipv6(ip)) & ":" & $(Port(fromBytesBE(uint16, msg[^2 ..^ 1])))
+        $(IpAddress(family: IPv6, address_v6: ip)) & ":" &
+          $(Port(fromBytesBE(uint16, msg[^2 ..^ 1])))
       of Socks5AddressType.FQDN.byte:
         await connSrc.readExactly(addr msg[0], 1)
         let n = int(uint8.fromBytes(msg[0 .. 0])) + 2 # +2 bytes for the port


### PR DESCRIPTION
Require nim-stew version >= 0.4.0 rather than using `#head`, as per [@arnetheduck's comment](https://discord.com/channels/613988663034118151/740631022080622745/1371484042800664671) as well as this recommendation in the project's README file:
> ⚠️ No API/ABI stability - in applications, pick a commit and stick with it ⚠️

Obs: this can only be merged after the tag has been created on [nim-stew](https://github.com/status-im/nim-stew)