### PR TITLE
test(yamux): Add unit tests - frame handling and stream initiation

### DIFF
--- a/tests/testyamux.nim
+++ b/tests/testyamux.nim
@@ -430,7 +430,7 @@ suite "Yamux":
 
   suite "Frame handling and stream initiation":
     asyncTest "Ping Syn responds Ping Ack":
-      mSetup(startHandlerA = false)
+      mSetup(startHandlera = false)
 
       let payload: uint32 = 0x12345678'u32
       await conna.write(YamuxHeader.ping(MsgFlags.Syn, payload))
@@ -442,7 +442,7 @@ suite "Yamux":
         header.length == payload
 
     asyncTest "Go Away Status responds with Go Away":
-      mSetup(startHandlerA = false)
+      mSetup(startHandlera = false)
 
       await conna.write(YamuxHeader.goAway(GoAwayStatus.ProtocolError))
 
@@ -457,7 +457,7 @@ suite "Yamux":
       YamuxHeader.windowUpdate(streamId = 5'u32, delta = 0, {Syn}),
     ]:
       asyncTest "Syn opens stream and sends Ack - " & $testCase:
-        mSetup(startHandlerA = false)
+        mSetup(startHandlera = false)
 
         yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
           try:
@@ -496,7 +496,7 @@ suite "Yamux":
       YamuxHeader.windowUpdate(streamId = 13'u32, delta = 0),
     ]:
       asyncTest "Reject invalid/unknown header - " & $badHeader:
-        mSetup(startHandlerA = false)
+        mSetup(startHandlera = false)
 
         await conna.write(badHeader)
 
@@ -511,7 +511,7 @@ suite "Yamux":
       # Cover the flush path: streamId not in channels, no Syn, with a pre-seeded
       # flush budget in yamuxb.flushed. First frame should be flushed (no GoAway),
       # second frame exceeding the remaining budget should trigger ProtocolError.
-      mSetup(startHandlerA = false)
+      mSetup(startHandlera = false)
 
       let streamId = 11'u32
       yamuxb.flushed[streamId] = 4 # allow up to 4 bytes to be flushed

--- a/tests/testyamux.nim
+++ b/tests/testyamux.nim
@@ -13,16 +13,12 @@ import sugar
 import chronos
 import ../libp2p/[stream/connection, stream/bridgestream, muxers/yamux/yamux]
 import ./helpers
+import ./utils/futures
 
 include ../libp2p/muxers/yamux/yamux
 
 proc newBlockerFut(): Future[void] {.async: (raises: [], raw: true).} =
   newFuture[void]()
-
-proc completedFuture(): Future[void] =
-  let f = newFuture[void]()
-  f.complete()
-  f
 
 suite "Yamux":
   teardown:

--- a/tests/testyamux.nim
+++ b/tests/testyamux.nim
@@ -54,7 +54,7 @@ suite "Yamux":
 
     defer:
       await allFutures(
-        conna.close(), connb.close(), yamuxa.close(), yamuxb.close(), handlerb, handlera
+        conna.close(), connb.close(), yamuxa.close(), yamuxb.close(), handlera, handlerb
       )
 
   suite "Simple Reading/Writing yamux messages":

--- a/tests/testyamux.nim
+++ b/tests/testyamux.nim
@@ -183,12 +183,12 @@ suite "Yamux":
 
       # Need to exhaust initial window first
       await wait(streamA.write(newSeq[byte](256000)), 1.seconds) # shouldn't block
-      await streamA.write(newSeq[byte](142))
+      await streamA.write(newSeq[byte](160))
       await streamA.close()
 
       await writerBlocker
 
-      # 1 for initial exhaustion + (142 / 20) = 9
+      # 1 for initial exhaustion + (160 / 20) = 9
       check numberOfRead == 9
 
     asyncTest "Saturate until reset":

--- a/tests/testyamux.nim
+++ b/tests/testyamux.nim
@@ -430,7 +430,7 @@ suite "Yamux":
       check (await streamA.readLp(100)) == fromHex("5678")
 
   suite "Frame handling and stream initiation":
-    asyncTest "Ping Syn produces Ping Ack":
+    asyncTest "Ping Syn responds Ping Ack":
       mSetup(startHandlerA = false)
 
       let payload: uint32 = 0x12345678'u32

--- a/tests/utils/futures.nim
+++ b/tests/utils/futures.nim
@@ -59,3 +59,8 @@ proc waitForStates*[T](
 ): Future[seq[FutureStateWrapper[T]]] {.async.} =
   await sleepAsync(timeout)
   return futures.mapIt(it.toState())
+
+proc completedFuture*(): Future[void] =
+  let f = newFuture[void]()
+  f.complete()
+  f


### PR DESCRIPTION
Changes:
- add new test suite for Yamux: `Frame handling and stream initiation`
- new tests:
  - `"Ping Syn responds Ping Ack"`
  - `"Go Away Status responds with Go Away"`
  - 2x `"Syn opens stream and sends Ack"`
    - Data header
    - WindowUpdate header
  - 5x `"Reject invalid/unknown header"`
    - Reserved parity on Data+Syn (even id against responder)
    - Reserved stream id 0
    - First frame missing Syn on unopened stream
    - Reserved parity on WindowUpdate+Syn (even id against responder)
    - Unknown stream WindowUpdate without Syn
  - `"Flush unknown-stream Data up to budget then ProtocolError when exceeded"`
