### PR TITLE
ci(dependencies): fix access to tokens

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,16 +15,26 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - repository: status-im/nimbus-eth2
+          - id: nimbus
+            repository: status-im/nimbus-eth2
             ref: unstable
-            token: ${{ secrets.ACTIONS_GITHUB_TOKEN_NIMBUS_ETH2 }}
-          - repository: waku-org/nwaku
+          - id: nwaku
+            repository: waku-org/nwaku
             ref: master
-            token: ${{ secrets.ACTIONS_GITHUB_TOKEN_NWAKU }}
-          - repository: codex-storage/nim-codex
+          - id: codex
+            repository: codex-storage/nim-codex
             ref: master
-            token: ${{ secrets.ACTIONS_GITHUB_TOKEN_NIM_CODEX }}
     steps:
+      - name: Set secret based on matrix target
+        run: |
+          if [ "${{ matrix.target.id }}" = "nimbus" ]; then
+            echo "REPO_TOKEN=${{ secrets.ACTIONS_GITHUB_TOKEN_NIMBUS_ETH2 }}" >> $GITHUB_ENV
+          elif [ "${{ matrix.target.id }}" = "nwaku" ]; then
+            echo "REPO_TOKEN=${{ secrets.ACTIONS_GITHUB_TOKEN_NWAKU }}" >> $GITHUB_ENV
+          elif [ "${{ matrix.target.id }}" = "codex" ]; then
+            echo "REPO_TOKEN=${{ secrets.ACTIONS_GITHUB_TOKEN_NIM_CODEX }}" >> $GITHUB_ENV
+          fi
+
       - name: Clone target repository
         uses: actions/checkout@v4
         with:
@@ -32,7 +42,7 @@ jobs:
           ref: ${{ matrix.target.ref}}
           path: nbc
           fetch-depth: 0
-          token: ${{ matrix.target.token }}
+          token: ${{ env.REPO_TOKEN }}
 
       - name: Checkout this ref in target repository
         run: |

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,15 +15,15 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - secret: ACTIONS_GITHUB_TOKEN_NIMBUS_ETH2
-            repository: status-im/nimbus-eth2
+          - repository: status-im/nimbus-eth2
             ref: unstable
-          - secret: ACTIONS_GITHUB_TOKEN_NWAKU
-            repository: waku-org/nwaku
+            secret: ACTIONS_GITHUB_TOKEN_NIMBUS_ETH2
+          - repository: waku-org/nwaku
             ref: master
-          - secret: ACTIONS_GITHUB_TOKEN_NIM_CODEX
-            repository: codex-storage/nim-codex
+            secret: ACTIONS_GITHUB_TOKEN_NWAKU
+          - repository: codex-storage/nim-codex
             ref: master
+            secret: ACTIONS_GITHUB_TOKEN_NIM_CODEX
     steps:
       - name: Clone target repository
         uses: actions/checkout@v4

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,26 +15,16 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - id: nimbus
+          - secret: ACTIONS_GITHUB_TOKEN_NIMBUS_ETH2
             repository: status-im/nimbus-eth2
             ref: unstable
-          - id: nwaku
+          - secret: ACTIONS_GITHUB_TOKEN_NWAKU
             repository: waku-org/nwaku
             ref: master
-          - id: codex
+          - secret: ACTIONS_GITHUB_TOKEN_NIM_CODEX
             repository: codex-storage/nim-codex
             ref: master
     steps:
-      - name: Set secret based on matrix target
-        run: |
-          if [ "${{ matrix.target.id }}" = "nimbus" ]; then
-            echo "REPO_TOKEN=${{ secrets.ACTIONS_GITHUB_TOKEN_NIMBUS_ETH2 }}" >> $GITHUB_ENV
-          elif [ "${{ matrix.target.id }}" = "nwaku" ]; then
-            echo "REPO_TOKEN=${{ secrets.ACTIONS_GITHUB_TOKEN_NWAKU }}" >> $GITHUB_ENV
-          elif [ "${{ matrix.target.id }}" = "codex" ]; then
-            echo "REPO_TOKEN=${{ secrets.ACTIONS_GITHUB_TOKEN_NIM_CODEX }}" >> $GITHUB_ENV
-          fi
-
       - name: Clone target repository
         uses: actions/checkout@v4
         with:
@@ -42,7 +32,7 @@ jobs:
           ref: ${{ matrix.target.ref}}
           path: nbc
           fetch-depth: 0
-          token: ${{ env.REPO_TOKEN }}
+          token: ${{ secrets[matrix.target.secret] }}
 
       - name: Checkout this ref in target repository
         run: |


### PR DESCRIPTION
we are having this error currently:
```
Invalid workflow file: .github/workflows/dependencies.yml#L20
The workflow is not valid. .github/workflows/dependencies.yml (Line: 20, Col: 20): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.ACTIONS_GITHUB_TOKEN_NIMBUS_ETH2 .github/workflows/dependencies.yml (Line: 23, Col: 20): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.ACTIONS_GITHUB_TOKEN_NWAKU
```

secrets could not be passed in matrix, and must be used from within job.

ci fixed proof: https://github.com/vacp2p/nim-libp2p/actions/workflows/dependencies.yml