### PR TITLE
chore: add TransportConfig

### DIFF
--- a/libp2p/transports/tortransport.nim
+++ b/libp2p/transports/tortransport.nim
@@ -18,7 +18,6 @@ import
   transport,
   tcptransport,
   ../switch,
-  ../autotls/service,
   ../builders,
   ../stream/[lpstream, connection, chronosstream],
   ../multiaddress,
@@ -304,7 +303,7 @@ proc new*(
     flags: set[ServerFlags] = {},
 ): TorSwitch {.raises: [LPError], public.} =
   var builder = SwitchBuilder.new().withRng(rng).withTransport(
-      proc(upgr: Upgrade, privateKey: PrivateKey, autotls: AutotlsService): Transport =
+      proc(upgr: Upgrade, privateKey: PrivateKey, config: TransportConfig): Transport =
         TorTransport.new(torServer, flags, upgr)
     )
   if addresses.len != 0:

--- a/tests/commoninterop.nim
+++ b/tests/commoninterop.nim
@@ -1,16 +1,14 @@
 import chronos, chronicles, stew/byteutils
 import helpers
 import ../libp2p
-import
-  ../libp2p/
-    [autotls/service, daemon/daemonapi, varint, transports/wstransport, crypto/crypto]
+import ../libp2p/[daemon/daemonapi, varint, transports/wstransport, crypto/crypto]
 import ../libp2p/protocols/connectivity/relay/[relay, client, utils]
 
 type
   SwitchCreator = proc(
     ma: MultiAddress = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet(),
     prov: TransportProvider = proc(
-        upgr: Upgrade, privateKey: PrivateKey, autotls: AutotlsService
+        upgr: Upgrade, privateKey: PrivateKey, config: TransportConfig
     ): Transport =
       TcpTransport.new({}, upgr),
     relay: Relay = Relay.new(circuitRelayV1 = true),
@@ -323,7 +321,7 @@ proc commonInteropTests*(name: string, swCreator: SwitchCreator) =
       let nativeNode = swCreator(
         ma = wsAddress,
         prov = proc(
-            upgr: Upgrade, privateKey: PrivateKey, autotls: AutotlsService
+            upgr: Upgrade, privateKey: PrivateKey, config: TransportConfig
         ): Transport =
           WsTransport.new(upgr),
       )

--- a/tests/testinterop.nim
+++ b/tests/testinterop.nim
@@ -2,13 +2,12 @@
 
 import helpers, commoninterop
 import ../libp2p
-import ../libp2p/autotls/service
 import ../libp2p/crypto/crypto, ../libp2p/protocols/connectivity/relay/relay
 
 proc switchMplexCreator(
     ma: MultiAddress = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet(),
     prov: TransportProvider = proc(
-        upgr: Upgrade, privateKey: PrivateKey, autotls: AutotlsService
+        upgr: Upgrade, privateKey: PrivateKey, config: TransportConfig
     ): Transport =
       TcpTransport.new({}, upgr),
     relay: Relay = Relay.new(circuitRelayV1 = true),
@@ -33,7 +32,7 @@ proc switchMplexCreator(
 proc switchYamuxCreator(
     ma: MultiAddress = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet(),
     prov: TransportProvider = proc(
-        upgr: Upgrade, privateKey: PrivateKey, autotls: AutotlsService
+        upgr: Upgrade, privateKey: PrivateKey, config: TransportConfig
     ): Transport =
       TcpTransport.new({}, upgr),
     relay: Relay = Relay.new(circuitRelayV1 = true),

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -14,7 +14,6 @@ import chronos
 import stew/byteutils
 import
   ../libp2p/[
-    autotls/service,
     errors,
     dial,
     switch,
@@ -996,7 +995,7 @@ suite "Switch":
         .withMplex()
         .withTransport(
           proc(
-              upgr: Upgrade, privateKey: PrivateKey, autotls: AutotlsService
+              upgr: Upgrade, privateKey: PrivateKey, config: TransportConfig
           ): Transport =
             WsTransport.new(upgr)
         )
@@ -1011,7 +1010,7 @@ suite "Switch":
         .withMplex()
         .withTransport(
           proc(
-              upgr: Upgrade, privateKey: PrivateKey, autotls: AutotlsService
+              upgr: Upgrade, privateKey: PrivateKey, config: TransportConfig
           ): Transport =
             WsTransport.new(upgr)
         )


### PR DESCRIPTION
This should be merged before https://github.com/vacp2p/nim-libp2p/pull/1539, which will then build on top of this to introduce `Opt`s in order to avoid `nil` checking.