### PR TITLE
test(gossipsub): gossipsub unit tests 1

### DIFF
--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -185,7 +185,7 @@ suite "GossipSub":
       check:
         stats[].topicInfos[topic].firstMessageDeliveries == 0.0
 
-  asyncTest "unsubscribePeer - removes peer from peersInIP collection":
+  asyncTest "unsubscribePeer - removes peer from peersInIP":
     # Given a GossipSub instance with one peer
     let
       (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)


### PR DESCRIPTION
Changes:
- add unit tests for `GossipSub` `gossipsub`:
  - `"onNewPeer - sets peer stats and budgets and disconnects if bad score"`
  - `"onPubSubPeerEvent - StreamClosed removes peer from mesh and fanout"`
  - `"onPubSubPeerEvent - DisconnectionRequested disconnects peer"`
  - `"unsubscribePeer - handles nil peer gracefully"`
  - `"unsubscribePeer - removes peer from mesh, gossipsub, fanout and subscribedDirectPeers"`
  - `"unsubscribePeer - resets firstMessageDeliveries in peerStats"`
  - `"unsubscribePeer - removes peer from peersInIP"`
  - `"handleSubscribe via rpcHandler - subscribe and unsubscribe with direct peer"`
  - `"handleSubscribe via rpcHandler - subscribe unknown peer"`