### PR TITLE
revert: disable transport interop with zig-v0.0.1 (#1372)

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -40,8 +40,6 @@ jobs:
           s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
           s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_REGION }}
-          # temporary disable interop with zig-v0.0.1
-          test-ignore: "nim-libp2p-head x zig-v0.0.1 (quic-v1)|zig-v0.0.1 x nim-libp2p-head (quic-v1)"
 
   run-hole-punching-interop:
     name: Run hole-punching interoperability tests


### PR DESCRIPTION
This reverts commit 2856db5490eea9d0595af09d8051ddcb40e4ae38.

riveting disabled zig from interrop test as issue is on nim-libp2p side. 
we should track to see if zig interop is working after fix is deployed.