### PR TITLE
chore(ci): initial flake.nix file with dev shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ git clone https://github.com/vacp2p/nim-libp2p
 cd nim-libp2p
 nimble install -dy
 ```
+You can use `nix develop` to start a shell with Nim and Nimble.
 ### Testing
 Run unit tests:
 ```sh

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1752620740,
+        "narHash": "sha256-f3pO+9lg66mV7IMmmIqG4PL3223TYMlnlw+pnpelbss=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "32a4e87942101f1c9f9865e04dc3ddb175f5f32e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "nim-libp2p dev shell flake";
+
+  nixConfig = {
+    extra-substituters = [ "https://nix-cache.status.im/" ];
+    extra-trusted-public-keys = [ "nix-cache.status.im-1:x/93lOfLU+duPplwMSBR+OlY4+mo+dCN7n0mr4oPwgY=" ];
+  };
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      stableSystems = [
+        "x86_64-linux" "aarch64-linux" "armv7a-linux"
+        "x86_64-darwin" "aarch64-darwin"
+        "x86_64-windows"
+      ];
+      forEach = nixpkgs.lib.genAttrs;
+      forAllSystems = forEach stableSystems;
+      pkgsFor = forEach stableSystems (
+        system: import nixpkgs { inherit system; }
+      );
+    in rec {
+      devShells = forAllSystems (system: {
+        default = pkgsFor.${system}.mkShell {
+          nativeBuildInputs = with pkgsFor.${system}; [
+            nim-2_2 nimble openssl.dev
+          ];
+        };
+      });
+    };
+}


### PR DESCRIPTION
Not much: only adds the openssl dependencies needed.

I have my nim and nimble requirements setup in my system configuration, hence why it's not in here.

For now, this is only really useful for _me_, but it can eventually becoming a powerful tool.

For example, with tho go daemon dependency, if that is put into the flake for a testing shell, anyone with a `nix` package manager (not neccisarily nixos), would be able to run `nix develop testing`, or something to that effect, and everything is automagically ready to run `nimble test`: all the dependencies (openssl, nim, nimble, go deamon, etc) are _just there_