### PR TITLE
chore: hide autotls under compile flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ Enable quic transport support
 nim c -d:libp2p_quic_support some_file.nim
 ```
 
+Enable autotls support
+```bash
+nim c -d:libp2p_autotls_support some_file.nim
+```
+
 Enable expensive metrics (ie, metrics with per-peer cardinality):
 ```bash
 nim c -d:libp2p_expensive_metrics some_file.nim

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -30,7 +30,7 @@ proc runTest(filename: string, moreoptions: string = "") =
   excstr.add(" " & moreoptions & " ")
   if getEnv("CICOV").len > 0:
     excstr &= " --nimcache:nimcache/" & filename & "-" & $excstr.hash
-  exec excstr & " -r -d:libp2p_quic_support tests/" & filename
+  exec excstr & " -r -d:libp2p_quic_support -d:libp2p_autotls_support tests/" & filename
   rmFile "tests/" & filename.toExe
 
 proc buildSample(filename: string, run = false, extraFlags = "") =

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -1,509 +1,519 @@
-import options, sequtils, strutils, json, uri
-from times import DateTime, parse
-import chronos/apps/http/httpclient, jwt, results, bearssl/pem, chronicles
+when defined(libp2p_autotls_support):
+  import options, sequtils, strutils, json, uri
+  from times import DateTime, parse
+  import chronos/apps/http/httpclient, jwt, results, bearssl/pem, chronicles
 
-import ./utils
-import ../../crypto/crypto
-import ../../crypto/rsa
+  import ./utils
+  import ../../crypto/crypto
+  import ../../crypto/rsa
 
-export ACMEError
+  export ACMEError
 
-logScope:
-  topics = "libp2p acme api"
+  logScope:
+    topics = "libp2p acme api"
 
-const
-  LetsEncryptURL* = "https://acme-v02.api.letsencrypt.org"
-  LetsEncryptURLStaging* = "https://acme-staging-v02.api.letsencrypt.org"
-  Alg = "RS256"
-  DefaultChalCompletedRetries = 10
-  DefaultChalCompletedRetryTime = 1.seconds
-  DefaultFinalizeRetries = 10
-  DefaultFinalizeRetryTime = 1.seconds
-  DefaultRandStringSize = 256
-  ACMEHttpHeaders = [("Content-Type", "application/jose+json")]
+  const
+    LetsEncryptURL* = "https://acme-v02.api.letsencrypt.org"
+    LetsEncryptURLStaging* = "https://acme-staging-v02.api.letsencrypt.org"
+    Alg = "RS256"
+    DefaultChalCompletedRetries = 10
+    DefaultChalCompletedRetryTime = 1.seconds
+    DefaultFinalizeRetries = 10
+    DefaultFinalizeRetryTime = 1.seconds
+    DefaultRandStringSize = 256
+    ACMEHttpHeaders = [("Content-Type", "application/jose+json")]
 
-type Authorization* = string
-type Domain* = string
-type Kid* = string
-type Nonce* = string
+  type Authorization* = string
+  type Domain* = string
+  type Kid* = string
+  type Nonce* = string
 
-type ACMEDirectory* = object
-  newNonce*: string
-  newOrder*: string
-  newAccount*: string
+  type ACMEDirectory* = object
+    newNonce*: string
+    newOrder*: string
+    newAccount*: string
 
-type ACMEApi* = ref object of RootObj
-  directory: Opt[ACMEDirectory]
-  session: HttpSessionRef
-  acmeServerURL*: Uri
+  type ACMEApi* = ref object of RootObj
+    directory: Opt[ACMEDirectory]
+    session: HttpSessionRef
+    acmeServerURL*: Uri
 
-type HTTPResponse* = object
-  body*: JsonNode
-  headers*: HttpTable
+  type HTTPResponse* = object
+    body*: JsonNode
+    headers*: HttpTable
 
-type JWK = object
-  kty: string
-  n: string
-  e: string
+  type JWK = object
+    kty: string
+    n: string
+    e: string
 
-# whether the request uses Kid or not
-type ACMERequestType = enum
-  ACMEJwkRequest
-  ACMEKidRequest
+  # whether the request uses Kid or not
+  type ACMERequestType = enum
+    ACMEJwkRequest
+    ACMEKidRequest
 
-type ACMERequestHeader = object
-  alg: string
-  typ: string
-  nonce: Nonce
-  url: string
-  case kind: ACMERequestType
-  of ACMEJwkRequest:
-    jwk: JWK
-  of ACMEKidRequest:
-    kid: Kid
+  type ACMERequestHeader = object
+    alg: string
+    typ: string
+    nonce: Nonce
+    url: string
+    case kind: ACMERequestType
+    of ACMEJwkRequest:
+      jwk: JWK
+    of ACMEKidRequest:
+      kid: Kid
 
-type Email = string
+  type Email = string
 
-type ACMERegisterRequest* = object
-  termsOfServiceAgreed: bool
-  contact: seq[Email]
+  type ACMERegisterRequest* = object
+    termsOfServiceAgreed: bool
+    contact: seq[Email]
 
-type ACMEAccountStatus = enum
-  valid = "valid"
-  deactivated = "deactivated"
-  revoked = "revoked"
+  type ACMEAccountStatus = enum
+    valid = "valid"
+    deactivated = "deactivated"
+    revoked = "revoked"
 
-type ACMERegisterResponseBody = object
-  status*: ACMEAccountStatus
+  type ACMERegisterResponseBody = object
+    status*: ACMEAccountStatus
 
-type ACMERegisterResponse* = object
-  kid*: Kid
-  status*: ACMEAccountStatus
+  type ACMERegisterResponse* = object
+    kid*: Kid
+    status*: ACMEAccountStatus
 
-type ACMEChallengeStatus* {.pure.} = enum
-  PENDING = "pending"
-  PROCESSING = "processing"
-  VALID = "valid"
-  INVALID = "invalid"
+  type ACMEChallengeStatus* {.pure.} = enum
+    PENDING = "pending"
+    PROCESSING = "processing"
+    VALID = "valid"
+    INVALID = "invalid"
 
-type ACMEOrderStatus* {.pure.} = enum
-  PENDING = "pending"
-  READY = "ready"
-  PROCESSING = "processing"
-  VALID = "valid"
-  INVALID = "invalid"
+  type ACMEOrderStatus* {.pure.} = enum
+    PENDING = "pending"
+    READY = "ready"
+    PROCESSING = "processing"
+    VALID = "valid"
+    INVALID = "invalid"
 
-type ACMEChallengeType* {.pure.} = enum
-  DNS01 = "dns-01"
-  HTTP01 = "http-01"
-  TLSALPN01 = "tls-alpn-01"
+  type ACMEChallengeType* {.pure.} = enum
+    DNS01 = "dns-01"
+    HTTP01 = "http-01"
+    TLSALPN01 = "tls-alpn-01"
 
-type ACMEChallengeToken* = string
+  type ACMEChallengeToken* = string
 
-type ACMEChallenge* = object
-  url*: string
-  `type`*: ACMEChallengeType
-  status*: ACMEChallengeStatus
-  token*: ACMEChallengeToken
+  type ACMEChallenge* = object
+    url*: string
+    `type`*: ACMEChallengeType
+    status*: ACMEChallengeStatus
+    token*: ACMEChallengeToken
 
-type ACMEChallengeIdentifier = object
-  `type`: string
-  value: string
+  type ACMEChallengeIdentifier = object
+    `type`: string
+    value: string
 
-type ACMEChallengeRequest = object
-  identifiers: seq[ACMEChallengeIdentifier]
+  type ACMEChallengeRequest = object
+    identifiers: seq[ACMEChallengeIdentifier]
 
-type ACMEChallengeResponseBody = object
-  status: ACMEOrderStatus
-  authorizations: seq[Authorization]
-  finalize: string
+  type ACMEChallengeResponseBody = object
+    status: ACMEOrderStatus
+    authorizations: seq[Authorization]
+    finalize: string
 
-type ACMEChallengeResponse* = object
-  status*: ACMEOrderStatus
-  authorizations*: seq[Authorization]
-  finalize*: string
-  order*: string
+  type ACMEChallengeResponse* = object
+    status*: ACMEOrderStatus
+    authorizations*: seq[Authorization]
+    finalize*: string
+    order*: string
 
-type ACMEChallengeResponseWrapper* = object
-  finalize*: string
-  order*: string
-  dns01*: ACMEChallenge
+  type ACMEChallengeResponseWrapper* = object
+    finalize*: string
+    order*: string
+    dns01*: ACMEChallenge
 
-type ACMEAuthorizationsResponse* = object
-  challenges*: seq[ACMEChallenge]
+  type ACMEAuthorizationsResponse* = object
+    challenges*: seq[ACMEChallenge]
 
-type ACMECompletedResponse* = object
-  url: string
+  type ACMECompletedResponse* = object
+    url: string
 
-type ACMECheckKind* = enum
-  ACMEOrderCheck
-  ACMEChallengeCheck
+  type ACMECheckKind* = enum
+    ACMEOrderCheck
+    ACMEChallengeCheck
 
-type ACMECheckResponse* = object
-  case kind: ACMECheckKind
-  of ACMEOrderCheck:
-    orderStatus: ACMEOrderStatus
-  of ACMEChallengeCheck:
-    chalStatus: ACMEChallengeStatus
-  retryAfter: Duration
-
-type ACMEFinalizeResponse* = object
-  status: ACMEOrderStatus
-
-type ACMEOrderResponse* = object
-  certificate: string
-  expires: string
-
-type ACMECertificateResponse* = object
-  rawCertificate*: string
-  certificateExpiry*: DateTime
-
-template handleError*(msg: string, body: untyped): untyped =
-  try:
-    body
-  except ACMEError as exc:
-    raise exc
-  except CancelledError as exc:
-    raise exc
-  except JsonKindError as exc:
-    raise newException(ACMEError, msg & ": Failed to decode JSON", exc)
-  except ValueError as exc:
-    raise newException(ACMEError, msg & ": Failed to decode JSON", exc)
-  except HttpError as exc:
-    raise newException(ACMEError, msg & ": Failed to connect to ACME server", exc)
-  except CatchableError as exc:
-    raise newException(ACMEError, msg & ": Unexpected error", exc)
-
-method post*(
-  self: ACMEApi, uri: Uri, payload: string
-): Future[HTTPResponse] {.
-  async: (raises: [ACMEError, HttpError, CancelledError]), base
-.}
-
-method get*(
-  self: ACMEApi, uri: Uri
-): Future[HTTPResponse] {.
-  async: (raises: [ACMEError, HttpError, CancelledError]), base
-.}
-
-proc new*(
-    T: typedesc[ACMEApi], acmeServerURL: Uri = parseUri(LetsEncryptURL)
-): ACMEApi =
-  let session = HttpSessionRef.new()
-
-  ACMEApi(
-    session: session, directory: Opt.none(ACMEDirectory), acmeServerURL: acmeServerURL
-  )
-
-proc getDirectory(
-    self: ACMEApi
-): Future[ACMEDirectory] {.async: (raises: [ACMEError, CancelledError]).} =
-  handleError("getDirectory"):
-    self.directory.valueOr:
-      let acmeResponse = await self.get(self.acmeServerURL / "directory")
-      let directory = acmeResponse.body.to(ACMEDirectory)
-      self.directory = Opt.some(directory)
-      directory
-
-method requestNonce*(
-    self: ACMEApi
-): Future[Nonce] {.async: (raises: [ACMEError, CancelledError]), base.} =
-  handleError("requestNonce"):
-    let acmeResponse = await self.get(parseUri((await self.getDirectory()).newNonce))
-    Nonce(acmeResponse.headers.keyOrError("Replay-Nonce"))
-
-# TODO: save n and e in account so we don't have to recalculate every time
-proc acmeHeader(
-    self: ACMEApi, uri: Uri, key: KeyPair, needsJwk: bool, kid: Opt[Kid]
-): Future[ACMERequestHeader] {.async: (raises: [ACMEError, CancelledError]).} =
-  if not needsJwk and kid.isNone():
-    raise newException(ACMEError, "kid not set")
-
-  if key.pubkey.scheme != PKScheme.RSA or key.seckey.scheme != PKScheme.RSA:
-    raise newException(ACMEError, "Unsupported signing key type")
-
-  let newNonce = await self.requestNonce()
-  if needsJwk:
-    let pubkey = key.pubkey.rsakey
-    let nArray = @(getArray(pubkey.buffer, pubkey.key.n, pubkey.key.nlen))
-    let eArray = @(getArray(pubkey.buffer, pubkey.key.e, pubkey.key.elen))
-    ACMERequestHeader(
-      kind: ACMEJwkRequest,
-      alg: Alg,
-      typ: "JWT",
-      nonce: newNonce,
-      url: $uri,
-      jwk: JWK(kty: "RSA", n: base64UrlEncode(nArray), e: base64UrlEncode(eArray)),
-    )
-  else:
-    ACMERequestHeader(
-      kind: ACMEKidRequest,
-      alg: Alg,
-      typ: "JWT",
-      nonce: newNonce,
-      url: $uri,
-      kid: kid.get(),
-    )
-
-method post*(
-    self: ACMEApi, uri: Uri, payload: string
-): Future[HTTPResponse] {.
-    async: (raises: [ACMEError, HttpError, CancelledError]), base
-.} =
-  let rawResponse = await HttpClientRequestRef
-  .post(self.session, $uri, body = payload, headers = ACMEHttpHeaders)
-  .get()
-  .send()
-  let body = await rawResponse.getResponseBody()
-  HTTPResponse(body: body, headers: rawResponse.headers)
-
-method get*(
-    self: ACMEApi, uri: Uri
-): Future[HTTPResponse] {.
-    async: (raises: [ACMEError, HttpError, CancelledError]), base
-.} =
-  let rawResponse = await HttpClientRequestRef.get(self.session, $uri).get().send()
-  let body = await rawResponse.getResponseBody()
-  HTTPResponse(body: body, headers: rawResponse.headers)
-
-proc createSignedAcmeRequest(
-    self: ACMEApi,
-    uri: Uri,
-    payload: auto,
-    key: KeyPair,
-    needsJwk: bool = false,
-    kid: Opt[Kid] = Opt.none(Kid),
-): Future[string] {.async: (raises: [ACMEError, CancelledError]).} =
-  if key.pubkey.scheme != PKScheme.RSA or key.seckey.scheme != PKScheme.RSA:
-    raise newException(ACMEError, "Unsupported signing key type")
-
-  let acmeHeader = await self.acmeHeader(uri, key, needsJwk, kid)
-  handleError("createSignedAcmeRequest"):
-    var token = toJWT(%*{"header": acmeHeader, "claims": payload})
-    let derPrivKey = key.seckey.rsakey.getBytes.get
-    let pemPrivKey: string = pemEncode(derPrivKey, "PRIVATE KEY")
-    token.sign(pemPrivKey)
-    $token.toFlattenedJson()
-
-proc requestRegister*(
-    self: ACMEApi, key: KeyPair
-): Future[ACMERegisterResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-  let registerRequest = ACMERegisterRequest(termsOfServiceAgreed: true)
-  handleError("acmeRegister"):
-    let payload = await self.createSignedAcmeRequest(
-      parseUri((await self.getDirectory()).newAccount),
-      registerRequest,
-      key,
-      needsJwk = true,
-    )
-    let acmeResponse =
-      await self.post(parseUri((await self.getDirectory()).newAccount), payload)
-    let acmeResponseBody = acmeResponse.body.to(ACMERegisterResponseBody)
-
-    ACMERegisterResponse(
-      status: acmeResponseBody.status, kid: acmeResponse.headers.keyOrError("location")
-    )
-
-proc requestNewOrder*(
-    self: ACMEApi, domains: seq[Domain], key: KeyPair, kid: Kid
-): Future[ACMEChallengeResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-  # request challenge from ACME server
-  let orderRequest = ACMEChallengeRequest(
-    identifiers: domains.mapIt(ACMEChallengeIdentifier(`type`: "dns", value: it))
-  )
-  handleError("requestNewOrder"):
-    let payload = await self.createSignedAcmeRequest(
-      parseUri((await self.getDirectory()).newOrder),
-      orderRequest,
-      key,
-      kid = Opt.some(kid),
-    )
-    let acmeResponse =
-      await self.post(parseUri((await self.getDirectory()).newOrder), payload)
-    let challengeResponseBody = acmeResponse.body.to(ACMEChallengeResponseBody)
-    if challengeResponseBody.authorizations.len == 0:
-      raise newException(ACMEError, "Authorizations field is empty")
-    ACMEChallengeResponse(
-      status: challengeResponseBody.status,
-      authorizations: challengeResponseBody.authorizations,
-      finalize: challengeResponseBody.finalize,
-      order: acmeResponse.headers.keyOrError("location"),
-    )
-
-proc requestAuthorizations*(
-    self: ACMEApi, authorizations: seq[Authorization], key: KeyPair, kid: Kid
-): Future[ACMEAuthorizationsResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-  handleError("requestAuthorizations"):
-    doAssert authorizations.len > 0
-    let acmeResponse = await self.get(parseUri(authorizations[0]))
-    acmeResponse.body.to(ACMEAuthorizationsResponse)
-
-proc requestChallenge*(
-    self: ACMEApi, domains: seq[Domain], key: KeyPair, kid: Kid
-): Future[ACMEChallengeResponseWrapper] {.async: (raises: [ACMEError, CancelledError]).} =
-  let orderResponse = await self.requestNewOrder(domains, key, kid)
-  if orderResponse.status != ACMEOrderStatus.PENDING and
-      orderResponse.status != ACMEOrderStatus.READY:
-    # ready is a valid status when renewing certs before expiry
-    raise newException(ACMEError, "Invalid new order status: " & $orderResponse.status)
-
-  let authorizationsResponse =
-    await self.requestAuthorizations(orderResponse.authorizations, key, kid)
-  if authorizationsResponse.challenges.len == 0:
-    raise newException(ACMEError, "No challenges received")
-
-  return ACMEChallengeResponseWrapper(
-    finalize: orderResponse.finalize,
-    order: orderResponse.order,
-    dns01: authorizationsResponse.challenges.filterIt(
-      it.`type` == ACMEChallengeType.DNS01
-    )[0],
-      # getting the first element is safe since we checked that authorizationsResponse.challenges.len != 0
-  )
-
-proc requestCheck*(
-    self: ACMEApi, checkURL: Uri, checkKind: ACMECheckKind, key: KeyPair, kid: Kid
-): Future[ACMECheckResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-  handleError("requestCheck"):
-    let acmeResponse = await self.get(checkURL)
-    let retryAfter =
-      try:
-        parseInt(acmeResponse.headers.keyOrError("Retry-After")).seconds
-      except ValueError:
-        DefaultChalCompletedRetryTime
-
-    case checkKind
+  type ACMECheckResponse* = object
+    case kind: ACMECheckKind
     of ACMEOrderCheck:
-      try:
-        ACMECheckResponse(
-          kind: checkKind,
-          orderStatus: parseEnum[ACMEOrderStatus](acmeResponse.body["status"].getStr),
-          retryAfter: retryAfter,
-        )
-      except ValueError:
-        raise newException(
-          ACMEError, "Invalid order status: " & acmeResponse.body["status"].getStr
-        )
+      orderStatus: ACMEOrderStatus
     of ACMEChallengeCheck:
-      try:
-        ACMECheckResponse(
-          kind: checkKind,
-          chalStatus: parseEnum[ACMEChallengeStatus](acmeResponse.body["status"].getStr),
-          retryAfter: retryAfter,
-        )
-      except ValueError:
-        raise newException(
-          ACMEError, "Invalid order status: " & acmeResponse.body["status"].getStr
-        )
+      chalStatus: ACMEChallengeStatus
+    retryAfter: Duration
 
-proc sendChallengeCompleted*(
-    self: ACMEApi, chalURL: Uri, key: KeyPair, kid: Kid
-): Future[ACMECompletedResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-  handleError("sendChallengeCompleted"):
-    let payload =
-      await self.createSignedAcmeRequest(chalURL, %*{}, key, kid = Opt.some(kid))
-    let acmeResponse = await self.post(chalURL, payload)
-    acmeResponse.body.to(ACMECompletedResponse)
+  type ACMEFinalizeResponse* = object
+    status: ACMEOrderStatus
 
-proc checkChallengeCompleted*(
-    self: ACMEApi,
-    checkURL: Uri,
-    key: KeyPair,
-    kid: Kid,
-    retries: int = DefaultChalCompletedRetries,
-): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
-  for i in 0 .. retries:
-    let checkResponse = await self.requestCheck(checkURL, ACMEChallengeCheck, key, kid)
-    case checkResponse.chalStatus
-    of ACMEChallengeStatus.PENDING:
-      await sleepAsync(checkResponse.retryAfter) # try again after some delay
-    of ACMEChallengeStatus.VALID:
-      return true
-    else:
-      raise newException(
-        ACMEError,
-        "Failed challenge completion: expected 'valid', got '" &
-          $checkResponse.chalStatus & "'",
-      )
-  return false
+  type ACMEOrderResponse* = object
+    certificate: string
+    expires: string
 
-proc completeChallenge*(
-    self: ACMEApi,
-    chalURL: Uri,
-    key: KeyPair,
-    kid: Kid,
-    retries: int = DefaultChalCompletedRetries,
-): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
-  let completedResponse = await self.sendChallengeCompleted(chalURL, key, kid)
-  # check until acme server is done (poll validation)
-  return await self.checkChallengeCompleted(chalURL, key, kid, retries = retries)
+  type ACMECertificateResponse* = object
+    rawCertificate*: string
+    certificateExpiry*: DateTime
 
-proc requestFinalize*(
-    self: ACMEApi, domain: Domain, finalize: Uri, key: KeyPair, kid: Kid
-): Future[ACMEFinalizeResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-  handleError("requestFinalize"):
-    let payload = await self.createSignedAcmeRequest(
-      finalize, %*{"csr": createCSR(domain)}, key, kid = Opt.some(kid)
+  template handleError*(msg: string, body: untyped): untyped =
+    try:
+      body
+    except ACMEError as exc:
+      raise exc
+    except CancelledError as exc:
+      raise exc
+    except JsonKindError as exc:
+      raise newException(ACMEError, msg & ": Failed to decode JSON", exc)
+    except ValueError as exc:
+      raise newException(ACMEError, msg & ": Failed to decode JSON", exc)
+    except HttpError as exc:
+      raise newException(ACMEError, msg & ": Failed to connect to ACME server", exc)
+    except CatchableError as exc:
+      raise newException(ACMEError, msg & ": Unexpected error", exc)
+
+  method post*(
+    self: ACMEApi, uri: Uri, payload: string
+  ): Future[HTTPResponse] {.
+    async: (raises: [ACMEError, HttpError, CancelledError]), base
+  .}
+
+  method get*(
+    self: ACMEApi, uri: Uri
+  ): Future[HTTPResponse] {.
+    async: (raises: [ACMEError, HttpError, CancelledError]), base
+  .}
+
+  proc new*(
+      T: typedesc[ACMEApi], acmeServerURL: Uri = parseUri(LetsEncryptURL)
+  ): ACMEApi =
+    let session = HttpSessionRef.new()
+
+    ACMEApi(
+      session: session, directory: Opt.none(ACMEDirectory), acmeServerURL: acmeServerURL
     )
-    let acmeResponse = await self.post(finalize, payload)
-    # server responds with updated order response
-    acmeResponse.body.to(ACMEFinalizeResponse)
 
-proc checkCertFinalized*(
-    self: ACMEApi,
-    order: Uri,
-    key: KeyPair,
-    kid: Kid,
-    retries: int = DefaultChalCompletedRetries,
-): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
-  for i in 0 .. retries:
-    let checkResponse = await self.requestCheck(order, ACMEOrderCheck, key, kid)
-    case checkResponse.orderStatus
-    of ACMEOrderStatus.VALID:
-      return true
-    of ACMEOrderStatus.PROCESSING:
-      await sleepAsync(checkResponse.retryAfter) # try again after some delay
+  proc getDirectory(
+      self: ACMEApi
+  ): Future[ACMEDirectory] {.async: (raises: [ACMEError, CancelledError]).} =
+    handleError("getDirectory"):
+      self.directory.valueOr:
+        let acmeResponse = await self.get(self.acmeServerURL / "directory")
+        let directory = acmeResponse.body.to(ACMEDirectory)
+        self.directory = Opt.some(directory)
+        directory
+
+  method requestNonce*(
+      self: ACMEApi
+  ): Future[Nonce] {.async: (raises: [ACMEError, CancelledError]), base.} =
+    handleError("requestNonce"):
+      let acmeResponse = await self.get(parseUri((await self.getDirectory()).newNonce))
+      Nonce(acmeResponse.headers.keyOrError("Replay-Nonce"))
+
+  # TODO: save n and e in account so we don't have to recalculate every time
+  proc acmeHeader(
+      self: ACMEApi, uri: Uri, key: KeyPair, needsJwk: bool, kid: Opt[Kid]
+  ): Future[ACMERequestHeader] {.async: (raises: [ACMEError, CancelledError]).} =
+    if not needsJwk and kid.isNone():
+      raise newException(ACMEError, "kid not set")
+
+    if key.pubkey.scheme != PKScheme.RSA or key.seckey.scheme != PKScheme.RSA:
+      raise newException(ACMEError, "Unsupported signing key type")
+
+    let newNonce = await self.requestNonce()
+    if needsJwk:
+      let pubkey = key.pubkey.rsakey
+      let nArray = @(getArray(pubkey.buffer, pubkey.key.n, pubkey.key.nlen))
+      let eArray = @(getArray(pubkey.buffer, pubkey.key.e, pubkey.key.elen))
+      ACMERequestHeader(
+        kind: ACMEJwkRequest,
+        alg: Alg,
+        typ: "JWT",
+        nonce: newNonce,
+        url: $uri,
+        jwk: JWK(kty: "RSA", n: base64UrlEncode(nArray), e: base64UrlEncode(eArray)),
+      )
     else:
-      error "Failed certificate finalization",
-        description = "expected 'valid', got '" & $checkResponse.orderStatus & "'"
-      return false # do not try again
+      ACMERequestHeader(
+        kind: ACMEKidRequest,
+        alg: Alg,
+        typ: "JWT",
+        nonce: newNonce,
+        url: $uri,
+        kid: kid.get(),
+      )
 
-  return false
-
-proc certificateFinalized*(
-    self: ACMEApi,
-    domain: Domain,
-    finalize: Uri,
-    order: Uri,
-    key: KeyPair,
-    kid: Kid,
-    retries: int = DefaultFinalizeRetries,
-): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
-  let finalizeResponse = await self.requestFinalize(domain, finalize, key, kid)
-  # keep checking order until cert is valid (done)
-  return await self.checkCertFinalized(order, key, kid, retries = retries)
-
-proc requestGetOrder*(
-    self: ACMEApi, order: Uri
-): Future[ACMEOrderResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-  handleError("requestGetOrder"):
-    let acmeResponse = await self.get(order)
-    acmeResponse.body.to(ACMEOrderResponse)
-
-proc downloadCertificate*(
-    self: ACMEApi, order: Uri
-): Future[ACMECertificateResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-  let orderResponse = await self.requestGetOrder(order)
-
-  handleError("downloadCertificate"):
+  method post*(
+      self: ACMEApi, uri: Uri, payload: string
+  ): Future[HTTPResponse] {.
+      async: (raises: [ACMEError, HttpError, CancelledError]), base
+  .} =
     let rawResponse = await HttpClientRequestRef
-    .get(self.session, orderResponse.certificate)
+    .post(self.session, $uri, body = payload, headers = ACMEHttpHeaders)
     .get()
     .send()
-    ACMECertificateResponse(
-      rawCertificate: bytesToString(await rawResponse.getBodyBytes()),
-      certificateExpiry: parse(orderResponse.expires, "yyyy-MM-dd'T'HH:mm:ss'Z'"),
+    let body = await rawResponse.getResponseBody()
+    HTTPResponse(body: body, headers: rawResponse.headers)
+
+  method get*(
+      self: ACMEApi, uri: Uri
+  ): Future[HTTPResponse] {.
+      async: (raises: [ACMEError, HttpError, CancelledError]), base
+  .} =
+    let rawResponse = await HttpClientRequestRef.get(self.session, $uri).get().send()
+    let body = await rawResponse.getResponseBody()
+    HTTPResponse(body: body, headers: rawResponse.headers)
+
+  proc createSignedAcmeRequest(
+      self: ACMEApi,
+      uri: Uri,
+      payload: auto,
+      key: KeyPair,
+      needsJwk: bool = false,
+      kid: Opt[Kid] = Opt.none(Kid),
+  ): Future[string] {.async: (raises: [ACMEError, CancelledError]).} =
+    if key.pubkey.scheme != PKScheme.RSA or key.seckey.scheme != PKScheme.RSA:
+      raise newException(ACMEError, "Unsupported signing key type")
+
+    let acmeHeader = await self.acmeHeader(uri, key, needsJwk, kid)
+    handleError("createSignedAcmeRequest"):
+      var token = toJWT(%*{"header": acmeHeader, "claims": payload})
+      let derPrivKey = key.seckey.rsakey.getBytes.get
+      let pemPrivKey: string = pemEncode(derPrivKey, "PRIVATE KEY")
+      token.sign(pemPrivKey)
+      $token.toFlattenedJson()
+
+  proc requestRegister*(
+      self: ACMEApi, key: KeyPair
+  ): Future[ACMERegisterResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+    let registerRequest = ACMERegisterRequest(termsOfServiceAgreed: true)
+    handleError("acmeRegister"):
+      let payload = await self.createSignedAcmeRequest(
+        parseUri((await self.getDirectory()).newAccount),
+        registerRequest,
+        key,
+        needsJwk = true,
+      )
+      let acmeResponse =
+        await self.post(parseUri((await self.getDirectory()).newAccount), payload)
+      let acmeResponseBody = acmeResponse.body.to(ACMERegisterResponseBody)
+
+      ACMERegisterResponse(
+        status: acmeResponseBody.status,
+        kid: acmeResponse.headers.keyOrError("location"),
+      )
+
+  proc requestNewOrder*(
+      self: ACMEApi, domains: seq[Domain], key: KeyPair, kid: Kid
+  ): Future[ACMEChallengeResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+    # request challenge from ACME server
+    let orderRequest = ACMEChallengeRequest(
+      identifiers: domains.mapIt(ACMEChallengeIdentifier(`type`: "dns", value: it))
+    )
+    handleError("requestNewOrder"):
+      let payload = await self.createSignedAcmeRequest(
+        parseUri((await self.getDirectory()).newOrder),
+        orderRequest,
+        key,
+        kid = Opt.some(kid),
+      )
+      let acmeResponse =
+        await self.post(parseUri((await self.getDirectory()).newOrder), payload)
+      let challengeResponseBody = acmeResponse.body.to(ACMEChallengeResponseBody)
+      if challengeResponseBody.authorizations.len == 0:
+        raise newException(ACMEError, "Authorizations field is empty")
+      ACMEChallengeResponse(
+        status: challengeResponseBody.status,
+        authorizations: challengeResponseBody.authorizations,
+        finalize: challengeResponseBody.finalize,
+        order: acmeResponse.headers.keyOrError("location"),
+      )
+
+  proc requestAuthorizations*(
+      self: ACMEApi, authorizations: seq[Authorization], key: KeyPair, kid: Kid
+  ): Future[ACMEAuthorizationsResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+    handleError("requestAuthorizations"):
+      doAssert authorizations.len > 0
+      let acmeResponse = await self.get(parseUri(authorizations[0]))
+      acmeResponse.body.to(ACMEAuthorizationsResponse)
+
+  proc requestChallenge*(
+      self: ACMEApi, domains: seq[Domain], key: KeyPair, kid: Kid
+  ): Future[ACMEChallengeResponseWrapper] {.
+      async: (raises: [ACMEError, CancelledError])
+  .} =
+    let orderResponse = await self.requestNewOrder(domains, key, kid)
+    if orderResponse.status != ACMEOrderStatus.PENDING and
+        orderResponse.status != ACMEOrderStatus.READY:
+      # ready is a valid status when renewing certs before expiry
+      raise
+        newException(ACMEError, "Invalid new order status: " & $orderResponse.status)
+
+    let authorizationsResponse =
+      await self.requestAuthorizations(orderResponse.authorizations, key, kid)
+    if authorizationsResponse.challenges.len == 0:
+      raise newException(ACMEError, "No challenges received")
+
+    return ACMEChallengeResponseWrapper(
+      finalize: orderResponse.finalize,
+      order: orderResponse.order,
+      dns01: authorizationsResponse.challenges.filterIt(
+        it.`type` == ACMEChallengeType.DNS01
+      )[0],
+        # getting the first element is safe since we checked that authorizationsResponse.challenges.len != 0
     )
 
-proc close*(self: ACMEApi) {.async: (raises: [CancelledError]).} =
-  await self.session.closeWait()
+  proc requestCheck*(
+      self: ACMEApi, checkURL: Uri, checkKind: ACMECheckKind, key: KeyPair, kid: Kid
+  ): Future[ACMECheckResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+    handleError("requestCheck"):
+      let acmeResponse = await self.get(checkURL)
+      let retryAfter =
+        try:
+          parseInt(acmeResponse.headers.keyOrError("Retry-After")).seconds
+        except ValueError:
+          DefaultChalCompletedRetryTime
+
+      case checkKind
+      of ACMEOrderCheck:
+        try:
+          ACMECheckResponse(
+            kind: checkKind,
+            orderStatus: parseEnum[ACMEOrderStatus](acmeResponse.body["status"].getStr),
+            retryAfter: retryAfter,
+          )
+        except ValueError:
+          raise newException(
+            ACMEError, "Invalid order status: " & acmeResponse.body["status"].getStr
+          )
+      of ACMEChallengeCheck:
+        try:
+          ACMECheckResponse(
+            kind: checkKind,
+            chalStatus:
+              parseEnum[ACMEChallengeStatus](acmeResponse.body["status"].getStr),
+            retryAfter: retryAfter,
+          )
+        except ValueError:
+          raise newException(
+            ACMEError, "Invalid order status: " & acmeResponse.body["status"].getStr
+          )
+
+  proc sendChallengeCompleted*(
+      self: ACMEApi, chalURL: Uri, key: KeyPair, kid: Kid
+  ): Future[ACMECompletedResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+    handleError("sendChallengeCompleted"):
+      let payload =
+        await self.createSignedAcmeRequest(chalURL, %*{}, key, kid = Opt.some(kid))
+      let acmeResponse = await self.post(chalURL, payload)
+      acmeResponse.body.to(ACMECompletedResponse)
+
+  proc checkChallengeCompleted*(
+      self: ACMEApi,
+      checkURL: Uri,
+      key: KeyPair,
+      kid: Kid,
+      retries: int = DefaultChalCompletedRetries,
+  ): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
+    for i in 0 .. retries:
+      let checkResponse =
+        await self.requestCheck(checkURL, ACMEChallengeCheck, key, kid)
+      case checkResponse.chalStatus
+      of ACMEChallengeStatus.PENDING:
+        await sleepAsync(checkResponse.retryAfter) # try again after some delay
+      of ACMEChallengeStatus.VALID:
+        return true
+      else:
+        raise newException(
+          ACMEError,
+          "Failed challenge completion: expected 'valid', got '" &
+            $checkResponse.chalStatus & "'",
+        )
+    return false
+
+  proc completeChallenge*(
+      self: ACMEApi,
+      chalURL: Uri,
+      key: KeyPair,
+      kid: Kid,
+      retries: int = DefaultChalCompletedRetries,
+  ): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
+    let completedResponse = await self.sendChallengeCompleted(chalURL, key, kid)
+    # check until acme server is done (poll validation)
+    return await self.checkChallengeCompleted(chalURL, key, kid, retries = retries)
+
+  proc requestFinalize*(
+      self: ACMEApi, domain: Domain, finalize: Uri, key: KeyPair, kid: Kid
+  ): Future[ACMEFinalizeResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+    handleError("requestFinalize"):
+      let payload = await self.createSignedAcmeRequest(
+        finalize, %*{"csr": createCSR(domain)}, key, kid = Opt.some(kid)
+      )
+      let acmeResponse = await self.post(finalize, payload)
+      # server responds with updated order response
+      acmeResponse.body.to(ACMEFinalizeResponse)
+
+  proc checkCertFinalized*(
+      self: ACMEApi,
+      order: Uri,
+      key: KeyPair,
+      kid: Kid,
+      retries: int = DefaultChalCompletedRetries,
+  ): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
+    for i in 0 .. retries:
+      let checkResponse = await self.requestCheck(order, ACMEOrderCheck, key, kid)
+      case checkResponse.orderStatus
+      of ACMEOrderStatus.VALID:
+        return true
+      of ACMEOrderStatus.PROCESSING:
+        await sleepAsync(checkResponse.retryAfter) # try again after some delay
+      else:
+        error "Failed certificate finalization",
+          description = "expected 'valid', got '" & $checkResponse.orderStatus & "'"
+        return false # do not try again
+
+    return false
+
+  proc certificateFinalized*(
+      self: ACMEApi,
+      domain: Domain,
+      finalize: Uri,
+      order: Uri,
+      key: KeyPair,
+      kid: Kid,
+      retries: int = DefaultFinalizeRetries,
+  ): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
+    let finalizeResponse = await self.requestFinalize(domain, finalize, key, kid)
+    # keep checking order until cert is valid (done)
+    return await self.checkCertFinalized(order, key, kid, retries = retries)
+
+  proc requestGetOrder*(
+      self: ACMEApi, order: Uri
+  ): Future[ACMEOrderResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+    handleError("requestGetOrder"):
+      let acmeResponse = await self.get(order)
+      acmeResponse.body.to(ACMEOrderResponse)
+
+  proc downloadCertificate*(
+      self: ACMEApi, order: Uri
+  ): Future[ACMECertificateResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+    let orderResponse = await self.requestGetOrder(order)
+
+    handleError("downloadCertificate"):
+      let rawResponse = await HttpClientRequestRef
+      .get(self.session, orderResponse.certificate)
+      .get()
+      .send()
+      ACMECertificateResponse(
+        rawCertificate: bytesToString(await rawResponse.getBodyBytes()),
+        certificateExpiry: parse(orderResponse.expires, "yyyy-MM-dd'T'HH:mm:ss'Z'"),
+      )
+
+  proc close*(self: ACMEApi) {.async: (raises: [CancelledError]).} =
+    await self.session.closeWait()
+
+else:
+  {.hint: "autotls disabled. Use -d:libp2p_autotls_support".}

--- a/libp2p/autotls/acme/client.nim
+++ b/libp2p/autotls/acme/client.nim
@@ -28,59 +28,66 @@ type ACMEClient* = ref object
 logScope:
   topics = "libp2p acme client"
 
-proc new*(
-    T: typedesc[ACMEClient],
-    rng: ref HmacDrbgContext = newRng(),
-    api: ACMEApi = ACMEApi.new(acmeServerURL = parseUri(LetsEncryptURL)),
-    key: Opt[KeyPair] = Opt.none(KeyPair),
-    kid: Kid = Kid(""),
-): T {.raises: [].} =
-  let key = key.valueOr:
-    KeyPair.random(PKScheme.RSA, rng[]).get()
-  T(api: api, key: key, kid: kid)
+when defined(libp2p_autotls_support):
+  proc new*(
+      T: typedesc[ACMEClient],
+      rng: ref HmacDrbgContext = newRng(),
+      api: ACMEApi = ACMEApi.new(acmeServerURL = parseUri(LetsEncryptURL)),
+      key: Opt[KeyPair] = Opt.none(KeyPair),
+      kid: Kid = Kid(""),
+  ): T {.raises: [].} =
+    let key = key.valueOr:
+      KeyPair.random(PKScheme.RSA, rng[]).get()
+    T(api: api, key: key, kid: kid)
 
-proc getOrInitKid*(
-    self: ACMEClient
-): Future[Kid] {.async: (raises: [ACMEError, CancelledError]).} =
-  if self.kid.len == 0:
-    let registerResponse = await self.api.requestRegister(self.key)
-    self.kid = registerResponse.kid
-  return self.kid
+  proc getOrInitKid*(
+      self: ACMEClient
+  ): Future[Kid] {.async: (raises: [ACMEError, CancelledError]).} =
+    if self.kid.len == 0:
+      let registerResponse = await self.api.requestRegister(self.key)
+      self.kid = registerResponse.kid
+    return self.kid
 
-proc genKeyAuthorization*(self: ACMEClient, token: string): KeyAuthorization =
-  base64UrlEncode(@(sha256.digest((token & "." & thumbprint(self.key)).toBytes).data))
+  proc genKeyAuthorization*(self: ACMEClient, token: string): KeyAuthorization =
+    base64UrlEncode(@(sha256.digest((token & "." & thumbprint(self.key)).toBytes).data))
 
-proc getChallenge*(
-    self: ACMEClient, domains: seq[api.Domain]
-): Future[ACMEChallengeResponseWrapper] {.async: (raises: [ACMEError, CancelledError]).} =
-  await self.api.requestChallenge(domains, self.key, await self.getOrInitKid())
+  proc getChallenge*(
+      self: ACMEClient, domains: seq[api.Domain]
+  ): Future[ACMEChallengeResponseWrapper] {.
+      async: (raises: [ACMEError, CancelledError])
+  .} =
+    await self.api.requestChallenge(domains, self.key, await self.getOrInitKid())
 
-proc getCertificate*(
-    self: ACMEClient, domain: api.Domain, challenge: ACMEChallengeResponseWrapper
-): Future[ACMECertificateResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-  let chalURL = parseUri(challenge.dns01.url)
-  let orderURL = parseUri(challenge.order)
-  let finalizeURL = parseUri(challenge.finalize)
-  trace "sending challenge completed notification"
-  discard
-    await self.api.sendChallengeCompleted(chalURL, self.key, await self.getOrInitKid())
+  proc getCertificate*(
+      self: ACMEClient, domain: api.Domain, challenge: ACMEChallengeResponseWrapper
+  ): Future[ACMECertificateResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+    let chalURL = parseUri(challenge.dns01.url)
+    let orderURL = parseUri(challenge.order)
+    let finalizeURL = parseUri(challenge.finalize)
+    trace "sending challenge completed notification"
+    discard await self.api.sendChallengeCompleted(
+      chalURL, self.key, await self.getOrInitKid()
+    )
 
-  trace "checking for completed challenge"
-  let completed =
-    await self.api.checkChallengeCompleted(chalURL, self.key, await self.getOrInitKid())
-  if not completed:
-    raise
-      newException(ACMEError, "Failed to signal ACME server about challenge completion")
+    trace "checking for completed challenge"
+    let completed = await self.api.checkChallengeCompleted(
+      chalURL, self.key, await self.getOrInitKid()
+    )
+    if not completed:
+      raise newException(
+        ACMEError, "Failed to signal ACME server about challenge completion"
+      )
 
-  trace "waiting for certificate to be finalized"
-  let finalized = await self.api.certificateFinalized(
-    domain, finalizeURL, orderURL, self.key, await self.getOrInitKid()
-  )
-  if not finalized:
-    raise newException(ACMEError, "Failed to finalize certificate for domain " & domain)
+    trace "waiting for certificate to be finalized"
+    let finalized = await self.api.certificateFinalized(
+      domain, finalizeURL, orderURL, self.key, await self.getOrInitKid()
+    )
+    if not finalized:
+      raise
+        newException(ACMEError, "Failed to finalize certificate for domain " & domain)
 
-  trace "downloading certificate"
-  await self.api.downloadCertificate(orderURL)
+    trace "downloading certificate"
+    await self.api.downloadCertificate(orderURL)
 
-proc close*(self: ACMEClient) {.async: (raises: [CancelledError]).} =
-  await self.api.close()
+  proc close*(self: ACMEClient) {.async: (raises: [CancelledError]).} =
+    await self.api.close()

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -10,217 +10,226 @@
 {.push raises: [].}
 {.push public.}
 
-import net, results, json, sequtils
+when defined(libp2p_autotls_support):
+  import net, results, json, sequtils
 
-import chronos/apps/http/httpclient, chronos, chronicles, bearssl/rand
+  import chronos/apps/http/httpclient, chronos, chronicles, bearssl/rand
 
-import
-  ./acme/client,
-  ./utils,
-  ../crypto/crypto,
-  ../nameresolving/dnsresolver,
-  ../peeridauth/client,
-  ../peerinfo,
-  ../switch,
-  ../utils/heartbeat,
-  ../wire
+  import
+    ./acme/client,
+    ./utils,
+    ../crypto/crypto,
+    ../nameresolving/dnsresolver,
+    ../peeridauth/client,
+    ../peerinfo,
+    ../switch,
+    ../utils/heartbeat,
+    ../wire
 
-logScope:
-  topics = "libp2p autotls"
+  logScope:
+    topics = "libp2p autotls"
 
-export LetsEncryptURL, AutoTLSError
+  export LetsEncryptURL, AutoTLSError
 
-const
-  DefaultDnsServers* =
-    @[
-      initTAddress("1.1.1.1:53"),
-      initTAddress("1.0.0.1:53"),
-      initTAddress("[2606:4700:4700::1111]:53"),
-    ]
-  DefaultRenewCheckTime* = 1.hours
-  DefaultRenewBufferTime = 1.hours
+  const
+    DefaultDnsServers* =
+      @[
+        initTAddress("1.1.1.1:53"),
+        initTAddress("1.0.0.1:53"),
+        initTAddress("[2606:4700:4700::1111]:53"),
+      ]
+    DefaultRenewCheckTime* = 1.hours
+    DefaultRenewBufferTime = 1.hours
 
-  AutoTLSBroker* = "registration.libp2p.direct"
-  AutoTLSDNSServer* = "libp2p.direct"
-  HttpOk* = 200
-  HttpCreated* = 201
-  # NoneIp is needed because nim 1.6.16 can't do proper generic inference
-  NoneIp = Opt.none(IpAddress)
+    AutoTLSBroker* = "registration.libp2p.direct"
+    AutoTLSDNSServer* = "libp2p.direct"
+    HttpOk* = 200
+    HttpCreated* = 201
+    # NoneIp is needed because nim 1.6.16 can't do proper generic inference
+    NoneIp = Opt.none(IpAddress)
 
-type SigParam = object
-  k: string
-  v: seq[byte]
+  type SigParam = object
+    k: string
+    v: seq[byte]
 
-type AutotlsCert* = ref object
-  cert*: TLSCertificate
-  expiry*: Moment
+  type AutotlsCert* = ref object
+    cert*: TLSCertificate
+    expiry*: Moment
 
-type AutotlsConfig* = ref object
-  acmeServerURL*: Uri
-  dnsResolver*: DnsResolver
-  ipAddress: Opt[IpAddress]
-  renewCheckTime*: Duration
-  renewBufferTime*: Duration
+  type AutotlsConfig* = ref object
+    acmeServerURL*: Uri
+    dnsResolver*: DnsResolver
+    ipAddress: Opt[IpAddress]
+    renewCheckTime*: Duration
+    renewBufferTime*: Duration
 
-type AutotlsService* = ref object of Service
-  acmeClient: ACMEClient
-  bearer*: Opt[BearerToken]
-  brokerClient: PeerIDAuthClient
-  cert*: Opt[AutotlsCert]
-  certReady*: AsyncEvent
-  config: AutotlsConfig
-  managerFut: Future[void]
-  peerInfo: PeerInfo
-  rng: ref HmacDrbgContext
+  type AutotlsService* = ref object of Service
+    acmeClient: ACMEClient
+    bearer*: Opt[BearerToken]
+    brokerClient: PeerIDAuthClient
+    cert*: Opt[AutotlsCert]
+    certReady*: AsyncEvent
+    config: AutotlsConfig
+    managerFut: Future[void]
+    peerInfo: PeerInfo
+    rng: ref HmacDrbgContext
 
-proc new*(T: typedesc[AutotlsCert], cert: TLSCertificate, expiry: Moment): T =
-  T(cert: cert, expiry: expiry)
+  proc new*(T: typedesc[AutotlsCert], cert: TLSCertificate, expiry: Moment): T =
+    T(cert: cert, expiry: expiry)
 
-proc getCertWhenReady*(
-    self: AutotlsService
-): Future[TLSCertificate] {.async: (raises: [AutoTLSError, CancelledError]).} =
-  await self.certReady.wait()
-  return self.cert.get.cert
+  proc getCertWhenReady*(
+      self: AutotlsService
+  ): Future[TLSCertificate] {.async: (raises: [AutoTLSError, CancelledError]).} =
+    await self.certReady.wait()
+    return self.cert.get.cert
 
-proc new*(
-    T: typedesc[AutotlsConfig],
-    ipAddress: Opt[IpAddress] = NoneIp,
-    nameServers: seq[TransportAddress] = DefaultDnsServers,
-    acmeServerURL: Uri = parseUri(LetsEncryptURL),
-    renewCheckTime: Duration = DefaultRenewCheckTime,
-    renewBufferTime: Duration = DefaultRenewBufferTime,
-): T =
-  T(
-    dnsResolver: DnsResolver.new(nameServers),
-    acmeServerURL: acmeServerURL,
-    ipAddress: ipAddress,
-    renewCheckTime: renewCheckTime,
-    renewBufferTime: renewBufferTime,
-  )
-
-proc new*(
-    T: typedesc[AutotlsService],
-    rng: ref HmacDrbgContext = newRng(),
-    config: AutotlsConfig = AutotlsConfig.new(),
-): T =
-  T(
-    acmeClient: ACMEClient.new(api = ACMEApi.new(acmeServerURL = config.acmeServerURL)),
-    brokerClient: PeerIDAuthClient.new(),
-    bearer: Opt.none(BearerToken),
-    cert: Opt.none(AutotlsCert),
-    certReady: newAsyncEvent(),
-    config: config,
-    managerFut: nil,
-    peerInfo: nil,
-    rng: rng,
-  )
-
-method setup*(
-    self: AutotlsService, switch: Switch
-): Future[bool] {.async: (raises: [CancelledError]).} =
-  trace "Setting up AutotlsService"
-  let hasBeenSetup = await procCall Service(self).setup(switch)
-  if hasBeenSetup:
-    self.peerInfo = switch.peerInfo
-    if self.config.ipAddress.isNone():
-      try:
-        self.config.ipAddress = Opt.some(getPublicIPAddress())
-      except AutoTLSError as exc:
-        error "Failed to get public IP address", err = exc.msg
-        return false
-    self.managerFut = self.run(switch)
-  return hasBeenSetup
-
-method issueCertificate(
-    self: AutotlsService
-) {.base, async: (raises: [AutoTLSError, ACMEError, PeerIDAuthError, CancelledError]).} =
-  trace "Issuing certificate"
-
-  assert not self.peerInfo.isNil(), "Cannot issue new certificate: peerInfo not set"
-
-  # generate autotls domain string: "*.{peerID}.libp2p.direct"
-  let baseDomain =
-    api.Domain(encodePeerId(self.peerInfo.peerId) & "." & AutoTLSDNSServer)
-  let domain = api.Domain("*." & baseDomain)
-
-  let acmeClient = self.acmeClient
-
-  trace "Requesting ACME challenge"
-  let dns01Challenge = await acmeClient.getChallenge(@[domain])
-  let keyAuth = acmeClient.genKeyAuthorization(dns01Challenge.dns01.token)
-  let strMultiaddresses: seq[string] = self.peerInfo.addrs.mapIt($it)
-  let payload = %*{"value": keyAuth, "addresses": strMultiaddresses}
-  let registrationURL = parseUri("https://" & AutoTLSBroker & "/v1/_acme-challenge")
-
-  trace "Sending challenge to AutoTLS broker"
-  let (bearer, response) =
-    await self.brokerClient.send(registrationURL, self.peerInfo, payload, self.bearer)
-  if self.bearer.isNone():
-    # save bearer token for future
-    self.bearer = Opt.some(bearer)
-  if response.status != HttpOk:
-    raise newException(
-      AutoTLSError, "Failed to authenticate with AutoTLS Broker at " & AutoTLSBroker
+  proc new*(
+      T: typedesc[AutotlsConfig],
+      ipAddress: Opt[IpAddress] = NoneIp,
+      nameServers: seq[TransportAddress] = DefaultDnsServers,
+      acmeServerURL: Uri = parseUri(LetsEncryptURL),
+      renewCheckTime: Duration = DefaultRenewCheckTime,
+      renewBufferTime: Duration = DefaultRenewBufferTime,
+  ): T =
+    T(
+      dnsResolver: DnsResolver.new(nameServers),
+      acmeServerURL: acmeServerURL,
+      ipAddress: ipAddress,
+      renewCheckTime: renewCheckTime,
+      renewBufferTime: renewBufferTime,
     )
 
-  debug "Waiting for DNS record to be set"
-  let dnsSet = await checkDNSRecords(
-    self.config.dnsResolver, self.config.ipAddress.get(), baseDomain, keyAuth
-  )
-  if not dnsSet:
-    raise newException(AutoTLSError, "DNS records not set")
+  proc new*(
+      T: typedesc[AutotlsService],
+      rng: ref HmacDrbgContext = newRng(),
+      config: AutotlsConfig = AutotlsConfig.new(),
+  ): T =
+    T(
+      acmeClient:
+        ACMEClient.new(api = ACMEApi.new(acmeServerURL = config.acmeServerURL)),
+      brokerClient: PeerIDAuthClient.new(),
+      bearer: Opt.none(BearerToken),
+      cert: Opt.none(AutotlsCert),
+      certReady: newAsyncEvent(),
+      config: config,
+      managerFut: nil,
+      peerInfo: nil,
+      rng: rng,
+    )
 
-  debug "Notifying challenge completion to ACME and downloading cert"
-  let certResponse = await acmeClient.getCertificate(domain, dns01Challenge)
+  method setup*(
+      self: AutotlsService, switch: Switch
+  ): Future[bool] {.async: (raises: [CancelledError]).} =
+    trace "Setting up AutotlsService"
+    let hasBeenSetup = await procCall Service(self).setup(switch)
+    if hasBeenSetup:
+      self.peerInfo = switch.peerInfo
+      if self.config.ipAddress.isNone():
+        try:
+          self.config.ipAddress = Opt.some(getPublicIPAddress())
+        except AutoTLSError as exc:
+          error "Failed to get public IP address", err = exc.msg
+          return false
+      self.managerFut = self.run(switch)
+    return hasBeenSetup
 
-  debug "Installing certificate"
-  let newCert =
-    try:
-      AutotlsCert.new(
-        TLSCertificate.init(certResponse.rawCertificate),
-        asMoment(certResponse.certificateExpiry),
+  method issueCertificate(
+      self: AutotlsService
+  ) {.
+      base, async: (raises: [AutoTLSError, ACMEError, PeerIDAuthError, CancelledError])
+  .} =
+    trace "Issuing certificate"
+
+    assert not self.peerInfo.isNil(), "Cannot issue new certificate: peerInfo not set"
+
+    # generate autotls domain string: "*.{peerID}.libp2p.direct"
+    let baseDomain =
+      api.Domain(encodePeerId(self.peerInfo.peerId) & "." & AutoTLSDNSServer)
+    let domain = api.Domain("*." & baseDomain)
+
+    let acmeClient = self.acmeClient
+
+    trace "Requesting ACME challenge"
+    let dns01Challenge = await acmeClient.getChallenge(@[domain])
+    let keyAuth = acmeClient.genKeyAuthorization(dns01Challenge.dns01.token)
+    let strMultiaddresses: seq[string] = self.peerInfo.addrs.mapIt($it)
+    let payload = %*{"value": keyAuth, "addresses": strMultiaddresses}
+    let registrationURL = parseUri("https://" & AutoTLSBroker & "/v1/_acme-challenge")
+
+    trace "Sending challenge to AutoTLS broker"
+    let (bearer, response) =
+      await self.brokerClient.send(registrationURL, self.peerInfo, payload, self.bearer)
+    if self.bearer.isNone():
+      # save bearer token for future
+      self.bearer = Opt.some(bearer)
+    if response.status != HttpOk:
+      raise newException(
+        AutoTLSError, "Failed to authenticate with AutoTLS Broker at " & AutoTLSBroker
       )
-    except TLSStreamProtocolError:
-      raise newException(AutoTLSError, "Could not parse downloaded certificates")
-  self.cert = Opt.some(newCert)
-  self.certReady.fire()
-  debug "Certificate installed"
 
-method run*(
-    self: AutotlsService, switch: Switch
-) {.async: (raises: [CancelledError]).} =
-  heartbeat "Certificate Management", self.config.renewCheckTime:
-    if self.cert.isNone():
+    debug "Waiting for DNS record to be set"
+    let dnsSet = await checkDNSRecords(
+      self.config.dnsResolver, self.config.ipAddress.get(), baseDomain, keyAuth
+    )
+    if not dnsSet:
+      raise newException(AutoTLSError, "DNS records not set")
+
+    debug "Notifying challenge completion to ACME and downloading cert"
+    let certResponse = await acmeClient.getCertificate(domain, dns01Challenge)
+
+    debug "Installing certificate"
+    let newCert =
       try:
-        await self.issueCertificate()
-      except CancelledError as exc:
-        raise exc
-      except CatchableError as exc:
-        error "Failed to issue certificate", err = exc.msg
-        break
+        AutotlsCert.new(
+          TLSCertificate.init(certResponse.rawCertificate),
+          asMoment(certResponse.certificateExpiry),
+        )
+      except TLSStreamProtocolError:
+        raise newException(AutoTLSError, "Could not parse downloaded certificates")
+    self.cert = Opt.some(newCert)
+    self.certReady.fire()
+    debug "Certificate installed"
 
-    # AutotlsService will renew the cert 1h before it expires
-    let cert = self.cert.get
-    let waitTime = cert.expiry - Moment.now - self.config.renewBufferTime
-    if waitTime <= self.config.renewBufferTime:
-      try:
-        await self.issueCertificate()
-      except CancelledError as exc:
-        raise exc
-      except CatchableError as exc:
-        error "Failed to renew certificate", err = exc.msg
-        break
+  method run*(
+      self: AutotlsService, switch: Switch
+  ) {.async: (raises: [CancelledError]).} =
+    heartbeat "Certificate Management", self.config.renewCheckTime:
+      if self.cert.isNone():
+        try:
+          await self.issueCertificate()
+        except CancelledError as exc:
+          raise exc
+        except CatchableError as exc:
+          error "Failed to issue certificate", err = exc.msg
+          break
 
-method stop*(
-    self: AutotlsService, switch: Switch
-): Future[bool] {.async: (raises: [CancelledError]).} =
-  let hasBeenStopped = await procCall Service(self).stop(switch)
-  if hasBeenStopped:
-    if not self.acmeClient.isNil():
-      await self.acmeClient.close()
-    if not self.brokerClient.isNil():
-      await self.brokerClient.close()
-    if not self.managerFut.isNil():
-      await self.managerFut.cancelAndWait()
-      self.managerFut = nil
-  return hasBeenStopped
+      # AutotlsService will renew the cert 1h before it expires
+      let cert = self.cert.get
+      let waitTime = cert.expiry - Moment.now - self.config.renewBufferTime
+      if waitTime <= self.config.renewBufferTime:
+        try:
+          await self.issueCertificate()
+        except CancelledError as exc:
+          raise exc
+        except CatchableError as exc:
+          error "Failed to renew certificate", err = exc.msg
+          break
+
+  method stop*(
+      self: AutotlsService, switch: Switch
+  ): Future[bool] {.async: (raises: [CancelledError]).} =
+    let hasBeenStopped = await procCall Service(self).stop(switch)
+    if hasBeenStopped:
+      if not self.acmeClient.isNil():
+        await self.acmeClient.close()
+      if not self.brokerClient.isNil():
+        await self.brokerClient.close()
+      if not self.managerFut.isNil():
+        await self.managerFut.cancelAndWait()
+        self.managerFut = nil
+    return hasBeenStopped
+
+else:
+  import ../switch
+  # Placeholder
+  type AutotlsService* = ref object of Service

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -6,104 +6,105 @@
 # at your option.
 # This file may not be copied, modified, or distributed except according to
 # those terms.
+when defined(libp2p_autotls_support):
+  {.push raises: [].}
+  {.push public.}
 
-{.push raises: [].}
-{.push public.}
+  import net, strutils
+  from times import DateTime, toTime, toUnix
 
-import net, strutils
-from times import DateTime, toTime, toUnix
+  import chronos, stew/base36, chronicles
 
-import chronos, stew/base36, chronicles
+  import
+    ../errors,
+    ../peerid,
+    ../multihash,
+    ../cid,
+    ../multicodec,
+    ../nameresolving/dnsresolver,
+    ./acme/client
 
-import
-  ./acme/client,
-  ../errors,
-  ../peerid,
-  ../multihash,
-  ../cid,
-  ../multicodec,
-  ../nameresolving/dnsresolver
+  const
+    DefaultDnsRetries = 10
+    DefaultDnsRetryTime = 1.seconds
 
-const
-  DefaultDnsRetries = 10
-  DefaultDnsRetryTime = 1.seconds
+  type AutoTLSError* = object of LPError
 
-type AutoTLSError* = object of LPError
-
-proc checkedGetPrimaryIPAddr*(): IpAddress {.raises: [AutoTLSError].} =
-  # This is so that we don't need to catch Exceptions directly
-  # since we support 1.6.16 and getPrimaryIPAddr before nim 2 didn't have explicit .raises. pragmas
-  try:
-    return getPrimaryIPAddr()
-  except Exception as exc:
-    raise newException(AutoTLSError, "Error while getting primary IP address", exc)
-
-proc isIPv4*(ip: IpAddress): bool =
-  ip.family == IpAddressFamily.IPv4
-
-proc isPublic*(ip: IpAddress): bool {.raises: [AutoTLSError].} =
-  let ip = $ip
-  try:
-    not (
-      ip.startsWith("10.") or
-      (ip.startsWith("172.") and parseInt(ip.split(".")[1]) in 16 .. 31) or
-      ip.startsWith("192.168.") or ip.startsWith("127.") or ip.startsWith("169.254.")
-    )
-  except ValueError as exc:
-    raise newException(AutoTLSError, "Failed to parse IP address", exc)
-
-proc getPublicIPAddress*(): IpAddress {.raises: [AutoTLSError].} =
-  let ip = checkedGetPrimaryIPAddr()
-  if not ip.isIPv4():
-    raise newException(AutoTLSError, "Host does not have an IPv4 address")
-  if not ip.isPublic():
-    raise newException(AutoTLSError, "Host does not have a public IPv4 address")
-  return ip
-
-proc asMoment*(dt: DateTime): Moment =
-  let unixTime: int64 = dt.toTime.toUnix
-  return Moment.init(unixTime, Second)
-
-proc encodePeerId*(peerId: PeerId): string {.raises: [AutoTLSError].} =
-  var mh: MultiHash
-  let decodeResult = MultiHash.decode(peerId.data, mh)
-  if decodeResult.isErr() or decodeResult.get() == -1:
-    raise
-      newException(AutoTLSError, "Failed to decode PeerId: invalid multihash format")
-
-  let cidResult = Cid.init(CIDv1, multiCodec("libp2p-key"), mh)
-  if cidResult.isErr():
-    raise newException(AutoTLSError, "Failed to initialize CID from multihash")
-
-  return Base36.encode(cidResult.get().data.buffer)
-
-proc checkDNSRecords*(
-    dnsResolver: DnsResolver,
-    ipAddress: IpAddress,
-    baseDomain: api.Domain,
-    keyAuth: KeyAuthorization,
-    retries: int = DefaultDnsRetries,
-): Future[bool] {.async: (raises: [AutoTLSError, CancelledError]).} =
-  # if my ip address is 100.10.10.3 then the ip4Domain will be:
-  #     100-10-10-3.{peerIdBase36}.libp2p.direct
-  # and acme challenge TXT domain will be:
-  #     _acme-challenge.{peerIdBase36}.libp2p.direct
-  let dashedIpAddr = ($ipAddress).replace(".", "-")
-  let acmeChalDomain = api.Domain("_acme-challenge." & baseDomain)
-  let ip4Domain = api.Domain(dashedIpAddr & "." & baseDomain)
-
-  var txt: seq[string]
-  var ip4: seq[TransportAddress]
-  for _ in 0 .. retries:
-    txt = await dnsResolver.resolveTxt(acmeChalDomain)
+  proc checkedGetPrimaryIPAddr*(): IpAddress {.raises: [AutoTLSError].} =
+    # This is so that we don't need to catch Exceptions directly
+    # since we support 1.6.16 and getPrimaryIPAddr before nim 2 didn't have explicit .raises. pragmas
     try:
-      ip4 = await dnsResolver.resolveIp(ip4Domain, 0.Port)
-    except CancelledError as exc:
-      raise exc
-    except CatchableError as exc:
-      error "Failed to resolve IP", description = exc.msg # retry
-  if txt.len > 0 and txt[0] == keyAuth and ip4.len > 0:
-    return true
-  await sleepAsync(DefaultDnsRetryTime)
+      return getPrimaryIPAddr()
+    except Exception as exc:
+      raise newException(AutoTLSError, "Error while getting primary IP address", exc)
 
-  return false
+  proc isIPv4*(ip: IpAddress): bool =
+    ip.family == IpAddressFamily.IPv4
+
+  proc isPublic*(ip: IpAddress): bool {.raises: [AutoTLSError].} =
+    let ip = $ip
+    try:
+      not (
+        ip.startsWith("10.") or
+        (ip.startsWith("172.") and parseInt(ip.split(".")[1]) in 16 .. 31) or
+        ip.startsWith("192.168.") or ip.startsWith("127.") or ip.startsWith("169.254.")
+      )
+    except ValueError as exc:
+      raise newException(AutoTLSError, "Failed to parse IP address", exc)
+
+  proc getPublicIPAddress*(): IpAddress {.raises: [AutoTLSError].} =
+    let ip = checkedGetPrimaryIPAddr()
+    if not ip.isIPv4():
+      raise newException(AutoTLSError, "Host does not have an IPv4 address")
+    if not ip.isPublic():
+      raise newException(AutoTLSError, "Host does not have a public IPv4 address")
+    return ip
+
+  proc asMoment*(dt: DateTime): Moment =
+    let unixTime: int64 = dt.toTime.toUnix
+    return Moment.init(unixTime, Second)
+
+  proc encodePeerId*(peerId: PeerId): string {.raises: [AutoTLSError].} =
+    var mh: MultiHash
+    let decodeResult = MultiHash.decode(peerId.data, mh)
+    if decodeResult.isErr() or decodeResult.get() == -1:
+      raise
+        newException(AutoTLSError, "Failed to decode PeerId: invalid multihash format")
+
+    let cidResult = Cid.init(CIDv1, multiCodec("libp2p-key"), mh)
+    if cidResult.isErr():
+      raise newException(AutoTLSError, "Failed to initialize CID from multihash")
+
+    return Base36.encode(cidResult.get().data.buffer)
+
+  when defined(libp2p_autotls_support):
+    proc checkDNSRecords*(
+        dnsResolver: DnsResolver,
+        ipAddress: IpAddress,
+        baseDomain: api.Domain,
+        keyAuth: KeyAuthorization,
+        retries: int = DefaultDnsRetries,
+    ): Future[bool] {.async: (raises: [AutoTLSError, CancelledError]).} =
+      # if my ip address is 100.10.10.3 then the ip4Domain will be:
+      #     100-10-10-3.{peerIdBase36}.libp2p.direct
+      # and acme challenge TXT domain will be:
+      #     _acme-challenge.{peerIdBase36}.libp2p.direct
+      let dashedIpAddr = ($ipAddress).replace(".", "-")
+      let acmeChalDomain = api.Domain("_acme-challenge." & baseDomain)
+      let ip4Domain = api.Domain(dashedIpAddr & "." & baseDomain)
+
+      var txt: seq[string]
+      var ip4: seq[TransportAddress]
+      for _ in 0 .. retries:
+        txt = await dnsResolver.resolveTxt(acmeChalDomain)
+        try:
+          ip4 = await dnsResolver.resolveIp(ip4Domain, 0.Port)
+        except CancelledError as exc:
+          raise exc
+        except CatchableError as exc:
+          error "Failed to resolve IP", description = exc.msg # retry
+      if txt.len > 0 and txt[0] == keyAuth and ip4.len > 0:
+        return true
+      await sleepAsync(DefaultDnsRetryTime)
+
+      return false

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -257,11 +257,12 @@ proc withAutonat*(b: SwitchBuilder): SwitchBuilder =
   b.autonat = true
   b
 
-proc withAutotls*(
-    b: SwitchBuilder, config: AutotlsConfig = AutotlsConfig.new()
-): SwitchBuilder {.public.} =
-  b.autotls = AutotlsService.new(config = config)
-  b
+when defined(libp2p_autotls_support):
+  proc withAutotls*(
+      b: SwitchBuilder, config: AutotlsConfig = AutotlsConfig.new()
+  ): SwitchBuilder {.public.} =
+    b.autotls = AutotlsService.new(config = config)
+    b
 
 proc withCircuitRelay*(b: SwitchBuilder, r: Relay = Relay.new()): SwitchBuilder =
   b.circuitRelay = r

--- a/tests/testintegration.nim
+++ b/tests/testintegration.nim
@@ -10,4 +10,5 @@ when defined(linux) and defined(amd64):
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-import testpeeridauth_integration, testautotls_integration
+when defined(libp2p_autotls_support):
+  import testpeeridauth_integration, testautotls_integration

--- a/tests/testnative.nim
+++ b/tests/testnative.nim
@@ -28,10 +28,13 @@ import
   transports/tls/testcertificate
 
 import
-  testautotls, testnameresolve, testmultistream, testbufferstream, testidentify,
+  testnameresolve, testmultistream, testbufferstream, testidentify,
   testobservedaddrmanager, testconnmngr, testswitch, testnoise, testpeerinfo,
   testpeerstore, testping, testmplex, testrelayv1, testrelayv2, testrendezvous,
   testdiscovery, testyamux, testautonat, testautonatservice, testautorelay, testdcutr,
   testhpservice, testutility, testhelpers, testwildcardresolverservice, testperf
 
 import kademlia/[testencoding, testroutingtable]
+
+when defined(libp2p_autotls_support):
+  import testautotls


### PR DESCRIPTION
Adds a `-d:libp2p_autotls_support` flag to enable the usage of AutoTLS
As suggested by @arnetheduck, we're disabling this feature, as any additional dependency is a potential security issue.
cc: @tersec 