### PR TITLE
feat(autotls): make wstransport use autotls

### DIFF
--- a/libp2p/autotls/mockservice.nim
+++ b/libp2p/autotls/mockservice.nim
@@ -1,0 +1,33 @@
+import ./service, ./acme/client, ../peeridauth/client
+
+import ../crypto/crypto, ../crypto/rsa, websock/websock
+
+type MockAutotlsService* = ref object of AutotlsService
+  mockedCert*: TLSCertificate
+  mockedKey*: TLSPrivateKey
+
+proc new*(
+    T: typedesc[MockAutotlsService],
+    rng: ref HmacDrbgContext = newRng(),
+    config: AutotlsConfig = AutotlsConfig.new(),
+): T =
+  T(
+    acmeClient: ACMEClient.new(api = ACMEApi.new(acmeServerURL = config.acmeServerURL)),
+    brokerClient: PeerIDAuthClient.new(),
+    bearer: Opt.none(BearerToken),
+    cert: Opt.none(AutotlsCert),
+    certReady: newAsyncEvent(),
+    config: config,
+    rng: rng,
+  )
+
+proc getTLSPrivkey*(self: MockAutotlsService): TLSPrivateKey =
+  self.mockedKey
+
+method getCertWhenReady*(
+    self: MockAutotlsService
+): Future[TLSCertificate] {.async: (raises: [AutoTLSError, CancelledError]).} =
+  return self.mockedCert
+
+method setup*(self: MockAutotlsService) {.base, async.} =
+  discard

--- a/libp2p/autotls/mockservice.nim
+++ b/libp2p/autotls/mockservice.nim
@@ -25,7 +25,7 @@ proc getTLSPrivkey*(self: MockAutotlsService): TLSPrivateKey =
   self.mockedKey
 
 method getCertWhenReady*(
-    self: MockAutotlsService
+    self: MockAutotlsService, timeout: Duration = DefaultWaitTimeout
 ): Future[TLSCertificate] {.async: (raises: [AutoTLSError, CancelledError]).} =
   return self.mockedCert
 

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -120,7 +120,7 @@ method getCertWhenReady*(
 
 method getTLSPrivkey*(
     self: AutotlsService
-): TLSPrivateKey {.base, raises: [AutoTLSError, TLSStreamProtocolError].} =
+): TLSPrivateKey {.base, gcsafe, raises: [AutoTLSError, TLSStreamProtocolError].} =
   let derPrivKey =
     try:
       self.acmeClient.key.seckey.rsakey.getBytes.get

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -185,7 +185,7 @@ proc withWsTransport*(
 ): SwitchBuilder =
   b.withTransport(
     proc(upgr: Upgrade, privateKey: PrivateKey, autotls: AutotlsService): Transport =
-      WsTransport.new(upgr, tlsPrivateKey, tlsCertificate, tlsFlags, flags)
+      WsTransport.new(upgr, tlsPrivateKey, tlsCertificate, autotls, tlsFlags, flags)
   )
 
 when defined(libp2p_quic_support):

--- a/libp2p/peeridauth/client.nim
+++ b/libp2p/peeridauth/client.nim
@@ -302,6 +302,8 @@ proc sendWithoutBearer(
   ):
     raise newException(PeerIDAuthError, "Failed to validate server's signature")
 
+  echo $authorizationResponse.response
+  echo $authorizationResponse.response.status
   return (authorizationResponse.bearer, authorizationResponse.response)
 
 proc sendWithBearer(

--- a/libp2p/protocols/connectivity/relay/rtransport.nim
+++ b/libp2p/protocols/connectivity/relay/rtransport.nim
@@ -31,7 +31,7 @@ type RelayTransport* = ref object of Transport
 
 method start*(
     self: RelayTransport, ma: seq[MultiAddress]
-) {.async: (raises: [LPError, transport.TransportError]).} =
+) {.async: (raises: [LPError, transport.TransportError, CancelledError]).} =
   if self.selfRunning:
     trace "Relay transport already running"
     return

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -344,8 +344,11 @@ proc start*(s: Switch) {.public, async: (raises: [CancelledError, LPError]).} =
     return
 
   debug "starting switch for peer", peerInfo = s.peerInfo
+
   var startFuts: seq[Future[void]]
   for t in s.transports:
+    echo "here1"
+    echo s.peerInfo.listenAddrs
     let addrs = s.peerInfo.listenAddrs.filterIt(t.handles(it))
 
     s.peerInfo.listenAddrs.keepItIf(it notin addrs)
@@ -365,10 +368,11 @@ proc start*(s: Switch) {.public, async: (raises: [CancelledError, LPError]).} =
       s.acceptFuts.add(s.accept(t))
       s.peerInfo.listenAddrs &= t.addrs
 
+  await s.peerInfo.update()
+
   for service in s.services:
     discard await service.setup(s)
 
-  await s.peerInfo.update()
   await s.ms.start()
   s.started = true
 

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -344,10 +344,6 @@ proc start*(s: Switch) {.public, async: (raises: [CancelledError, LPError]).} =
     return
 
   debug "starting switch for peer", peerInfo = s.peerInfo
-
-  for service in s.services:
-    discard await service.setup(s)
-
   var startFuts: seq[Future[void]]
   for t in s.transports:
     let addrs = s.peerInfo.listenAddrs.filterIt(t.handles(it))
@@ -368,6 +364,9 @@ proc start*(s: Switch) {.public, async: (raises: [CancelledError, LPError]).} =
     if t.addrs.len > 0 or t.running:
       s.acceptFuts.add(s.accept(t))
       s.peerInfo.listenAddrs &= t.addrs
+
+  for service in s.services:
+    discard await service.setup(s)
 
   await s.peerInfo.update()
   await s.ms.start()

--- a/libp2p/transports/memorytransport.nim
+++ b/libp2p/transports/memorytransport.nim
@@ -52,7 +52,7 @@ proc listenAddress(self: MemoryTransport, ma: MultiAddress): MultiAddress =
 
 method start*(
     self: MemoryTransport, addrs: seq[MultiAddress]
-) {.async: (raises: [LPError, transport.TransportError]).} =
+) {.async: (raises: [LPError, transport.TransportError, CancelledError]).} =
   if self.running:
     return
 

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -210,7 +210,7 @@ method handles*(transport: QuicTransport, address: MultiAddress): bool {.raises:
 
 method start*(
     self: QuicTransport, addrs: seq[MultiAddress]
-) {.async: (raises: [LPError, transport.TransportError]).} =
+) {.async: (raises: [LPError, transport.TransportError, CancelledError]).} =
   doAssert self.listener.isNil, "start() already called"
   #TODO handle multiple addr
 

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -107,7 +107,7 @@ proc new*(
 
 method start*(
     self: TcpTransport, addrs: seq[MultiAddress]
-): Future[void] {.async: (raises: [LPError, transport.TransportError]).} =
+): Future[void] {.async: (raises: [LPError, transport.TransportError, CancelledError]).} =
   ## Start transport listening to the given addresses - for dial-only transports,
   ## start with an empty list
 

--- a/libp2p/transports/tortransport.nim
+++ b/libp2p/transports/tortransport.nim
@@ -250,7 +250,7 @@ method dial*(
 
 method start*(
     self: TorTransport, addrs: seq[MultiAddress]
-) {.async: (raises: [LPError, transport.TransportError]).} =
+) {.async: (raises: [LPError, transport.TransportError, CancelledError]).} =
   ## listen on the transport
   ##
 

--- a/libp2p/transports/transport.nim
+++ b/libp2p/transports/transport.nim
@@ -42,7 +42,7 @@ proc newTransportClosedError*(parent: ref Exception = nil): ref TransportError =
 
 method start*(
     self: Transport, addrs: seq[MultiAddress]
-) {.base, async: (raises: [LPError, TransportError]).} =
+) {.base, async: (raises: [LPError, TransportError, CancelledError]).} =
   ## start the transport
   ##
 

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -137,8 +137,12 @@ method start*(
   # use autotls if possible (and if cert/key not specified)
   if not self.secure and not self.autotls.isNil():
     try:
+      echo "cert.isSome() == " & $self.autotls.cert.isSome()
+      echo "before getCertWhenReady"
       self.tlsCertificate = await self.autotls.getCertWhenReady()
+      echo "after getCertWhenReady"
       self.tlsPrivateKey = self.autotls.getTLSPrivkey()
+      echo "after getTLSPrivkey"
     except AutoTLSError as exc:
       raise newException(LPError, exc.msg, exc)
     except TLSStreamProtocolError as exc:

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -123,7 +123,7 @@ proc secure*(self: WsTransport): bool =
 
 method start*(
     self: WsTransport, addrs: seq[MultiAddress]
-) {.async: (raises: [LPError, transport.TransportError]).} =
+) {.async: (raises: [LPError, transport.TransportError, CancelledError]).} =
   ## listen on the transport
   ##
 
@@ -142,8 +142,6 @@ method start*(
     except AutoTLSError as exc:
       raise newException(LPError, exc.msg, exc)
     except TLSStreamProtocolError as exc:
-      raise newException(LPError, exc.msg, exc)
-    except CancelledError as exc:
       raise newException(LPError, exc.msg, exc)
 
   self.wsserver = WSServer.new(factories = self.factories, rng = self.rng)

--- a/tests/testintegration.nim
+++ b/tests/testintegration.nim
@@ -10,4 +10,4 @@ when defined(linux) and defined(amd64):
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-import testpeeridauth_integration, testautotls_integration
+import testpeeridauth_integration, testautotls_integration, testwstransport_integration

--- a/tests/testwstransport.nim
+++ b/tests/testwstransport.nim
@@ -12,6 +12,8 @@
 import chronos, stew/byteutils
 import
   ../libp2p/[
+    autotls/service,
+    autotls/mockservice,
     stream/connection,
     transports/transport,
     transports/wstransport,
@@ -23,6 +25,98 @@ import
 import ./helpers, ./commontransport
 
 const
+  AutoTLSCertificate =
+    """
+-----BEGIN CERTIFICATE-----
+MIID5DCCA2mgAwIBAgISLHPA5xRAjh3ZwYmBw4ISA+7LMAoGCCqGSM49BAMDMFIx
+CzAJBgNVBAYTAlVTMSAwHgYDVQQKExcoU1RBR0lORykgTGV0J3MgRW5jcnlwdDEh
+MB8GA1UEAxMYKFNUQUdJTkcpIFBzZXVkbyBQbHVtIEU1MB4XDTI1MDcwMjE3NDQ1
+M1oXDTI1MDkzMDE3NDQ1MlowADBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABAh4
+VNa76Ycl6RpoZ2qfM7biZzC/nz4G7lArKBMPyMUh0EX6U22VaZdxOvTfglRUxtJa
+NMleBtUhDcZd4HCkNZGjggJvMIICazAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0lBBYw
+FAYIKwYBBQUHAwEGCCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwHQYDVR0OBBYEFJgN
+WGKp9N/2bWsjD2ugSkt/8jlBMB8GA1UdIwQYMBaAFPxG0QFDX7t7pj0waK4RuuC8
+bcnTMDYGCCsGAQUFBwEBBCowKDAmBggrBgEFBQcwAoYaaHR0cDovL3N0Zy1lNS5p
+LmxlbmNyLm9yZy8wXAYDVR0RAQH/BFIwUIJOKi5rNTFxemk1dXF1NWRoOGRpY3ps
+bzJwZDc3djBic2Vkb2tzaXo1dnk4ZXF3MnJwaWpnZ2ozdzlnNm81ejlpcy5saWJw
+MnAuZGlyZWN0MBMGA1UdIAQMMAowCAYGZ4EMAQIBMDEGA1UdHwQqMCgwJqAkoCKG
+IGh0dHA6Ly9zdGctZTUuYy5sZW5jci5vcmcvNzYuY3JsMIIBDAYKKwYBBAHWeQIE
+AgSB/QSB+gD4AHYA3Zk0/KXnJIDJVmh9gTSZCEmySfe1adjHvKs/XMHzbmQAAAGX
+zHNiGAAABAMARzBFAiBVH0V4L9LG5ksU+hOvFVgT51WUpStneTVwdSdOGbdm6gIh
+ANdv5EQZI1vOVxok4D1lh1Z7hS7nfTG5HCIBbZ19iAKOAH4A2KJiliJSBM2181NJ
+WC5O1mWiRRsPJ6i2iWE2s7n8BwgAAAGXzHNnWwAIAAAFAD6beWUEAwBHMEUCIAOv
+AXuiujBNXne+BzzivJGbr3F0wKK7xhxIBfr/jGgyAiEA/xpSIMMcxZmH5Q4UlZj+
+EH9kAlEXwmI/MFemd7pdH54wCgYIKoZIzj0EAwMDaQAwZgIxAJXdmvcIxiLPx33H
+4WgXbDfjzZHiqyn+5t+73GZUDfyVotuiOvoRPpAp0L+WRS33iQIxAPWcAtrmyb7M
+/BXH2ccVFRUtAJTxajwBcN9un7GJUIAb9Fbz6EOBGTT7pukEc155Zw==
+-----END CERTIFICATE-----
+
+-----BEGIN CERTIFICATE-----
+MIIEljCCAn6gAwIBAgIQRzEp1D1mDiVVv4b1zlB56jANBgkqhkiG9w0BAQsFADBm
+MQswCQYDVQQGEwJVUzEzMDEGA1UEChMqKFNUQUdJTkcpIEludGVybmV0IFNlY3Vy
+aXR5IFJlc2VhcmNoIEdyb3VwMSIwIAYDVQQDExkoU1RBR0lORykgUHJldGVuZCBQ
+ZWFyIFgxMB4XDTI0MDMxMzAwMDAwMFoXDTI3MDMxMjIzNTk1OVowUjELMAkGA1UE
+BhMCVVMxIDAeBgNVBAoTFyhTVEFHSU5HKSBMZXQncyBFbmNyeXB0MSEwHwYDVQQD
+ExgoU1RBR0lORykgUHNldWRvIFBsdW0gRTUwdjAQBgcqhkjOPQIBBgUrgQQAIgNi
+AATljbbcV+mqWZa3g+z0bDOuBpZOtbi48iK9rjLtPdRU0WsgVp53MW3nXFU6qVYV
+zEYaYd6PSmec0Tj3R5zEp5/F+cuOjTdh3AkTMzYm1tkflocPBN5APHYZ+76WxZad
+q+WjggEAMIH9MA4GA1UdDwEB/wQEAwIBhjAdBgNVHSUEFjAUBggrBgEFBQcDAgYI
+KwYBBQUHAwEwEgYDVR0TAQH/BAgwBgEB/wIBADAdBgNVHQ4EFgQU/EbRAUNfu3um
+PTBorhG64LxtydMwHwYDVR0jBBgwFoAUtfNl8v6wCpIf+zx980SgrGMlwxQwNgYI
+KwYBBQUHAQEEKjAoMCYGCCsGAQUFBzAChhpodHRwOi8vc3RnLXgxLmkubGVuY3Iu
+b3JnLzATBgNVHSAEDDAKMAgGBmeBDAECATArBgNVHR8EJDAiMCCgHqAchhpodHRw
+Oi8vc3RnLXgxLmMubGVuY3Iub3JnLzANBgkqhkiG9w0BAQsFAAOCAgEAAtCGn4iG
+cupruhkCTcoDqSIVTFgVR8JJ3GvGL7SYwIc4Fn0As66nQgnkATIzF5+gFb+CXEQD
+qR2Jo+R38OeT7lQ1rNDcaJcbY6hL8cNRku3QlcfdYODZ5pgTVH04gTZUJISZKLjD
+kMMcQIDZlF7iYqTvmHbn2ISSKorsJ3QKAvWhHwMoJtocSz3VeDJIep5QtbHnoXh1
+/dyDx7sp8RuhC0eO9ElTgDtiA2V6JxigLPzqcnibBBR4bFLGtMNE4EvOOD/Fkd0L
+hdGDbAMNd+O06n+b0rgmDvg75IgOV6fpDrdZFoiNfCckOEJh9v10uYt4pTc3B6lf
+zI/X3EWP1H4VJmsYuy+OA29jPeP831sAObZtd3RWv0LQPrMfx6FCmy4AaeYEMvul
+FrF6OX+JbssE+bn83F+sGEMZu/eVBwwKh3db7+2UduMdTOb8DePE3Aqlg9zofS8X
+9fJXrrp+PPrdQyvM3e8DxuioWa9GLG30yD9WD6WTlSiiOrdWGOzisWpW4shFoL8u
+0EfmeLVU4JVbauhOYZASQXABNeXewe9lqJWwfqaARYpRjyf+jRibn22H5NVK4Vog
+l55Iq1rUgjc8r493NaNrlNwG7va7Ztkch5lJ3oL/FEVlVSK4snTbgb0b5qjQz3SA
+i7rA/8QRZvOLnKNtdEUlDZNrzkZwHNluLGw=
+-----END CERTIFICATE-----
+"""
+
+  AutoTLSKey =
+    """
+-----BEGIN PRIVATE KEY-----
+MIIG4wIBAAKCAYEAvwGLPY+4xuaVU4Uw0pFazEM2UT9l6BYOjuK+amdUHNLcj1Mdh3DXTJUIHt1c
+79Aa3I4Vi6cFg1Kz14aQvwOYW+bX5MwLeOlotWCSlx4pHb6kv2kevNzmp4RCp0D1bEqts3Gae7ql
+V+2ygteeliHjgGBJFdrPK9QbdPtbjhc5lWKDmiTuAwg26qDDsdCjupTPf75TRc8Z1I5JbWzRH26M
+wxyZCslIaz7IWXjABpnPU+c5W6D/Iv4wVij/ihQOzGVoq+3luOpxohtycMX3di+tmRbdE7+q8ZXD
+MYaZxjls1m+30MPo0DXoEheR1y3TpSDo6ekC71vRUiDQ+MZ8vyO0t5Hedcsq4gc2Ox3Hszqh45Ck
+4xSqNnVDtRffWak3RzqZpqEoj09pvXh9THJH5O+9+0echYW2rmckN8w0UXF/82lZYffWcmU2Mhjj
+xoNomkk6NZFKoqHCqL5l1oR0WLTAFlI8csSVxsS/tpaIIpaGI33hP3YyE7IRL309GGFRKrT9AgMB
+AAECggGBAJ+VxqR0xElKtlDF43jLATXQoj1X3uj+JMO1Jqr4EgrTEnydUPqsiPXvPo2rHc8v7IGC
+JPY9YhnKq3/TanRtqIqAYLlE0gD/4wBH47Jm/KthcXyLc6cQWZZ0psvfNi54ZpCaxhvCYgsJCjDP
+vixpvA6yY93ip11TJm2i5Wfed7ocSSAs4r+dyWRXVannTCTD2Go+toyI8GfrSeYnGMJON0V9S1D7
+w4n3NqWqgaYCNHtBoWaxKPovrmsObhMLlyGnR09TtWbBZ3FjlUMOwWu6B4qX/+dFgK9qynDIPfQ7
+HOw2mZFD5pFZhgtLnzhIAbrjDPWtwt67mAvedDzr+3nzp2DKTlP+RgTy++hnWM/0YDZ5zuAtuQFo
+q0MeRVK3svTQlTkO38FYMPdDcl2NlET8KA0qI/kDL5Ip6Eb5uB+tEvLAg+4dR6YuVCRVod+JzPEb
+U/jxeN5uTlM9GYkm0jg0FWTqxn4vq1j6haMREgXa3Q8eFluRy220buVsE+37FKDA8QKBwQDjtWuc
+FpwYdjM7KHKuCuBJBb2mVvcC+BubUFlHNvYBJHqpNXp8Q7qf+miaF59R2cg+Zaa0NtxSL/EVatTr
+yOdmhf/87aNkbxgZ7++ImO1pn/iBA0cmI1Kgz3Bzkn1pu9DDaxQ7zqpwwdU1zyuhDjaqowIvifLq
++ujDCqvVGTg0pJaVpP7oNmElQ9i1kNpbGTVQ8IliYONf0AFzZ8vRuJ/Vej3JcFJHL/coQrt27tpI
+s8urMD76dcg0qcrYfoh8HwcCgcEA1ry/LuEx9uIpsNZLCi4ZkrhMoadG8ACOasGxj6FE2SE/GZ39
+uPNSNViZq503nzNq1db9Pt+Bta+IQej1ppaVV4vmtWXtD2cBJUv8Jpr4xz3A0Gurqmjih94Yro9v
+Ig5JrLc0/v4grdhnkJZsKcWtfx+wQfCUJNlN/BsFuIUASfa3xVeomjgicRSsQ73HXYA5KVkQnn4K
+RYfBsgKqqe0x69PYi0Qsawngtd4bq1Bvfy0svf6qX0WdOEOXOxWVLgbbAoHANrL68Zjg0GN8dQaH
+XdWRARmW8CFN3vG4t/t6JshGGgooSQNms/kVGJ7vh6yLAf99wbdrbzkKfde0Yv+xvB4bsB4aWyi+
+qj6hnIFtmfOafFgIOv2NltS/YY/TJIAZDlAmmvra9m7ztHhrfiyQ/3RJn33e5YqOxvGU/l1O37ba
+MJMk9TeYYDHH7kq5AQyV13Jbw2C0r+Q0Wmy+HHnflTZzdrWRqBUKPr1/8rTtEWnZF8PQ9gN17XZj
+rHrpFk52/NH7AoHAeldKrRDMAJZVnlRYqFIfa8HolujQt4f5m8UCvovox7PzWUrz9N1b5ty1oFqQ
+B/mpUm+MFLgOFE8PWE27Ns/wAdLI/Gw3pWDP/EnQPMZqGkmKgrP1N79N4I6ejUVW0ZZGT0qJvQVX
+5PO3/V5V/W6MLDMHnmnMXToY/hr/JWNRCNKxXJNWkZaNuNNIWcfTv+d/qZj+qO2yOG7h4eM3DF0A
+5hTp+F482DbmeXczWGUZQOGh7hUbR/BHZHjNvnHLbk+lAoHAX+64DM//5Zkex93fAVB02aFzSGie
+0RH+2fKShZt3BVAWkPswmauL0LIl/cpIqtKwKDomXGw92EiJORQ4oFxt29lnzNYAZr8Jab3iRwCh
+NESce1bIOj4HHTrdTiOzeEgax31D7K1qS4bB8BKOaoEIUaFXdBxoZlEgWP6QjHEyjxgt7w5eMcwI
+ssSVAvL2spb2VgtwE2TZ9wQLBDJiz41qddH6TOXFxCwScf7rL3H/hyLHmmu6U1a2Vf6s4wUG6lHW
+-----END PRIVATE KEY-----
+"""
+
   SecureKey =
     """
 -----BEGIN PRIVATE KEY-----
@@ -78,6 +172,7 @@ suite "WebSocket transport":
         Upgrade(),
         TLSPrivateKey.init(SecureKey),
         TLSCertificate.init(SecureCert),
+        nil, # autotls
         {TLSFlags.NoVerifyHost, TLSFlags.NoVerifyServerName},
       )
     except CatchableError:
@@ -91,6 +186,7 @@ suite "WebSocket transport":
       Upgrade(),
       TLSPrivateKey.init(SecureKey),
       TLSCertificate.init(SecureCert),
+      nil, # autotls
       {TLSFlags.NoVerifyHost},
     )
 
@@ -136,3 +232,72 @@ suite "WebSocket transport":
     await closing
 
     await transport1.stop()
+
+  asyncTest "no tlscertificate but autotls specified":
+    let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
+
+    let autotls = MockAutotlsService.new()
+    autotls.mockedKey = TLSPrivateKey.init(AutoTLSKey)
+    autotls.mockedCert = TLSCertificate.init(AutoTLSCertificate)
+    await autotls.setup()
+
+    let wstransport = WsTransport.new(
+      Upgrade(),
+      nil, # TLSPrivateKey
+      nil, # TLSCertificate
+      autotls,
+      {TLSFlags.NoVerifyHost, TLSFlags.NoVerifyServerName},
+    )
+    await wstransport.start(ma)
+    defer:
+      await wstransport.stop()
+
+    # TLSPrivateKey and TLSCertificate should be set
+    check wstransport.secure
+
+    # autotls should be used
+    check wstransport.tlsCertificate == await autotls.getCertWhenReady()
+
+  asyncTest "tlscertificate and autotls specified":
+    let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
+
+    let autotls = MockAutotlsService.new()
+    autotls.mockedKey = TLSPrivateKey.init(AutoTLSKey)
+    autotls.mockedCert = TLSCertificate.init(AutoTLSCertificate)
+    await autotls.setup()
+    let secureCert = TLSCertificate.init(SecureCert)
+    let secureKey = TLSPrivateKey.init(SecureKey)
+
+    let wstransport = WsTransport.new(
+      Upgrade(),
+      secureKey,
+      secureCert,
+      autotls,
+      {TLSFlags.NoVerifyHost, TLSFlags.NoVerifyServerName},
+    )
+    await wstransport.start(ma)
+    defer:
+      await wstransport.stop()
+
+    # TLSPrivateKey and TLSCertificate should be set
+    check wstransport.secure
+
+    # autotls should be ignored
+    check wstransport.tlsCertificate == secureCert
+    check wstransport.tlsPrivateKey == secureKey
+
+  asyncTest "no tlscertificate or autotls specified":
+    let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
+    let wstransport = WsTransport.new(
+      Upgrade(),
+      nil, # TLSPrivateKey
+      nil, # TLSCertificate
+      nil, # autotls
+      {TLSFlags.NoVerifyHost, TLSFlags.NoVerifyServerName},
+    )
+    await wstransport.start(ma)
+    defer:
+      await wstransport.stop()
+
+    # TLSPrivateKey and TLSCertificate should not be set
+    check not wstransport.secure

--- a/tests/testwstransport.nim
+++ b/tests/testwstransport.nim
@@ -233,7 +233,7 @@ suite "WebSocket transport":
 
     await transport1.stop()
 
-  asyncTest "no tlscertificate but autotls specified":
+  asyncTest "autotls certificate is used when manual tlscertificate is not specified":
     let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
 
     let autotls = MockAutotlsService.new()
@@ -258,7 +258,7 @@ suite "WebSocket transport":
     # autotls should be used
     check wstransport.tlsCertificate == await autotls.getCertWhenReady()
 
-  asyncTest "tlscertificate and autotls specified":
+  asyncTest "manually set tlscertificate is preferred over autotls when both are specified":
     let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
 
     let autotls = MockAutotlsService.new()
@@ -286,7 +286,7 @@ suite "WebSocket transport":
     check wstransport.tlsCertificate == secureCert
     check wstransport.tlsPrivateKey == secureKey
 
-  asyncTest "no tlscertificate or autotls specified":
+  asyncTest "wstransport is not secure when both manual tlscertificate and autotls are not specified":
     let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
     let wstransport = WsTransport.new(
       Upgrade(),

--- a/tests/testwstransport_integration.nim
+++ b/tests/testwstransport_integration.nim
@@ -1,0 +1,93 @@
+# Nim-Libp2p
+# Copyright (c) 2023 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [].}
+
+import chronos
+import chronos/apps/http/httpclient
+import
+  ../libp2p/[
+    stream/connection,
+    upgrademngrs/upgrade,
+    autotls/acme/client,
+    autotls/service,
+    autotls/utils,
+    multiaddress,
+    switch,
+    builders,
+    wire,
+    protocols/ping,
+  ]
+
+from ./helpers import suite, asyncTest, asyncTeardown, checkTrackers, skip, check
+
+when defined(linux) and defined(amd64):
+  {.used.}
+
+  suite "WebSocket transport integration":
+    teardown:
+      checkTrackers()
+
+    asyncTest "autotls certificate is used when manual tlscertificate is not specified":
+      let ip =
+        try:
+          getPublicIPAddress()
+        except:
+          skip() # host doesn't have public IPv4 address
+          return
+
+      echo "1"
+      let pingProtocol = Ping.new(rng = newRng())
+
+      echo "2"
+      let switch1 = SwitchBuilder
+        .new()
+        .withRng(newRng())
+        .withAddress(MultiAddress.init("/ip4/" & $ip & "/tcp/0/wss").tryGet())
+        .withWsTransport()
+        .withAutotls(
+          config = AutotlsConfig.new(acmeServerURL = parseUri(LetsEncryptURLStaging))
+        )
+        .withYamux()
+        .withNoise()
+        .build()
+      echo "3"
+
+      let switch2 = SwitchBuilder
+        .new()
+        .withRng(newRng())
+        .withAddress(MultiAddress.init("/ip4/" & $ip & "/tcp/0/wss").tryGet())
+        .withWsTransport()
+        .withAutotls(
+          config = AutotlsConfig.new(acmeServerURL = parseUri(LetsEncryptURLStaging))
+        )
+        .withYamux()
+        .withNoise()
+        .build()
+
+      echo "4"
+      switch1.mount(pingProtocol)
+
+      echo "5"
+      await switch1.start()
+      echo "5.1"
+      await switch2.start()
+      echo "6"
+
+      # should succeed
+      let conn =
+        await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, PingCodec)
+      echo "7"
+      discard await pingProtocol.ping(conn)
+      echo "8"
+
+      defer:
+        await conn.close()
+        await switch1.stop()
+        await switch2.stop()

--- a/tests/testwstransport_integration.nim
+++ b/tests/testwstransport_integration.nim
@@ -35,12 +35,11 @@ when defined(linux) and defined(amd64):
       checkTrackers()
 
     asyncTest "autotls certificate is used when manual tlscertificate is not specified":
-      let ip =
-        try:
-          getPublicIPAddress()
-        except:
-          skip() # host doesn't have public IPv4 address
-          return
+      try:
+        discard getPublicIPAddress()
+      except:
+        skip() # host doesn't have public IPv4 address
+        return
 
       echo "1"
       let pingProtocol = Ping.new(rng = newRng())
@@ -49,7 +48,8 @@ when defined(linux) and defined(amd64):
       let switch1 = SwitchBuilder
         .new()
         .withRng(newRng())
-        .withAddress(MultiAddress.init("/ip4/" & $ip & "/tcp/0/wss").tryGet())
+        .withAddress(MultiAddress.init("/ip4/0.0.0.0/tcp/0/wss").tryGet())
+        .withTcpTransport()
         .withWsTransport()
         .withAutotls(
           config = AutotlsConfig.new(acmeServerURL = parseUri(LetsEncryptURLStaging))
@@ -62,7 +62,8 @@ when defined(linux) and defined(amd64):
       let switch2 = SwitchBuilder
         .new()
         .withRng(newRng())
-        .withAddress(MultiAddress.init("/ip4/" & $ip & "/tcp/0/wss").tryGet())
+        .withAddress(MultiAddress.init("/ip4/0.0.0.0/tcp/0/wss").tryGet())
+        .withTcpTransport()
         .withWsTransport()
         .withAutotls(
           config = AutotlsConfig.new(acmeServerURL = parseUri(LetsEncryptURLStaging))
@@ -77,17 +78,17 @@ when defined(linux) and defined(amd64):
       echo "5"
       await switch1.start()
       echo "5.1"
-      await switch2.start()
-      echo "6"
+      # await switch2.start()
+      # echo "6"
 
-      # should succeed
-      let conn =
-        await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, PingCodec)
-      echo "7"
-      discard await pingProtocol.ping(conn)
-      echo "8"
+      # # should succeed
+      # let conn =
+      #   await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, PingCodec)
+      # echo "7"
+      # discard await pingProtocol.ping(conn)
+      # echo "8"
 
       defer:
-        await conn.close()
+        #   await conn.close()
         await switch1.stop()
-        await switch2.stop()
+      #   await switch2.stop()


### PR DESCRIPTION
This should be the last part of autotls: after a cert is downloaded, `wstransport` incorporates it.