### PR TITLE
fix: memory consumption in yamux and pubsubpeer

### DIFF
--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -274,7 +274,7 @@ method readOnce*(
     raise
       if channel.remoteReset:
         trace "stream is remote reset when readOnce", channel = $channel
-        newLPStreamResetError()()
+        newLPStreamResetError()
       elif channel.closedLocally:
         trace "stream is closed locally when readOnce", channel = $channel
         newLPStreamClosedError()

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -377,9 +377,9 @@ proc sendLoop(channel: YamuxChannel) {.async.} =
       inBuffer.inc(bufferToSend)
 
     trace "try to send the buffer", h = $header
-    channel.sendWindow.dec(inBuffer)
     try:
       await channel.conn.write(sendBuffer)
+      channel.sendWindow.dec(inBuffer)
     except LPStreamError as exc:
       error "failed to send the buffer", description = exc.msg
       let connDown = newLPStreamConnDownError(exc)

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -274,7 +274,7 @@ method readOnce*(
     raise
       if channel.remoteReset:
         trace "stream is remote reset when readOnce", channel = $channel
-        newLPStreamRemoteClosedError()
+        newLPStreamResetError()()
       elif channel.closedLocally:
         trace "stream is closed locally when readOnce", channel = $channel
         newLPStreamClosedError()

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -526,7 +526,10 @@ method close*(m: Yamux) {.async: (raises: []).} =
   trace "Closing yamux"
   let channels = toSeq(m.channels.values())
   for channel in channels:
-    channel.clearQueues(newLPStreamEOFError())
+    for toSend in channel.sendQueue:
+      toSend.fut.fail(newLPStreamEOFError())
+      channel.sendQueue = @[]
+
     channel.sendWindow = 0
     channel.closedLocally = true
     channel.isReset = true

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -271,7 +271,7 @@ method readOnce*(
     raise
       if channel.remoteReset:
         trace "stream is remote reset when readOnce", channel = $channel
-        newLPStreamResetError()
+        newLPStreamRemoteClosedError()
       elif channel.closedLocally:
         trace "stream is closed locally when readOnce", channel = $channel
         newLPStreamClosedError()
@@ -400,7 +400,7 @@ method write*(
 
   if channel.remoteReset:
     trace "stream is reset when write", channel = $channel
-    resFut.fail(newLPStreamResetError())
+    resFut.fail(newLPStreamRemoteClosedError())
     return resFut
 
   if channel.closedLocally or channel.isReset:

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -528,8 +528,7 @@ method close*(m: Yamux) {.async: (raises: []).} =
   for channel in channels:
     for toSend in channel.sendQueue:
       toSend.fut.fail(newLPStreamEOFError())
-      channel.sendQueue = @[]
-
+    channel.sendQueue = @[]
     channel.sendWindow = 0
     channel.closedLocally = true
     channel.isReset = true

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -523,9 +523,7 @@ method close*(m: Yamux) {.async: (raises: []).} =
   trace "Closing yamux"
   let channels = toSeq(m.channels.values())
   for channel in channels:
-    for toSend in channel.sendQueue:
-      toSend.fut.complete()
-    channel.sendQueue = @[]
+    channel.clearQueues()
     channel.sendWindow = 0
     channel.closedLocally = true
     channel.isReset = true

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -218,10 +218,8 @@ method closeImpl*(channel: YamuxChannel) {.async: (raises: []).} =
     await channel.actuallyClose()
 
 proc clearQueues(channel: YamuxChannel) =
-  # Free memory
   for toSend in channel.sendQueue:
-    toSend.fut.fail(newLPStreamEOFError())
-
+    toSend.fut.complete()
   channel.sendQueue = @[]
   channel.recvQueue.clear()
 

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -135,12 +135,11 @@ proc windowUpdate(
   )
 
 type
-  ToSend =
-    tuple[
-      data: seq[byte],
-      sent: int,
-      fut: Future[void].Raising([CancelledError, LPStreamError]),
-    ]
+  ToSend = ref object
+    data: seq[byte]
+    sent: int
+    fut: Future[void].Raising([CancelledError, LPStreamError])
+
   YamuxChannel* = ref object of Connection
     id: uint32
     recvWindow: int
@@ -227,9 +226,11 @@ proc reset(channel: YamuxChannel, isLocal: bool = false) {.async: (raises: []).}
   trace "Reset channel"
   channel.isReset = true
   channel.remoteReset = not isLocal
-  for (d, s, fut) in channel.sendQueue:
-    fut.fail(newLPStreamEOFError())
+  for toSend in channel.sendQueue:
+    toSend.fut.complete()
+
   channel.sendQueue = @[]
+  channel.recvQueue.clear()
   channel.sendWindow = 0
   if not channel.closedLocally:
     if isLocal and not channel.isSending:
@@ -278,6 +279,7 @@ method readOnce*(
         trace "stream is down when readOnce", channel = $channel
         newLPStreamConnDownError()
   if channel.isEof:
+    await channel.reset()
     raise newLPStreamRemoteClosedError()
   if channel.recvQueue.isEmpty():
     channel.receivedData.clear()
@@ -292,6 +294,7 @@ method readOnce*(
     await closedRemotelyFut or receivedDataFut
     if channel.closedRemotely.isSet() and channel.recvQueue.isEmpty():
       channel.isEof = true
+      await channel.reset()
       return
         0 # we return 0 to indicate that the channel is closed for reading from now on
 
@@ -315,17 +318,12 @@ proc gotDataFromRemote(
 proc setMaxRecvWindow*(channel: YamuxChannel, maxRecvWindow: int) =
   channel.maxRecvWindow = maxRecvWindow
 
-proc trySend(
-    channel: YamuxChannel
-) {.async: (raises: [CancelledError, LPStreamError]).} =
-  if channel.isSending:
-    return
-  channel.isSending = true
-  defer:
-    channel.isSending = false
+proc sendLoop(channel: YamuxChannel) {.async.} =
+  const NumBytesHeader = 12
 
-  while channel.sendQueue.len != 0:
-    channel.sendQueue.keepItIf(not (it.fut.cancelled() and it.sent == 0))
+  while channel.sendQueue.len > 0:
+    channel.sendQueue.keepItIf(not it.fut.finished())
+
     if channel.sendWindow == 0:
       trace "trying to send while the sendWindow is empty"
       if channel.lengthSendQueueWithLimit() > channel.maxSendQueueSize:
@@ -337,54 +335,54 @@ proc trySend(
 
     let
       bytesAvailable = channel.lengthSendQueue()
-      toSend = min(channel.sendWindow, bytesAvailable)
+      numBytesToSend = min(channel.sendWindow, bytesAvailable)
     var
-      sendBuffer = newSeqUninit[byte](toSend + 12)
-      header = YamuxHeader.data(channel.id, toSend.uint32)
+      sendBuffer = newSeqUninit[byte](NumBytesHeader + numBytesToSend)
+      header = YamuxHeader.data(channel.id, numBytesToSend.uint32)
       inBuffer = 0
 
-    if toSend >= bytesAvailable and channel.closedLocally:
-      trace "last buffer we'll sent on this channel", toSend, bytesAvailable
+    if numBytesToSend >= bytesAvailable and channel.closedLocally:
+      trace "last buffer we will send on this channel", numBytesToSend, bytesAvailable
       header.flags.incl({Fin})
 
-    sendBuffer[0 ..< 12] = header.encode()
+    sendBuffer[0 ..< NumBytesHeader] = header.encode()
 
     var futures: seq[Future[void].Raising([CancelledError, LPStreamError])]
-    while inBuffer < toSend:
+    while inBuffer < numBytesToSend:
+      var toSend = channel.sendQueue[0]
       # concatenate the different message we try to send into one buffer
-      let (data, sent, fut) = channel.sendQueue[0]
-      let bufferToSend = min(data.len - sent, toSend - inBuffer)
+      let bufferToSend = min(toSend.data.len - toSend.sent, numBytesToSend - inBuffer)
 
-      sendBuffer.toOpenArray(12, 12 + toSend - 1)[
+      sendBuffer.toOpenArray(NumBytesHeader, NumBytesHeader + numBytesToSend - 1)[
         inBuffer ..< (inBuffer + bufferToSend)
-      ] = channel.sendQueue[0].data.toOpenArray(sent, sent + bufferToSend - 1)
+      ] = toSend.data.toOpenArray(toSend.sent, toSend.sent + bufferToSend - 1)
+
       channel.sendQueue[0].sent.inc(bufferToSend)
-      if channel.sendQueue[0].sent >= data.len:
+
+      if toSend.sent >= toSend.data.len:
         # if every byte of the message is in the buffer, add the write future to the
         # sequence of futures to be completed (or failed) when the buffer is sent
-        futures.add(fut)
+        futures.add(toSend.fut)
         channel.sendQueue.delete(0)
+
       inBuffer.inc(bufferToSend)
 
     trace "try to send the buffer", h = $header
-    channel.sendWindow.dec(toSend)
+    channel.sendWindow.dec(inBuffer)
     try:
       await channel.conn.write(sendBuffer)
-    except CancelledError:
-      trace "cancelled sending the buffer"
-      for fut in futures.items():
-        fut.cancelSoon()
-      await channel.reset()
-      break
     except LPStreamError as exc:
-      trace "failed to send the buffer"
+      error "failed to send the buffer", description = exc.msg
       let connDown = newLPStreamConnDownError(exc)
-      for fut in futures.items():
+      for fut in futures:
         fut.fail(connDown)
+
       await channel.reset()
       break
-    for fut in futures.items():
+
+    for fut in futures:
       fut.complete()
+
     channel.activity = true
 
 method write*(
@@ -392,21 +390,21 @@ method write*(
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   ## Write to yamux channel
   ##
-  result = newFuture[void]("Yamux Send")
+  var resFut = newFuture[void]("Yamux Send")
+
   if channel.remoteReset:
     trace "stream is reset when write", channel = $channel
-    result.fail(newLPStreamResetError())
-    return result
+    resFut.fail(newLPStreamResetError())
   if channel.closedLocally or channel.isReset:
-    result.fail(newLPStreamClosedError())
-    return result
+    resFut.fail(newLPStreamClosedError())
   if msg.len == 0:
-    result.complete()
-    return result
-  channel.sendQueue.add((msg, 0, result))
+    resFut.complete()
+  channel.sendQueue.add(ToSend(data: msg, sent: 0, fut: resFut))
   when defined(libp2p_yamux_metrics):
     libp2p_yamux_send_queue.observe(channel.lengthSendQueue().int64)
-  asyncSpawn channel.trySend()
+
+  asyncSpawn channel.sendLoop()
+  return resFut
 
 proc open(channel: YamuxChannel) {.async: (raises: [CancelledError, LPStreamError]).} =
   ## Open a yamux channel by sending a window update with Syn or Ack flag
@@ -415,6 +413,8 @@ proc open(channel: YamuxChannel) {.async: (raises: [CancelledError, LPStreamErro
     trace "Try to open channel twice"
     return
   channel.opened = true
+  channel.isReset = false
+
   await channel.conn.write(
     YamuxHeader.windowUpdate(
       channel.id,
@@ -507,8 +507,8 @@ method close*(m: Yamux) {.async: (raises: []).} =
   trace "Closing yamux"
   let channels = toSeq(m.channels.values())
   for channel in channels:
-    for (d, s, fut) in channel.sendQueue:
-      fut.fail(newLPStreamEOFError())
+    for toSend in channel.sendQueue:
+      toSend.fut.complete()
     channel.sendQueue = @[]
     channel.sendWindow = 0
     channel.closedLocally = true
@@ -523,6 +523,8 @@ method close*(m: Yamux) {.async: (raises: []).} =
   except LPStreamError as exc:
     trace "failed to send goAway", description = exc.msg
   await m.connection.close()
+
+  m.isClosed = true
   trace "Closed yamux"
 
 proc handleStream(m: Yamux, channel: YamuxChannel) {.async: (raises: []).} =
@@ -600,7 +602,7 @@ method handle*(m: Yamux) {.async: (raises: []).} =
 
         if header.msgType == WindowUpdate:
           channel.sendWindow += int(header.length)
-          await channel.trySend()
+          asyncSpawn channel.sendLoop()
         else:
           if header.length.int > channel.recvWindow.int:
             # check before allocating the buffer

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -521,7 +521,6 @@ method close*(m: Yamux) {.async: (raises: []).} =
   if m.isClosed == true:
     trace "Already closed"
     return
-  m.isClosed = true
 
   trace "Closing yamux"
   let channels = toSeq(m.channels.values())

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -526,7 +526,7 @@ method close*(m: Yamux) {.async: (raises: []).} =
   trace "Closing yamux"
   let channels = toSeq(m.channels.values())
   for channel in channels:
-    channel.clearQueues()
+    channel.clearQueues(newLPStreamEOFError())
     channel.sendWindow = 0
     channel.closedLocally = true
     channel.isReset = true

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -360,6 +360,7 @@ proc sendMsgContinue(conn: Connection, msgFut: Future[void]) {.async: (raises: [
 
   try:
     await msgFut
+    trace "sent pubsub message to remote", conn
   except CatchableError as exc:
     error "Unexpected exception", conn, description = exc.msg
 

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -357,13 +357,17 @@ proc clearSendPriorityQueue(p: PubSubPeer) =
 
 proc sendMsgContinue(conn: Connection, msgFut: Future[void]) {.async: (raises: []).} =
   # Continuation for a pending `sendMsg` future from below
+
   try:
     await msgFut
-    trace "sent pubsub message to remote", conn
-  except CatchableError as exc: # never cancelled
+  except CatchableError as exc:
+    error "Unexpected exception", conn, description = exc.msg
+
+  ## possible error should be handled in the following manner because we use raw future
+  if msgFut.failed:
     # Because we detach the send call from the currently executing task using
     # asyncSpawn, no exceptions may leak out of it
-    trace "Unable to send to remote", conn, description = exc.msg
+    error "Unable to send to remote", conn, description = msgFut.error().msg
     # Next time sendConn is used, it will be have its close flag set and thus
     # will be recycled
 

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -362,13 +362,13 @@ proc sendMsgContinue(conn: Connection, msgFut: Future[void]) {.async: (raises: [
     await msgFut
     trace "sent pubsub message to remote", conn
   except CatchableError as exc:
-    error "Unexpected exception", conn, description = exc.msg
+    trace "Unexpected exception", conn, description = exc.msg
 
   ## possible error should be handled in the following manner because we use raw future
   if msgFut.failed:
     # Because we detach the send call from the currently executing task using
     # asyncSpawn, no exceptions may leak out of it
-    error "Unable to send to remote", conn, description = msgFut.error().msg
+    trace "Unable to send to remote", conn, description = msgFut.error().msg
     # Next time sendConn is used, it will be have its close flag set and thus
     # will be recycled
 

--- a/tests/testyamux.nim
+++ b/tests/testyamux.nim
@@ -362,7 +362,8 @@ suite "Yamux":
       await streamA.writeLp(fromHex("1234"))
       expect LPStreamRemoteClosedError:
         discard await streamA.readLp(100)
-      await streamA.writeLp(fromHex("5678"))
+      expect LPStreamRemoteClosedError:
+        await streamA.writeLp(fromHex("5678"))
       await streamA.close()
 
     asyncTest "Local & Remote reset":

--- a/tests/testyamux.nim
+++ b/tests/testyamux.nim
@@ -362,8 +362,7 @@ suite "Yamux":
       await streamA.writeLp(fromHex("1234"))
       expect LPStreamRemoteClosedError:
         discard await streamA.readLp(100)
-      expect LPStreamRemoteClosedError:
-        await streamA.writeLp(fromHex("5678"))
+      await streamA.writeLp(fromHex("5678"))
       await streamA.close()
 
     asyncTest "Local & Remote reset":


### PR DESCRIPTION
## Description
This PR aims to avoid endlessly keep allocating memory when publishing. See [this](https://github.com/waku-org/nwaku/issues/3496#issuecomment-3102867775) for details.

There are some style/nitpick changes but the ones that give real impact to memory consumption are:
- Addition of `channel.clearQueues()` in yamux.nim `readOnce` methods
-  Replace `channel.sendQueue.keepItIf(not (it.fut.cancelled() and it.sent == 0))` with `channel.sendQueue.keepItIf(not it.fut.finished())`

This PR is fundamentally inspired by the following @NagyZoltanPeter 's comment: https://github.com/vacp2p/nim-libp2p/pull/1540#issuecomment-3071666756. So kudos to you my friend if we manage to merge it :partying_face: :raised_hands: 



---

## How to replicate

Follow these instructions: https://github.com/waku-org/nwaku/issues/3496#issuecomment-3102252599
( there is another approach, using waku simulator, Zoltán can give better insight on that one .)