### PR TITLE
test(gossipsub): Performance tests - base scenario and runner

### DIFF
--- a/performance/.gitignore
+++ b/performance/.gitignore
@@ -1,0 +1,3 @@
+nimbledeps/*
+output/
+bin/

--- a/performance/Dockerfile
+++ b/performance/Dockerfile
@@ -1,0 +1,24 @@
+# Create the build image
+FROM nimlang/nim:2.2.4-alpine-regular AS build
+
+WORKDIR /node
+
+COPY libp2p.nimble config.nims ./
+RUN git config --global http.sslVerify false
+RUN nimble install -y
+
+COPY . .
+RUN nimble c -d:chronicles_colors=None --threads:on -d:metrics -d:libp2p_network_protocols_metrics -d:release performance/main.nim
+
+
+FROM nimlang/nim:2.2.4-alpine-slim
+
+WORKDIR /node
+
+COPY --from=build /node/performance/main /node/main
+
+RUN chmod +x main
+
+VOLUME ["/output"]
+
+ENTRYPOINT ["./main"]

--- a/performance/main.nim
+++ b/performance/main.nim
@@ -1,0 +1,4 @@
+import chronos
+import ./scenarios
+
+waitFor(test1())

--- a/performance/main.nim
+++ b/performance/main.nim
@@ -1,4 +1,4 @@
 import chronos
 import ./scenarios
 
-waitFor(test1())
+waitFor(baseTest())

--- a/performance/runner.sh
+++ b/performance/runner.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Create Docker network
+network="performance-test-network"
+if ! docker network inspect "$network" > /dev/null 2>&1; then
+  docker network create --attachable --driver bridge "$network" > /dev/null
+fi
+
+# Clean up output
+output_dir="$(pwd)/performance/output"
+mkdir -p "$output_dir"
+rm -f "$output_dir"/*.json
+
+# Run Test Nodes
+container_names=()
+PEERS=10
+for ((i = 0; i < $PEERS; i++)); do
+    hostname_prefix="node-" 
+    hostname="$hostname_prefix$i"
+
+    docker run -d \
+      --name "$hostname" \
+      -e NODE_ID="$i" \
+      -e HOSTNAME_PREFIX="$hostname_prefix" \
+      -v "$output_dir:/output" \
+      --hostname="$hostname" \
+      --network="$network" \
+      test-node > /dev/null
+
+    container_names+=("$hostname")
+done
+
+# Show logs in real time for all containers
+for container_name in "${container_names[@]}"; do
+    docker logs -f "$container_name" &
+done
+
+# Wait for all containers to finish
+for container_name in "${container_names[@]}"; do
+    docker wait "$container_name" > /dev/null
+done
+
+# Clean up all containers
+for container_name in "${container_names[@]}"; do
+    docker rm -f "$container_name" > /dev/null
+done
+
+# Remove the custom Docker network
+docker network rm "$network" > /dev/null
+exit 0

--- a/performance/scenarios.nim
+++ b/performance/scenarios.nim
@@ -14,10 +14,10 @@ proc test1*() {.async.} =
     nodeCount = 10
     publisherCount = 10
     peerLimit = 5
-    msgCount = 50
-    msgInterval = 100
-    msgSize = 100
-    warmupCount = 5
+    msgCount = 200
+    msgInterval = 20 # ms
+    msgSize = 500 # bytes
+    warmupCount = 20
 
   # --- Node Setup ---
   let
@@ -50,7 +50,6 @@ proc test1*() {.async.} =
   await sleepAsync(5.seconds)
 
   # --- Peer Discovery & Connection ---
-
   var peersAddresses = resolvePeersAddresses(nodeCount, hostnamePrefix, nodeId)
   rng.shuffle(peersAddresses)
 
@@ -65,14 +64,12 @@ proc test1*() {.async.} =
     gossipSub, warmupCount, msgCount, msgInterval, msgSize, publisherCount, nodeId
   )
 
-  # Wait for all messages to be delivered
-  info "Waiting 2 seconds for message delivery..."
+  info "Waiting 2 seconds for message delivery"
   await sleepAsync(2.seconds)
 
-  # Performance summary
+  # --- Performance summary  ---
   let stats = getStats(receivedMessages[], sentMessages)
   info "Performance summary", nodeId, stats = $stats
 
-  # Write stats to JSON file in shared volume
   let outputPath = "/output/" & hostname & ".json"
   writeResultsToJson(outputPath, scenario, stats)

--- a/performance/scenarios.nim
+++ b/performance/scenarios.nim
@@ -1,0 +1,78 @@
+import metrics
+import metrics/chronos_httpserver
+import os
+import strutils
+import ../libp2p
+import ../libp2p/protocols/ping
+import ./utils
+from nativesockets import getHostname
+
+proc test1*() {.async.} =
+  const
+    # --- Scenario ---
+    scenario = "Base test"
+    nodeCount = 10
+    publisherCount = 10
+    peerLimit = 5
+    msgCount = 50
+    msgInterval = 100
+    msgSize = 100
+    warmupCount = 5
+
+  # --- Node Setup ---
+  let
+    hostnamePrefix = getEnv("HOSTNAME_PREFIX", "unknown")
+    nodeId = parseInt(getEnv("NODE_ID", "0"))
+    hostname = getHostname()
+    rng = libp2p.newRng()
+
+  let (switch, gossipSub, pingProtocol) = setupNode(nodeId, rng)
+  gossipSub.setGossipSubParams()
+
+  var (messageHandler, receivedMessages) = createMessageHandler(nodeId)
+  gossipSub.subscribe(topic, messageHandler)
+
+  gossipSub.addValidator([topic], defaultMessageValidator)
+
+  switch.mount(gossipSub)
+  switch.mount(pingProtocol)
+
+  await switch.start()
+  defer:
+    await switch.stop()
+
+  info "Node started, waiting 5s",
+    nodeId,
+    address = switch.peerInfo.addrs,
+    peerId = switch.peerInfo.peerId,
+    isPublisher = nodeId <= publisherCount,
+    hostname = hostname
+  await sleepAsync(5.seconds)
+
+  # --- Peer Discovery & Connection ---
+
+  var peersAddresses = resolvePeersAddresses(nodeCount, hostnamePrefix, nodeId)
+  rng.shuffle(peersAddresses)
+
+  await connectPeers(switch, peersAddresses, peerLimit, nodeId)
+
+  info "Mesh populated, waiting 5s",
+    nodeId, meshSize = gossipSub.mesh.getOrDefault(topic).len
+  await sleepAsync(5.seconds)
+
+  # --- Message Publishing ---
+  let sentMessages = await publishMessagesWithWarmup(
+    gossipSub, warmupCount, msgCount, msgInterval, msgSize, publisherCount, nodeId
+  )
+
+  # Wait for all messages to be delivered
+  info "Waiting 2 seconds for message delivery..."
+  await sleepAsync(2.seconds)
+
+  # Performance summary
+  let stats = getStats(receivedMessages[], sentMessages)
+  info "Performance summary", nodeId, stats = $stats
+
+  # Write stats to JSON file in shared volume
+  let outputPath = "/output/" & hostname & ".json"
+  writeResultsToJson(outputPath, scenario, stats)

--- a/performance/scenarios.nim
+++ b/performance/scenarios.nim
@@ -7,7 +7,7 @@ import ../libp2p/protocols/ping
 import ./utils
 from nativesockets import getHostname
 
-proc test1*() {.async.} =
+proc baseTest*() {.async.} =
   const
     # --- Scenario ---
     scenario = "Base test"

--- a/performance/utils.nim
+++ b/performance/utils.nim
@@ -1,0 +1,253 @@
+import stew/byteutils
+import stew/endians2
+import strutils
+import strformat
+import sequtils
+import tables
+import hashes
+import metrics
+import metrics/chronos_httpserver
+import chronos
+import json
+import ../libp2p
+import ../libp2p/protocols/pubsub/rpc/messages
+import ../libp2p/muxers/mplex/lpchannel
+import ../libp2p/protocols/ping
+
+const
+  topic* = "test"
+  warmupData* = "warmup".toBytes()
+
+proc msgIdProvider*(m: Message): Result[MessageId, ValidationResult] =
+  ok(($m.data.hash).toBytes())
+
+proc startMetricsServer*(
+    serverIp: IpAddress, serverPort: Port
+): Result[MetricsHttpServerRef, string] =
+  info "Starting metrics HTTP server", serverIp = $serverIp, serverPort = $serverPort
+  let metricsServerRes = MetricsHttpServerRef.new($serverIp, serverPort)
+  if metricsServerRes.isErr():
+    return err("metrics HTTP server start failed: " & $metricsServerRes.error)
+  let server = metricsServerRes.value
+  try:
+    waitFor server.start()
+  except CatchableError:
+    return err("metrics HTTP server start failed: " & getCurrentExceptionMsg())
+  info "Metrics HTTP server started", serverIp = $serverIp, serverPort = $serverPort
+  ok(metricsServerRes.value)
+
+proc setupNode*(nodeId: int, rng: ref HmacDrbgContext): (Switch, GossipSub, Ping) =
+  let
+    myPort = 5000 + nodeId
+    myAddress = "0.0.0.0:" & $myPort
+    address = initTAddress(myAddress)
+
+    switch = SwitchBuilder
+      .new()
+      .withAddress(MultiAddress.init(address).tryGet())
+      .withRng(rng)
+      .withYamux()
+      .withMaxConnections(250)
+      .withTcpTransport(flags = {ServerFlags.TcpNoDelay})
+      .withNoise()
+      .build()
+
+    gossipSub = GossipSub.init(
+      switch = switch,
+      msgIdProvider = msgIdProvider,
+      verifySignature = false,
+      anonymize = true,
+    )
+
+    pingProtocol = Ping.new(rng = rng)
+
+  return (switch, gossipSub, pingProtocol)
+
+proc setGossipSubParams*(gossipSub: GossipSub) =
+  gossipSub.parameters.floodPublish = true
+  gossipSub.parameters.opportunisticGraftThreshold = -10000
+  gossipSub.parameters.heartbeatInterval = 1.seconds
+  gossipSub.parameters.pruneBackoff = 60.seconds
+  gossipSub.parameters.gossipFactor = 0.25
+  gossipSub.parameters.d = 6
+  gossipSub.parameters.dLow = 4
+  gossipSub.parameters.dHigh = 8
+  gossipSub.parameters.dScore = 6
+  gossipSub.parameters.dOut = 3
+  gossipSub.parameters.dLazy = 6
+  gossipSub.topicParams[topic] = TopicParams(
+    topicWeight: 1,
+    firstMessageDeliveriesWeight: 1,
+    firstMessageDeliveriesCap: 30,
+    firstMessageDeliveriesDecay: 0.9,
+  )
+
+proc getLatency*(timestamp: int64): float =
+  let nowNs = Moment.now().epochNanoSeconds()
+  let diff = (nowNs - timestamp).nanoseconds()
+  let latencyMs = float(diff.nanoseconds()) / 1000000.0
+
+  return latencyMs
+
+proc formatLatencyMs*(latency: float): string =
+  return formatFloat(latency, ffDecimal, 3)
+
+proc defaultMessageValidator*(
+    topic: string, msg: Message
+): Future[ValidationResult] {.async.} =
+  ValidationResult.Accept
+
+proc createMessageHandler*(
+    nodeId: int
+): (proc(topic: string, data: seq[byte]) {.async.}, ref Table[uint64, float]) =
+  var receivedMessages = new Table[uint64, float]
+
+  proc messageHandler(topic: string, data: seq[byte]) {.async.} =
+    # Skip warm-up messages
+    if data == warmupData:
+      return
+
+    let msgId = uint64.fromBytesLE(data)
+
+    let sentNs = int64(msgId)
+    let latency = getLatency(sentNs)
+
+    receivedMessages[msgId] = latency
+    info "Message delivered", msgId = msgId, latency = formatLatencyMs(latency), nodeId
+
+  return (messageHandler, receivedMessages)
+
+proc resolvePeersAddresses*(
+    nodeCount: int, hostnamePrefix: string, nodeId: int
+): seq[MultiAddress] =
+  var addrs: seq[MultiAddress]
+
+  for i in 0 ..< nodeCount:
+    if i == nodeId:
+      continue # skip self
+
+    let peerAddr = hostnamePrefix & $i & ":" & $(5000 + i)
+    try:
+      let resolved = resolveTAddress(peerAddr).mapIt(MultiAddress.init(it).tryGet())
+      addrs.add(resolved)
+
+      debug "Peer resolved", nodeId, peerAddr = peerAddr, resolved = resolved
+    except CatchableError as exc:
+      warn "Failed to resolve address", peerAddr = peerAddr, error = exc.msg
+
+  return addrs
+
+proc connectPeers*(
+    switch: Switch, peersAddresses: seq[MultiAddress], peerLimit: int, nodeId: int
+) {.async.} =
+  var
+    connected = 0
+    index = 0
+  while connected < peerLimit:
+    while true:
+      let address = peersAddresses[index]
+      try:
+        let peerId =
+          await switch.connect(address, allowUnknownPeerId = true).wait(5.seconds)
+        connected.inc()
+        index.inc()
+        debug "Connected peer", nodeId, address = address
+        break
+      except CatchableError as exc:
+        warn "Failed to dial, waiting 5s", nodeId, address = address, error = exc.msg
+        await sleepAsync(5.seconds)
+
+proc publishMessagesWithWarmup*(
+    gossipSub: GossipSub,
+    warmupCount: int,
+    msgCount: int,
+    msgInterval: int,
+    msgSize: int,
+    publisherCount: int,
+    nodeId: int,
+): Future[seq[uint64]] {.async.} =
+  # Warm-up phase
+  info "Sending warmup messages", nodeId
+  for msg in 0 ..< warmupCount:
+    await sleepAsync(msgInterval)
+    discard await gossipSub.publish(topic, warmupData)
+
+  # Measured phase
+  var sentMessages: seq[uint64]
+  for msg in 0 ..< msgCount:
+    await sleepAsync(msgInterval)
+    if msg mod publisherCount == nodeId:
+      let timestamp = Moment.now().epochNanoSeconds()
+      var data = @(toBytesLE(uint64(timestamp))) & newSeq[byte](msgSize)
+
+      info "Sending message", msgId = timestamp, nodeId = nodeId
+      doAssert((await gossipSub.publish(topic, data)) > 0)
+      sentMessages.add(uint64(timestamp))
+
+  return sentMessages
+
+type LatencyStats* = object
+  minLatencyMs*: float
+  maxLatencyMs*: float
+  avgLatencyMs*: float
+
+proc getLatencyStats*(latencies: seq[float]): LatencyStats =
+  var minLatencyMs, maxLatencyMs, avgLatencyMs: float
+  if latencies.len > 0:
+    minLatencyMs = latencies.min
+    maxLatencyMs = latencies.max
+    var sumLatency: float = 0.0
+    for l in latencies:
+      sumLatency += l
+    avgLatencyMs = sumLatency / float(latencies.len)
+  else:
+    minLatencyMs = 0.0
+    maxLatencyMs = 0.0
+    avgLatencyMs = 0.0
+
+  let latency = LatencyStats(
+    minLatencyMs: minLatencyMs, maxLatencyMs: maxLatencyMs, avgLatencyMs: avgLatencyMs
+  )
+
+  return latency
+
+type Stats* = object
+  totalSent*: int
+  totalReceived*: int
+  latency*: LatencyStats
+
+proc getStats*(
+    receivedMessages: Table[uint64, float], sentMessages: seq[uint64]
+): Stats =
+  let latencyStats = getLatencyStats(receivedMessages.values().toSeq())
+
+  let stats = Stats(
+    totalSent: sentMessages.len,
+    totalReceived: receivedMessages.len,
+    latency: latencyStats,
+  )
+
+  return stats
+
+proc `$`*(stats: Stats): string =
+  return
+    fmt"Messages: sent={stats.totalSent}, received={stats.totalReceived}, " &
+    fmt"Latency (ms): min={formatLatencyMs(stats.latency.minLatencyMs)}, " &
+    fmt"max={formatLatencyMs(stats.latency.maxLatencyMs)}, " &
+    fmt"avg={formatLatencyMs(stats.latency.avgLatencyMs)}"
+
+proc writeResultsToJson*(outputPath: string, scenario: string, stats: Stats) =
+  let json =
+    %*{
+      "results": [
+        {
+          "scenario": scenario,
+          "totalSent": stats.totalSent,
+          "totalReceived": stats.totalReceived,
+          "minLatency": formatLatencyMs(stats.latency.minLatencyMs),
+          "maxLatency": formatLatencyMs(stats.latency.maxLatencyMs),
+          "avgLatency": formatLatencyMs(stats.latency.avgLatencyMs),
+        }
+      ]
+    }
+  writeFile(outputPath, json.pretty)

--- a/performance/utils.nim
+++ b/performance/utils.nim
@@ -21,21 +21,6 @@ const
 proc msgIdProvider*(m: Message): Result[MessageId, ValidationResult] =
   ok(($m.data.hash).toBytes())
 
-proc startMetricsServer*(
-    serverIp: IpAddress, serverPort: Port
-): Result[MetricsHttpServerRef, string] =
-  info "Starting metrics HTTP server", serverIp = $serverIp, serverPort = $serverPort
-  let metricsServerRes = MetricsHttpServerRef.new($serverIp, serverPort)
-  if metricsServerRes.isErr():
-    return err("metrics HTTP server start failed: " & $metricsServerRes.error)
-  let server = metricsServerRes.value
-  try:
-    waitFor server.start()
-  except CatchableError:
-    return err("metrics HTTP server start failed: " & getCurrentExceptionMsg())
-  info "Metrics HTTP server started", serverIp = $serverIp, serverPort = $serverPort
-  ok(metricsServerRes.value)
-
 proc setupNode*(nodeId: int, rng: ref HmacDrbgContext): (Switch, GossipSub, Ping) =
   let
     myPort = 5000 + nodeId

--- a/performance/utils.nim
+++ b/performance/utils.nim
@@ -32,7 +32,6 @@ proc setupNode*(nodeId: int, rng: ref HmacDrbgContext): (Switch, GossipSub, Ping
       .withAddress(MultiAddress.init(address).tryGet())
       .withRng(rng)
       .withYamux()
-      .withMaxConnections(250)
       .withTcpTransport(flags = {ServerFlags.TcpNoDelay})
       .withNoise()
       .build()
@@ -177,24 +176,20 @@ type LatencyStats* = object
   avgLatencyMs*: float
 
 proc getLatencyStats*(latencies: seq[float]): LatencyStats =
-  var minLatencyMs, maxLatencyMs, avgLatencyMs: float
-  if latencies.len > 0:
-    minLatencyMs = latencies.min
-    maxLatencyMs = latencies.max
-    var sumLatency: float = 0.0
-    for l in latencies:
-      sumLatency += l
-    avgLatencyMs = sumLatency / float(latencies.len)
-  else:
+  var
     minLatencyMs = 0.0
     maxLatencyMs = 0.0
     avgLatencyMs = 0.0
 
-  let latency = LatencyStats(
+  if latencies.len > 0:
+    minLatencyMs = latencies.min
+    maxLatencyMs = latencies.max
+    let sumLatency = foldl(latencies, a + b, 0.0)
+    avgLatencyMs = sumLatency / float(latencies.len)
+
+  return LatencyStats(
     minLatencyMs: minLatencyMs, maxLatencyMs: maxLatencyMs, avgLatencyMs: avgLatencyMs
   )
-
-  return latency
 
 type Stats* = object
   totalSent*: int


### PR DESCRIPTION
This PR is a follow up to the https://github.com/vacp2p/nim-libp2p/pull/1544 - it contains refactored base scenario with a test runner.

**What’s included?**
- **Dockerfile**:
  - Installs dependencies and compiles the node test logic
- **Test runner**:
  - Spins up multiple Docker containers (each running a `nim-libp2p` node with the test script).
  - Cleans up containers and output files before and after each run.
- **Node test logic**:
  - Configures each GossipSub node.
  - Handles peer discovery, connection, and message publishing.
  - Measures message delivery latency (in milliseconds, with microsecond resolution) for each node.
  - Collects per-node stats: messages sent/received, latency (min/max/avg).
  - Writes results to a JSON file for aggregation after the test run.

### How to run locally
```bash
# Build docker image
docker build -f performance/Dockerfile -t test-node .

# Run the test
./performance/runner.sh 
```