### PR TITLE
fix(ci-daily): delete cache action will continue on error

### DIFF
--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -24,14 +24,7 @@ on:
         default: "[]"
 
 jobs:
-  delete_cache:
-    name: Delete github action's branch cache
-    runs-on: ubuntu-latest
-    steps:
-      - uses: snnaplab/delete-branch-cache-action@v1
-
   test:
-    needs: delete_cache
     timeout-minutes: 40
     strategy:
       fail-fast: false

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -24,7 +24,15 @@ on:
         default: "[]"
 
 jobs:
+  delete_cache:
+    name: Delete github action's branch cache
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: snnaplab/delete-branch-cache-action@v1
+
   test:
+    needs: delete_cache
     timeout-minutes: 40
     strategy:
       fail-fast: false


### PR DESCRIPTION
scheduled daily job was failing on `delete_cache` job. https://github.com/vacp2p/nim-libp2p/actions/runs/15385632375

this PR adds `continue-on-error` in case if this job fails, so we can continue with daily test job.
we ultimately only care about outcome of test job (if it succeeds with cache removed or not).