### PR TITLE
test: various improvements

### DIFF
--- a/tests/pubsub/integration/testgossipsubmessagehandling.nim
+++ b/tests/pubsub/integration/testgossipsubmessagehandling.nim
@@ -403,7 +403,7 @@ suite "GossipSub Integration - Message Handling":
     # Send message that will be accepted by the receiver's validator
     tryPublish await nodes[0].publish("foo", "Hello!".toBytes()), 1
 
-    check:
+    checkUntilTimeout:
       recvCounter == 1
       validatedCounter == 1
       sendCounter == 1

--- a/tests/transports/stream_tests.nim
+++ b/tests/transports/stream_tests.nim
@@ -125,6 +125,7 @@ template streamTransportTest*(
       await conn.close()
 
       await sleepAsync(20.milliseconds)
+      await client.stop()
 
       clientHandlerDone.complete()
 
@@ -238,6 +239,7 @@ template streamTransportTest*(
       # Intentionally do not close streams, they should be closed with muxer
       await muxer.close()
       await conn.close()
+      await client.stop()
 
     let server = transportProvider()
     await server.start(ma)
@@ -383,6 +385,7 @@ template streamTransportTest*(
 
       await muxer.close()
       await conn.close()
+      await client.stop()
 
     let server = transportProvider()
     await server.start(ma)
@@ -485,6 +488,7 @@ template streamTransportTest*(
       await stream.close()
       await muxer.close()
       await conn.close()
+      await client.stop()
 
     let server = transportProvider()
     await server.start(ma)

--- a/tests/transports/utils.nim
+++ b/tests/transports/utils.nim
@@ -142,9 +142,8 @@ proc serverHandlerSingleStream*(
     let muxer = streamProvider(conn)
     muxer.streamHandler = handler
 
-    let muxerTask = muxer.handle()
+    await muxer.handle()
 
-    await muxerTask
     await muxer.close()
     await conn.close()
   except CatchableError as exc:
@@ -165,8 +164,10 @@ proc clientRunSingleStream*(
     let stream = await muxer.newStream()
     await handler(stream)
 
+    await stream.close()
     await muxer.close()
     await conn.close()
+    await client.stop()
   except CatchableError as exc:
     raiseAssert "should not fail: " & exc.msg
 


### PR DESCRIPTION
- stop client (ported from lsquic pr)
- utilize `checkUntilTimeout` to avoid flakyness
- 