### PR TITLE
fix: add missing import for linux/amd64 daily job

### DIFF
--- a/tests/testautotls_integration.nim
+++ b/tests/testautotls_integration.nim
@@ -31,6 +31,8 @@ import ./helpers
 when defined(linux) and defined(amd64):
   {.used.}
 
+  import ../libp2p/utils/ipaddr
+
   suite "AutoTLS Integration":
     asyncTeardown:
       checkTrackers()


### PR DESCRIPTION
https://github.com/vacp2p/nim-libp2p/actions/runs/17876578854/job/50838745472