### PR TITLE
fix(daily): testintegration only used on amd64

### DIFF
--- a/tests/testautotls_integration.nim
+++ b/tests/testautotls_integration.nim
@@ -9,7 +9,6 @@
 
 {.push raises: [].}
 
-import uri
 import chronos
 import chronos/apps/http/httpclient
 import

--- a/tests/testintegration.nim
+++ b/tests/testintegration.nim
@@ -1,4 +1,5 @@
-{.used.}
+when defined(linux) and defined(amd64):
+  {.used.}
 
 # Nim-Libp2p
 # Copyright (c) 2023 Status Research & Development GmbH


### PR DESCRIPTION
Make `testintegration.nim` only be imported on amd64 (not i386)

- Daily CI (amd64): https://github.com/vacp2p/nim-libp2p/actions/runs/16000555195
- Daily CI (i386): https://github.com/vacp2p/nim-libp2p/actions/runs/16000560351