### PR TITLE
fix: pubsub signature verification

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -725,9 +725,8 @@ method rpcHandler*(
       continue
 
     if (msg.signature.len > 0 or g.verifySignature) and not msg.verify():
-      # always validate if signature is present or required
-      debug "Dropping message due to failed signature verification",
-        msgId = shortLog(msgId), peer
+      debug "Dropping message due to failed signature verification", msg = msg
+
       await g.punishInvalidMessage(peer, msg)
       continue
 

--- a/tests/pubsub/testmessage.nim
+++ b/tests/pubsub/testmessage.nim
@@ -27,6 +27,28 @@ suite "Message":
 
     check verify(msg)
 
+  test "signature with missing key":
+    let
+      seqno = 11'u64
+      seckey = PrivateKey.random(Ed25519, rng[]).get()
+      pubkey = seckey.getPublicKey().get()
+      peer = PeerInfo.new(seckey)
+    check peer.peerId.hasPublicKey() == true
+    var msg = Message.init(some(peer), @[], "topic", some(seqno), sign = true)
+    msg.key = @[]
+    # get the key from fromPeer field (inlined)
+    check verify(msg)
+
+  test "signature without inlined pubkey in peerId":
+    let
+      seqno = 11'u64
+      peer = PeerInfo.new(PrivateKey.random(RSA, rng[]).get())
+    var msg = Message.init(some(peer), @[], "topic", some(seqno), sign = true)
+    msg.key = @[]
+    # shouldn't work since there's no key field
+    # and the key is not inlined in peerid (too large)
+    check verify(msg) == false
+
   test "defaultMsgIdProvider success":
     let
       seqno = 11'u64


### PR DESCRIPTION
Fixing pubsub signature verification as per [the spec](https://github.com/libp2p/specs/blob/0caf71bb29a525ab0ef14ea4511d68e873d4a2d9/pubsub/README.md?plain=1#L215-L216)