### PR TITLE
chore: remove support for nim 1.6

### DIFF
--- a/.github/actions/install_nim/action.yml
+++ b/.github/actions/install_nim/action.yml
@@ -8,7 +8,7 @@ inputs:
     default: "amd64"
   nim_ref:
     description: "Nim version"
-    default: "version-1-6"
+    default: "version-2-0"
   shell:
     description: "Shell to run commands in"
     default: "bash --noprofile --norc -e -o pipefail"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,6 @@ jobs:
           - os: windows
             cpu: amd64
         nim:
-          - ref: version-1-6
-            memory_management: refc
           - ref: version-2-0
             memory_management: refc
           - ref: version-2-2

--- a/.github/workflows/daily_amd64.yml
+++ b/.github/workflows/daily_amd64.yml
@@ -11,7 +11,6 @@ jobs:
     uses: ./.github/workflows/daily_common.yml
     with:
       nim: "[
-          {'ref': 'version-1-6', 'memory_management': 'refc'},
           {'ref': 'version-2-0', 'memory_management': 'refc'},
           {'ref': 'version-2-2', 'memory_management': 'refc'},
           {'ref': 'devel', 'memory_management': 'refc'},
@@ -23,7 +22,6 @@ jobs:
     with:
       pinned_deps: true
       nim: "[
-          {'ref': 'version-1-6', 'memory_management': 'refc'},
           {'ref': 'version-2-0', 'memory_management': 'refc'},
           {'ref': 'version-2-2', 'memory_management': 'refc'},
           {'ref': 'devel', 'memory_management': 'refc'},

--- a/.github/workflows/daily_i386.yml
+++ b/.github/workflows/daily_i386.yml
@@ -11,7 +11,6 @@ jobs:
     uses: ./.github/workflows/daily_common.yml
     with:
       nim: "[
-          {'ref': 'version-1-6', 'memory_management': 'refc'},
           {'ref': 'version-2-0', 'memory_management': 'refc'},
           {'ref': 'version-2-2', 'memory_management': 'refc'},
           {'ref': 'devel', 'memory_management': 'refc'},

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -36,7 +36,7 @@ jobs:
           shell: bash
           os: linux
           cpu: amd64
-          nim_ref: version-1-6
+          nim_ref: version-2-2
 
       - name: Restore deps from cache
         id: deps-cache

--- a/.pinned
+++ b/.pinned
@@ -1,5 +1,5 @@
 bearssl;https://github.com/status-im/nim-bearssl@#34d712933a4e0f91f5e66bc848594a581504a215
-chronicles;https://github.com/status-im/nim-chronicles@#81a4a7a360c78be9c80c8f735c76b6d4a1517304
+chronicles;https://github.com/status-im/nim-chronicles@#61759a5e8df8f4d68bcd1b4b8c1adab3e72bbd8d
 chronos;https://github.com/status-im/nim-chronos@#b55e2816eb45f698ddaca8d8473e401502562db2
 dnsclient;https://github.com/ba0f3/dnsclient.nim@#23214235d4784d24aceed99bbfe153379ea557c8
 faststreams;https://github.com/status-im/nim-faststreams@#c51315d0ae5eb2594d0bf41181d0e1aca1b3c01d
@@ -8,7 +8,7 @@ json_serialization;https://github.com/status-im/nim-json-serialization@#2b1c5eb1
 metrics;https://github.com/status-im/nim-metrics@#6142e433fc8ea9b73379770a788017ac528d46ff
 ngtcp2;https://github.com/status-im/nim-ngtcp2@#9456daa178c655bccd4a3c78ad3b8cce1f0add73
 nimcrypto;https://github.com/cheatfate/nimcrypto@#19c41d6be4c00b4a2c8000583bd30cf8ceb5f4b1
-quic;https://github.com/status-im/nim-quic.git@#dd4e715ab4b32de6f9e93208d6ba9d52ed2c2d7a
+quic;https://github.com/status-im/nim-quic.git@#6e5f3854b3803af4cf9a375c3b1b4d39f0f9e9bd
 results;https://github.com/arnetheduck/nim-results@#df8113dda4c2d74d460a8fa98252b0b771bf1f27
 secp256k1;https://github.com/status-im/nim-secp256k1@#f808ed5e7a7bfc42204ec7830f14b7a42b63c284
 serialization;https://github.com/status-im/nim-serialization@#548d0adc9797a10b2db7f788b804330306293088

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Learn more about libp2p at [**libp2p.io**](https://libp2p.io) and follow libp2p'
 
 ## Install
 
-> The currently supported Nim versions are 1.6, 2.0 and 2.2.
+> The currently supported Nim versions are 2.0 and 2.2.
 
 ```
 nimble install libp2p
@@ -197,7 +197,7 @@ The versioning follows [semver](https://semver.org/), with some additions:
 - Some of libp2p procedures are marked as `.public.`, they will remain compatible during each `MAJOR` version
 - The rest of the procedures are considered internal, and can change at any `MINOR` version (but remain compatible for each new `PATCH`)
 
-We aim to be compatible at all time with at least 2 Nim `MINOR` versions, currently `1.6 & 2.0`
+We aim to be compatible at all time with at least 2 Nim `MINOR` versions, currently `2.0 & 2.2`
 
 ## License
 

--- a/examples/circuitrelay.nim
+++ b/examples/circuitrelay.nim
@@ -1,3 +1,4 @@
+{.used.}
 ## # Circuit Relay example
 ##
 ## Circuit Relay can be used when a node cannot reach another node

--- a/examples/directchat.nim
+++ b/examples/directchat.nim
@@ -1,3 +1,4 @@
+{.used.}
 when not (compileOption("threads")):
   {.fatal: "Please, compile this program with the --threads:on option!".}
 

--- a/examples/helloworld.nim
+++ b/examples/helloworld.nim
@@ -1,3 +1,5 @@
+{.used.}
+
 import chronos # an efficient library for async
 import stew/byteutils # various utils
 import libp2p

--- a/examples/tutorial_1_connect.nim
+++ b/examples/tutorial_1_connect.nim
@@ -1,3 +1,4 @@
+{.used.}
 ## # Simple ping tutorial
 ##
 ## Hi all, welcome to the first nim-libp2p tutorial!

--- a/examples/tutorial_2_customproto.nim
+++ b/examples/tutorial_2_customproto.nim
@@ -1,3 +1,4 @@
+{.used.}
 ## # Custom protocol in libp2p
 ##
 ## In the [previous tutorial](tutorial_1_connect.md), we've looked at how to create a simple ping program using the `nim-libp2p`.

--- a/examples/tutorial_3_protobuf.nim
+++ b/examples/tutorial_3_protobuf.nim
@@ -1,3 +1,4 @@
+{.used.}
 ## # Protobuf usage
 ##
 ## In the [previous tutorial](tutorial_2_customproto.md), we created a simple "ping" protocol.

--- a/examples/tutorial_4_gossipsub.nim
+++ b/examples/tutorial_4_gossipsub.nim
@@ -1,3 +1,4 @@
+{.used.}
 ## # GossipSub
 ##
 ## In this tutorial, we'll build a simple GossipSub network

--- a/examples/tutorial_5_discovery.nim
+++ b/examples/tutorial_5_discovery.nim
@@ -1,3 +1,4 @@
+{.used.}
 ## # Discovery Manager
 ##
 ## In the [previous tutorial](tutorial_4_gossipsub.md), we built a custom protocol using [protobuf](https://developers.google.com/protocol-buffers) and

--- a/examples/tutorial_6_game.nim
+++ b/examples/tutorial_6_game.nim
@@ -1,3 +1,4 @@
+{.used.}
 ## # Tron example
 ##
 ## In this tutorial, we will create a video game based on libp2p, using

--- a/interop/hole-punching/Dockerfile
+++ b/interop/hole-punching/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5-labs
-FROM nimlang/nim:2.0.14 as builder
+FROM nimlang/nim:latest as builder
 
 WORKDIR /workspace
 

--- a/interop/hole-punching/Dockerfile
+++ b/interop/hole-punching/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5-labs
-FROM nimlang/nim:1.6.16 as builder
+FROM nimlang/nim:2.0.16 as builder
 
 WORKDIR /workspace
 

--- a/interop/hole-punching/Dockerfile
+++ b/interop/hole-punching/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5-labs
-FROM nimlang/nim:2.0.16 as builder
+FROM nimlang/nim:2.0.14 as builder
 
 WORKDIR /workspace
 

--- a/interop/transport/Dockerfile
+++ b/interop/transport/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5-labs
-FROM nimlang/nim:2.0.16 as builder
+FROM nimlang/nim:2.0.14 as builder
 
 WORKDIR /app
 

--- a/interop/transport/Dockerfile
+++ b/interop/transport/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5-labs
-FROM nimlang/nim:1.6.16 as builder
+FROM nimlang/nim:2.0.16 as builder
 
 WORKDIR /app
 

--- a/interop/transport/Dockerfile
+++ b/interop/transport/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.5-labs
-FROM nimlang/nim:2.0.14 as builder
+FROM nimlang/nim:latest as builder
 
 WORKDIR /app
 

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -9,8 +9,8 @@ skipDirs = @["tests", "examples", "Nim", "tools", "scripts", "docs"]
 
 requires "nim >= 2.0.0",
   "nimcrypto >= 0.6.0 & < 0.7.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.5",
-  "chronicles >= 0.11.0", "chronos >= 4.0.4", "metrics", "secp256k1", "stew >= 0.4.0",
-  "websock >= 0.2.0", "unittest2", "results", "quic >= 0.2.10",
+  "chronicles >= 0.11.0 & < 0.12.0", "chronos >= 4.0.4", "metrics", "secp256k1",
+  "stew >= 0.4.0", "websock >= 0.2.0", "unittest2", "results", "quic >= 0.2.10",
   "https://github.com/vacp2p/nim-jwt.git#18f8378de52b241f321c1f9ea905456e89b95c6f"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -7,7 +7,7 @@ description = "LibP2P implementation"
 license = "MIT"
 skipDirs = @["tests", "examples", "Nim", "tools", "scripts", "docs"]
 
-requires "nim >= 1.6.0",
+requires "nim >= 2.0.0",
   "nimcrypto >= 0.6.0 & < 0.7.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.5",
   "chronicles >= 0.10.3 & < 0.11.0", "chronos >= 4.0.4", "metrics", "secp256k1",
   "stew >= 0.4.0", "websock >= 0.2.0", "unittest2", "results", "quic >= 0.2.9",

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -9,8 +9,9 @@ skipDirs = @["tests", "examples", "Nim", "tools", "scripts", "docs"]
 
 requires "nim >= 2.0.0",
   "nimcrypto >= 0.6.0 & < 0.7.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.5",
-  "chronicles >= 0.10.3 & < 0.11.0", "chronos >= 4.0.4", "metrics", "secp256k1",
-  "stew >= 0.4.0", "websock >= 0.2.0", "unittest2", "results", "quic >= 0.2.9",
+  "chronicles >= 0.11.0", "chronos >= 4.0.4", "metrics", "secp256k1", "stew >= 0.4.0",
+  "websock >= 0.2.0", "unittest2", "results",
+  "https://github.com/vacp2p/nim-quic.git#6e5f3854b3803af4cf9a375c3b1b4d39f0f9e9bd",
   "https://github.com/vacp2p/nim-jwt.git#18f8378de52b241f321c1f9ea905456e89b95c6f"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -59,6 +59,9 @@ method readOnce*(
   try:
     if stream.cached.len == 0:
       stream.cached = await stream.stream.read()
+      if stream.cached.len == 0:
+        raise newLPStreamEOFError()
+
     result = min(nbytes, stream.cached.len)
     copyMem(pbytes, addr stream.cached[0], result)
     stream.cached = stream.cached[result ..^ 1]


### PR DESCRIPTION
Since nimbus, waku and codex (which are our most important clients) no longer support nim 1.6, as, we hope, most of our users also have, we've decided to drop support for nim 1.6.