### PR TITLE
fix(peeridauth): fix peeridauth_integration import

### DIFF
--- a/tests/testpeeridauth_integration.nim
+++ b/tests/testpeeridauth_integration.nim
@@ -12,7 +12,7 @@
 import json, uri
 import chronos
 import chronos/apps/http/httpclient
-import ../libp2p/[stream/connection, upgrademngrs/upgrade, peeridauth, wire]
+import ../libp2p/[stream/connection, upgrademngrs/upgrade, peeridauth/client, wire]
 
 import ./helpers
 


### PR DESCRIPTION
Fixed wrong import on `testpeeridauth_integration.nim` that caused daily CI to fail: https://github.com/vacp2p/nim-libp2p/actions/runs/15817189298/job/44578136248#step:8:2345