### PR TITLE
chore(autotls): only import dnsclient when autotls is required

### DIFF
--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -17,7 +17,7 @@ import
   ./acme/client,
   ./utils,
   ../crypto/crypto,
-  ../nameresolving/dnsresolver,
+  ../nameresolving/nameresolver,
   ../peeridauth/client,
   ../switch,
   ../peerinfo,
@@ -59,7 +59,7 @@ type AutotlsCert* = ref object
 
 type AutotlsConfig* = ref object
   acmeServerURL*: Uri
-  dnsResolver*: DnsResolver
+  nameResolver*: NameResolver
   ipAddress: Opt[IpAddress]
   renewCheckTime*: Duration
   renewBufferTime*: Duration
@@ -84,8 +84,9 @@ when defined(libp2p_autotls_support):
   import
     ../crypto/rsa,
     ../utils/heartbeat,
+    ../transports/transport,
     ../transports/tcptransport,
-    ../transports/transport
+    ../nameresolving/dnsresolver
 
   proc new*(
       T: typedesc[AutotlsCert],
@@ -112,7 +113,7 @@ when defined(libp2p_autotls_support):
       issueRetryTime: Duration = DefaultIssueRetryTime,
   ): T =
     T(
-      dnsResolver: DnsResolver.new(nameServers),
+      nameResolver: DnsResolver.new(nameServers),
       acmeServerURL: acmeServerURL,
       ipAddress: ipAddress,
       renewCheckTime: renewCheckTime,
@@ -204,7 +205,7 @@ when defined(libp2p_autotls_support):
     let ip4Domain = api.Domain(dashedIpAddr & "." & baseDomain)
     debug "Waiting for DNS record to be set", ip = ip4Domain, acme = acmeChalDomain
     let dnsSet = await checkDNSRecords(
-      self.config.dnsResolver, self.config.ipAddress.get(), baseDomain, keyAuth
+      self.config.nameResolver, self.config.ipAddress.get(), baseDomain, keyAuth
     )
     if not dnsSet:
       error "DNS records not set"

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -30,7 +30,7 @@ when defined(libp2p_autotls_support):
     ../multihash,
     ../cid,
     ../multicodec,
-    ../nameresolving/dnsresolver,
+    ../nameresolving/nameresolver,
     ./acme/client
 
   proc checkedGetPrimaryIPAddr*(): IpAddress {.raises: [AutoTLSError].} =
@@ -81,7 +81,7 @@ when defined(libp2p_autotls_support):
     return Base36.encode(cidResult.get().data.buffer)
 
   proc checkDNSRecords*(
-      dnsResolver: DnsResolver,
+      nameResolver: NameResolver,
       ipAddress: IpAddress,
       baseDomain: api.Domain,
       keyAuth: KeyAuthorization,
@@ -98,9 +98,9 @@ when defined(libp2p_autotls_support):
     var txt: seq[string]
     var ip4: seq[TransportAddress]
     for _ in 0 .. retries:
-      txt = await dnsResolver.resolveTxt(acmeChalDomain)
+      txt = await nameResolver.resolveTxt(acmeChalDomain)
       try:
-        ip4 = await dnsResolver.resolveIp(ip4Domain, 0.Port)
+        ip4 = await nameResolver.resolveIp(ip4Domain, 0.Port)
       except CancelledError as exc:
         raise exc
       except CatchableError as exc:


### PR DESCRIPTION
This will keep clients such as `nimbus` from having to vendor [`dnsclient.nim`](https://github.com/ba0f3/dnsclient.nim) unless they're using autotls (i.e. using `-d:libp2p_autotls_support`) 