### PR TITLE
fix(linters): use workaround for reviewdog bug

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 2  # In PR, has extra merge commit: ^1 = PR, ^2 = base
 
       - name: Check `nph` formatting
-        uses: arnetheduck/nph-action@v1
+        uses: arnetheduck/nph-action@ef5e9fae6dbaf88ec4308cbede780a0ba45f845d
         with:
           version: 0.6.1
           options: "examples libp2p tests interop tools *.nim*"

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -538,7 +538,7 @@ proc send*(
       encodeRpcMsg(msg, anonymize)
 
   # Messages should not exceed 90% of maxMessageSize. Guessing 10% protobuf overhead.
-  let maxEncodedMsgSize = (p.maxMessageSize * 90) div 100 
+  let maxEncodedMsgSize = (p.maxMessageSize * 90) div 100
 
   if encoded.len > maxEncodedMsgSize and msg.messages.len > 1:
     for encodedSplitMsg in splitRPCMsg(p, msg, maxEncodedMsgSize, anonymize):


### PR DESCRIPTION
Use https://github.com/arnetheduck/nph-action/pull/1 to work around [reviewdog's bug](https://github.com/reviewdog/action-suggester/pull/98) until they release a new version with the fix.