### PR TITLE
chore: allowing setting the reuseConnection parameter when dialing

### DIFF
--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -337,6 +337,7 @@ method dial*(
     addrs: seq[MultiAddress],
     protos: seq[string],
     forceDial = false,
+    reuseConnection = true,
 ): Future[Connection] {.async: (raises: [DialFailedError, CancelledError]).} =
   ## create a protocol stream and establish
   ## a connection if one doesn't exist already
@@ -355,7 +356,8 @@ method dial*(
 
   try:
     trace "Dialing (new)", peerId, protos
-    conn = await self.internalConnect(Opt.some(peerId), addrs, forceDial)
+    conn =
+      await self.internalConnect(Opt.some(peerId), addrs, forceDial, reuseConnection)
     trace "Opening stream", conn
     stream = await self.connManager.getStream(conn)
 


### PR DESCRIPTION
Adding the `reuseConnection` parameter to `dial` so it can be set when calling `internalConnect` according to the user's need