### PR TITLE
feat(gossipsub): Add support for skipping message insertion into the message cache (Mix protocol integration)

### DIFF
--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -192,7 +192,7 @@ method init*(f: FloodSub) =
   f.codec = FloodSubCodec
 
 method publish*(
-    f: FloodSub, topic: string, data: seq[byte], useCustomConn: bool = false
+    f: FloodSub, topic: string, data: seq[byte], publishParams: Option[PublishParams] = none(PublishParams),
 ): Future[int] {.async: (raises: []).} =
   # base returns always 0
   discard await procCall PubSub(f).publish(topic, data)

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -775,7 +775,10 @@ proc makePeersForPublishDefault(
   return peers
 
 method publish*(
-    g: GossipSub, topic: string, data: seq[byte], useCustomConn: bool = false
+    g: GossipSub,
+    topic: string,
+    data: seq[byte],
+    publishParams: Option[PublishParams] = none(PublishParams),
 ): Future[int] {.async: (raises: []).} =
   logScope:
     topic
@@ -789,8 +792,12 @@ method publish*(
 
   trace "Publishing message on topic", data = data.shortLog
 
+  var pubParams = publishParams.get(PublishParams())
+  if publishParams.isSome:
+    pubParams = publishParams.get()
+
   let peers =
-    if useCustomConn:
+    if pubParams.useCustomConn:
       g.makePeersForPublishUsingCustomConn(topic)
     else:
       g.makePeersForPublishDefault(topic, data)
@@ -828,7 +835,8 @@ method publish*(
     trace "Dropping already-seen message"
     return 0
 
-  g.mcache.put(msgId, msg)
+  if not pubParams.skipMCache:
+    g.mcache.put(msgId, msg)
 
   if g.parameters.sendIDontWantOnPublish and isLargeMessage(msg, msgId):
     g.sendIDontWant(msg, msgId, peers)
@@ -837,7 +845,7 @@ method publish*(
     peers,
     RPCMsg(messages: @[msg]),
     isHighPriority = true,
-    useCustomConn = useCustomConn,
+    useCustomConn = pubParams.useCustomConn,
   )
 
   if g.knownTopics.contains(topic):

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -145,6 +145,10 @@ type
     ## we have to store it, which may be an attack vector.
     ## This callback can be used to reject topic we're not interested in
 
+  PublishParams* = object
+    useCustomConn*: bool
+    skipMCache*: bool
+
   PubSub* {.public.} = ref object of LPProtocol
     switch*: Switch # the switch used to dial/connect to peers
     peerInfo*: PeerInfo # this peer's info
@@ -570,7 +574,10 @@ proc subscribe*(p: PubSub, topic: string, handler: TopicHandler) {.public.} =
   p.updateTopicMetrics(topic)
 
 method publish*(
-    p: PubSub, topic: string, data: seq[byte], useCustomConn: bool = false
+    p: PubSub,
+    topic: string,
+    data: seq[byte],
+    publishParams: Option[PublishParams] = none(PublishParams),
 ): Future[int] {.base, async: (raises: []), public.} =
   ## publish to a ``topic``
   ##

--- a/tests/pubsub/integration/testgossipsubcustomconn.nim
+++ b/tests/pubsub/integration/testgossipsubcustomconn.nim
@@ -69,7 +69,9 @@ suite "GossipSub Integration - Custom Connection Support":
     nodes[1].subscribe(topic, handler)
     await waitSub(nodes[0], nodes[1], topic)
 
-    tryPublish await nodes[0].publish(topic, "hello".toBytes(), useCustomConn = true), 1
+    tryPublish await nodes[0].publish(
+      topic, "hello".toBytes(), publishParams = some(PublishParams(useCustomConn: true))
+    ), 1
 
     check:
       peerSelectionCalled
@@ -90,7 +92,11 @@ suite "GossipSub Integration - Custom Connection Support":
 
     var raised = false
     try:
-      discard await nodes[0].publish(topic, "hello".toBytes(), useCustomConn = true)
+      discard await nodes[0].publish(
+        topic,
+        "hello".toBytes(),
+        publishParams = some(PublishParams(useCustomConn: true)),
+      )
     except Defect:
       raised = true
 

--- a/tests/pubsub/integration/testgossipsubskipmcache.nim
+++ b/tests/pubsub/integration/testgossipsubskipmcache.nim
@@ -1,0 +1,66 @@
+# Nim-LibP2P
+# Copyright (c) 2023-2024 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0 ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.used.}
+
+import chronos
+import stew/byteutils
+import ../utils
+import ../../../libp2p/protocols/pubsub/[gossipsub, peertable, pubsubpeer]
+import ../../../libp2p/protocols/pubsub/rpc/[messages]
+import ../../helpers
+
+suite "GossipSub Integration - Skip MCache Support":
+  teardown:
+    checkTrackers()
+
+  asyncTest "publish with skipMCache prevents message from being added to mcache":
+    let
+      topic = "test"
+      handler = proc(topic: string, data: seq[byte]) {.async.} =
+        discard
+      nodes = generateNodes(2, gossip = true)
+
+    startNodesAndDeferStop(nodes)
+    await connectNodesStar(nodes)
+
+    nodes[1].subscribe(topic, handler)
+    await waitSub(nodes[0], nodes[1], topic)
+
+    let publishData = "hello".toBytes()
+
+    let msgId = GossipSub(nodes[0]).getMsgId(topic, publishData)
+
+    tryPublish await nodes[0].publish(
+      topic, publishData, publishParams = some(PublishParams(useCustomConn: true))
+    ), 1
+
+    check msgId notin GossipSub(nodes[0]).mcache.msgs
+
+  asyncTest "publish without skipMCache adds message to mcache":
+    let
+      topic = "test"
+      handler = proc(topic: string, data: seq[byte]) {.async.} =
+        discard
+      nodes = generateNodes(2, gossip = true)
+
+    startNodesAndDeferStop(nodes)
+    await connectNodesStar(nodes)
+
+    nodes[1].subscribe(topic, handler)
+    await waitSub(nodes[0], nodes[1], topic)
+
+    let publishData = "hello".toBytes()
+    let msgId = GossipSub(nodes[0]).getMsgId(topic, publishData)
+
+    tryPublish await nodes[0].publish(
+      topic, publishData, publishParams = none(PublishParams)
+    ), 1
+
+    check msgId in GossipSub(nodes[0]).mcache.msgs


### PR DESCRIPTION
This PR implements support in GossipSub for protocols like the [Mix protocol](https://rfc.vac.dev/vac/raw/mix), which require skipping message insertion into the message cache (mcache)

### Summary of changes
- Introduces a new `PublishParams` object, which bundles optional parameters (_e.g.,_ `useCustomConn`) for the `GossipSub.publish` function.
- Adds a `skipMCache` flag (defaults to false) to the `PublishParams` object.
- When `skipMCache` is true, the published message is not added to the mcache.
- This prevents the message from being advertised via `IHAVE` control messages.

### Motivation
This is part of ongoing integration work for the Mix protocol — a custom, stateless libp2p protocol designed for anonymous message routing in peer-to-peer networks.
The `skipMCache` flag is designed to be generic and may be reused by other protocols that require fine-grained control over whether messages are advertised via `IHAVE`. This is particularly useful in protocols aiming to preserve anonymity.

### Notes
- All changes are backward-compatible; default `publish` behavior is unaffected.
- A new integration test verifies that messages published with `skipMCache = true` do not appear in the local message cache.
- Code has been formatted using `nph`.

### Related
- VAC RAW RFC: [Mix Protocol](https://rfc.vac.dev/vac/raw/mix)
- Follow-up to: #1420

