### PR TITLE
fix(autonat-v2): service setting up correctly

### DIFF
--- a/libp2p/protocols/connectivity/autonatv2/client.nim
+++ b/libp2p/protocols/connectivity/autonatv2/client.nim
@@ -58,11 +58,10 @@ proc handleDialBack(
 
 proc new*(
     T: typedesc[AutonatV2Client],
-    dialer: Dial,
     rng: ref HmacDrbgContext,
     dialBackTimeout: Duration = DefaultDialBackTimeout,
 ): T =
-  let client = T(dialer: dialer, rng: rng, dialBackTimeout: dialBackTimeout)
+  let client = T(rng: rng, dialBackTimeout: dialBackTimeout)
 
   # handler for DialBack messages
   proc handleStream(
@@ -86,6 +85,9 @@ proc new*(
   client.handler = handleStream
   client.codec = $AutonatV2Codec.DialBack
   client
+
+proc setup*(self: AutonatV2Client, switch: Switch) =
+  self.dialer = switch.dialer
 
 proc handleDialDataRequest*(
     conn: Connection, req: DialDataRequest

--- a/tests/testautonatv2.nim
+++ b/tests/testautonatv2.nim
@@ -32,8 +32,9 @@ proc setupAutonat(
   let
     src = newStandardSwitchBuilder(addrs = srcAddrs).build()
     dst = newStandardSwitchBuilder().withAutonatV2Server(config = config).build()
-    client = AutonatV2Client.new(src, newRng())
+    client = AutonatV2Client.new(newRng())
 
+  client.setup(src)
   src.mount(client)
   await src.start()
   await dst.start()
@@ -280,10 +281,11 @@ suite "AutonatV2":
     let
       src = newStandardSwitchBuilder().build()
       dst = newStandardSwitchBuilder().build()
-      client = AutonatV2Client.new(src, newRng())
+      client = AutonatV2Client.new(newRng())
       autonatV2Mock = AutonatV2Mock.new()
       reqAddrs = @[MultiAddress.init("/ip4/127.0.0.1/tcp/4040").get()]
 
+    client.setup(src)
     dst.mount(autonatV2Mock)
     src.mount(client)
     await src.start()


### PR DESCRIPTION
Fix config ordering that prevented `withAutonatV2` to correctly setup a service.