### PR TITLE
chore: pass localAddr in noise, mplex and yamux

### DIFF
--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -95,6 +95,7 @@ proc newStreamInternal*(
 
   result.peerId = m.connection.peerId
   result.observedAddr = m.connection.observedAddr
+  result.localAddr = m.connection.localAddr
   result.transportDir = m.connection.transportDir
   when defined(libp2p_agents_metrics):
     result.shortAgent = m.connection.shortAgent

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -515,6 +515,7 @@ proc createStream(
   stream.initStream()
   stream.peerId = m.connection.peerId
   stream.observedAddr = m.connection.observedAddr
+  stream.localAddr = m.connection.localAddr
   stream.transportDir = m.connection.transportDir
   when defined(libp2p_agents_metrics):
     stream.shortAgent = m.connection.shortAgent

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -583,7 +583,8 @@ method handshake*(
           )
       conn.peerId = pid
 
-      var tmp = NoiseConnection.new(conn, conn.peerId, conn.observedAddr)
+      var tmp =
+        NoiseConnection.new(conn, conn.peerId, conn.observedAddr, conn.localAddr)
       if initiator:
         tmp.readCs = handshakeRes.cs2
         tmp.writeCs = handshakeRes.cs1

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -51,12 +51,14 @@ proc new*(
     conn: Connection,
     peerId: PeerId,
     observedAddr: Opt[MultiAddress],
+    localAddr: Opt[MultiAddress],
     timeout: Duration = DefaultConnectionTimeout,
 ): T =
   result = T(
     stream: conn,
     peerId: peerId,
     observedAddr: observedAddr,
+    localAddr: localAddr,
     closeEvent: conn.closeEvent,
     timeout: timeout,
     dir: conn.dir,


### PR DESCRIPTION
Follow up to https://github.com/vacp2p/nim-libp2p/pull/1651 which also passed `localAddr` in Mplex, Yamux and Noise.