### PR TITLE
fix: invalid parameter passed in builder being used as channel count size

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -159,7 +159,9 @@ proc withYamux*(
     outTimeout: Duration = 5.minutes,
 ): SwitchBuilder =
   proc newMuxer(conn: Connection): Muxer =
-    Yamux.new(conn, windowSize, inTimeout = inTimeout, outTimeout = outTimeout)
+    Yamux.new(
+      conn, windowSize = windowSize, inTimeout = inTimeout, outTimeout = outTimeout
+    )
 
   assert b.muxers.countIt(it.codec == YamuxCodec) == 0, "Yamux build multiple times"
   b.muxers.add(MuxerProvider.new(newMuxer, YamuxCodec))

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -154,13 +154,18 @@ proc withMplex*(
 
 proc withYamux*(
     b: SwitchBuilder,
+    maxChannCount: int = MaxChannelCount,
     windowSize: int = YamuxDefaultWindowSize,
     inTimeout: Duration = 5.minutes,
     outTimeout: Duration = 5.minutes,
 ): SwitchBuilder =
   proc newMuxer(conn: Connection): Muxer =
     Yamux.new(
-      conn, windowSize = windowSize, inTimeout = inTimeout, outTimeout = outTimeout
+      conn,
+      maxChannCount = maxChannCount,
+      windowSize = windowSize,
+      inTimeout = inTimeout,
+      outTimeout = outTimeout,
     )
 
   assert b.muxers.countIt(it.codec == YamuxCodec) == 0, "Yamux build multiple times"

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -596,7 +596,9 @@ method handle*(m: Yamux) {.async: (raises: []).} =
               raise newException(YamuxError, "Peer used our reserved stream id")
             let newStream =
               m.createStream(header.streamId, false, m.windowSize, m.maxSendQueueSize)
-            if m.channels.len >= m.maxChannCount:
+            if m.channels.len > m.maxChannCount:
+              warn "too many channels created by remote peer",
+                peerId = m.connection.peerId, allowedMax = m.maxChannCount
               await newStream.reset()
               continue
             await newStream.open()

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -24,7 +24,7 @@ const
   YamuxVersion = 0.uint8
   YamuxDefaultWindowSize* = 256000
   MaxSendQueueSize = 256000
-  MaxChannelCount = 200
+  MaxChannelCount* = 256
 
 when defined(libp2p_yamux_metrics):
   declareGauge libp2p_yamux_channels, "yamux channels", labels = ["initiator", "peer"]


### PR DESCRIPTION
While discussing the usage of close/closeWithEOF with @NagyZoltanPeter, i realized that we werent enforcing correctly the max channel count due to passing the windowSize in the wrong parameter order. This meant that in practice we would be able to create a max of 256000 streams.

This PR fixes this, however, it means that nwaku will need to add `close` / `closeWithEOF` wherever a stream is being used, otherwise the app is going to quickly run into exceptions due to too many channels being opened, because of the 200 streams limit. ~~**This max number of streams is global, not per peer.**~~ 

**EDIT**: as described by @NagyZoltanPeter [it's per peer, not global](https://github.com/vacp2p/nim-libp2p/pull/1724#issuecomment-3342084488)

cc: @vacp2p/waku 

Streams in libp2p are not reused. The only thing that is reused is the transport connection (the actual socket). A new stream is created everytime a request is received in a handler, or a dial is performed, thus it's necessary to close the streams once done with them.

To quickly see the scenario that nwaku will run into once this fix is put in place you can use the following test unit:

```nim
{.used.}

import results, unittest2, options, stew/byteutils
import ../libp2p/[peerid, multiaddress, switch, builders, crypto/crypto]
import ./utils/async_tests
import helpers

const TestCodec = "/test/1.0.0"

type TestProtocol* = ref object of LPProtocol

proc newTestProtocol*(): TestProtocol =
  let testProto = TestProtocol()
  testProto.codec = TestCodec
  testProto.handler = proc(
      conn: Connection, proto: string
  ) {.async: (raises: [CancelledError]).} =
    try:
      let msg = string.fromBytes(await conn.readLp(1024))
      echo "RECEIVED: " & msg
    except LPStreamError as exc:
      echo "STREAM ERROR: " & exc.msg
  testProto

suite "Test Protocol":
  asyncTeardown:
    checkTrackers()

  asyncTest "hello world":
    let
      alice = SwitchBuilder
        .new()
        .withRng(newRng())
        .withTcpTransport()
        .withAddress(MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet())
        .withYamux()
        .build()
      bob = SwitchBuilder
        .new()
        .withRng(newRng())
        .withTcpTransport()
        .withAddress(MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet())
        .withYamux()
        .build()

    alice.mount(newTestProtocol())

    await alice.start()
    await bob.start()

    for i in 1 .. 201: #  <<<<<<<<<<<<< Until 200 it works
      let conn = await bob.dial(alice.peerInfo.peerId, alice.peerInfo.addrs, TestCodec)
      await conn.writeLp("Hello World")

    echo "SUCCESS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
    await sleepAsync(10.minutes)
```
And you will see a `Unhandled error: failed new dial: max allowed channel count exceeded [DialFailedError]`. Or if creating multiple clients, a `too many channels created by remote peer` warning log. 