### PR TITLE
chore: utilizing newSeqUninitialized

### DIFF
--- a/libp2p/cid.nim
+++ b/libp2p/cid.nim
@@ -123,7 +123,7 @@ proc decode(data: openArray[char]): Result[Cid, CidError] =
     return err(CidError.Incorrect)
   if len(data) == 46:
     if data[0] == 'Q' and data[1] == 'm':
-      buffer = newSeq[byte](BTCBase58.decodedLength(len(data)))
+      buffer = newSeqUninitialized[byte](BTCBase58.decodedLength(len(data)))
       if BTCBase58.decode(data, buffer, plen) != Base58Status.Success:
         return err(CidError.Incorrect)
       buffer.setLen(plen)
@@ -131,7 +131,7 @@ proc decode(data: openArray[char]): Result[Cid, CidError] =
     let length = MultiBase.decodedLength(data[0], len(data))
     if length == -1:
       return err(CidError.Incorrect)
-    buffer = newSeq[byte](length)
+    buffer = newSeqUninitialized[byte](length)
     if MultiBase.decode(data, buffer, plen) != MultiBaseStatus.Success:
       return err(CidError.Incorrect)
     buffer.setLen(plen)

--- a/libp2p/crypto/crypto.nim
+++ b/libp2p/crypto/crypto.nim
@@ -873,7 +873,7 @@ proc stretchKeys*(
   var seed = "key expansion"
   result.macsize = 20
   let length = result.ivsize + result.keysize + result.macsize
-  result.data = newSeq[byte](2 * length)
+  result.data = newSeqUninitialized[byte](2 * length)
 
   if hashType == "SHA256":
     makeSecret(result.data, HMAC[sha256], sharedSecret, seed)
@@ -904,7 +904,7 @@ template macOpenArray*(secret: Secret, id: int): untyped =
 
 proc iv*(secret: Secret, id: int): seq[byte] {.inline.} =
   ## Get array of bytes with with initial vector.
-  result = newSeq[byte](secret.ivsize)
+  result = newSeqUninitialized[byte](secret.ivsize)
   var offset =
     if id == 0:
       0
@@ -913,7 +913,7 @@ proc iv*(secret: Secret, id: int): seq[byte] {.inline.} =
   copyMem(addr result[0], unsafeAddr secret.data[offset], secret.ivsize)
 
 proc key*(secret: Secret, id: int): seq[byte] {.inline.} =
-  result = newSeq[byte](secret.keysize)
+  result = newSeqUninitialized[byte](secret.keysize)
   var offset =
     if id == 0:
       0
@@ -923,7 +923,7 @@ proc key*(secret: Secret, id: int): seq[byte] {.inline.} =
   copyMem(addr result[0], unsafeAddr secret.data[offset], secret.keysize)
 
 proc mac*(secret: Secret, id: int): seq[byte] {.inline.} =
-  result = newSeq[byte](secret.macsize)
+  result = newSeqUninitialized[byte](secret.macsize)
   var offset =
     if id == 0:
       0

--- a/libp2p/crypto/ecnist.nim
+++ b/libp2p/crypto/ecnist.nim
@@ -929,7 +929,7 @@ proc getSecret*(pubkey: EcPublicKey, seckey: EcPrivateKey): seq[byte] =
   var data: array[Secret521Length, byte]
   let res = toSecret(pubkey, seckey, data)
   if res > 0:
-    result = newSeq[byte](res)
+    result = newSeqUninitialized[byte](res)
     copyMem(addr result[0], addr data[0], res)
 
 proc sign*[T: byte | char](
@@ -943,7 +943,7 @@ proc sign*[T: byte | char](
   var impl = ecGetDefault()
   if seckey.key.curve in EcSupportedCurvesCint:
     var sig = new EcSignature
-    sig.buffer = newSeq[byte](256)
+    sig.buffer = newSeqUninitialized[byte](256)
     var kv = addr sha256Vtable
     kv.init(addr hc.vtable)
     if len(message) > 0:

--- a/libp2p/crypto/ecnist.nim
+++ b/libp2p/crypto/ecnist.nim
@@ -458,7 +458,7 @@ proc getBytes*(seckey: EcPrivateKey): EcResult[seq[byte]] =
   if isNil(seckey):
     return err(EcKeyIncorrectError)
   if seckey.key.curve in EcSupportedCurvesCint:
-    var res = newSeq[byte]()
+    var res = newSeqUninitialized[byte](0)
     let length = ?seckey.toBytes(res)
     res.setLen(length)
     discard ?seckey.toBytes(res)
@@ -471,7 +471,7 @@ proc getBytes*(pubkey: EcPublicKey): EcResult[seq[byte]] =
   if isNil(pubkey):
     return err(EcKeyIncorrectError)
   if pubkey.key.curve in EcSupportedCurvesCint:
-    var res = newSeq[byte]()
+    var res = newSeqUninitialized[byte](0)
     let length = ?pubkey.toBytes(res)
     res.setLen(length)
     discard ?pubkey.toBytes(res)
@@ -483,7 +483,7 @@ proc getBytes*(sig: EcSignature): EcResult[seq[byte]] =
   ## Serialize EC signature ``sig`` to ASN.1 DER binary form and return it.
   if isNil(sig):
     return err(EcSignatureError)
-  var res = newSeq[byte]()
+  var res = newSeqUninitialized[byte](0)
   let length = ?sig.toBytes(res)
   res.setLen(length)
   discard ?sig.toBytes(res)
@@ -494,7 +494,7 @@ proc getRawBytes*(seckey: EcPrivateKey): EcResult[seq[byte]] =
   if isNil(seckey):
     return err(EcKeyIncorrectError)
   if seckey.key.curve in EcSupportedCurvesCint:
-    var res = newSeq[byte]()
+    var res = newSeqUninitialized[byte](0)
     let length = ?seckey.toRawBytes(res)
     res.setLen(length)
     discard ?seckey.toRawBytes(res)
@@ -507,7 +507,7 @@ proc getRawBytes*(pubkey: EcPublicKey): EcResult[seq[byte]] =
   if isNil(pubkey):
     return err(EcKeyIncorrectError)
   if pubkey.key.curve in EcSupportedCurvesCint:
-    var res = newSeq[byte]()
+    var res = newSeqUninitialized[byte](0)
     let length = ?pubkey.toRawBytes(res)
     res.setLen(length)
     discard ?pubkey.toRawBytes(res)
@@ -519,7 +519,7 @@ proc getRawBytes*(sig: EcSignature): EcResult[seq[byte]] =
   ## Serialize EC signature ``sig`` to raw binary form and return it.
   if isNil(sig):
     return err(EcSignatureError)
-  var res = newSeq[byte]()
+  var res = newSeqUninitialized[byte](0)
   let length = ?sig.toBytes(res)
   res.setLen(length)
   discard ?sig.toBytes(res)

--- a/libp2p/crypto/minasn1.nim
+++ b/libp2p/crypto/minasn1.nim
@@ -679,15 +679,15 @@ proc init*(t: typedesc[Asn1Buffer], data: string): Asn1Buffer =
 
 proc init*(t: typedesc[Asn1Buffer]): Asn1Buffer =
   ## Initialize empty ``Asn1Buffer``.
-  Asn1Buffer(buffer: newSeq[byte]())
+  Asn1Buffer(buffer: newSeqUninitialized[byte](0))
 
 proc init*(t: typedesc[Asn1Composite], tag: Asn1Tag): Asn1Composite =
   ## Initialize ``Asn1Composite`` with tag ``tag``.
-  Asn1Composite(tag: tag, buffer: newSeq[byte]())
+  Asn1Composite(tag: tag, buffer: newSeqUninitialized[byte](0))
 
 proc init*(t: typedesc[Asn1Composite], idx: int): Asn1Composite =
   ## Initialize ``Asn1Composite`` with tag context-specific id ``id``.
-  Asn1Composite(tag: Asn1Tag.Context, idx: idx, buffer: newSeq[byte]())
+  Asn1Composite(tag: Asn1Tag.Context, idx: idx, buffer: newSeqUninitialized[byte](0))
 
 proc `$`*(buffer: Asn1Buffer): string =
   ## Return string representation of ``buffer``.

--- a/libp2p/crypto/rsa.nim
+++ b/libp2p/crypto/rsa.nim
@@ -124,7 +124,7 @@ proc random*[T: RsaKP](
     length = eko + ((bits + 7) shr 3)
 
   let res = new T
-  res.buffer = newSeq[byte](length)
+  res.buffer = newSeqUninitialized[byte](length)
 
   var keygen = rsaKeygenGetDefault()
 
@@ -169,7 +169,7 @@ proc copy*[T: RsaPKI](key: T): T =
         key.seck.dqlen.uint + key.seck.iqlen.uint + key.pubk.nlen.uint +
         key.pubk.elen.uint + key.pexplen.uint
       result = new RsaPrivateKey
-      result.buffer = newSeq[byte](length)
+      result.buffer = newSeqUninitialized[byte](length)
       let po: uint = 0
       let qo = po + key.seck.plen
       let dpo = qo + key.seck.qlen
@@ -207,7 +207,7 @@ proc copy*[T: RsaPKI](key: T): T =
     if len(key.buffer) > 0:
       let length = key.key.nlen + key.key.elen
       result = new RsaPublicKey
-      result.buffer = newSeq[byte](length)
+      result.buffer = newSeqUninitialized[byte](length)
       let no = 0
       let eo = no + key.key.nlen
       copyMem(addr result.buffer[no], key.key.n, key.key.nlen)
@@ -226,7 +226,7 @@ proc getPublicKey*(key: RsaPrivateKey): RsaPublicKey =
   doAssert(not isNil(key))
   let length = key.pubk.nlen + key.pubk.elen
   result = new RsaPublicKey
-  result.buffer = newSeq[byte](length)
+  result.buffer = newSeqUninitialized[byte](length)
   result.key.n = addr result.buffer[0]
   result.key.e = addr result.buffer[key.pubk.nlen]
   copyMem(addr result.buffer[0], cast[pointer](key.pubk.n), key.pubk.nlen)
@@ -357,7 +357,7 @@ proc getBytes*(key: RsaPrivateKey): RsaResult[seq[byte]] =
   ## return it.
   if isNil(key):
     return err(RsaKeyIncorrectError)
-  var res = newSeq[byte](4096)
+  var res = newSeqUninitialized[byte](4096)
   let length = ?key.toBytes(res)
   if length > 0:
     res.setLen(length)
@@ -370,7 +370,7 @@ proc getBytes*(key: RsaPublicKey): RsaResult[seq[byte]] =
   ## return it.
   if isNil(key):
     return err(RsaKeyIncorrectError)
-  var res = newSeq[byte](4096)
+  var res = newSeqUninitialized[byte](4096)
   let length = ?key.toBytes(res)
   if length > 0:
     res.setLen(length)
@@ -382,7 +382,7 @@ proc getBytes*(sig: RsaSignature): RsaResult[seq[byte]] =
   ## Serialize RSA signature ``sig`` to raw binary form and return it.
   if isNil(sig):
     return err(RsaSignatureError)
-  var res = newSeq[byte](4096)
+  var res = newSeqUninitialized[byte](4096)
   let length = ?sig.toBytes(res)
   if length > 0:
     res.setLen(length)
@@ -753,7 +753,7 @@ proc sign*[T: byte | char](
   var hash: array[32, byte]
   let impl = rsaPkcs1SignGetDefault()
   var res = new RsaSignature
-  res.buffer = newSeq[byte]((key.seck.nBitlen + 7) shr 3)
+  res.buffer = newSeqUninitialized[byte]((key.seck.nBitlen + 7) shr 3)
   var kv = addr sha256Vtable
   kv.init(addr hc.vtable)
   if len(message) > 0:

--- a/libp2p/crypto/secp.nim
+++ b/libp2p/crypto/secp.nim
@@ -182,7 +182,7 @@ proc getBytes*(key: SkPublicKey): seq[byte] {.inline.} =
 
 proc getBytes*(sig: SkSignature): seq[byte] {.inline.} =
   ## Serialize Secp256k1 `signature` and return it.
-  result = newSeq[byte](72)
+  result = newSeqUninitialized[byte](72)
   let length = toBytes(sig, result)
   result.setLen(length)
 

--- a/libp2p/daemon/daemonapi.nim
+++ b/libp2p/daemon/daemonapi.nim
@@ -496,7 +496,7 @@ proc recvMessage(
     size: uint
     length: int
     res: VarintResult[void]
-  var buffer = newSeq[byte](10)
+  var buffer = newSeqUninitialized[byte](10)
   try:
     for i in 0 ..< len(buffer):
       await conn.readExactly(addr buffer[i], 1)
@@ -957,8 +957,7 @@ proc openStream*(
       var res: seq[byte]
       if pb.getRequiredField(ResponseType.STREAMINFO.int, res).isOk():
         let resPb = initProtoBuffer(res)
-        # stream.peer = newSeq[byte]()
-        var raddress = newSeq[byte]()
+        var raddress = newSeqUninitialized[byte](0)
         stream.protocol = ""
         resPb.getRequiredField(1, stream.peer).tryGet()
         resPb.getRequiredField(2, raddress).tryGet()
@@ -977,7 +976,7 @@ proc streamHandler(server: StreamServer, transp: StreamTransport) {.async.} =
   var message = await transp.recvMessage()
   var pb = initProtoBuffer(message)
   var stream = new P2PStream
-  var raddress = newSeq[byte]()
+  var raddress = newSeqUninitialized[byte](0)
   stream.protocol = ""
   pb.getRequiredField(1, stream.peer).tryGet()
   pb.getRequiredField(2, raddress).tryGet()
@@ -1116,7 +1115,7 @@ proc dhtGetSinglePeerInfo(pb: ProtoBuffer): PeerInfo {.raises: [DaemonLocalError
     raise newException(DaemonLocalError, "Missing required field `peer`!")
 
 proc dhtGetSingleValue(pb: ProtoBuffer): seq[byte] {.raises: [DaemonLocalError].} =
-  result = newSeq[byte]()
+  result = newSeqUninitialized[byte](0)
   if pb.getRequiredField(3, result).isErr():
     raise newException(DaemonLocalError, "Missing field `value`!")
 
@@ -1453,8 +1452,8 @@ proc pubsubPublish*(
     await api.closeConnection(transp)
 
 proc getPubsubMessage*(pb: ProtoBuffer): PubSubMessage =
-  result.data = newSeq[byte]()
-  result.seqno = newSeq[byte]()
+  result.data = newSeqUninitialized[byte](0)
+  result.seqno = newSeqUninitialized[byte](0)
   discard pb.getField(1, result.peer)
   discard pb.getField(2, result.data)
   discard pb.getField(3, result.seqno)

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -223,7 +223,7 @@ proc p2pStB(s: string, vb: var VBuffer): bool =
 
 proc p2pBtS(vb: var VBuffer, s: var string): bool =
   ## P2P address bufferToString() implementation.
-  var address = newSeq[byte]()
+  var address = newSeqUninitialized[byte](0)
   if vb.readSeq(address) > 0:
     var mh: MultiHash
     if MultiHash.decode(address, mh).isOk:
@@ -232,7 +232,7 @@ proc p2pBtS(vb: var VBuffer, s: var string): bool =
 
 proc p2pVB(vb: var VBuffer): bool =
   ## P2P address validateBuffer() implementation.
-  var address = newSeq[byte]()
+  var address = newSeqUninitialized[byte](0)
   if vb.readSeq(address) > 0:
     var mh: MultiHash
     if MultiHash.decode(address, mh).isOk:
@@ -555,7 +555,7 @@ proc protoAddress*(ma: MultiAddress): MaResult[seq[byte]] =
   ##
   ## If current MultiAddress do not have argument value, then result array will
   ## be empty.
-  var buffer = newSeq[byte](len(ma.data.buffer))
+  var buffer = newSeqUninitialized[byte](len(ma.data.buffer))
   let res = ?protoArgument(ma, buffer)
   buffer.setLen(res)
   ok(buffer)
@@ -569,7 +569,7 @@ proc protoArgument*(ma: MultiAddress): MaResult[seq[byte]] =
 
 proc getPart(ma: MultiAddress, index: int): MaResult[MultiAddress] =
   var header: uint64
-  var data = newSeq[byte]()
+  var data = newSeqUninitialized[byte](0)
   var offset = 0
   var vb = ma
   var res: MultiAddress
@@ -643,7 +643,7 @@ proc `[]`*(ma: MultiAddress, slice: HSlice): MaResult[MultiAddress] {.inline.} =
 iterator items*(ma: MultiAddress): MaResult[MultiAddress] =
   ## Iterates over all addresses inside of MultiAddress ``ma``.
   var header: uint64
-  var data = newSeq[byte]()
+  var data = newSeqUninitialized[byte](0)
   var vb = ma
   while true:
     if vb.data.isEmpty():

--- a/libp2p/multibase.nim
+++ b/libp2p/multibase.nim
@@ -533,7 +533,7 @@ proc decode*(
     let empty: seq[byte] = @[]
     ok(empty) # empty
   else:
-    var buffer = newSeq[byte](mb.decl(length - 1))
+    var buffer = newSeqUninitialized[byte](mb.decl(length - 1))
     var outlen = 0
     let res = mb.decr(inbytes.toOpenArray(1, length - 1), buffer, outlen)
     if res != MultiBaseStatus.Success:

--- a/libp2p/nameresolving/dnsresolver.nim
+++ b/libp2p/nameresolving/dnsresolver.nim
@@ -42,13 +42,13 @@ proc questionToBuf(address: string, kind: QKind): seq[byte] =
     buf
   except IOError as exc:
     info "Failed to created DNS buffer", description = exc.msg
-    newSeq[byte](0)
+    newSeqUninitialized[byte](0)
   except OSError as exc:
     info "Failed to created DNS buffer", description = exc.msg
-    newSeq[byte](0)
+    newSeqUninitialized[byte](0)
   except ValueError as exc:
     info "Failed to created DNS buffer", description = exc.msg
-    newSeq[byte](0)
+    newSeqUninitialized[byte](0)
 
 proc getDnsResponse(
     dnsServer: TransportAddress, address: string, kind: QKind

--- a/libp2p/nameresolving/dnsresolver.nim
+++ b/libp2p/nameresolving/dnsresolver.nim
@@ -37,7 +37,7 @@ proc questionToBuf(address: string, kind: QKind): seq[byte] =
     let dataLen = requestStream.getPosition()
     requestStream.setPosition(0)
 
-    var buf = newSeq[byte](dataLen)
+    var buf = newSeqUninitialized[byte](dataLen)
     discard requestStream.readData(addr buf[0], dataLen)
     buf
   except IOError as exc:

--- a/libp2p/peerid.nim
+++ b/libp2p/peerid.nim
@@ -142,7 +142,7 @@ func init*(pid: var PeerId, data: string): bool =
   ## Initialize peer id from base58 encoded string representation.
   ##
   ## Returns ``true`` if peer was successfully initialiazed.
-  var p = newSeq[byte](len(data) + 4)
+  var p = newSeqUninitialized[byte](len(data) + 4)
   var length = 0
   if Base58.decode(data, p, length) == Base58Status.Success:
     p.setLen(length)

--- a/libp2p/protobuf/minprotobuf.nim
+++ b/libp2p/protobuf/minprotobuf.nim
@@ -154,7 +154,6 @@ proc initProtoBuffer*(options: set[ProtoFlags] = {}): ProtoBuffer =
     # Our buffer will start from position 4, so we can store length of buffer
     # in [0, 3].
     result.buffer = newSeqUninitialized[byte](4)
-    result.buffer.setLen(4)
     result.offset = 4
 
 proc write*[T: ProtoScalar](pb: var ProtoBuffer, field: int, value: T) =

--- a/libp2p/protobuf/minprotobuf.nim
+++ b/libp2p/protobuf/minprotobuf.nim
@@ -148,7 +148,6 @@ proc initProtoBuffer*(options: set[ProtoFlags] = {}): ProtoBuffer =
     # Our buffer will start from position 10, so we can store length of buffer
     # in [0, 9].
     result.buffer = newSeqUninitialized[byte](10)
-    result.buffer.setLen(10)
     result.offset = 10
   elif {WithUint32LeLength, WithUint32BeLength} * options != {}:
     # Our buffer will start from position 4, so we can store length of buffer

--- a/libp2p/protobuf/minprotobuf.nim
+++ b/libp2p/protobuf/minprotobuf.nim
@@ -142,17 +142,18 @@ proc initProtoBuffer*(
   result.options = options
 
 proc initProtoBuffer*(options: set[ProtoFlags] = {}): ProtoBuffer =
-  ## Initialize ProtoBuffer with new sequence of capacity ``cap``.
-  result.buffer = newSeq[byte]()
+  ## Initialize ProtoBuffer with new sequence of capacity ``cap``
   result.options = options
   if WithVarintLength in options:
     # Our buffer will start from position 10, so we can store length of buffer
     # in [0, 9].
+    result.buffer = newSeqUninitialized[byte](10)
     result.buffer.setLen(10)
     result.offset = 10
   elif {WithUint32LeLength, WithUint32BeLength} * options != {}:
     # Our buffer will start from position 4, so we can store length of buffer
     # in [0, 3].
+    result.buffer = newSeqUninitialized[byte](4)
     result.buffer.setLen(4)
     result.offset = 4
 

--- a/libp2p/protocols/kademlia/routingtable.nim
+++ b/libp2p/protocols/kademlia/routingtable.nim
@@ -112,7 +112,7 @@ proc randomKeyInBucketRange*(
   let totalBits = raw.len * 8
   let lsbStart = bucketIndex + 1
   let lsbBytes = (totalBits - lsbStart + 7) div 8
-  var randomBuf = newSeq[byte](lsbBytes)
+  var randomBuf = newSeqUninitialized[byte](lsbBytes)
   hmacDrbgGenerate(rng[], randomBuf)
 
   for i in lsbStart ..< totalBits:

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -221,7 +221,7 @@ proc handle*(p: PubSubPeer, conn: Connection) {.async: (raises: []).} =
           conn, peer = p, closed = conn.closed, data = data.shortLog
 
         await p.handler(p, data)
-        data = newSeq[byte]() # Release memory
+        data = newSeqUninitialized[byte](0) # Release memory
     except PeerRateLimitError as exc:
       debug "Peer rate limit exceeded, exiting read while",
         conn, peer = p, description = exc.msg

--- a/libp2p/transports/tls/certificate.nim
+++ b/libp2p/transports/tls/certificate.nim
@@ -98,7 +98,7 @@ func makeSignatureMessage(pubKey: seq[byte]): seq[byte] {.inline.} =
   ##
   let P2P_SIGNING_PREFIX = "libp2p-tls-handshake:".toBytes()
   let prefixLen = P2P_SIGNING_PREFIX.len.int
-  let msg = newSeq[byte](prefixLen + pubKey.len)
+  let msg = newSeqUninitialized[byte](prefixLen + pubKey.len)
   copyMem(msg[0].unsafeAddr, P2P_SIGNING_PREFIX[0].unsafeAddr, prefixLen)
   copyMem(msg[prefixLen].unsafeAddr, pubKey[0].unsafeAddr, pubKey.len.int)
 

--- a/libp2p/utils/zeroqueue.nim
+++ b/libp2p/utils/zeroqueue.nim
@@ -77,7 +77,7 @@ proc popChunkSeq*(q: var ZeroQueue, count: int): seq[byte] =
     return @[]
 
   let chunk = q.popChunk(count)
-  var dest = newSeq[byte](chunk.len())
+  var dest = newSeqUninitialized[byte](chunk.len())
   let offsetPtr = cast[ptr byte](cast[int](unsafeAddr chunk.data[0]) + chunk.start)
   copyMem(dest[0].addr, offsetPtr, chunk.len())
 


### PR DESCRIPTION
utilizing `newSeqUninitialized` instead of `newSeq` to gain bit more performance when initializing sequences.

in this pr,  `newSeqUninitialized` is utilized only in places where it can directly replace `newSeq` without any change to other logic. 