### PR TITLE
fix: dont send GoAway for unknown streams and mark streams as closed on conn close

### DIFF
--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -533,13 +533,13 @@ method close*(m: Yamux) {.async: (raises: []).} =
   trace "Closing yamux"
   let channels = toSeq(m.channels.values())
   for channel in channels:
-    for toSend in channel.sendQueue:
-      toSend.fut.fail(newLPStreamEOFError())
-    channel.sendQueue = @[]
+    channel.clearQueues(newLPStreamEOFError())
+    channel.recvWindow = 0
     channel.sendWindow = 0
     channel.closedLocally = true
     channel.isReset = true
     channel.opened = false
+    channel.isClosed = true
     await channel.remoteClosed()
     channel.receivedData.fire()
   try:
@@ -611,8 +611,10 @@ method handle*(m: Yamux) {.async: (raises: []).} =
               if header.length > 0:
                 var buffer = newSeqUninit[byte](header.length)
                 await m.connection.readExactly(addr buffer[0], int(header.length))
-          do:
-            raise newException(YamuxError, "Unknown stream ID: " & $header.streamId)
+
+          # If we do not have a stream, likely we sent a RST and/or closed the stream
+          trace "unknown stream id", id = header.streamId
+
           continue
 
         let channel =

--- a/tests/testyamux.nim
+++ b/tests/testyamux.nim
@@ -488,12 +488,8 @@ suite "Yamux":
       YamuxHeader.data(streamId = 2'u32, length = 0, {Syn}),
       # Reserved stream id 0
       YamuxHeader.data(streamId = 0'u32, length = 0, {Syn}),
-      # First frame missing Syn on unopened stream
-      YamuxHeader.data(streamId = 7'u32, length = 0),
       # Reserved parity on WindowUpdate+Syn (even id against responder)
       YamuxHeader.windowUpdate(streamId = 4'u32, delta = 0, {Syn}),
-      # Unknown stream WindowUpdate without Syn
-      YamuxHeader.windowUpdate(streamId = 13'u32, delta = 0),
     ]:
       asyncTest "Reject invalid/unknown header - " & $badHeader:
         mSetup(startHandlera = false)


### PR DESCRIPTION
@Ivansete-status reported that in nwaku's [test_peer_manager.nim](https://github.com/waku-org/nwaku/blob/5e7b8ebfffb2f8b204f92a3b7c2dd7cd7995bfa1/tests/test_peer_manager.nim#L465) tests were failing because connections weren’t marked as closed. During investigation, i found a timing window where a streamId can still arrive after being marked closed.

Current behavior sends a GoAway in this case, but that will cause problems as it will close all active streams. Not a major problem if peers arent chatty but if multiple streams are open, it will be noticeable. This might be why some interop tests with js-waku over wss under heavy lightpush load are flaky as reported by @NagyZoltanPeter

So, besides marking streams as closed, Instead of sending GoAway, unknown streamIds are now ignored: data is flushed and the stream discarded. This matches behavior in:
- [go-yamux](https://github.com/libp2p/go-yamux/blob/master/session.go#L769-L778)
- [js-libp2p-yamux](https://github.com/ChainSafe/js-libp2p-yamux/blob/36cd721cff4b5db073857d8229c7935b6ca76b71/src/muxer.ts#L497-L506)

