### PR TITLE
feat: create toBytesLE and toBytesBE

### DIFF
--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -12,7 +12,7 @@
 import sequtils, std/[tables]
 import chronos, chronicles, metrics, stew/[endians2, byteutils, objects]
 import ../muxer, ../../stream/connection
-import ../../utils/[zeroqueue, sequninit]
+import ../../utils/[zeroqueue, sequninit], ../../utility
 
 export muxer
 
@@ -91,10 +91,10 @@ proc `$`(header: YamuxHeader): string =
 proc encode(header: YamuxHeader): array[12, byte] =
   result[0] = header.version
   result[1] = uint8(header.msgType)
-  result[2 .. 3] = toBytesBE(uint16(cast[uint8](header.flags)))
+  toBytesBE(uint16(cast[uint8](header.flags)), result, 2)
     # workaround https://github.com/nim-lang/Nim/issues/21789
-  result[4 .. 7] = toBytesBE(header.streamId)
-  result[8 .. 11] = toBytesBE(header.length)
+  toBytesBE(header.streamId, result, 4)
+  toBytesBE(header.length, result, 8)
 
 proc write(
     conn: LPStream, header: YamuxHeader

--- a/libp2p/protobuf/minprotobuf.nim
+++ b/libp2p/protobuf/minprotobuf.nim
@@ -187,12 +187,12 @@ proc write*[T: ProtoScalar](pb: var ProtoBuffer, field: int, value: T) =
   elif T is float32:
     doAssert(pb.isEnough(uint64(sizeof(T))))
     let u32 = cast[uint32](value)
-    pb.buffer[pb.offset ..< pb.offset + sizeof(T)] = u32.toBytesLE()
+    toBytesLE(u32, pb.buffer, pb.offset)
     pb.offset += sizeof(T)
   elif T is float64:
     doAssert(pb.isEnough(uint64(sizeof(T))))
     let u64 = cast[uint64](value)
-    pb.buffer[pb.offset ..< pb.offset + sizeof(T)] = u64.toBytesLE()
+    toBytesLE(u64, pb.buffer, pb.offset)
     pb.offset += sizeof(T)
 
 proc writePacked*[T: ProtoScalar](
@@ -235,12 +235,12 @@ proc writePacked*[T: ProtoScalar](
     elif T is float32:
       doAssert(pb.isEnough(uint64(sizeof(T))))
       let u32 = cast[uint32](item)
-      pb.buffer[pb.offset ..< pb.offset + sizeof(T)] = u32.toBytesLE()
+      toBytesLE(u32, pb.buffer, pb.offset)
       pb.offset += sizeof(T)
     elif T is float64:
       doAssert(pb.isEnough(uint64(sizeof(T))))
       let u64 = cast[uint64](item)
-      pb.buffer[pb.offset ..< pb.offset + sizeof(T)] = u64.toBytesLE()
+      toBytesLE(u64, pb.buffer, pb.offset)
       pb.offset += sizeof(T)
 
 proc write*[T: byte | char](pb: var ProtoBuffer, field: int, value: openArray[T]) =
@@ -281,12 +281,12 @@ proc finish*(pb: var ProtoBuffer) =
   elif WithUint32BeLength in pb.options:
     doAssert(len(pb.buffer) >= 4)
     let size = uint(len(pb.buffer) - 4)
-    pb.buffer[0 ..< 4] = toBytesBE(uint32(size))
+    toBytesBE(uint32(size), pb.buffer, 0)
     pb.offset = 4
   elif WithUint32LeLength in pb.options:
     doAssert(len(pb.buffer) >= 4)
     let size = uint(len(pb.buffer) - 4)
-    pb.buffer[0 ..< 4] = toBytesLE(uint32(size))
+    toBytesLE(uint32(size), pb.buffer, 0)
     pb.offset = 4
   else:
     doAssert(len(pb.buffer) > 0)

--- a/libp2p/utility.nim
+++ b/libp2p/utility.nim
@@ -11,9 +11,10 @@
 
 import std/[sets, options, macros]
 import stew/byteutils
+import stew/endians2
 import results
 
-export results
+export results, endians2
 
 ## public pragma is marker of "public" api subject to stronger stability guarantees.
 template public*() {.pragma.}
@@ -143,3 +144,26 @@ template filterIt*[T](set: HashSet[T], condition: untyped): HashSet[T] =
       if condition:
         filtered.incl(it)
   filtered
+
+# In-place byte conversion utilities
+# These functions write directly to allocated buffers instead of returning new arrays
+
+func toBytesLE*(value: SomeEndianInt, dest: var openArray[byte], offset: int = 0) {.public.} =
+  ## Convert a native endian integer to little endian bytes and write to dest at offset.
+  ## The dest array must have at least sizeof(value) bytes available from offset.
+  when sizeof(value) == 1:
+    dest[offset] = cast[byte](value)
+  else:
+    let bytes = value.toBytesLE()
+    for i in 0 ..< sizeof(value):
+      dest[offset + i] = bytes[i]
+
+func toBytesBE*(value: SomeEndianInt, dest: var openArray[byte], offset: int = 0) {.public.} =
+  ## Convert a native endian integer to big endian bytes and write to dest at offset.
+  ## The dest array must have at least sizeof(value) bytes available from offset.
+  when sizeof(value) == 1:
+    dest[offset] = cast[byte](value)
+  else:
+    let bytes = value.toBytesBE()
+    for i in 0 ..< sizeof(value):
+      dest[offset + i] = bytes[i]


### PR DESCRIPTION
**What**

  Adds new in-place byte conversion utilities that write directly to allocated
  buffers:
  - toBytesLE*(value: SomeEndianInt, dest: var openArray[byte], offset: int = 0)
  - toBytesBE*(value: SomeEndianInt, dest: var openArray[byte], offset: int = 0)

  Updates Yamux and Protobuf modules to use the new utilities.

  **Why**

  Current toBytesLE/toBytesBE functions create temporary arrays that are immediately
  copied to pre-allocated buffers. This causes unnecessary allocations and memory
  copies in hot paths like network protocol encoding.

**Links**
Issue: [1522](https://github.com/vacp2p/nim-libp2p/issues/1522)