### PR TITLE
fix(daily): fix typo in testintegration

### DIFF
--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -96,4 +96,4 @@ jobs:
 
           export NIMFLAGS="${NIMFLAGS} --mm:${{ matrix.nim.memory_management }}"
           nimble test
-          nimble testintegraion
+          nimble testintegration


### PR DESCRIPTION
This fixes a typo `testintegraion` -> `testintegration` that is causing daily actions to fail