### PR TITLE
feat(perf): add stats

### DIFF
--- a/libp2p/protocols/perf/client.nim
+++ b/libp2p/protocols/perf/client.nim
@@ -29,7 +29,7 @@ proc new*(T: typedesc[PerfClient]): T =
   return T()
 
 proc currentStats*(p: PerfClient): Stats =
-  p.stats
+  return p.stats
 
 proc perf*(
     p: PerfClient, conn: Connection, sizeToWrite: uint64 = 0, sizeToRead: uint64 = 0

--- a/libp2p/protocols/perf/client.nim
+++ b/libp2p/protocols/perf/client.nim
@@ -75,6 +75,6 @@ proc perf*(
 
   p.stats.isFinal = true
 
-  trace "finishing performance benchmark", p.stats.duration
+  trace "finishing performance benchmark", duration = p.stats.duration
 
   return p.stats.duration

--- a/libp2p/protocols/perf/client.nim
+++ b/libp2p/protocols/perf/client.nim
@@ -54,7 +54,10 @@ proc perf*(
 
   while size > 0:
     let toRead = min(size, PerfSize)
-    await conn.readExactly(addr buf[0], toRead.int)
+    try:
+      await conn.readExactly(addr buf[0], toRead.int)
+    except LPStreamClosedError:
+      break
     size = size - toRead
     p.stats.duration = Moment.now() - start
     p.stats.downloadBytes += toRead

--- a/libp2p/protocols/perf/client.nim
+++ b/libp2p/protocols/perf/client.nim
@@ -72,6 +72,6 @@ proc perf*(
 
   p.stats.isFinal = true
 
-  let duration = Moment.now() - start
-  trace "finishing performance benchmark", duration
-  return duration
+  trace "finishing performance benchmark", p.stats.duration
+  
+  return p.stats.duration

--- a/libp2p/protocols/perf/client.nim
+++ b/libp2p/protocols/perf/client.nim
@@ -45,8 +45,12 @@ proc perf*(
     let toWrite = min(size, PerfSize)
     await conn.write(buf[0 ..< toWrite])
     size -= toWrite
-    p.stats.duration = Moment.now() - start
-    p.stats.uploadBytes += toWrite
+
+    # set stats using copy value to avoid race condition
+    var statsCopy = p.stats
+    statsCopy.duration = Moment.now() - start
+    statsCopy.uploadBytes += toWrite
+    p.stats = statsCopy
 
   await conn.close()
 
@@ -59,8 +63,12 @@ proc perf*(
     except LPStreamClosedError:
       break
     size = size - toRead
-    p.stats.duration = Moment.now() - start
-    p.stats.downloadBytes += toRead
+
+    # set stats using copy value to avoid race condition
+    var statsCopy = p.stats
+    statsCopy.duration = Moment.now() - start
+    statsCopy.downloadBytes += toRead
+    p.stats = statsCopy
 
   p.stats.isFinal = true
 

--- a/libp2p/protocols/perf/client.nim
+++ b/libp2p/protocols/perf/client.nim
@@ -47,12 +47,12 @@ proc perf*(
   while size > 0:
     let toWrite = min(size, PerfSize)
     await conn.write(buf[0 ..< toWrite])
-    size -= toWrite
+    size -= toWrite.uint64
 
     # set stats using copy value to avoid race condition
     var statsCopy = p.stats
     statsCopy.duration = Moment.now() - start
-    statsCopy.uploadBytes += toWrite
+    statsCopy.uploadBytes += toWrite.uint64
     p.stats = statsCopy
 
   await conn.close()
@@ -62,12 +62,12 @@ proc perf*(
   while size > 0:
     let toRead = min(size, PerfSize)
     await conn.readExactly(addr buf[0], toRead.int)
-    size = size - toRead
+    size = size - toRead.uint64
 
     # set stats using copy value to avoid race condition
     var statsCopy = p.stats
     statsCopy.duration = Moment.now() - start
-    statsCopy.downloadBytes += toRead
+    statsCopy.downloadBytes += toRead.uint64
     p.stats = statsCopy
 
   p.stats.isFinal = true

--- a/libp2p/protocols/perf/client.nim
+++ b/libp2p/protocols/perf/client.nim
@@ -47,12 +47,12 @@ proc perf*(
   while size > 0:
     let toWrite = min(size, PerfSize)
     await conn.write(buf[0 ..< toWrite])
-    size -= toWrite.uint64
+    size -= toWrite.uint
 
     # set stats using copy value to avoid race condition
     var statsCopy = p.stats
     statsCopy.duration = Moment.now() - start
-    statsCopy.uploadBytes += toWrite.uint64
+    statsCopy.uploadBytes += toWrite.uint
     p.stats = statsCopy
 
   await conn.close()
@@ -62,12 +62,12 @@ proc perf*(
   while size > 0:
     let toRead = min(size, PerfSize)
     await conn.readExactly(addr buf[0], toRead.int)
-    size = size - toRead.uint64
+    size = size - toRead.uint
 
     # set stats using copy value to avoid race condition
     var statsCopy = p.stats
     statsCopy.duration = Moment.now() - start
-    statsCopy.downloadBytes += toRead.uint64
+    statsCopy.downloadBytes += toRead.uint
     p.stats = statsCopy
 
   p.stats.isFinal = true

--- a/libp2p/protocols/perf/client.nim
+++ b/libp2p/protocols/perf/client.nim
@@ -23,10 +23,13 @@ type Stats* = object
   duration*: Duration
 
 type PerfClient* = ref object
-  stats*: Stats
+  stats: Stats
 
 proc new*(T: typedesc[PerfClient]): T =
   return T()
+
+proc currentStats*(p: PerfClient): Stats =
+  p.stats
 
 proc perf*(
     p: PerfClient, conn: Connection, sizeToWrite: uint64 = 0, sizeToRead: uint64 = 0
@@ -73,5 +76,5 @@ proc perf*(
   p.stats.isFinal = true
 
   trace "finishing performance benchmark", p.stats.duration
-  
+
   return p.stats.duration

--- a/libp2p/protocols/perf/client.nim
+++ b/libp2p/protocols/perf/client.nim
@@ -61,10 +61,7 @@ proc perf*(
 
   while size > 0:
     let toRead = min(size, PerfSize)
-    try:
-      await conn.readExactly(addr buf[0], toRead.int)
-    except LPStreamClosedError:
-      break
+    await conn.readExactly(addr buf[0], toRead.int)
     size = size - toRead
 
     # set stats using copy value to avoid race condition

--- a/tests/testnative.nim
+++ b/tests/testnative.nim
@@ -33,6 +33,5 @@ import
   testpeerstore, testping, testmplex, testrelayv1, testrelayv2, testrendezvous,
   testdiscovery, testyamux, testautonat, testautonatservice, testautorelay, testdcutr,
   testhpservice, testutility, testhelpers, testwildcardresolverservice, testperf
-  testhpservice, testutility, testhelpers, testwildcardresolverservice
 
 import kademlia/testencoding

--- a/tests/testnative.nim
+++ b/tests/testnative.nim
@@ -32,4 +32,4 @@ import
   testobservedaddrmanager, testconnmngr, testswitch, testnoise, testpeerinfo,
   testpeerstore, testping, testmplex, testrelayv1, testrelayv2, testrendezvous,
   testdiscovery, testyamux, testautonat, testautonatservice, testautorelay, testdcutr,
-  testhpservice, testutility, testhelpers, testwildcardresolverservice
+  testhpservice, testutility, testhelpers, testwildcardresolverservice, testperf

--- a/tests/testperf.nim
+++ b/tests/testperf.nim
@@ -89,12 +89,14 @@ suite "Perf protocol":
     var perfClient = PerfClient.new()
     var perfFut: Future[Duration]
     try:
+      # start perf future with large download request
+      # this will make perf execute for longer so we can cancel it
       perfFut = perfClient.perf(conn, 1.uint64, 1000000000000.uint64)
     except CatchableError:
       discard
 
+    # after some time upload should be finished
     await sleepAsync(50.milliseconds)
-
     var stats = perfClient.currentStats()
     check:
       stats.isFinal == false
@@ -103,6 +105,7 @@ suite "Perf protocol":
     perfFut.cancel() # cancelling future will raise exception
     await sleepAsync(50.milliseconds)
 
+    # after cancelling perf, stats must indicate that it is final one
     stats = perfClient.currentStats()
     check:
       stats.isFinal == true

--- a/tests/testperf.nim
+++ b/tests/testperf.nim
@@ -63,7 +63,7 @@ suite "Perf protocol":
     checkTrackers()
 
   asyncTest "tcp::yamux":
-    return # test fails with some issue reading last packet
+    return # nim-libp2p#1462 test fails with stream closed error
     let server = createSwitch(isServer = true, useYamux = true)
     let client = createSwitch(useYamux = true)
     await runTest(server, client)

--- a/tests/testperf.nim
+++ b/tests/testperf.nim
@@ -1,0 +1,74 @@
+{.used.}
+
+# Nim-Libp2p
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+import chronos
+import ../libp2p
+import
+  ../libp2p/[switch, protocols/perf/client, protocols/perf/server, protocols/perf/core]
+import ./helpers
+
+proc createSwitch(
+    isServer: bool = false, useMplex: bool = false, useYamux: bool = false
+): Switch =
+  var builder = SwitchBuilder
+    .new()
+    .withRng(newRng())
+    .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
+    .withTcpTransport()
+    .withNoise()
+  if useMplex:
+    builder = builder.withMplex()
+  if useYamux:
+    builder = builder.withYamux()
+
+  var switch = builder.build()
+
+  if isServer:
+    switch.mount(Perf.new())
+
+  return switch
+
+proc runTest(server: Switch, client: Switch) {.async.} =
+  const
+    bytesToUpload = 100000
+    bytesToDownload = 10000000
+
+  await server.start()
+  await client.start()
+
+  defer:
+    await client.stop()
+    await server.stop()
+
+  let conn = await client.dial(server.peerInfo.peerId, server.peerInfo.addrs, PerfCodec)
+  var perfClient = PerfClient.new()
+  discard await perfClient.perf(conn, bytesToUpload, bytesToDownload)
+
+  let finalStats = perfClient.currentStats()
+  check:
+    finalStats.isFinal == true
+    finalStats.uploadBytes == bytesToUpload
+    finalStats.downloadBytes == bytesToDownload
+
+suite "Perf protocol":
+  teardown:
+    checkTrackers()
+
+  asyncTest "tcp::yamux":
+    return # test fails with some issue reading last packet
+    let server = createSwitch(isServer = true, useYamux = true)
+    let client = createSwitch(useYamux = true)
+    await runTest(server, client)
+
+  asyncTest "tcp::mplex":
+    let server = createSwitch(isServer = true, useMplex = true)
+    let client = createSwitch(useMplex = true)
+    await runTest(server, client)


### PR DESCRIPTION
- adding stats to Perf client, needed by perf benchmarking implementation (https://github.com/libp2p/test-plans/pull/658)
- adding tests for Perf protocol
- discovered bug #1462
