### PR TITLE
fix: don't check for errors as `close()` will only contain futures that raise `[]`

### DIFF
--- a/libp2p/errors.nim
+++ b/libp2p/errors.nim
@@ -27,7 +27,7 @@ macro checkFutures*[F](futs: seq[F], exclude: untyped = []): untyped =
     quote:
       for res in `futs`:
         if res.failed:
-          let exc = res.readError()
+          let exc = res.error
           # We still don't abort but warn
           debug "A future has failed, enable trace logging for details",
             error = exc.name
@@ -37,7 +37,7 @@ macro checkFutures*[F](futs: seq[F], exclude: untyped = []): untyped =
       for res in `futs`:
         block check:
           if res.failed:
-            let exc = res.readError()
+            let exc = res.error
             for i in 0 ..< `nexclude`:
               if exc of `exclude`[i]:
                 trace "A future has failed", error = exc.name, description = exc.msg

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -212,11 +212,9 @@ method stop*(self: WsTransport) {.async: (raises: []).} =
     trace "Stopping WS transport"
     await procCall Transport(self).stop() # call base
 
-    checkFutures(
-      await allFinished(
-        self.connections[Direction.In].mapIt(it.close()) &
-          self.connections[Direction.Out].mapIt(it.close())
-      )
+    discard await allFinished(
+      self.connections[Direction.In].mapIt(it.close()) &
+        self.connections[Direction.Out].mapIt(it.close())
     )
 
     var toWait: seq[Future[void]]


### PR DESCRIPTION
Fixes #1601