### PR TITLE
fix: revert reviewdog workaround

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 2  # In PR, has extra merge commit: ^1 = PR, ^2 = base
 
       - name: Check `nph` formatting
-        uses: arnetheduck/nph-action@ef5e9fae6dbaf88ec4308cbede780a0ba45f845d
+        uses: arnetheduck/nph-action@v1
         with:
           version: 0.6.1
           options: "examples libp2p tests interop tools *.nim*"


### PR DESCRIPTION
reverts https://github.com/vacp2p/nim-libp2p/pull/1668 since bug was fixed in reviewdog