### PR TITLE
fix(autotls): private checkedGetPrimaryIPAddr

### DIFF
--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -30,7 +30,7 @@ const
 
 type AutoTLSError* = object of LPError
 
-proc checkedGetPrimaryIPAddr(): IpAddress {.raises: [AutoTLSError].} =
+proc checkedGetPrimaryIPAddr*(): IpAddress {.raises: [AutoTLSError].} =
   # This is so that we don't need to catch Exceptions directly
   # since we support 1.6.16 and getPrimaryIPAddr before nim 2 didn't have explicit .raises. pragmas
   try:

--- a/tests/testautotls_integration.nim
+++ b/tests/testautotls_integration.nim
@@ -19,6 +19,7 @@ import
     autotls/acme/api,
     autotls/acme/client,
     autotls/manager,
+    autotls/utils,
     multiaddress,
     switch,
     builders,


### PR DESCRIPTION
Fixes failing `testautotls_integration.nim` affecting daily CI runs.