### PR TITLE
chore: nimble config tidy

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -5,12 +5,13 @@ if dirExists("nimbledeps/pkgs2"):
   switch("NimblePath", "nimbledeps/pkgs2")
 
 switch("warningAsError", "UnusedImport:on")
+switch("warningAsError", "UseBase:on")
 switch("warning", "CaseTransition:off")
 switch("warning", "ObservableStores:off")
 switch("warning", "LockLevel:off")
+
 --styleCheck:
   usages
-switch("warningAsError", "UseBase:on")
 --styleCheck:
   error
 --mm:
@@ -23,7 +24,7 @@ if defined(windows) and not defined(vcc):
   --define:
     nimRawSetjmp
 
-# begin Nimble config (version 1)
-when fileExists("nimble.paths"):
+# begin Nimble config (version 2)
+when withDir(thisDir(), system.fileExists("nimble.paths")):
   include "nimble.paths"
 # end Nimble config


### PR DESCRIPTION
- group `warningAsError` together
- `# begin Nimble config (version 2)` changes is always made when doing `nimble setup -l` so why not have it always