### PR TITLE
test: increase timeout

### DIFF
--- a/tests/testdaemon.nim
+++ b/tests/testdaemon.nim
@@ -116,8 +116,8 @@ suite "libp2p-daemon test suite":
     check:
       waitFor(connectStreamTest()) == true
   asyncTest "GossipSub test":
-    checkUntilTimeout:
+    checkUntilTimeoutCustom(10.seconds, 100.milliseconds):
       (await pubsubTest({PSGossipSub}))
   asyncTest "FloodSub test":
-    checkUntilTimeout:
+    checkUntilTimeoutCustom(10.seconds, 100.milliseconds):
       (await pubsubTest({PSFloodSub}))


### PR DESCRIPTION
Issue: https://github.com/vacp2p/nim-libp2p/issues/1459

Changes:
- use `checkUntilTimeoutCustom(10.seconds, 100.milliseconds):` to bring back timeout value from before https://github.com/vacp2p/nim-libp2p/pull/1437