### PR TITLE
chore(hp): add timeout on dial

### DIFF
--- a/tests/hole-punching-interop/hole_punching.nim
+++ b/tests/hole-punching-interop/hole_punching.nim
@@ -43,7 +43,7 @@ proc createSwitch(r: Relay = nil, hpService: Service = nil): Switch =
   s.mount(Ping.new(rng = rng))
   return s
 
-proc main() {.async.} =
+proc main(): Future[string] {.async.} =
   let relayClient = RelayClient.new()
   let autoRelayService = AutoRelayService.new(1, relayClient, nil, newRng())
   let autonatClientStub = AutonatClientStub.new(expectedDials = 1)
@@ -123,9 +123,10 @@ proc main() {.async.} =
     )
     echo &"""{{"rtt_to_holepunched_peer_millis":{delay.millis}}}"""
 
+  return "done"
+
 try:
-  let fut = main().wait(4.minutes)
-  discard waitFor(fut)
+  discard waitFor(main().wait(4.minutes))
 except AsyncTimeoutError:
   error "Program execution timed out."
   quit(-1)

--- a/tests/hole-punching-interop/hole_punching.nim
+++ b/tests/hole-punching-interop/hole_punching.nim
@@ -124,7 +124,8 @@ proc main() {.async.} =
     echo &"""{{"rtt_to_holepunched_peer_millis":{delay.millis}}}"""
 
 try:
-  discard waitFor(main().wait(4.minutes))
+  let fut = main().wait(4.minutes)
+  discard waitFor(fut)
 except AsyncTimeoutError:
   error "Program execution timed out."
   quit(-1)

--- a/tests/hole-punching-interop/hole_punching.nim
+++ b/tests/hole-punching-interop/hole_punching.nim
@@ -44,92 +44,84 @@ proc createSwitch(r: Relay = nil, hpService: Service = nil): Switch =
   return s
 
 proc main() {.async.} =
+  let relayClient = RelayClient.new()
+  let autoRelayService = AutoRelayService.new(1, relayClient, nil, newRng())
+  let autonatClientStub = AutonatClientStub.new(expectedDials = 1)
+  autonatClientStub.answer = NotReachable
+  let autonatService = AutonatService.new(autonatClientStub, newRng(), maxQueueSize = 1)
+  let hpservice = HPService.new(autonatService, autoRelayService)
+
+  let
+    isListener = getEnv("MODE") == "listen"
+    switch = createSwitch(relayClient, hpservice)
+    auxSwitch = createSwitch()
+    redisClient = open("redis", 6379.Port)
+
+  debug "Connected to redis"
+
+  await switch.start()
+  await auxSwitch.start()
+
+  let relayAddr =
+    try:
+      redisClient.bLPop(@["RELAY_TCP_ADDRESS"], 0)
+    except Exception as e:
+      raise newException(CatchableError, e.msg)
+
+  debug "All relay addresses", relayAddr
+
+  # This is necessary to make the autonat service work. It will ask this peer for our reachability which the autonat
+  # client stub will answer NotReachable.
+  await switch.connect(auxSwitch.peerInfo.peerId, auxSwitch.peerInfo.addrs)
+
+  # Wait for autonat to be NotReachable
+  while autonatService.networkReachability != NetworkReachability.NotReachable:
+    await sleepAsync(100.milliseconds)
+
+  # This will trigger the autonat relay service to make a reservation.
+  let relayMA = MultiAddress.init(relayAddr[1]).tryGet()
+
   try:
-    let relayClient = RelayClient.new()
-    let autoRelayService = AutoRelayService.new(1, relayClient, nil, newRng())
-    let autonatClientStub = AutonatClientStub.new(expectedDials = 1)
-    autonatClientStub.answer = NotReachable
-    let autonatService =
-      AutonatService.new(autonatClientStub, newRng(), maxQueueSize = 1)
-    let hpservice = HPService.new(autonatService, autoRelayService)
+    debug "Dialing relay...", relayMA
+    let relayId = await switch.connect(relayMA).wait(30.seconds)
+    debug "Connected to relay", relayId
+  except AsyncTimeoutError:
+    raise newException(CatchableError, "Connection to relay timed out")
 
-    let
-      isListener = getEnv("MODE") == "listen"
-      switch = createSwitch(relayClient, hpservice)
-      auxSwitch = createSwitch()
-      redisClient = open("redis", 6379.Port)
+  # Wait for our relay address to be published
+  while not switch.peerInfo.addrs.anyIt(it.contains(multiCodec("p2p-circuit")).tryGet()):
+    await sleepAsync(100.milliseconds)
 
-    debug "Connected to redis"
+  if isListener:
+    let listenerPeerId = switch.peerInfo.peerId
+    discard redisClient.rPush("LISTEN_CLIENT_PEER_ID", $listenerPeerId)
+    debug "Pushed listener client peer id to redis", listenerPeerId
 
-    await switch.start()
-    await auxSwitch.start()
-
-    let relayAddr =
+    # Nothing to do anymore, wait to be killed
+    await sleepAsync(2.minutes)
+  else:
+    let listenerId =
       try:
-        redisClient.bLPop(@["RELAY_TCP_ADDRESS"], 0)
+        PeerId.init(redisClient.bLPop(@["LISTEN_CLIENT_PEER_ID"], 0)[1]).tryGet()
       except Exception as e:
         raise newException(CatchableError, e.msg)
 
-    debug "All relay addresses", relayAddr
+    debug "Got listener peer id", listenerId
+    let listenerRelayAddr = MultiAddress.init($relayMA & "/p2p-circuit").tryGet()
 
-    # This is necessary to make the autonat service work. It will ask this peer for our reachability which the autonat
-    # client stub will answer NotReachable.
-    await switch.connect(auxSwitch.peerInfo.peerId, auxSwitch.peerInfo.addrs)
+    debug "Dialing listener relay address", listenerRelayAddr
+    await switch.connect(listenerId, @[listenerRelayAddr])
 
-    # Wait for autonat to be NotReachable
-    while autonatService.networkReachability != NetworkReachability.NotReachable:
-      await sleepAsync(100.milliseconds)
+    # wait for hole-punching to complete in the background
+    await sleepAsync(5000.milliseconds)
 
-    # This will trigger the autonat relay service to make a reservation.
-    let relayMA = MultiAddress.init(relayAddr[1]).tryGet()
-
-    try:
-      debug "Dialing relay...", relayMA
-      let relayId = await switch.connect(relayMA).wait(30.seconds)
-      debug "Connected to relay", relayId
-    except AsyncTimeoutError:
-      raise newException(CatchableError, "Connection to relay timed out")
-
-    # Wait for our relay address to be published
-    while not switch.peerInfo.addrs.anyIt(
-      it.contains(multiCodec("p2p-circuit")).tryGet()
+    let conn = switch.connManager.selectMuxer(listenerId).connection
+    let channel = await switch.dial(listenerId, @[listenerRelayAddr], PingCodec)
+    let delay = await Ping.new().ping(channel)
+    await allFuturesThrowing(
+      channel.close(), conn.close(), switch.stop(), auxSwitch.stop()
     )
-    :
-      await sleepAsync(100.milliseconds)
-
-    if isListener:
-      let listenerPeerId = switch.peerInfo.peerId
-      discard redisClient.rPush("LISTEN_CLIENT_PEER_ID", $listenerPeerId)
-      debug "Pushed listener client peer id to redis", listenerPeerId
-
-      # Nothing to do anymore, wait to be killed
-      await sleepAsync(2.minutes)
-    else:
-      let listenerId =
-        try:
-          PeerId.init(redisClient.bLPop(@["LISTEN_CLIENT_PEER_ID"], 0)[1]).tryGet()
-        except Exception as e:
-          raise newException(CatchableError, e.msg)
-
-      debug "Got listener peer id", listenerId
-      let listenerRelayAddr = MultiAddress.init($relayMA & "/p2p-circuit").tryGet()
-
-      debug "Dialing listener relay address", listenerRelayAddr
-      await switch.connect(listenerId, @[listenerRelayAddr])
-
-      # wait for hole-punching to complete in the background
-      await sleepAsync(5000.milliseconds)
-
-      let conn = switch.connManager.selectMuxer(listenerId).connection
-      let channel = await switch.dial(listenerId, @[listenerRelayAddr], PingCodec)
-      let delay = await Ping.new().ping(channel)
-      await allFuturesThrowing(
-        channel.close(), conn.close(), switch.stop(), auxSwitch.stop()
-      )
-      echo &"""{{"rtt_to_holepunched_peer_millis":{delay.millis}}}"""
-      quit(0)
-  except CatchableError as e:
-    error "Unexpected error", description = e.msg
+    echo &"""{{"rtt_to_holepunched_peer_millis":{delay.millis}}}"""
 
 try:
   discard waitFor(main().wait(4.minutes))

--- a/tests/transport-interop/main.nim
+++ b/tests/transport-interop/main.nim
@@ -101,7 +101,8 @@ proc main() {.async.} =
     )
 
 try:
-  discard waitFor(main().wait(testTimeout))
+  let fut = main().wait(testTimeout)
+  discard waitFor(main().wait(fut))
 except AsyncTimeoutError:
   error "Program execution timed out."
   quit(-1)

--- a/tests/transport-interop/main.nim
+++ b/tests/transport-interop/main.nim
@@ -11,7 +11,7 @@ let testTimeout =
   except CatchableError:
     3.minutes
 
-proc main(): Future[string] {.async.} =
+proc main() {.async.} =
   let
     transport = getEnv("transport")
     muxer = getEnv("muxer")
@@ -100,10 +100,14 @@ proc main(): Future[string] {.async.} =
       )
     )
 
-  return "done"
-
 try:
-  discard waitFor(main().wait(testTimeout))
+  proc mainAsync(): Future[string] {.async.} =
+    # mainAsync wraps main and returns some value, as otherwise
+    # 'waitFor(fut)' has no type (or is ambiguous)
+    await main()
+    return "done"
+
+  discard waitFor(mainAsync().wait(testTimeout))
 except AsyncTimeoutError:
   error "Program execution timed out."
   quit(-1)

--- a/tests/transport-interop/main.nim
+++ b/tests/transport-interop/main.nim
@@ -11,7 +11,7 @@ let testTimeout =
   except CatchableError:
     3.minutes
 
-proc main() {.async.} =
+proc main(): Future[string] {.async.} =
   let
     transport = getEnv("transport")
     muxer = getEnv("muxer")
@@ -99,10 +99,11 @@ proc main() {.async.} =
         pingRTTMilllis: float(pingDelay.milliseconds),
       )
     )
+  
+  return "done"
 
 try:
-  let fut = main().wait(testTimeout)
-  discard waitFor(main().wait(fut))
+  discard waitFor(main().wait(testTimeout))
 except AsyncTimeoutError:
   error "Program execution timed out."
   quit(-1)

--- a/tests/transport-interop/main.nim
+++ b/tests/transport-interop/main.nim
@@ -99,7 +99,12 @@ proc main() {.async.} =
         pingRTTMilllis: float(pingDelay.milliseconds),
       )
     )
-    quit(0)
 
-discard waitFor(main().withTimeout(testTimeout))
-quit(1)
+try:
+  discard waitFor(main().wait(testTimeout))
+except AsyncTimeoutError:
+  error "Program execution timed out."
+  quit(-1)
+except CatchableError as e:
+  error "Unexpected error", description = e.msg
+  quit(-1)

--- a/tests/transport-interop/main.nim
+++ b/tests/transport-interop/main.nim
@@ -99,7 +99,7 @@ proc main(): Future[string] {.async.} =
         pingRTTMilllis: float(pingDelay.milliseconds),
       )
     )
-  
+
   return "done"
 
 try:


### PR DESCRIPTION
this pr adds timeout on `dial` to test theory if hole punching intepor test are failing due to dial hanging indefinitely.

reasons to support this theory:
- unit tests are hanging  #1377
- hp hanging clues (#1367):
  -  the last message in logs is `Dialing peer`
  - test ends after bit after 4min (there is timeout on total execution time to 4min)

-----------

second change, hp and transport interop tests have not correctly processed main future:
- should quit(0) if program is successful 
- after timeout there is no error message
 

 