### PR TITLE
chore(exception): capture possible exception in dialer

### DIFF
--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -9,8 +9,7 @@
 
 import std/tables
 
-import stew/results
-import pkg/[chronos, chronicles, metrics]
+import pkg/[chronos, chronicles, metrics, results]
 
 import
   dial,


### PR DESCRIPTION
While running `tests/all_tests_common.nim` in [nwaku](https://github.com/waku-org/nwaku) I came across the following error:

```nim
Error: tryValue(protoArgument(lastPart)) can raise an unlisted exception: ref ResultError[system.string]
```
This PR avoids this compilation issue.
