### PR TITLE
test(gossipsub): rpcHandler - rateLimit and punishInvalidMessage tests

### DIFF
--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -1,5 +1,5 @@
 # Nim-LibP2P
-# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Copyright (c) 2023-2025 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -17,11 +17,12 @@ import ../../libp2p/protocols/pubsub/rpc/[message, protobuf]
 import ../helpers
 
 suite "GossipSub":
+  const topic = "foobar"
+
   teardown:
     checkTrackers()
 
   asyncTest "subscribe/unsubscribeAll":
-    let topic = "foobar"
     let (gossipSub, conns, peers) =
       setupGossipSubWithPeers(15, topic, populateGossipsub = true, populateMesh = true)
     defer:
@@ -44,7 +45,6 @@ suite "GossipSub":
       topic in gossipSub.gossipsub # but still in gossipsub table (for fanning out)
 
   asyncTest "Drop messages of topics without subscription":
-    let topic = "foobar"
     var (gossipSub, conns, peers) = setupGossipSubWithPeers(30, topic)
     defer:
       await teardownGossipSub(gossipSub, conns)
@@ -66,7 +66,7 @@ suite "GossipSub":
 
     var tooManyTopics: seq[string]
     for i in 0 .. gossipSub.topicsHigh + 10:
-      tooManyTopics &= "topic" & $i
+      tooManyTopics &= topic & $i
     let lotOfSubs = RPCMsg.withSubs(tooManyTopics, true)
 
     let conn = TestBufferStream.new(noop)
@@ -93,7 +93,6 @@ suite "GossipSub":
 
   asyncTest "Peer is disconnected and rate limit is hit when overhead rate limit is exceeded":
     # Given a GossipSub instance with one peer
-    const topic = "foobar"
     let
       (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
       peer = peers[0]
@@ -130,7 +129,6 @@ suite "GossipSub":
 
   asyncTest "Peer is punished when message contains invalid sequence number":
     # Given a GossipSub instance with one peer
-    const topic = "foobar"
     let
       (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
       peer = peers[0]
@@ -154,7 +152,6 @@ suite "GossipSub":
 
   asyncTest "Peer is punished when message id generation fails":
     # Given a GossipSub instance with one peer
-    const topic = "foobar"
     let
       (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
       peer = peers[0]
@@ -182,7 +179,6 @@ suite "GossipSub":
 
   asyncTest "Peer is punished when signature verification fails":
     # Given a GossipSub instance with one peer
-    const topic = "foobar"
     let
       (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
       peer = peers[0]
@@ -205,7 +201,6 @@ suite "GossipSub":
 
   asyncTest "Peer is punished when message validation is rejected":
     # Given a GossipSub instance with one peer
-    const topic = "foobar"
     let
       (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
       peer = peers[0]

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -128,7 +128,7 @@ suite "GossipSub":
     check:
       currentRateLimitHits("unknown") == rateLimitHits + 1
 
-  asyncTest "Peer is punished if message contains invalid sequence number":
+  asyncTest "Peer is punished when message contains invalid sequence number":
     # Given a GossipSub instance with one peer
     const topic = "foobar"
     let
@@ -152,7 +152,7 @@ suite "GossipSub":
       check:
         stats[].topicInfos[topic].invalidMessageDeliveries == 1.0
 
-  asyncTest "Peer is punished if message id generation fails":
+  asyncTest "Peer is punished when message id generation fails":
     # Given a GossipSub instance with one peer
     const topic = "foobar"
     let

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -1,5 +1,5 @@
 # Nim-LibP2P
-# Copyright (c) 2023-2025 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -17,18 +17,15 @@ import ../../libp2p/protocols/pubsub/rpc/[message, protobuf]
 import ../helpers
 
 suite "GossipSub":
-  const topic = "foobar"
-  var gossipSub {.threadvar.}: TestGossipSub
-  var conns {.threadvar.}: seq[Connection]
-  var peers {.threadvar.}: seq[PubSubPeer]
-
-  asyncTeardown:
-    await teardownGossipSub(gossipSub, conns)
+  teardown:
     checkTrackers()
 
   asyncTest "subscribe/unsubscribeAll":
-    (gossipSub, conns, peers) =
+    let topic = "foobar"
+    let (gossipSub, conns, peers) =
       setupGossipSubWithPeers(15, topic, populateGossipsub = true, populateMesh = true)
+    defer:
+      await teardownGossipSub(gossipSub, conns)
 
     # test via dynamic dispatch
     gossipSub.PubSub.subscribe(topic, voidTopicHandler)
@@ -47,7 +44,10 @@ suite "GossipSub":
       topic in gossipSub.gossipsub # but still in gossipsub table (for fanning out)
 
   asyncTest "Drop messages of topics without subscription":
-    (gossipSub, conns, peers) = setupGossipSubWithPeers(30, topic)
+    let topic = "foobar"
+    var (gossipSub, conns, peers) = setupGossipSubWithPeers(30, topic)
+    defer:
+      await teardownGossipSub(gossipSub, conns)
 
     # generate messages
     var seqno = 0'u64
@@ -93,10 +93,13 @@ suite "GossipSub":
 
   asyncTest "Peer is disconnected and rate limit is hit when overhead rate limit is exceeded":
     # Given a GossipSub instance with one peer
-    (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
+    const topic = "foobar"
     let
+      (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
       peer = peers[0]
       rateLimitHits = currentRateLimitHits("unknown")
+    defer:
+      await teardownGossipSub(gossipSub, conns)
 
     # And signature verification disabled to avoid message being dropped
     gossipSub.verifySignature = false
@@ -127,8 +130,12 @@ suite "GossipSub":
 
   asyncTest "Peer is punished when message contains invalid sequence number":
     # Given a GossipSub instance with one peer
-    (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
-    let peer = peers[0]
+    const topic = "foobar"
+    let
+      (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
+      peer = peers[0]
+    defer:
+      await teardownGossipSub(gossipSub, conns)
 
     # And signature verification disabled to avoid message being dropped
     gossipSub.verifySignature = false
@@ -147,8 +154,12 @@ suite "GossipSub":
 
   asyncTest "Peer is punished when message id generation fails":
     # Given a GossipSub instance with one peer
-    (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
-    let peer = peers[0]
+    const topic = "foobar"
+    let
+      (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
+      peer = peers[0]
+    defer:
+      await teardownGossipSub(gossipSub, conns)
 
     # And signature verification disabled to avoid message being dropped
     gossipSub.verifySignature = false
@@ -171,8 +182,12 @@ suite "GossipSub":
 
   asyncTest "Peer is punished when signature verification fails":
     # Given a GossipSub instance with one peer
-    (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
-    let peer = peers[0]
+    const topic = "foobar"
+    let
+      (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
+      peer = peers[0]
+    defer:
+      await teardownGossipSub(gossipSub, conns)
 
     # And signature verification enabled
     gossipSub.verifySignature = true
@@ -190,8 +205,12 @@ suite "GossipSub":
 
   asyncTest "Peer is punished when message validation is rejected":
     # Given a GossipSub instance with one peer
-    (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
-    let peer = peers[0]
+    const topic = "foobar"
+    let
+      (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
+      peer = peers[0]
+    defer:
+      await teardownGossipSub(gossipSub, conns)
 
     # And signature verification disabled to avoid message being dropped earlier
     gossipSub.verifySignature = false

--- a/tests/pubsub/utils.nim
+++ b/tests/pubsub/utils.nim
@@ -542,10 +542,10 @@ proc baseTestProcedure*(
 proc `$`*(peer: PubSubPeer): string =
   shortLog(peer)
 
-proc currentRateLimitHits*(): float64 =
+proc currentRateLimitHits*(label: string = "nim-libp2p"): float64 =
   try:
     libp2p_gossipsub_peers_rate_limit_hits.valueByName(
-      "libp2p_gossipsub_peers_rate_limit_hits_total", @["nim-libp2p"]
+      "libp2p_gossipsub_peers_rate_limit_hits_total", @[label]
     )
   except KeyError:
     0


### PR DESCRIPTION
Changes:
- add unit tests for Gossipsub `rpcHandler` around `rateLimit` and penalising peers with `punishInvalidMessage`:
  - `"Peer is disconnected and rate limit is hit when overhead rate limit is exceeded"`
  -  `"Peer is punished when message contains invalid sequence number"`
  -  `"Peer is punished when message id generation fails"`
  -  `"Peer is punished when signature verification fails"`
  -  `"Peer is punished when message validation is rejected"`