### PR TITLE
fix: more secure send loop in yamux and exception-handling-code cleanup in pubsubpeer

### DIFF
--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -383,12 +383,10 @@ proc sendLoop(channel: YamuxChannel) {.async: (raises: []).} =
     try:
       await channel.conn.write(sendBuffer)
       channel.sendWindow.dec(inBuffer)
-    except CancelledError as exc:
-      trace "cancelled sending the buffer", description = exc.msg
-      for fut in futures.items():
-        fut.cancelSoon()
-      await channel.reset()
-      break
+    except CancelledError:
+      ## Just for compiler. This should never happen as sendLoop is started by asyncSpawn.
+      ## Therefore, no one owns that sendLoop's future and no one can cancel it.
+      discard
     except LPStreamError as exc:
       error "failed to send the buffer", description = exc.msg
       let connDown = newLPStreamConnDownError(exc)

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -360,21 +360,13 @@ proc clearSendPriorityQueue(p: PubSubPeer) =
 
 proc sendMsgContinue(conn: Connection, msgFut: Future[void]) {.async: (raises: []).} =
   # Continuation for a pending `sendMsg` future from below
-
   try:
     await msgFut
     trace "sent pubsub message to remote", conn
   except CatchableError as exc:
-    trace "Unexpected exception", conn, description = exc.msg
-
-  ## possible error should be handled in the following manner because we use raw future
-  if msgFut.failed:
-    # Because we detach the send call from the currently executing task using
-    # asyncSpawn, no exceptions may leak out of it
-    trace "Unable to send to remote", conn, description = msgFut.error().msg
+    trace "Unexpected exception in sendMsgContinue", conn, description = exc.msg
     # Next time sendConn is used, it will be have its close flag set and thus
     # will be recycled
-
     await conn.close() # This will clean up the send connection
 
 proc sendMsgSlow(p: PubSubPeer, msg: seq[byte]) {.async: (raises: [CancelledError]).} =


### PR DESCRIPTION

This PR is motivated by: 

https://github.com/vacp2p/nim-libp2p/pull/1570#discussion_r2228640214 --> Cleanup `libp2p/protocols/pubsub/pubsubpeer.nim`. There's no need to check the `failed` field in a `raw` future because `await` already extracts the exception in `try: await rawFut except`. 

https://github.com/vacp2p/nim-libp2p/pull/1570#discussion_r2228646674 --> Make `sendLoop` more secure and make sure it doesn't throw any exception