### PR TITLE
chore: revert excp type in yamux write

### DIFF
--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -406,7 +406,7 @@ method write*(
 
   if channel.remoteReset:
     trace "stream is reset when write", channel = $channel
-    resFut.fail(newLPStreamRemoteClosedError())
+    resFut.fail(newLPStreamResetError())
     return resFut
 
   if channel.closedLocally or channel.isReset:


### PR DESCRIPTION
This PR is aimed to tackle this comment: https://github.com/vacp2p/nim-libp2p/pull/1570#discussion_r2228487960