### PR TITLE
test(gossipsub): Topic Membership Tests - updated

### DIFF
--- a/tests/pubsub/testgossipsubmeshmanagement.nim
+++ b/tests/pubsub/testgossipsubmeshmanagement.nim
@@ -521,10 +521,10 @@ suite "GossipSub Mesh Management":
 
     await invalidDetected.wait(10.seconds)
 
-  asyncTest "mesh and gossipsub populated when subscribed":
+  asyncTest "mesh and gossipsub updated when topic subscribed and unsubscribed":
     let
       numberOfNodes = 5
-      topic = "test-topic"
+      topic = "foobar"
       nodes = generateNodes(numberOfNodes, gossip = true).toGossipSub()
 
     startNodesAndDeferStop(nodes)
@@ -534,7 +534,7 @@ suite "GossipSub Mesh Management":
     subscribeAllNodes(nodes, topic, voidTopicHandler)
     await waitForHeartbeat()
 
-    # Then their related attributes should reflect that
+    # Then mesh and gossipsub should be populated
     for node in nodes:
       check node.topics.contains(topic)
       check node.gossipsub.hasKey(topic)
@@ -542,31 +542,20 @@ suite "GossipSub Mesh Management":
       check node.mesh.hasKey(topic)
       check node.mesh[topic].len() == numberOfNodes - 1
 
-  asyncTest "mesh and gossipsub updated when unsubscribed":
-    let
-      numberOfNodes = 5
-      topic = "test-topic"
-      nodes = generateNodes(numberOfNodes, gossip = true).toGossipSub()
-
-    startNodesAndDeferStop(nodes)
-    await connectNodesStar(nodes)
-    subscribeAllNodes(nodes, topic, voidTopicHandler)
-    await waitForHeartbeat()
-
     # When all nodes unsubscribe from the topic
     unsubscribeAllNodes(nodes, topic, voidTopicHandler)
     await waitForHeartbeat()
 
-    # Then the topic should be removed from relevant data structures
+    # Then the topic should be removed from mesh and gossipsub
     for node in nodes:
       check topic notin node.topics
       check topic notin node.mesh
       check topic notin node.gossipsub
 
-  asyncTest "handle SUBSCRIBE and UNSUBSCRIBE multiple topics":
+  asyncTest "handle subscribe and unsubscribe for multiple topics":
     let
       numberOfNodes = 3
-      topics = @["topic1", "topic2", "topic3"]
+      topics = @["foobar1", "foobar2", "foobar3"]
       nodes = generateNodes(numberOfNodes, gossip = true).toGossipSub()
 
     startNodesAndDeferStop(nodes)

--- a/tests/pubsub/utils.nim
+++ b/tests/pubsub/utils.nim
@@ -344,6 +344,12 @@ proc subscribeAllNodes*[T: PubSub](
   for node in nodes:
     node.subscribe(topic, topicHandler)
 
+proc unsubscribeAllNodes*[T: PubSub](
+    nodes: seq[T], topic: string, topicHandler: TopicHandler
+) =
+  for node in nodes:
+    node.unsubscribe(topic, topicHandler)
+
 proc subscribeAllNodes*[T: PubSub](
     nodes: seq[T], topic: string, topicHandlers: seq[TopicHandler]
 ) =


### PR DESCRIPTION
This PR tries to revive another stale PR with tests - [test(gossipsub): Topic Membership Tests](https://github.com/vacp2p/nim-libp2p/pull/1201) - which I just closed.

Actions taken:
- copied the tests from the original PR
- updated them to the latest conventions
- removed unnecessary tests:
  - `"subscription limit test"` - test had a wrong assumption around the limit of the topic a local node can subscribe to and test logic itself was incorrect, another test around this already exist: https://github.com/vacp2p/nim-libp2p/blob/4d0b4ecc2217c669583d7e262a9e4b658fe6bcca/tests/pubsub/testgossipsubmessagehandling.nim#L113
  - `"handle JOIN topic and mesh is updated"` - doesn't add anything new, repeats `"mesh and gossipsub populated when subscribed"`
  - `"multiple peers join and leave topic simultaneously"` -  doesn't add anything new,  repeats `"handle SUBSCRIBE and UNSUBSCRIBE multiple topics"`