### PR TITLE
fix(quic): add getWrapped method for QuicStream

### DIFF
--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -42,6 +42,9 @@ proc new(
   procCall P2PConnection(quicstream).initStream()
   quicstream
 
+method getWrapped*(self: QuicStream): P2PConnection =
+  nil
+
 template mapExceptions(body: untyped) =
   try:
     body


### PR DESCRIPTION
node using quic transport was crashing with:

```
Unhandled defect: [Connection.getWrapped] abstract method not implemented! [AssertionDefect]
```

because `QuicStream` did not had `getWrapped` method specified