### PR TITLE
feat(perf): implement proper half-close semantics

### DIFF
--- a/.pinned
+++ b/.pinned
@@ -8,7 +8,7 @@ json_serialization;https://github.com/status-im/nim-json-serialization@#2b1c5eb1
 metrics;https://github.com/status-im/nim-metrics@#6142e433fc8ea9b73379770a788017ac528d46ff
 ngtcp2;https://github.com/status-im/nim-ngtcp2@#9456daa178c655bccd4a3c78ad3b8cce1f0add73
 nimcrypto;https://github.com/cheatfate/nimcrypto@#19c41d6be4c00b4a2c8000583bd30cf8ceb5f4b1
-quic;https://github.com/status-im/nim-quic.git@#d9a4cbccd509f7a3ee835f75b01dec29d27a0f14
+quic;https://github.com/status-im/nim-quic.git@#a5bd3dd
 results;https://github.com/arnetheduck/nim-results@#df8113dda4c2d74d460a8fa98252b0b771bf1f27
 secp256k1;https://github.com/status-im/nim-secp256k1@#f808ed5e7a7bfc42204ec7830f14b7a42b63c284
 serialization;https://github.com/status-im/nim-serialization@#548d0adc9797a10b2db7f788b804330306293088

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -10,7 +10,7 @@ skipDirs = @["tests", "examples", "Nim", "tools", "scripts", "docs"]
 requires "nim >= 2.0.0",
   "nimcrypto >= 0.6.0 & < 0.7.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.5",
   "chronicles >= 0.11.0 & < 0.12.0", "chronos >= 4.0.4", "metrics", "secp256k1",
-  "stew >= 0.4.0", "websock >= 0.2.0", "unittest2", "results", "quic >= 0.2.10",
+  "stew >= 0.4.0", "websock >= 0.2.0", "unittest2", "results", "quic >= 0.2.11",
   "https://github.com/vacp2p/nim-jwt.git#18f8378de52b241f321c1f9ea905456e89b95c6f"
 
 let nimc = getEnv("NIMC", "nim") # Which nim compiler to use

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -150,6 +150,10 @@ method close*(s: LPChannel) {.async: (raises: []).} =
 
   trace "Closed channel", s, len = s.len
 
+method closeWrite*(s: LPChannel) {.async: (raises: []).} =
+  ## For mplex, closeWrite is the same as close - it implements half-close
+  await s.close()
+
 method initStream*(s: LPChannel) =
   if s.objName.len == 0:
     s.objName = LPChannelTrackerName

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -217,6 +217,10 @@ method closeImpl*(channel: YamuxChannel) {.async: (raises: []).} =
         discard
     await channel.actuallyClose()
 
+method closeWrite*(channel: YamuxChannel) {.async: (raises: []).} =
+  ## For yamux, closeWrite is the same as close - it implements half-close
+  await channel.close()
+
 proc clearQueues(channel: YamuxChannel, error: ref CatchableError = nil) =
   for toSend in channel.sendQueue:
     if error.isNil():

--- a/libp2p/protocols/perf/client.nim
+++ b/libp2p/protocols/perf/client.nim
@@ -12,8 +12,6 @@
 import chronos, chronicles, sequtils
 import stew/endians2
 import ./core, ../../stream/connection
-when defined(libp2p_quic_support):
-  import ../../transports/quictransport
 
 logScope:
   topics = "libp2p perf"
@@ -59,13 +57,8 @@ proc perf*(
       statsCopy.uploadBytes += toWrite.uint
       p.stats = statsCopy
 
-    # Close connection after writing for TCP, but not for QUIC
-    when defined(libp2p_quic_support):
-      if not (conn of QuicStream):
-        await conn.close()
-      # For QUIC streams, don't close yet - let server manage lifecycle
-    else:
-      await conn.close()
+    # Close write side of the stream (half-close) to signal EOF to server
+    await conn.closeWrite()
 
     size = sizeToRead
 
@@ -80,10 +73,8 @@ proc perf*(
       statsCopy.downloadBytes += toRead.uint
       p.stats = statsCopy
 
-    # Close QUIC connections after read phase
-    when defined(libp2p_quic_support):
-      if conn of QuicStream:
-        await conn.close()
+    # Close the connection after reading
+    await conn.close()
   except CancelledError as e:
     raise e
   except LPStreamError as e:

--- a/libp2p/protocols/perf/server.nim
+++ b/libp2p/protocols/perf/server.nim
@@ -14,8 +14,6 @@
 import chronos, chronicles
 import stew/endians2
 import ./core, ../protocol, ../../stream/connection, ../../utility
-when defined(libp2p_quic_support):
-  import ../../transports/quictransport
 
 export chronicles, connection
 
@@ -37,33 +35,19 @@ proc new*(T: typedesc[Perf]): T {.public.} =
       size = uint64.fromBytesBE(sizeBuffer)
 
       var toReadBuffer: array[PerfSize, byte]
-      try:
-        # Different handling for QUIC vs TCP streams
-        when defined(libp2p_quic_support):
-          if conn of QuicStream:
-            # QUIC needs timeout-based approach to detect end of upload
-            while not conn.atEof:
-              let readFut = conn.readOnce(addr toReadBuffer[0], PerfSize)
-              let read = readFut.read()
-              if read == 0:
-                break
-              bytesRead += read
-          else:
-            # TCP streams handle EOF properly
-            while true:
-              let read = await conn.readOnce(addr toReadBuffer[0], PerfSize)
-              if read == 0:
-                break
-              bytesRead += read
-        else:
-          # TCP streams handle EOF properly
-          while true:
-            let read = await conn.readOnce(addr toReadBuffer[0], PerfSize)
-            if read == 0:
-              break
-            bytesRead += read
-      except CatchableError:
-        discard
+      # Read client data until EOF (when client closes write side)
+      trace "Server: Starting to read client data"
+      while true:
+        try:
+          let read = await conn.readOnce(addr toReadBuffer[0], PerfSize)
+          if read == 0:
+            trace "Server: EOF reached, bytesRead", bytesRead
+            break  # EOF reached
+          bytesRead += read
+          trace "Server: Read bytes", read, totalBytesRead = bytesRead
+        except CatchableError as exc:
+          trace "Server: Exception while reading", exc = exc.msg
+          break  # Connection error or EOF
 
       var buf: array[PerfSize, byte]
       while size > 0:

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -151,6 +151,19 @@ method closed*(s: ChronosStream): bool =
 method atEof*(s: ChronosStream): bool =
   s.client.atEof()
 
+method closeWrite*(s: ChronosStream) {.async: (raises: []).} =
+  ## Close the write side of the TCP connection using half-close
+  if not s.client.closed():
+    try:
+      await s.client.shutdownWait()
+      trace "Write side closed", address = $s.client.remoteAddress(), s
+    except TransportError:
+      # Ignore transport errors during shutdown
+      discard
+    except CatchableError:
+      # Ignore other errors during shutdown
+      discard
+
 method closeImpl*(s: ChronosStream) {.async: (raises: []).} =
   trace "Shutting down chronos stream", address = $s.client.remoteAddress(), s
 

--- a/libp2p/stream/connection.nim
+++ b/libp2p/stream/connection.nim
@@ -40,6 +40,12 @@ type
 
 proc timeoutMonitor(s: Connection) {.async: (raises: []).}
 
+method closeWrite*(s: Connection): Future[void] {.base, async: (raises: []).} =
+  ## Close the write side of the connection
+  ## Subclasses should implement this for their specific transport
+  ## Default implementation just closes the entire connection
+  await s.close()
+
 func shortLog*(conn: Connection): string =
   try:
     if conn == nil:

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -78,6 +78,13 @@ method write*(
 
 {.pop.}
 
+method closeWrite*(stream: QuicStream) {.async: (raises: []).} =
+  ## Close the write side of the QUIC stream
+  try:
+    await stream.stream.closeWrite()
+  except CatchableError as exc:
+    discard
+
 method closeImpl*(stream: QuicStream) {.async: (raises: []).} =
   try:
     await stream.stream.close()


### PR DESCRIPTION
  - Add closeWrite method to Connection base class
  - Implement closeWrite for ChronosStream (TCP), QuicStream, LPChannel (mplex), YamuxChannel
  - Fix PERF client to use closeWrite instead of full close
  - Fix PERF server EOF detection to work with muxed connections
  - Ensures PERF protocol compliance