### PR TITLE
fix: force close of streams instead of reset when closing connection

### DIFF
--- a/tests/testperf.nim
+++ b/tests/testperf.nim
@@ -63,7 +63,6 @@ suite "Perf protocol":
     checkTrackers()
 
   asyncTest "tcp::yamux":
-    return # nim-libp2p#1462 test fails with stream closed error
     let server = createSwitch(isServer = true, useYamux = true)
     let client = createSwitch(useYamux = true)
     await runTest(server, client)


### PR DESCRIPTION
Fixes #1462

Even tho we do not handle half closed states correctly, i dived deeper into how [js-waku handles yamux closing a connection](https://github.com/ChainSafe/js-libp2p-yamux/blob/master/src/muxer.ts#L308) and noticed that streams are not reset there but closed instead, so implemented something similar while we refactor the connection abstractions.
