### PR TITLE
feat(withNone): add withNone utility template

### DIFF
--- a/libp2p/utility.nim
+++ b/libp2p/utility.nim
@@ -110,6 +110,35 @@ macro withValue*[T](self: Opt[T] | Option[T], value, body, elseStmt: untyped): u
     else:
       `elseBody`
 
+template withNone*[T](self: Opt[T] | Option[T], body: untyped): untyped =
+  ## This template provides a convenient way to work with `Option` types in Nim.
+  ## It allows you to execute a block of code (`body`) only when the `Option` is empty.
+  ## This the opposite of what withValue does.
+  ##
+  ## `self` is the `Option` instance being checked.
+  ## `body` is a block of code that is executed only if `self` is none.
+  ##
+  ## Example:
+  ## ```nim
+  ## let myOpt = Opt.none(int)
+  ## myOpt.withNone:
+  ##   echo "myOpt is none!"
+  ## ```
+  ##
+  ## Note: This is a template, and it will be inlined at the call site, offering good performance.
+  let temp = (self)
+  if temp.isNone:
+    body
+
+template withNone*[T, E](self: Result[T, E], body: untyped): untyped =
+  self.toOpt().withNone(body)
+
+macro withNone*[T](self: Opt[T] | Option[T], body, elseStmt: untyped): untyped =
+  let elseBody = elseStmt[0]
+  quote:
+    let temp = (`self`)
+    if temp.isNone: `body` else: `elseBody`
+
 template valueOr*[T](self: Option[T], body: untyped): untyped =
   let temp = (self)
   if temp.isSome:

--- a/tests/testutility.nim
+++ b/tests/testutility.nim
@@ -70,7 +70,7 @@ suite "Utility":
     check not (compiles do:
       result: uint = safeConvert[int](11.uint))
 
-suite "withValue and valueOr templates":
+suite "withValue, withNone and valueOr templates":
   type
     TestObj = ref object
       x: int
@@ -140,6 +140,44 @@ suite "withValue and valueOr templates":
       v.x.inc()
 
     check obj.x == 8
+
+  test "withNone calls right branch when Opt/Option is some":
+    var counter = 0
+    # check Opt/Option withNone with else
+    Opt.some(counter).withNone:
+      fail()
+    else:
+      counter.inc()
+    Opt.some(counter).withNone:
+      fail()
+    else:
+      counter.inc()
+    check counter == 2
+
+    # check Opt/Option withValue without else
+    Opt.some(counter).withNone:
+      fail()
+    Opt.some(counter).withNone:
+      fail()
+
+  test "withNone calls right branch when Opt/Option is none":
+    var counter = 1
+    # check Opt/Option withValue with else
+    Opt.none(int).withNone:
+      counter.inc()
+    else:
+      fail()
+    none(int).withNone:
+      counter.inc()
+    else:
+      fail()
+
+    # check Opt/Option withValue without else
+    Opt.none(int).withNone:
+      counter.inc()
+    none(int).withNone:
+      counter.inc()
+    check counter == 5
 
   test "valueOr calls with and without proc call":
     var obj = none(TestObj).valueOr:


### PR DESCRIPTION
usage:
```nim
myOpt: Opt[int] = Opt.none(int)
myOpt.withNone:
  echo "this should run"
else:
  echo "this should not run"
```

Else is optional, so you can also do only:
 ```nim
myOpt: Opt[int] = Opt.none(int)
myOpt.withNone:
  echo "this should run"
```

Inspired by the `withSome(value)` template