### PR TITLE
remove macos-13 from the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,6 @@ jobs:
             cpu: i386
           - os: linux-gcc-14
             cpu: amd64
-          - os: macos
-            cpu: amd64
           - os: macos-14
             cpu: arm64
           - os: windows
@@ -44,10 +42,6 @@ jobs:
           - platform:
               os: linux-gcc-14
             builder: ubuntu-24.04
-            shell: bash
-          - platform:
-              os: macos
-            builder: macos-13
             shell: bash
           - platform:
               os: macos-14


### PR DESCRIPTION
It is no longer supported, starting from September 1st: https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down