### PR TITLE
fix(quic): race errors when stopping transport

### DIFF
--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -277,7 +277,8 @@ method start*(
 
 method stop*(transport: QuicTransport) {.async: (raises: []).} =
   if transport.running:
-    for c in transport.connections:
+    let conns = transport.connections[0 .. ^1] 
+    for c in conns:
       await c.close()
     await procCall Transport(transport).stop()
     try:
@@ -316,11 +317,11 @@ method accept*(
 ): Future[connection.Connection] {.
     async: (raises: [transport.TransportError, CancelledError])
 .} =
-  doAssert not self.listener.isNil, "call start() before calling accept()"
-
   if not self.running:
     # stop accept only when transport is stopped (not when error occurs)
     raise newException(QuicTransportAcceptStopped, "Quic transport stopped")
+  
+  doAssert not self.listener.isNil, "call start() before calling accept()"
 
   try:
     let connection = await self.listener.accept()

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -277,7 +277,7 @@ method start*(
 
 method stop*(transport: QuicTransport) {.async: (raises: []).} =
   if transport.running:
-    let conns = transport.connections[0 .. ^1] 
+    let conns = transport.connections[0 .. ^1]
     for c in conns:
       await c.close()
     await procCall Transport(transport).stop()
@@ -320,7 +320,7 @@ method accept*(
   if not self.running:
     # stop accept only when transport is stopped (not when error occurs)
     raise newException(QuicTransportAcceptStopped, "Quic transport stopped")
-  
+
   doAssert not self.listener.isNil, "call start() before calling accept()"
 
   try:


### PR DESCRIPTION
- `not self.listener.isNil call start() before calling accept() [AssertionDefect]` 
 can happen when server is being stopped, and still accepting, so this `doAssert` was moved below `if not self.running:` as sanity check 

- `the length of the seq changed while iterating over it [AssertionDefect]`
 can happen when connection is stopped with transport; so connection's onClose callback is modifying transport.connection while stop() is iterating of connections.
