### PR TITLE
chore(yamux): improve performance with zero allocation queue

### DIFF
--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -12,6 +12,7 @@
 import sequtils, std/[tables]
 import chronos, chronicles, metrics, stew/[endians2, byteutils, objects]
 import ../muxer, ../../stream/connection
+import ../../utils/zeroqueue
 
 export muxer
 
@@ -151,7 +152,7 @@ type
     opened: bool
     isSending: bool
     sendQueue: seq[ToSend]
-    recvQueue: seq[byte]
+    recvQueue: ZeroQueue
     isReset: bool
     remoteReset: bool
     closedRemotely: AsyncEvent
@@ -229,7 +230,6 @@ proc reset(channel: YamuxChannel, isLocal: bool = false) {.async: (raises: []).}
   for (d, s, fut) in channel.sendQueue:
     fut.fail(newLPStreamEOFError())
   channel.sendQueue = @[]
-  channel.recvQueue = @[]
   channel.sendWindow = 0
   if not channel.closedLocally:
     if isLocal and not channel.isSending:
@@ -252,7 +252,7 @@ proc updateRecvWindow(
   ##
   # In order to avoid spamming a window update everytime a byte is read,
   # we send it everytime half of the maxRecvWindow is read.
-  let inWindow = channel.recvWindow + channel.recvQueue.len
+  let inWindow = channel.recvWindow + channel.recvQueue.len()
   if inWindow > channel.maxRecvWindow div 2:
     return
 
@@ -279,7 +279,7 @@ method readOnce*(
         newLPStreamConnDownError()
   if channel.isEof:
     raise newLPStreamRemoteClosedError()
-  if channel.recvQueue.len == 0:
+  if channel.recvQueue.isEmpty():
     channel.receivedData.clear()
     let
       closedRemotelyFut = channel.closedRemotely.wait()
@@ -290,31 +290,26 @@ method readOnce*(
       if not receivedDataFut.finished():
         await receivedDataFut.cancelAndWait()
     await closedRemotelyFut or receivedDataFut
-    if channel.closedRemotely.isSet() and channel.recvQueue.len == 0:
+    if channel.closedRemotely.isSet() and channel.recvQueue.isEmpty():
       channel.isEof = true
       return
         0 # we return 0 to indicate that the channel is closed for reading from now on
 
-  let toRead = min(channel.recvQueue.len, nbytes)
-
-  var p = cast[ptr UncheckedArray[byte]](pbytes)
-  toOpenArray(p, 0, nbytes - 1)[0 ..< toRead] =
-    channel.recvQueue.toOpenArray(0, toRead - 1)
-  channel.recvQueue = channel.recvQueue[toRead ..^ 1]
+  let consumed = channel.recvQueue.consumeTo(pbytes, nbytes)
 
   # We made some room in the recv buffer let the peer know
   await channel.updateRecvWindow()
   channel.activity = true
-  return toRead
+  return consumed
 
 proc gotDataFromRemote(
     channel: YamuxChannel, b: seq[byte]
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
   channel.recvWindow -= b.len
-  channel.recvQueue = channel.recvQueue.concat(b)
+  channel.recvQueue.push(b)
   channel.receivedData.fire()
   when defined(libp2p_yamux_metrics):
-    libp2p_yamux_recv_queue.observe(channel.recvQueue.len.int64)
+    libp2p_yamux_recv_queue.observe(channel.recvQueue.len().int64)
   await channel.updateRecvWindow()
 
 proc setMaxRecvWindow*(channel: YamuxChannel, maxRecvWindow: int) =

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -252,7 +252,7 @@ proc updateRecvWindow(
   ##
   # In order to avoid spamming a window update everytime a byte is read,
   # we send it everytime half of the maxRecvWindow is read.
-  let inWindow = channel.recvWindow + channel.recvQueue.len()
+  let inWindow = channel.recvWindow + channel.recvQueue.len
   if inWindow > channel.maxRecvWindow div 2:
     return
 
@@ -309,7 +309,7 @@ proc gotDataFromRemote(
   channel.recvQueue.push(b)
   channel.receivedData.fire()
   when defined(libp2p_yamux_metrics):
-    libp2p_yamux_recv_queue.observe(channel.recvQueue.len().int64)
+    libp2p_yamux_recv_queue.observe(channel.recvQueue.len.int64)
   await channel.updateRecvWindow()
 
 proc setMaxRecvWindow*(channel: YamuxChannel, maxRecvWindow: int) =

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -257,7 +257,7 @@ proc updateRecvWindow(
     return
 
   let delta = channel.maxRecvWindow - inWindow
-  channel.recvWindow.inc(delta)
+  channel.recvWindow.inc(delta.int)
   await channel.conn.write(YamuxHeader.windowUpdate(channel.id, delta.uint32))
   trace "increasing the recvWindow", delta
 

--- a/libp2p/utils/zeroqueue.nim
+++ b/libp2p/utils/zeroqueue.nim
@@ -1,4 +1,16 @@
+# Nim-Libp2p
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
 type ZeroQueue* = object
+  # ZeroQueue is queue structure optimized for efficient pushing and popping of 
+  # byte sequences `seq[byte]`. This type is useful for streaming or buffering 
+  # scenarios where chunks of binary data are accumulated and consumed incrementally.
   data: seq[seq[byte]] = @[]
 
 proc clear*(q: var ZeroQueue) =
@@ -22,13 +34,18 @@ proc pop*(q: var ZeroQueue, count: int): seq[byte] =
     return @[]
 
   let first = q.data[0]
+
+  # first frame has up to requested count elements,
+  # queue will return this frame (frame might have less then requested)
   if first.len <= count:
     q.data = q.data[1 ..^ 1]
     return first
-  else:
-    let ret = first[0 ..< count]
-    q.data[0] = first[count ..^ 1]
-    return ret
+
+  # first frame has more elements then requested count, 
+  # queue will return view of first count elements, leaving the rest in the queue
+  let ret = first[0 ..< count]
+  q.data[0] = first[count ..^ 1]
+  return ret
 
 proc consumeTo*(q: var ZeroQueue, pbytes: pointer, nbytes: int): int =
   var consumed = 0

--- a/libp2p/utils/zeroqueue.nim
+++ b/libp2p/utils/zeroqueue.nim
@@ -1,0 +1,41 @@
+type ZeroQueue* = object
+  data: seq[seq[byte]] = @[]
+
+proc clear*(q: var ZeroQueue) =
+  q.data = @[]
+
+proc isEmpty*(q: ZeroQueue): bool =
+  return q.data.len == 0
+
+proc len*(q: ZeroQueue): int64 =
+  var l: int64
+  for b in q.data:
+    l += b.len
+  return l
+
+proc push*(q: var ZeroQueue, b: seq[byte]) =
+  if b.len > 0:
+    q.data.add(b)
+
+proc pop*(q: var ZeroQueue, count: int): seq[byte] =
+  if q.data.len == 0 or count == 0:
+    return @[]
+
+  let first = q.data[0]
+  if first.len <= count:
+    q.data = q.data[1 ..^ 1]
+    return first
+  else:
+    let ret = first[0 ..< count]
+    q.data[0] = first[count ..^ 1]
+    return ret
+
+proc consumeTo*(q: var ZeroQueue, pbytes: pointer, nbytes: int): int =
+  var consumed = 0
+  while consumed < nbytes and not q.isEmpty():
+    let data = q.pop(nbytes - consumed)
+    let dest = cast[pointer](cast[ByteAddress](pbytes) + consumed)
+    copyMem(dest, unsafeAddr data[0], data.len)
+    consumed += data.len
+
+  return consumed

--- a/libp2p/utils/zeroqueue.nim
+++ b/libp2p/utils/zeroqueue.nim
@@ -9,10 +9,13 @@
 
 import std/deques
 
-type Chunk = object
+type Chunk = ref object
   data: seq[byte]
   size: int
   start: int
+
+template clone(c: Chunk): Chunk =
+  Chunk(data: c.data, size: c.size, start: c.start)
 
 template newChunk(b: sink seq[byte]): Chunk =
   Chunk(data: b, size: b.len, start: 0)
@@ -52,7 +55,7 @@ proc popChunk(q: var ZeroQueue, count: int): Chunk {.inline.} =
 
   # first chunk has more elements then requested count, 
   # queue will return view of first count elements, leaving the rest in the queue
-  var ret = first
+  var ret = first.clone()
   ret.size = ret.start + count
   first.start += count
   q.chunks.addFirst(first)

--- a/libp2p/utils/zeroqueue.nim
+++ b/libp2p/utils/zeroqueue.nim
@@ -11,7 +11,7 @@ type ZeroQueue* = object
   # ZeroQueue is queue structure optimized for efficient pushing and popping of 
   # byte sequences `seq[byte]`. This type is useful for streaming or buffering 
   # scenarios where chunks of binary data are accumulated and consumed incrementally.
-  data: seq[seq[byte]] = @[]
+  data: seq[seq[byte]]
 
 proc clear*(q: var ZeroQueue) =
   q.data = @[]

--- a/libp2p/utils/zeroqueue.nim
+++ b/libp2p/utils/zeroqueue.nim
@@ -7,6 +7,8 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+import std/deques
+
 type Chunk = object
   data: seq[byte]
   size: int
@@ -22,38 +24,38 @@ type ZeroQueue* = object
   # ZeroQueue is queue structure optimized for efficient pushing and popping of 
   # byte sequences `seq[byte]` (called chunks). This type is useful for streaming or buffering 
   # scenarios where chunks of binary data are accumulated and consumed incrementally.
-  chunks: seq[Chunk]
+  chunks: Deque[Chunk]
 
 proc clear*(q: var ZeroQueue) =
-  q.chunks = @[]
+  q.chunks.clear()
 
 proc isEmpty*(q: ZeroQueue): bool =
-  return q.chunks.len == 0
+  return q.chunks.len() == 0
 
 proc len*(q: ZeroQueue): int64 =
   var l: int64
-  for b in q.chunks:
+  for b in q.chunks.items():
     l += b.len()
   return l
 
 proc push*(q: var ZeroQueue, b: sink seq[byte]) =
   if b.len > 0:
-    q.chunks.add(newChunk(b))
+    q.chunks.addLast(newChunk(b))
 
 proc popChunk(q: var ZeroQueue, count: int): Chunk {.inline.} =
-  let first = q.chunks[0]
+  var first = q.chunks.popFirst()
 
-  # first frame has up to requested count elements,
-  # queue will return this frame (frame might have less then requested)
+  # first chunk has up to requested count elements,
+  # queue will return this chunk (chunk might have less then requested)
   if first.len() <= count:
-    q.chunks = q.chunks[1 ..^ 1]
     return first
 
-  # first frame has more elements then requested count, 
+  # first chunk has more elements then requested count, 
   # queue will return view of first count elements, leaving the rest in the queue
   var ret = first
-  q.chunks[0].start += count
   ret.size = ret.start + count
+  first.start += count
+  q.chunks.addFirst(first)
   return ret
 
 proc consumeTo*(q: var ZeroQueue, pbytes: pointer, nbytes: int): int =

--- a/libp2p/utils/zeroqueue.nim
+++ b/libp2p/utils/zeroqueue.nim
@@ -61,7 +61,7 @@ proc consumeTo*(q: var ZeroQueue, pbytes: pointer, nbytes: int): int =
   while consumed < nbytes and not q.isEmpty():
     let chunk = q.popChunk(nbytes - consumed)
     let dest = cast[pointer](cast[ByteAddress](pbytes) + consumed)
-    let offsetPtr = cast[ptr byte](cast[int](chunk.data[0].addr) + chunk.start)
+    let offsetPtr = cast[ptr byte](cast[int](unsafeAddr chunk.data[0]) + chunk.start)
     copyMem(dest, offsetPtr, chunk.len())
     consumed += chunk.len()
 
@@ -73,7 +73,7 @@ proc popChunkSeq*(q: var ZeroQueue, count: int): seq[byte] =
 
   let chunk = q.popChunk(count)
   var dest = newSeq[byte](chunk.len())
-  let offsetPtr = cast[ptr byte](cast[int](chunk.data[0].addr) + chunk.start)
+  let offsetPtr = cast[ptr byte](cast[int](unsafeAddr chunk.data[0]) + chunk.start)
   copyMem(dest[0].addr, offsetPtr, chunk.len())
 
   return dest

--- a/libp2p/utils/zeroqueue.nim
+++ b/libp2p/utils/zeroqueue.nim
@@ -7,52 +7,73 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
+type Chunk = object
+  data: seq[byte]
+  size: int
+  start: int
+
+template newChunk(b: sink seq[byte]): Chunk =
+  Chunk(data: b, size: b.len, start: 0)
+
+template len(c: Chunk): int =
+  c.size - c.start
+
 type ZeroQueue* = object
   # ZeroQueue is queue structure optimized for efficient pushing and popping of 
-  # byte sequences `seq[byte]`. This type is useful for streaming or buffering 
+  # byte sequences `seq[byte]` (called chunks). This type is useful for streaming or buffering 
   # scenarios where chunks of binary data are accumulated and consumed incrementally.
-  data: seq[seq[byte]]
+  chunks: seq[Chunk]
 
 proc clear*(q: var ZeroQueue) =
-  q.data = @[]
+  q.chunks = @[]
 
 proc isEmpty*(q: ZeroQueue): bool =
-  return q.data.len == 0
+  return q.chunks.len == 0
 
 proc len*(q: ZeroQueue): int64 =
   var l: int64
-  for b in q.data:
-    l += b.len
+  for b in q.chunks:
+    l += b.len()
   return l
 
-proc push*(q: var ZeroQueue, b: seq[byte]) =
+proc push*(q: var ZeroQueue, b: sink seq[byte]) =
   if b.len > 0:
-    q.data.add(b)
+    q.chunks.add(newChunk(b))
 
-proc pop*(q: var ZeroQueue, count: int): seq[byte] =
-  if q.data.len == 0 or count == 0:
-    return @[]
-
-  let first = q.data[0]
+proc popChunk(q: var ZeroQueue, count: int): Chunk {.inline.} =
+  let first = q.chunks[0]
 
   # first frame has up to requested count elements,
   # queue will return this frame (frame might have less then requested)
-  if first.len <= count:
-    q.data = q.data[1 ..^ 1]
+  if first.len() <= count:
+    q.chunks = q.chunks[1 ..^ 1]
     return first
 
   # first frame has more elements then requested count, 
   # queue will return view of first count elements, leaving the rest in the queue
-  let ret = first[0 ..< count]
-  q.data[0] = first[count ..^ 1]
+  var ret = first
+  q.chunks[0].start += count
+  ret.size = ret.start + count
   return ret
 
 proc consumeTo*(q: var ZeroQueue, pbytes: pointer, nbytes: int): int =
   var consumed = 0
   while consumed < nbytes and not q.isEmpty():
-    let data = q.pop(nbytes - consumed)
+    let chunk = q.popChunk(nbytes - consumed)
     let dest = cast[pointer](cast[ByteAddress](pbytes) + consumed)
-    copyMem(dest, unsafeAddr data[0], data.len)
-    consumed += data.len
+    let offsetPtr = cast[ptr byte](cast[int](chunk.data[0].addr) + chunk.start)
+    copyMem(dest, offsetPtr, chunk.len())
+    consumed += chunk.len()
 
   return consumed
+
+proc popChunkSeq*(q: var ZeroQueue, count: int): seq[byte] =
+  if q.isEmpty:
+    return @[]
+
+  let chunk = q.popChunk(count)
+  var dest = newSeq[byte](chunk.len())
+  let offsetPtr = cast[ptr byte](cast[int](chunk.data[0].addr) + chunk.start)
+  copyMem(dest[0].addr, offsetPtr, chunk.len())
+
+  return dest

--- a/tests/testnative.nim
+++ b/tests/testnative.nim
@@ -11,7 +11,7 @@
 
 import
   testvarint, testconnection, testbridgestream, testminprotobuf, teststreamseq,
-  testsemaphore, testheartbeat, testfuture
+  testsemaphore, testheartbeat, testfuture, testzeroqueue
 
 import testminasn1, testrsa, testecnist, tested25519, testsecp256k1, testcrypto
 

--- a/tests/testperf.nim
+++ b/tests/testperf.nim
@@ -16,18 +16,29 @@ import
 import ./helpers
 
 proc createSwitch(
-    isServer: bool = false, useMplex: bool = false, useYamux: bool = false
+    isServer: bool = false,
+    useQuic: bool = false,
+    useMplex: bool = false,
+    useYamux: bool = false,
 ): Switch =
-  var builder = SwitchBuilder
-    .new()
-    .withRng(newRng())
-    .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
-    .withTcpTransport()
-    .withNoise()
-  if useMplex:
-    builder = builder.withMplex()
-  if useYamux:
-    builder = builder.withYamux()
+  var builder = SwitchBuilder.new()
+  builder = builder.withRng(newRng()).withNoise()
+
+  if useQuic:
+    builder = builder.withQuicTransport().withAddresses(
+        @[MultiAddress.init("/ip4/127.0.0.1/udp/0/quic-v1").tryGet()]
+      )
+  else:
+    builder = builder.withTcpTransport().withAddresses(
+        @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
+      )
+
+    if useMplex:
+      builder = builder.withMplex()
+    elif useYamux:
+      builder = builder.withYamux()
+    else:
+      raiseAssert "must use mplex or yamux"
 
   var switch = builder.build()
 
@@ -43,13 +54,12 @@ proc runTest(server: Switch, client: Switch) {.async.} =
 
   await server.start()
   await client.start()
-
   defer:
     await client.stop()
     await server.stop()
 
   let conn = await client.dial(server.peerInfo.peerId, server.peerInfo.addrs, PerfCodec)
-  var perfClient = PerfClient.new()
+  let perfClient = PerfClient.new()
   discard await perfClient.perf(conn, bytesToUpload, bytesToDownload)
 
   let stats = perfClient.currentStats()
@@ -58,9 +68,51 @@ proc runTest(server: Switch, client: Switch) {.async.} =
     stats.uploadBytes == bytesToUpload
     stats.downloadBytes == bytesToDownload
 
+proc runTestWithException(server: Switch, client: Switch) {.async.} =
+  const
+    bytesToUpload = 1.uint64
+    bytesToDownload = 10000000000.uint64
+      # use large downlaod request which will make perf to execute for longer
+      # giving us change to stop it
+
+  await server.start()
+  await client.start()
+  defer:
+    await client.stop()
+    await server.stop()
+
+  let conn = await client.dial(server.peerInfo.peerId, server.peerInfo.addrs, PerfCodec)
+  let perfClient = PerfClient.new()
+  let perfFut = perfClient.perf(conn, bytesToUpload, bytesToDownload)
+
+  # after some time upload should be finished and download should be ongoing
+  await sleepAsync(200.milliseconds)
+  var stats = perfClient.currentStats()
+  check:
+    stats.isFinal == false
+    stats.uploadBytes == bytesToUpload
+    stats.downloadBytes > 0
+
+  perfFut.cancel() # cancelling future will raise exception in perfClient
+  await sleepAsync(10.milliseconds)
+
+  # after cancelling perf, stats must indicate that it is final one
+  stats = perfClient.currentStats()
+  check:
+    stats.isFinal == true
+    stats.uploadBytes == bytesToUpload
+    stats.downloadBytes > 0
+    stats.downloadBytes < bytesToDownload # download must not be completed
+
 suite "Perf protocol":
   teardown:
     checkTrackers()
+
+  asyncTest "quic":
+    return # nim-libp2p#1482: currently it does not work with quic
+    let server = createSwitch(isServer = true, useQuic = true)
+    let client = createSwitch(useQuic = true)
+    await runTest(server, client)
 
   asyncTest "tcp::yamux":
     let server = createSwitch(isServer = true, useYamux = true)
@@ -72,40 +124,12 @@ suite "Perf protocol":
     let client = createSwitch(useMplex = true)
     await runTest(server, client)
 
-  asyncTest "perf with exception":
+  asyncTest "perf with exception::yamux":
+    let server = createSwitch(isServer = true, useYamux = true)
+    let client = createSwitch(useYamux = true)
+    await runTestWithException(server, client)
+
+  asyncTest "perf with exception::mplex":
     let server = createSwitch(isServer = true, useMplex = true)
     let client = createSwitch(useMplex = true)
-
-    await server.start()
-    await client.start()
-
-    defer:
-      await client.stop()
-      await server.stop()
-
-    let conn =
-      await client.dial(server.peerInfo.peerId, server.peerInfo.addrs, PerfCodec)
-    var perfClient = PerfClient.new()
-    var perfFut: Future[Duration]
-    try:
-      # start perf future with large download request
-      # this will make perf execute for longer so we can cancel it
-      perfFut = perfClient.perf(conn, 1.uint64, 1000000000000.uint64)
-    except CatchableError:
-      discard
-
-    # after some time upload should be finished
-    await sleepAsync(50.milliseconds)
-    var stats = perfClient.currentStats()
-    check:
-      stats.isFinal == false
-      stats.uploadBytes == 1
-
-    perfFut.cancel() # cancelling future will raise exception
-    await sleepAsync(50.milliseconds)
-
-    # after cancelling perf, stats must indicate that it is final one
-    stats = perfClient.currentStats()
-    check:
-      stats.isFinal == true
-      stats.uploadBytes == 1
+    await runTestWithException(server, client)

--- a/tests/testzeroqueue.nim
+++ b/tests/testzeroqueue.nim
@@ -15,8 +15,7 @@ import ../libp2p/utils/zeroqueue
 proc toSeq(p: pointer, length: int): seq[byte] =
   let b = cast[ptr UncheckedArray[byte]](p)
   result = newSeq[byte](length)
-  for i in 0 ..< length:
-    result[i] = b[i]
+  copyMem(result[0].addr, p, length)
 
 suite "ZeroQueue":
   test "push-pop":

--- a/tests/testzeroqueue.nim
+++ b/tests/testzeroqueue.nim
@@ -23,23 +23,30 @@ suite "ZeroQueue":
     var q: ZeroQueue
     check q.len() == 0
     check q.isEmpty()
-    check q.pop(1).len == 0
+    check q.popSeq(1).len == 0 # pop empty seq when queue is empty
 
     q.push(@[1'u8, 2, 3])
     q.push(@[4'u8, 5])
     check q.len() == 5
     check not q.isEmpty()
 
-    check q.pop(0).len == 0
-    check @[1'u8, 2, 3] == q.pop(3) # pop eactly the size
-    check @[4'u8] == q.pop(1) # pop less the pushed
-    check @[5'u8] == q.pop(5) # pop more then pushed
+    check q.popSeq(3) == @[1'u8, 2, 3] # pop eactly the size of the chunk
+    check q.popSeq(1) == @[4'u8] # pop less then size of the chunk
+    check q.popSeq(5) == @[5'u8] # pop more then size of the chunk
     check q.isEmpty()
 
     # should not push empty seq
     q.push(@[])
     q.push(@[])
     check q.isEmpty()
+
+  test "clear":
+    var q: ZeroQueue
+    q.push(@[1'u8, 2, 3])
+    check not q.isEmpty()
+    q.clear()
+    check q.isEmpty()
+    check q.len() == 0
 
   test "consumeTo":
     var q: ZeroQueue
@@ -49,25 +56,31 @@ suite "ZeroQueue":
       dealloc(pbytes)
 
     # consumeTo should fill up to nbytes (queue is emptied)
-    q.clear()
     q.push(@[1'u8, 2, 3])
     q.push(@[4'u8, 5])
     q.push(@[6'u8, 7])
     check q.consumeTo(pbytes, nbytes) == 7
-    check q.isEmpty()
     check toSeq(pbytes, 7) == @[1'u8, 2, 3, 4, 5, 6, 7]
+    check q.isEmpty()
 
     # consumeTo should fill only 1 element, leaving 2 elements in the queue
-    q.clear()
     q.push(@[1'u8, 2, 3])
     check q.consumeTo(pbytes, 1) == 1
-    check not q.isEmpty()
     check toSeq(pbytes, 1) == @[1'u8]
+    check q.len() == 2
+    # assert remaning elements
+    check q.consumeTo(pbytes, nbytes) == 2
+    check toSeq(pbytes, 2) == @[2'u8, 3]
+    check q.isEmpty()
 
     # consumeTo should fill only 3 element, leaving 2 elements in the queue
     q.clear()
     q.push(@[4'u8, 5])
     q.push(@[1'u8, 2, 3])
     check q.consumeTo(pbytes, 3) == 3
-    check not q.isEmpty()
     check toSeq(pbytes, 3) == @[4'u8, 5, 1]
+    check q.len() == 2
+    # assert remaning elements
+    check q.consumeTo(pbytes, nbytes) == 2
+    check toSeq(pbytes, 2) == @[2'u8, 3]
+    check q.isEmpty()

--- a/tests/testzeroqueue.nim
+++ b/tests/testzeroqueue.nim
@@ -1,0 +1,58 @@
+{.used.}
+
+import unittest2
+
+import ../libp2p/utils/zeroqueue
+
+proc toSeq(p: pointer, length: int): seq[byte] =
+  let b = cast[ptr UncheckedArray[byte]](p)
+  result = newSeq[byte](length)
+  for i in 0 ..< length:
+    result[i] = b[i]
+
+suite "ZeroQueue":
+  test "All":
+    var q: ZeroQueue
+    check q.len() == 0
+    check q.isEmpty()
+    check q.pop(1).len == 0
+
+    q.push(@[10'u8, 20, 30])
+    q.push(@[40'u8, 50])
+    check q.len() == 5
+    check not q.isEmpty()
+
+    check q.pop(0).len == 0
+    check @[10'u8, 20, 30] == q.pop(3) # pop eactly the size
+    check @[40'u8] == q.pop(1) # pop less the pushed
+    check @[50'u8] == q.pop(5) # pop more then pushed
+    check q.isEmpty()
+
+    let nbytes = 20
+    var pbytes = alloc(nbytes)
+    defer:
+      dealloc(pbytes)
+
+    # consumeTo should fill up to nbytes (queue is emptied)
+    q.clear()
+    q.push(@[10'u8, 20, 30])
+    q.push(@[40'u8, 50])
+    q.push(@[41'u8, 51])
+    check q.consumeTo(pbytes, nbytes) == 7
+    check q.isEmpty()
+    check toSeq(pbytes, 7) == @[10'u8, 20, 30, 40, 50, 41, 51]
+
+    # consumeTo should fill only 1 element, leaving 2 elements in the queue
+    q.clear()
+    q.push(@[11'u8, 22, 33])
+    check q.consumeTo(pbytes, 1) == 1
+    check not q.isEmpty()
+    check toSeq(pbytes, 1) == @[11'u8]
+
+    # consumeTo should fill only 3 element, leaving 2 elements in the queue
+    q.clear()
+    q.push(@[44'u8, 55])
+    q.push(@[11'u8, 22, 33])
+    check q.consumeTo(pbytes, 3) == 3
+    check not q.isEmpty()
+    check toSeq(pbytes, 3) == @[44'u8, 55, 11]

--- a/tests/testzeroqueue.nim
+++ b/tests/testzeroqueue.nim
@@ -19,21 +19,21 @@ proc toSeq(p: pointer, length: int): seq[byte] =
     result[i] = b[i]
 
 suite "ZeroQueue":
-  test "All":
+  test "push-pop":
     var q: ZeroQueue
     check q.len() == 0
     check q.isEmpty()
     check q.pop(1).len == 0
 
-    q.push(@[10'u8, 20, 30])
-    q.push(@[40'u8, 50])
+    q.push(@[1'u8, 2, 3])
+    q.push(@[4'u8, 5])
     check q.len() == 5
     check not q.isEmpty()
 
     check q.pop(0).len == 0
-    check @[10'u8, 20, 30] == q.pop(3) # pop eactly the size
-    check @[40'u8] == q.pop(1) # pop less the pushed
-    check @[50'u8] == q.pop(5) # pop more then pushed
+    check @[1'u8, 2, 3] == q.pop(3) # pop eactly the size
+    check @[4'u8] == q.pop(1) # pop less the pushed
+    check @[5'u8] == q.pop(5) # pop more then pushed
     check q.isEmpty()
 
     # should not push empty seq
@@ -41,6 +41,8 @@ suite "ZeroQueue":
     q.push(@[])
     check q.isEmpty()
 
+  test "consumeTo":
+    var q: ZeroQueue
     let nbytes = 20
     var pbytes = alloc(nbytes)
     defer:
@@ -48,24 +50,24 @@ suite "ZeroQueue":
 
     # consumeTo should fill up to nbytes (queue is emptied)
     q.clear()
-    q.push(@[10'u8, 20, 30])
-    q.push(@[40'u8, 50])
-    q.push(@[41'u8, 51])
+    q.push(@[1'u8, 2, 3])
+    q.push(@[4'u8, 5])
+    q.push(@[6'u8, 7])
     check q.consumeTo(pbytes, nbytes) == 7
     check q.isEmpty()
-    check toSeq(pbytes, 7) == @[10'u8, 20, 30, 40, 50, 41, 51]
+    check toSeq(pbytes, 7) == @[1'u8, 2, 3, 4, 5, 6, 7]
 
     # consumeTo should fill only 1 element, leaving 2 elements in the queue
     q.clear()
-    q.push(@[11'u8, 22, 33])
+    q.push(@[1'u8, 2, 3])
     check q.consumeTo(pbytes, 1) == 1
     check not q.isEmpty()
-    check toSeq(pbytes, 1) == @[11'u8]
+    check toSeq(pbytes, 1) == @[1'u8]
 
     # consumeTo should fill only 3 element, leaving 2 elements in the queue
     q.clear()
-    q.push(@[44'u8, 55])
-    q.push(@[11'u8, 22, 33])
+    q.push(@[4'u8, 5])
+    q.push(@[1'u8, 2, 3])
     check q.consumeTo(pbytes, 3) == 3
     check not q.isEmpty()
-    check toSeq(pbytes, 3) == @[44'u8, 55, 11]
+    check toSeq(pbytes, 3) == @[4'u8, 5, 1]

--- a/tests/testzeroqueue.nim
+++ b/tests/testzeroqueue.nim
@@ -1,7 +1,15 @@
 {.used.}
 
-import unittest2
+# Nim-Libp2p
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
 
+import unittest2
 import ../libp2p/utils/zeroqueue
 
 proc toSeq(p: pointer, length: int): seq[byte] =
@@ -26,6 +34,11 @@ suite "ZeroQueue":
     check @[10'u8, 20, 30] == q.pop(3) # pop eactly the size
     check @[40'u8] == q.pop(1) # pop less the pushed
     check @[50'u8] == q.pop(5) # pop more then pushed
+    check q.isEmpty()
+
+    # should not push empty seq
+    q.push(@[])
+    q.push(@[])
     check q.isEmpty()
 
     let nbytes = 20

--- a/tests/testzeroqueue.nim
+++ b/tests/testzeroqueue.nim
@@ -23,16 +23,16 @@ suite "ZeroQueue":
     var q: ZeroQueue
     check q.len() == 0
     check q.isEmpty()
-    check q.popSeq(1).len == 0 # pop empty seq when queue is empty
+    check q.popChunkSeq(1).len == 0 # pop empty seq when queue is empty
 
     q.push(@[1'u8, 2, 3])
     q.push(@[4'u8, 5])
     check q.len() == 5
     check not q.isEmpty()
 
-    check q.popSeq(3) == @[1'u8, 2, 3] # pop eactly the size of the chunk
-    check q.popSeq(1) == @[4'u8] # pop less then size of the chunk
-    check q.popSeq(5) == @[5'u8] # pop more then size of the chunk
+    check q.popChunkSeq(3) == @[1'u8, 2, 3] # pop eactly the size of the chunk
+    check q.popChunkSeq(1) == @[4'u8] # pop less then size of the chunk
+    check q.popChunkSeq(5) == @[5'u8] # pop more then size of the chunk
     check q.isEmpty()
 
     # should not push empty seq


### PR DESCRIPTION
this pr improves yamux performance by 20-40% as observed when running perf test. 

previously data was constantly appended to `recvQueue` which caused memory trashing due to resizing. 
change from this pr introduced `ZeroQueue` that will allow data to be appended and consumed with zero allocations.