### PR TITLE
chore(switch): remove unnecesery debug log entry

### DIFF
--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -361,8 +361,6 @@ proc start*(s: Switch) {.public, async: (raises: [CancelledError, LPError]).} =
         await fut
         s.acceptFuts.add(s.accept(t))
         s.peerInfo.listenAddrs &= t.addrs
-  debug "switch addresses",
-    addrs = s.peerInfo.addrs, listenAddrs = s.peerInfo.listenAddrs
 
   # some transports require some services to be running
   # in order to finish their startup process


### PR DESCRIPTION
- position of "switch addresses" is not correct if any transport other then tcp is used (addresses will always be empty since transport is not started at this point)
- log is redundant with `Started libp2p node` debug log below that shows full peer info