### PR TITLE
perf(noise): encryptWithAd improvement

### DIFF
--- a/libp2p/crypto/chacha20poly1305.nim
+++ b/libp2p/crypto/chacha20poly1305.nim
@@ -53,7 +53,7 @@ proc encrypt*(
     key: ChaChaPolyKey,
     nonce: ChaChaPolyNonce,
     tag: var ChaChaPolyTag,
-    data: var openArray[byte],
+    data: openArray[byte],
     aad: openArray[byte],
 ) =
   let ad =


### PR DESCRIPTION
some performance improvement for `encryptWithAd`
- better allocation (exactly as needed)
- utilize `newSeqUninit`
- memory copied instead of adding with  `.add`