### PR TITLE
fix: typo on startAt

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -890,7 +890,7 @@ method publish*(
 
   let pubParams = publishParams.get(PublishParams())
 
-  let peers =
+  var peers =
     if pubParams.useCustomConn:
       g.makePeersForPublishUsingCustomConn(topic)
     else:

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -948,7 +948,7 @@ when defined(libp2p_gossipsub_1_4):
           let expires = starts + transmissionTimeMs.milliseconds
 
           # Setting new data before reinserting the preamble
-          expiredOngoingReceive.startAt = starts
+          expiredOngoingReceive.startsAt = starts
           expiredOngoingReceive.expiresAt = expires
           expiredOngoingReceive.sender = peer
           g.ongoingIWantReceives[expiredOngoingReceive.messageId] =

--- a/tests/pubsub/testpreamblestore.nim
+++ b/tests/pubsub/testpreamblestore.nim
@@ -56,13 +56,16 @@ suite "preamble store":
       let p = mockPreamble(id, peer, 0.seconds, i.seconds)
       store.insert(id, p)
 
-    var last = Moment.low()
+    var lastExpiresAt = Moment.low()
+    var lastStartsAt = Moment.low()
     while true:
       let popped = store.popExpired(Moment.now() + 20.seconds)
       if popped.isNone:
         break
-      check popped.get().expiresAt >= last
-      last = popped.get().expiresAt
+      check popped.get().expiresAt >= lastExpiresAt
+      lastExpiresAt = popped.get().expiresAt
+      check popped.get().startsAt >= lastStartsAt
+      lastStartsAt = popped.get().startsAt
 
   asyncTest "deletion marks AND heap pop discards deleted":
     let m1 = MessageId(@[1.byte, 1.byte, 1.byte])


### PR DESCRIPTION
Typo was making [coverage tests](https://github.com/vacp2p/nim-libp2p/actions/runs/16417473361/job/46386856516?pr=1561) fail:

```
/home/runner/work/nim-libp2p/nim-libp2p/libp2p/protocols/pubsub/gossipsub/behavior.nim(951, 41) Error: undeclared field: 'startAt=' for type types.PreambleInfo [type declared in /home/runner/work/nim-libp2p/nim-libp2p/libp2p/protocols/pubsub/gossipsub/types.nim(75, 3)
```