### PR TITLE
fix: mark channel as reset to not read after closed

### DIFF
--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -517,6 +517,7 @@ method close*(m: Yamux) {.async: (raises: []).} =
     channel.sendQueue = @[]
     channel.sendWindow = 0
     channel.closedLocally = true
+    channel.isReset = true
     channel.opened = false
     await channel.remoteClosed()
     channel.receivedData.fire()


### PR DESCRIPTION
Fixes flaky test seen in https://github.com/vacp2p/nim-libp2p/actions/runs/15827052104/job/44609916834?pr=1470

Besides closing a channel, also mark them as reset so it's not possible to later call readOnce after a yamux session is closed, otherwise a StreamRemotelyClosed error is triggered while it should say StreamClosed as the closing happened locally first.

This is mostly a patch and should be fixed once proper half-closed stream state is added. (Because then it would be just a matter of reading whether `stream.readState == closed` is true or not (do note this attribute does not exist now)