### PR TITLE
fix: avoid raw async methods

### DIFF
--- a/libp2p/protocols/connectivity/relay/utils.nim
+++ b/libp2p/protocols/connectivity/relay/utils.nim
@@ -36,21 +36,21 @@ proc sendStatus*(
 
 proc sendHopStatus*(
     conn: Connection, code: StatusV2
-) {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
+) {.async: (raises: [CancelledError, LPStreamError]).} =
   trace "send hop relay/v2 status", status = $code & "(" & $ord(code) & ")"
   let
     msg = HopMessage(msgType: HopMessageType.Status, status: Opt.some(code))
     pb = encode(msg)
-  conn.writeLp(pb.buffer)
+  await conn.writeLp(pb.buffer)
 
 proc sendStopStatus*(
     conn: Connection, code: StatusV2
-) {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
+) {.async: (raises: [CancelledError, LPStreamError]).} =
   trace "send stop relay/v2 status", status = $code & " (" & $ord(code) & ")"
   let
     msg = StopMessage(msgType: StopMessageType.Status, status: Opt.some(code))
     pb = encode(msg)
-  conn.writeLp(pb.buffer)
+  await conn.writeLp(pb.buffer)
 
 proc bridge*(
     connSrc: Connection, connDst: Connection


### PR DESCRIPTION
## Description

Simple PR to encourage minimize the use of `raw: true` methods/procs as much as possible.

According to [this](https://status-im.github.io/nim-chronos/async_procs.html#raw-async-procedures), the `raw: true` technique bypasses the `async` transformation performed by the the compiler. Then, when using `raw: true`, the returned `Future[T]` should be _manually_ completed or failed. Making the code prone to errors because is very easy to overlook any detail.

Also, notice that the `raw: true` bypasses the usual `Future` exception handling, leading to unattended exceptions. Therefore, the following `await msgFut` ( await writeLp(...) ) can throw an exception that may not be caught properly: https://github.com/vacp2p/nim-libp2p/blob/eee8341ad2fdf9cb2b4258eefd282026eeb56297/libp2p/protocols/pubsub/pubsubpeer.nim#L357

..which in turn I think is the first candidate to lead to the memory issues described by @NagyZoltanPeter in
- https://github.com/waku-org/nwaku/issues/3496

-------

Besides, and according to [nim-chronos docs](https://status-im.github.io/nim-chronos/async_procs.html#raw-async-procedures), the `raw: true` procs/methods should not raise any exception for the reason exposed above.

-------

Summarizing, let's avoid using `raw: true` as much as possible :)

