### PR TITLE
chore: add missing import

### DIFF
--- a/libp2p/protocols/connectivity/autonatv2/client.nim
+++ b/libp2p/protocols/connectivity/autonatv2/client.nim
@@ -10,7 +10,7 @@
 {.push raises: [].}
 
 import results
-import chronos, chronicles
+import chronos, chronicles, tables
 import
   ../../protocol,
   ../../../switch,


### PR DESCRIPTION
nimbus-eth2 CI complains otherwise

```
2025-09-12T19:29:10.1341407Z /github-runner/github-runner-node-01/workspace/nimbus-eth2/nimbus-eth2/vendor/nim-libp2p/libp2p/protocols/connectivity/autonatv2/client.nim(36, 19) Error: undeclared identifier: 'Table'
2025-09-12T19:29:10.1342866Z candidates (edit distance, scope distance); see '--spellSuggest': 
2025-09-12T19:29:10.1343438Z  (3, 2): 'File'
2025-09-12T19:29:10.1343776Z  (3, 2): 'Page'
2025-09-12T19:29:10.1344074Z  (3, 2): 'Pause'
2025-09-12T19:29:10.2258408Z make: *** [Makefile:451: ncli_testnet] Error 1
```

cc: @tersec @jakubgs 