### PR TITLE
chore(acme): add MockACMEApi for testing

### DIFF
--- a/libp2p/autotls/acme/mockapi.nim
+++ b/libp2p/autotls/acme/mockapi.nim
@@ -1,0 +1,37 @@
+import chronos, chronos/apps/http/httpclient, json
+
+import ./api, ./utils
+
+export api
+
+type MockACMEApi* = ref object of ACMEApi
+  parent*: ACMEApi
+  mockedHeaders*: HttpTable
+  mockedBody*: JsonNode
+
+proc new*(
+    T: typedesc[MockACMEApi]
+): Future[MockACMEApi] {.async: (raises: [ACMEError, CancelledError]).} =
+  let directory = ACMEDirectory(
+    newNonce: LetsEncryptURL & "/new-nonce",
+    newOrder: LetsEncryptURL & "/new-order",
+    newAccount: LetsEncryptURL & "/new-account",
+  )
+  MockACMEApi(
+    session: HttpSessionRef.new(), directory: directory, acmeServerURL: LetsEncryptURL
+  )
+
+method requestNonce*(
+    self: MockACMEApi
+): Future[Nonce] {.async: (raises: [ACMEError, CancelledError]).} =
+  return self.acmeServerURL & "/acme/1234"
+
+method post*(
+    self: MockACMEApi, url: string, payload: string
+): Future[HTTPResponse] {.async: (raises: [ACMEError, HttpError, CancelledError]).} =
+  HTTPResponse(body: self.mockedBody, headers: self.mockedHeaders)
+
+method get*(
+    self: MockACMEApi, url: string
+): Future[HTTPResponse] {.async: (raises: [ACMEError, HttpError, CancelledError]).} =
+  HTTPResponse(body: self.mockedBody, headers: self.mockedHeaders)

--- a/libp2p/autotls/acme/utils.nim
+++ b/libp2p/autotls/acme/utils.nim
@@ -4,6 +4,11 @@ import ../../transports/tls/certificate_ffi
 
 type ACMEError* = object of LPError
 
+proc keyOrError*(table: HttpTable, key: string): string {.raises: [ValueError].} =
+  if not table.contains(key):
+    raise newException(ValueError, "key " & key & " not present in headers")
+  table.getString(key)
+
 proc base64UrlEncode*(data: seq[byte]): string =
   ## Encodes data using base64url (RFC 4648 §5) — no padding, URL-safe
   var encoded = base64.encode(data, safe = true)

--- a/tests/testautotls.nim
+++ b/tests/testautotls.nim
@@ -1,0 +1,178 @@
+{.used.}
+
+# Nim-Libp2p
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [].}
+
+import sequtils, json
+import chronos, chronos/apps/http/httpclient
+import ../libp2p/[stream/connection, upgrademngrs/upgrade, autotls/acme/mockapi, wire]
+
+import ./helpers
+
+suite "AutoTLS ACME Client":
+  var api {.threadvar.}: MockACMEApi
+  var key {.threadvar.}: KeyPair
+
+  asyncTeardown:
+    await api.close()
+    checkTrackers()
+
+  asyncSetup:
+    api = await MockACMEApi.new()
+    api.mockedHeaders = HttpTable.init()
+    key = KeyPair.random(PKScheme.RSA, newRng()[]).get()
+
+  asyncTest "register to acme server":
+    api.mockedBody = %*{"status": "valid"}
+    api.mockedHeaders.add("location", "some-expected-kid")
+
+    let registerResponse = await api.requestRegister(key)
+    check registerResponse.kid == "some-expected-kid"
+
+  asyncTest "request challenge for a domain":
+    api.mockedBody =
+      %*{
+        "status": "pending",
+        "authorizations": ["expected-authorizations-url"],
+        "finalize": "expected-finalize-url",
+      }
+    api.mockedHeaders.set("location", "expected-order-url")
+
+    let challengeResponse =
+      await api.requestNewOrder(@["some.dummy.domain.com"], key, "kid")
+    check challengeResponse.status == ACMEChallengeStatus.pending
+    check challengeResponse.authorizations == ["expected-authorizations-url"]
+    check challengeResponse.finalize == "expected-finalize-url"
+    check challengeResponse.orderURL == "expected-order-url"
+
+    # reset mocked obj for second request
+    api.mockedBody =
+      %*{
+        "challenges": [
+          {
+            "url": "expected-dns01-url",
+            "type": "dns-01",
+            "status": "pending",
+            "token": "expected-dns01-token",
+          }
+        ]
+      }
+
+    let authorizationsResponse =
+      await api.requestAuthorizations(challengeResponse.authorizations, key, "kid")
+    check authorizationsResponse.challenges.len > 0
+
+    let dns01 = authorizationsResponse.challenges.filterIt(it.`type` == "dns-01")[0]
+    check dns01.url == "expected-dns01-url"
+    check dns01.`type` == "dns-01"
+    check dns01.token == "expected-dns01-token"
+    check dns01.status == ACMEChallengeStatus.pending
+
+  asyncTest "register with unsupported keys":
+    let unsupportedSchemes = [PKScheme.Ed25519, PKScheme.Secp256k1, PKScheme.ECDSA]
+    for scheme in unsupportedSchemes:
+      let unsupportedKey = KeyPair.random(scheme, newRng()[]).get()
+      expect(ACMEError):
+        discard await api.requestRegister(unsupportedKey)
+
+  asyncTest "request challenge with invalid kid":
+    expect(ACMEError):
+      discard await api.requestChallenge(@["domain.com"], key, "invalid_kid_here")
+
+  asyncTest "challenge completed successful":
+    api.mockedBody = %*{"checkURL": "some-check-url"}
+    discard await api.requestCompleted("some-chal-url", key, "kid")
+
+    api.mockedBody = %*{"status": "valid"}
+    api.mockedHeaders.add("Retry-After", "1")
+    let completed = await api.checkChallengeCompleted("some-chal-url", key, "kid")
+    check completed == true
+
+  asyncTest "challenge completed max retries reached":
+    api.mockedBody = %*{"checkURL": "some-check-url"}
+    discard await api.requestCompleted("some-chal-url", key, "kid")
+
+    api.mockedBody = %*{"status": "pending"}
+    api.mockedHeaders.add("Retry-After", "1")
+    let completed =
+      await api.checkChallengeCompleted("some-chal-url", key, "kid", retries = 1)
+    check completed == false
+
+  asyncTest "challenge completed invalid":
+    api.mockedBody = %*{"checkURL": "some-check-url"}
+    discard await api.requestCompleted("some-chal-url", key, "kid")
+
+    api.mockedBody = %*{"status": "invalid"}
+    api.mockedHeaders.add("Retry-After", "1")
+    expect(ACMEError):
+      discard await api.checkChallengeCompleted("some-chal-url", key, "kid")
+
+  asyncTest "finalize certificate successful":
+    api.mockedBody = %*{"status": "valid"}
+    api.mockedHeaders.add("Retry-After", "1")
+    let finalized = await api.certificateFinalized(
+      "some-domain", "some-finalize-url", "some-order-url", key, "kid"
+    )
+    check finalized == true
+
+  asyncTest "finalize certificate max retries reached":
+    api.mockedBody = %*{"status": "processing"}
+    api.mockedHeaders.add("Retry-After", "1")
+    let finalized = await api.certificateFinalized(
+      "some-domain", "some-finalize-url", "some-order-url", key, "kid", retries = 1
+    )
+    check finalized == false
+
+  asyncTest "finalize certificate invalid":
+    api.mockedBody = %*{"status": "invalid"}
+    api.mockedHeaders.add("Retry-After", "1")
+    expect(ACMEError):
+      discard await api.certificateFinalized(
+        "some-domain", "some-finalize-url", "some-order-url", key, "kid"
+      )
+
+  asyncTest "expect error on invalid JSON response":
+    api.mockedBody = %*{"inexistent field": "invalid value"}
+
+    expect(ACMEError):
+      # avoid calling overloaded mock method requestNonce here since we want to test the actual thing
+      discard await procCall requestNonce(ACMEApi(api))
+
+    expect(ACMEError):
+      discard await api.requestRegister(key)
+
+    expect(ACMEError):
+      discard await api.requestNewOrder(@["some-domain"], key, "kid")
+
+    expect(ACMEError):
+      discard await api.requestAuthorizations(@["auth-1", "auth-2"], key, "kid")
+
+    expect(ACMEError):
+      discard await api.requestChallenge(@["domain-1", "domain-2"], key, "kid")
+
+    expect(ACMEError):
+      discard await api.requestCheck(
+        "some-check-url", ACMECheckKind.ACMEOrderCheck, key, "kid"
+      )
+
+    expect(ACMEError):
+      discard await api.requestCheck(
+        "some-check-url", ACMECheckKind.ACMEChallengeCheck, key, "kid"
+      )
+
+    expect(ACMEError):
+      discard await api.requestCompleted("some-chal-url", key, "kid")
+
+    expect(ACMEError):
+      discard await api.requestFinalize("some-domain", "some-finalize-url", key, "kid")
+
+    expect(ACMEError):
+      discard await api.requestGetOrder("some-order-url")

--- a/tests/testautotls_integration.nim
+++ b/tests/testautotls_integration.nim
@@ -47,14 +47,3 @@ suite "AutoTLS Integration":
     check challenge.dns01.`type`.len() > 0
     check challenge.dns01.status == ACMEChallengeStatus.pending
     check challenge.dns01.token.len() > 0
-
-  asyncTest "test register with unsupported keys":
-    let unsupportedSchemes = [PKScheme.Ed25519, PKScheme.Secp256k1, PKScheme.ECDSA]
-    for scheme in unsupportedSchemes:
-      let unsupportedKey = KeyPair.random(scheme, newRng()[]).get()
-      expect(ACMEError):
-        discard await api.requestRegister(unsupportedKey)
-
-  asyncTest "test request challenge with invalid kid":
-    expect(ACMEError):
-      discard await api.requestChallenge(@["domain.com"], key, "invalid_kid_here")

--- a/tests/testnative.nim
+++ b/tests/testnative.nim
@@ -28,7 +28,7 @@ import
   transports/tls/testcertificate
 
 import
-  testnameresolve, testmultistream, testbufferstream, testidentify,
+  testautotls, testnameresolve, testmultistream, testbufferstream, testidentify,
   testobservedaddrmanager, testconnmngr, testswitch, testnoise, testpeerinfo,
   testpeerstore, testping, testmplex, testrelayv1, testrelayv2, testrendezvous,
   testdiscovery, testyamux, testautonat, testautonatservice, testautorelay, testdcutr,


### PR DESCRIPTION
1. Add a mocked ACME API for unit testing
2. Slightly modify `libp2p/autotls/acme/api.nim`
3. Move some tests from `testautotls_integration.nim` to `testautotls.nim` 