### PR TITLE
chore: remove unused import

### DIFF
--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -11,8 +11,7 @@
 
 import std/[oids, strformat]
 import pkg/[chronos, chronicles, metrics]
-import
-  ./coder, ../muxer, ../../stream/[bufferstream, connection], ../../peerinfo
+import ./coder, ../muxer, ../../stream/[bufferstream, connection], ../../peerinfo
 
 export connection
 


### PR DESCRIPTION
removed unused import `streamseq`. 

it's also very interesting that compiler did not recognized this so far although unused imports are considered [compile time errors](https://github.com/vacp2p/nim-libp2p/blob/729e879c1cd97fe4c77873459cad9a212a7b3496/config.nims#L7).