### PR TITLE
chore: temporarily disable performance plots from being published

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,11 +1,6 @@
 name: Performance
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
-  merge_group:
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
This task is causing the repo to be 500mb to clone.
Disabling the task temporarily while we find out where to put the performance plots