### PR TITLE
chore: fix import warnings

### DIFF
--- a/libp2p.nim
+++ b/libp2p.nim
@@ -52,7 +52,6 @@ else:
       stream/connection,
       transports/transport,
       transports/tcptransport,
-      transports/quictransport,
       protocols/secure/noise,
       cid,
       multihash,

--- a/libp2p.nim
+++ b/libp2p.nim
@@ -52,6 +52,7 @@ else:
       stream/connection,
       transports/transport,
       transports/tcptransport,
+      transports/quictransport,
       protocols/secure/noise,
       cid,
       multihash,
@@ -69,4 +70,4 @@ else:
   export
     minprotobuf, switch, peerid, peerinfo, connection, multiaddress, crypto, lpstream,
     bufferstream, muxer, mplex, transport, tcptransport, noise, errors, cid, multihash,
-    multicodec, builders, pubsub
+    multicodec, builders, pubsub, quictransport

--- a/libp2p/protocols/connectivity/autonat/client.nim
+++ b/libp2p/protocols/connectivity/autonat/client.nim
@@ -9,7 +9,7 @@
 
 {.push raises: [].}
 
-import stew/results
+import results
 import chronos, chronicles
 import ../../../switch, ../../../multiaddress, ../../../peerid
 import core

--- a/libp2p/protocols/connectivity/dcutr/client.nim
+++ b/libp2p/protocols/connectivity/dcutr/client.nim
@@ -11,7 +11,7 @@
 
 import std/sequtils
 
-import stew/results
+import results
 import chronos, chronicles
 
 import core

--- a/libp2p/protocols/connectivity/dcutr/server.nim
+++ b/libp2p/protocols/connectivity/dcutr/server.nim
@@ -10,8 +10,8 @@
 {.push raises: [].}
 
 import std/[sets, sequtils]
-import stew/[results, objects]
-import chronos, chronicles
+import stew/objects
+import results, chronos, chronicles
 
 import core
 import

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -29,7 +29,7 @@ import
   ../../utility,
   ../../switch
 
-import stew/results
+import results
 export results
 
 import ./gossipsub/[types, scoring, behavior], ../../utils/heartbeat

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -31,7 +31,7 @@ import
   ../../errors,
   ../../utility
 
-import stew/results
+import results
 export results
 
 export tables, sets

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -9,8 +9,8 @@
 
 {.push raises: [].}
 
-import std/[sequtils, strutils, tables, hashes, options, sets, deques]
-import stew/results
+import std/[sequtils, tables, hashes, options, sets, deques]
+import results
 import chronos, chronicles, nimcrypto/sha2, metrics
 import chronos/ratelimit
 import

--- a/libp2p/protocols/pubsub/timedcache.nim
+++ b/libp2p/protocols/pubsub/timedcache.nim
@@ -10,7 +10,7 @@
 {.push raises: [].}
 
 import std/[hashes, sets]
-import chronos/timer, stew/results
+import chronos/timer, results
 
 import ../../utility
 

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -12,7 +12,7 @@
 {.push raises: [].}
 
 import std/[sequtils]
-import stew/results
+import results
 import chronos, chronicles
 import
   transport,

--- a/tests/commoninterop.nim
+++ b/tests/commoninterop.nim
@@ -1,4 +1,3 @@
-import options, tables
 import chronos, chronicles, stew/byteutils
 import helpers
 import ../libp2p

--- a/tests/pubsub/testfloodsub.nim
+++ b/tests/pubsub/testfloodsub.nim
@@ -9,12 +9,11 @@
 
 {.used.}
 
-import sequtils, options, tables, sets
+import sequtils, tables, sets
 import chronos, stew/byteutils
 import
   utils,
   ../../libp2p/[
-    errors,
     switch,
     stream/connection,
     crypto/crypto,

--- a/tests/pubsub/testgossipsubmessagehandling.nim
+++ b/tests/pubsub/testgossipsubmessagehandling.nim
@@ -16,7 +16,6 @@ import sugar
 import chronicles
 import ../../libp2p/protocols/pubsub/[gossipsub, mcache, peertable, timedcache]
 import ../../libp2p/protocols/pubsub/rpc/[message, protobuf]
-import ../../libp2p/muxers/muxer
 import ../helpers, ../utils/[futures]
 
 const MsgIdSuccess = "msg id gen success"

--- a/tests/pubsub/utils.nim
+++ b/tests/pubsub/utils.nim
@@ -5,7 +5,7 @@ const
   libp2p_pubsub_anonymize {.booldefine.} = false
 
 import hashes, random, tables, sets, sequtils, sugar
-import chronos, stew/[byteutils, results], chronos/ratelimit
+import chronos, results, stew/byteutils, chronos/ratelimit
 import
   ../../libp2p/[
     builders,
@@ -18,7 +18,7 @@ import
     protocols/pubsub/rpc/messages,
     protocols/secure/secure,
   ]
-import ../helpers, ../utils/futures
+import ../helpers
 import chronicles
 
 export builders

--- a/tests/testbufferstream.nim
+++ b/tests/testbufferstream.nim
@@ -10,7 +10,7 @@
 # those terms.
 
 import chronos, stew/byteutils
-import ../libp2p/stream/bufferstream, ../libp2p/stream/lpstream, ../libp2p/errors
+import ../libp2p/stream/bufferstream, ../libp2p/stream/lpstream
 
 import ./helpers
 

--- a/tests/testconnmngr.nim
+++ b/tests/testconnmngr.nim
@@ -12,9 +12,7 @@
 import std/[sequtils, tables]
 import results
 import chronos
-import
-  ../libp2p/
-    [connmanager, stream/connection, crypto/crypto, muxers/muxer, peerinfo]
+import ../libp2p/[connmanager, stream/connection, crypto/crypto, muxers/muxer, peerinfo]
 
 import helpers
 

--- a/tests/testconnmngr.nim
+++ b/tests/testconnmngr.nim
@@ -10,11 +10,11 @@
 # those terms.
 
 import std/[sequtils, tables]
-import stew/results
+import results
 import chronos
 import
   ../libp2p/
-    [connmanager, stream/connection, crypto/crypto, muxers/muxer, peerinfo, errors]
+    [connmanager, stream/connection, crypto/crypto, muxers/muxer, peerinfo]
 
 import helpers
 

--- a/tests/testdiscovery.nim
+++ b/tests/testdiscovery.nim
@@ -18,7 +18,7 @@ import
     discovery/discoverymngr,
     discovery/rendezvousinterface,
   ]
-import ./helpers, ./utils/[futures, async_tests]
+import ./helpers, ./utils/async_tests
 
 proc createSwitch(rdv: RendezVous = RendezVous.new()): Switch =
   SwitchBuilder

--- a/tests/testinterop.nim
+++ b/tests/testinterop.nim
@@ -1,6 +1,6 @@
 import helpers, commoninterop
 import ../libp2p
-import ../libp2p/crypto/crypto, ../libp2p/protocols/connectivity/relay/[relay, client]
+import ../libp2p/crypto/crypto, ../libp2p/protocols/connectivity/relay/relay
 
 proc switchMplexCreator(
     ma: MultiAddress = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet(),

--- a/tests/testnative.nim
+++ b/tests/testnative.nim
@@ -24,8 +24,7 @@ import
   testtortransport,
   testwstransport,
   testquic,
-  testmemorytransport,
-  transports/tls/testcertificate
+  testmemorytransport
 
 import
   testnameresolve, testmultistream, testbufferstream, testidentify,

--- a/tests/testnative.nim
+++ b/tests/testnative.nim
@@ -24,7 +24,8 @@ import
   testtortransport,
   testwstransport,
   testquic,
-  testmemorytransport
+  testmemorytransport,
+  transports/tls/testcertificate
 
 import
   testnameresolve, testmultistream, testbufferstream, testidentify,

--- a/tests/testrendezvous.nim
+++ b/tests/testrendezvous.nim
@@ -12,7 +12,7 @@
 import sequtils, strutils
 import chronos
 import ../libp2p/[protocols/rendezvous, switch, builders]
-import ../libp2p/discovery/[rendezvousinterface, discoverymngr]
+import ../libp2p/discovery/discoverymngr
 import ./helpers
 
 proc createSwitch(rdv: RendezVous = RendezVous.new()): Switch =

--- a/tests/testwildcardresolverservice.nim
+++ b/tests/testwildcardresolverservice.nim
@@ -9,8 +9,7 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-import std/[options, sequtils]
-import stew/[byteutils]
+import std/options
 import chronos, metrics
 import unittest2
 import ../libp2p/[builders, switch]

--- a/tests/transports/tls/testcertificate.nim
+++ b/tests/transports/tls/testcertificate.nim
@@ -1,3 +1,5 @@
+{.used.}
+
 import unittest2
 
 import times

--- a/tests/transports/tls/testcertificate.nim
+++ b/tests/transports/tls/testcertificate.nim
@@ -1,6 +1,6 @@
 import unittest2
 
-import times, base64
+import times
 import ../../../libp2p/transports/tls/certificate
 import ../../../libp2p/transports/tls/certificate_ffi
 import ../../../libp2p/crypto/crypto

--- a/tests/utils/futures.nim
+++ b/tests/utils/futures.nim
@@ -1,4 +1,4 @@
-import chronos/futures, stew/results, chronos, sequtils
+import chronos/futures, results, chronos, sequtils
 
 const
   DURATION_TIMEOUT* = 1.seconds


### PR DESCRIPTION
- change from deprecated `stew/results` to `results`
- remove unused imports, as reported by the compiler