### PR TITLE
test(rendezvous): Registration TTL tests

### DIFF
--- a/libp2p/protocols/rendezvous.nim
+++ b/libp2p/protocols/rendezvous.nim
@@ -72,7 +72,7 @@ type
   Register = object
     ns: string
     signedPeerRecord: seq[byte]
-    ttl: Opt[uint64] # in seconds
+    ttl*: Opt[uint64] # in seconds
 
   RegisterResponse = object
     status: ResponseStatus
@@ -315,7 +315,7 @@ type
   RegisteredData = object
     expiration*: Moment
     peerId*: PeerId
-    data: Register
+    data*: Register
 
   RendezVous* = ref object of LPProtocol
     # Registered needs to be an offsetted sequence

--- a/libp2p/protocols/rendezvous.nim
+++ b/libp2p/protocols/rendezvous.nim
@@ -35,7 +35,10 @@ declareGauge(libp2p_rendezvous_namespaces, "number of registered namespaces")
 
 const
   RendezVousCodec* = "/rendezvous/1.0.0"
+  # Default minimum TTL per libp2p spec
   MinimumDuration* = 2.hours
+  # Lower validation limit to accommodate Waku requirements
+  MinimumAcceptedDuration = 1.minutes
   MaximumDuration = 72.hours
   MaximumMessageLen = 1 shl 22 # 4MB
   MinimumNamespaceLen = 1
@@ -744,10 +747,10 @@ proc new*(
     minDuration = MinimumDuration,
     maxDuration = MaximumDuration,
 ): T {.raises: [RendezVousError].} =
-  if minDuration < 1.minutes:
+  if minDuration < MinimumAcceptedDuration:
     raise newException(RendezVousError, "TTL too short: 1 minute minimum")
 
-  if maxDuration > 72.hours:
+  if maxDuration > MaximumDuration:
     raise newException(RendezVousError, "TTL too long: 72 hours maximum")
 
   if minDuration >= maxDuration:


### PR DESCRIPTION
Changes:
- small refactor of `rendezvous`:
  - use constants in the TTL validation
  - add `MinimumAcceptedDuration` constant and comments explaining the difference between `MinimumDuration`
  - rename `defaultDT` into `expiredDT` to reflect better it's function in marking records as expired
- new tests:
  - `"Peer default TTL is saved when advertised"`
  - `"Peer TTL is saved when advertised with TTL"`
  - `"Peer can reregister to update its TTL before previous TTL expires"`
