### PR TITLE
chore: make quic optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,5 +118,5 @@ jobs:
           nimble --version
           gcc --version
 
-          NIMFLAGS="${NIMFLAGS} --mm:${{ matrix.nim.memory_management }}"
+          export NIMFLAGS="${NIMFLAGS} -d:libp2p_quic_support --mm:${{ matrix.nim.memory_management }}" 
           nimble test

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Run test suite with coverage flags
         run: |
-          export NIMFLAGS="--lineDir:on --passC:-fprofile-arcs --passC:-ftest-coverage --passL:-fprofile-arcs --passL:-ftest-coverage"
+          export NIMFLAGS="-d:libp2p_quic_support --lineDir:on --passC:-fprofile-arcs --passC:-ftest-coverage --passL:-fprofile-arcs --passL:-ftest-coverage"
           nimble testnative
           nimble testpubsub
           nimble testfilter

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -97,5 +97,5 @@ jobs:
             dependency_solver="legacy"
           fi
 
-          NIMFLAGS="${NIMFLAGS} --mm:${{ matrix.nim.memory_management }} --solver:${dependency_solver}"
+          export NIMFLAGS="${NIMFLAGS} -d:libp2p_quic_support --mm:${{ matrix.nim.memory_management }} --solver:${dependency_solver}"
           nimble test

--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ The code follows the [Status Nim Style Guide](https://status-im.github.io/nim-st
 
 ### Compile time flags
 
+Enable quic transport support
+```bash
+nim c -d:libp2p_quic_support some_file.nim
+```
+
 Enable expensive metrics (ie, metrics with per-peer cardinality):
 ```bash
 nim c -d:libp2p_expensive_metrics some_file.nim

--- a/libp2p.nim
+++ b/libp2p.nim
@@ -52,7 +52,6 @@ else:
       stream/connection,
       transports/transport,
       transports/tcptransport,
-      transports/quictransport,
       protocols/secure/noise,
       cid,
       multihash,
@@ -70,4 +69,8 @@ else:
   export
     minprotobuf, switch, peerid, peerinfo, connection, multiaddress, crypto, lpstream,
     bufferstream, muxer, mplex, transport, tcptransport, noise, errors, cid, multihash,
-    multicodec, builders, pubsub, quictransport
+    multicodec, builders, pubsub
+
+  when defined(libp2p_quic_support):
+    import libp2p/transports/quictransport
+    export quictransport

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -23,7 +23,7 @@ import
   stream/connection,
   multiaddress,
   crypto/crypto,
-  transports/[transport, tcptransport, quictransport, memorytransport],
+  transports/[transport, tcptransport, memorytransport],
   muxers/[muxer, mplex/mplex, yamux/yamux],
   protocols/[identify, secure/secure, secure/noise, rendezvous],
   protocols/connectivity/[autonat/server, relay/relay, relay/client, relay/rtransport],
@@ -169,11 +169,14 @@ proc withTcpTransport*(
       TcpTransport.new(flags, upgr)
   )
 
-proc withQuicTransport*(b: SwitchBuilder): SwitchBuilder {.public.} =
-  b.withTransport(
-    proc(upgr: Upgrade, privateKey: PrivateKey): Transport =
-      QuicTransport.new(upgr, privateKey)
-  )
+when defined(libp2p_quic_support):
+  import transports/quictransport
+
+  proc withQuicTransport*(b: SwitchBuilder): SwitchBuilder {.public.} =
+    b.withTransport(
+      proc(upgr: Upgrade, privateKey: PrivateKey): Transport =
+        QuicTransport.new(upgr, privateKey)
+    )
 
 proc withMemoryTransport*(b: SwitchBuilder): SwitchBuilder {.public.} =
   b.withTransport(

--- a/tests/transport-interop/Dockerfile
+++ b/tests/transport-interop/Dockerfile
@@ -13,6 +13,6 @@ COPY . nim-libp2p/
 
 RUN \
   cd nim-libp2p && \
-  nim c --skipProjCfg --skipParentCfg --NimblePath:./nimbledeps/pkgs -p:nim-libp2p -d:chronicles_log_level=WARN -d:chronicles_default_output_device=stderr --threads:off ./tests/transport-interop/main.nim
+  nim c --skipProjCfg --skipParentCfg --NimblePath:./nimbledeps/pkgs -p:nim-libp2p -d:libp2p_quic_support -d:chronicles_log_level=WARN -d:chronicles_default_output_device=stderr --threads:off ./tests/transport-interop/main.nim
 
 ENTRYPOINT ["/app/nim-libp2p/tests/transport-interop/main"]


### PR DESCRIPTION
Link for discussion: https://discord.com/channels/613988663034118151/740631022080622745/1374293099811176509

the newest nim-libp2p adds three extra runtime deps: libcrypto.so.3, libz.so.1, and libzstd.so.1. Using shared libraries is not really aligned with nimbus-eth2’s current design goals, which avoid unnecessary shared libs—especially since these don't bring clear benefits as Quic is currently not being used.

@arnetheduck described that one of the requirements is to static link everything, and openssl makes that needlessly painful. To sidestep this, we should transition to a statically-linkable crypto lib like aws-lc or boringssl (both have clean static builds out of the box:
- https://github.com/aws/aws-lc/blob/main/BUILDING.md
- https://boringssl.googlesource.com/boringssl/+/HEAD/BUILDING.md#building)

meanwhile, to let nimbus keep up with upstream libp2p without tripping over quic deps, i've added a build toggle: `libp2p_quic_support`. if not set, quic gets excluded.

cc: @tersec 