### PR TITLE
experiment: fix for quic pubsub tests

### DIFF
--- a/tests/pubsub/utils.nim
+++ b/tests/pubsub/utils.nim
@@ -195,7 +195,9 @@ proc generateNodes*(
 ): seq[PubSub] =
   for i in 0 ..< num:
     let switch = newStandardSwitch(
-      secureManagers = secureManagers, sendSignedPeerRecord = sendSignedPeerRecord
+      secureManagers = secureManagers,
+      sendSignedPeerRecord = sendSignedPeerRecord,
+      transport = TransportType.QUIC,
     )
     let pubsub =
       if gossip:


### PR DESCRIPTION
this fix solves issue  #1603 when quic transport is used.

```
nim c -r -d:libp2p_quic_support -d:chronicles_log_level=ERROR tests/pubsub/integration/testgossipsubmessagehandling.nim
```