### PR TITLE
chore: allFuturesThrowing renamed to allFuturesRaising

### DIFF
--- a/interop/hole-punching/hole_punching.nim
+++ b/interop/hole-punching/hole_punching.nim
@@ -126,7 +126,7 @@ proc main() {.async.} =
     let conn = switch.connManager.selectMuxer(listenerId).connection
     let channel = await switch.dial(listenerId, @[listenerRelayAddr], PingCodec)
     let delay = await Ping.new().ping(channel)
-    await allFuturesThrowing(
+    await allFuturesRaising(
       channel.close(), conn.close(), switch.stop(), auxSwitch.stop()
     )
     echo &"""{{"rtt_to_holepunched_peer_millis":{delay.millis}}}"""

--- a/tests/libp2p/muxers/test_mplex.nim
+++ b/tests/libp2p/muxers/test_mplex.nim
@@ -416,7 +416,7 @@ suite "Mplex":
       # this would hang
       .withTimeout(100.millis)
 
-      check await allFuturesThrowing(readerFut, writerFut).withTimeout(100.millis)
+      check await allFuturesRaising(readerFut, writerFut).withTimeout(100.millis)
 
       await conn.close()
 
@@ -485,7 +485,7 @@ suite "Mplex":
       await conn.close()
       await acceptFut.wait(1.seconds)
       await mplexDialFut.wait(1.seconds)
-      await allFuturesThrowing(transport1.stop(), transport2.stop())
+      await allFuturesRaising(transport1.stop(), transport2.stop())
       await listenFut
 
     asyncTest "read/write receiver lazy":
@@ -524,7 +524,7 @@ suite "Mplex":
       await conn.close()
       await acceptFut.wait(1.seconds)
       await mplexDialFut
-      await allFuturesThrowing(transport1.stop(), transport2.stop())
+      await allFuturesRaising(transport1.stop(), transport2.stop())
       await listenFut
 
     asyncTest "write fragmented":
@@ -577,7 +577,7 @@ suite "Mplex":
       await conn.close()
       await acceptFut
       await mplexDialFut
-      await allFuturesThrowing(transport1.stop(), transport2.stop())
+      await allFuturesRaising(transport1.stop(), transport2.stop())
 
       await listenFut
 
@@ -615,7 +615,7 @@ suite "Mplex":
       await conn.close()
       await acceptFut.wait(1.seconds)
       await mplexDialFut
-      await allFuturesThrowing(transport1.stop(), transport2.stop())
+      await allFuturesRaising(transport1.stop(), transport2.stop())
       await listenFut
 
     asyncTest "multiple streams":
@@ -663,7 +663,7 @@ suite "Mplex":
       await conn.close()
       await acceptFut.wait(1.seconds)
       await mplexDialFut
-      await allFuturesThrowing(transport1.stop(), transport2.stop())
+      await allFuturesRaising(transport1.stop(), transport2.stop())
       await listenFut
 
     asyncTest "multiple read/write streams":
@@ -714,7 +714,7 @@ suite "Mplex":
       await acceptFut.wait(1.seconds)
       await mplexDialFut
       await mplexDial.close()
-      await allFuturesThrowing(transport1.stop(), transport2.stop())
+      await allFuturesRaising(transport1.stop(), transport2.stop())
       await listenFut
 
     asyncTest "channel closes listener with EOF":
@@ -761,7 +761,7 @@ suite "Mplex":
 
       await conn.close()
       await mplexDialFut
-      await allFuturesThrowing(transport1.stop(), transport2.stop())
+      await allFuturesRaising(transport1.stop(), transport2.stop())
       await acceptFut
 
     asyncTest "channel closes dialer with EOF":
@@ -811,13 +811,13 @@ suite "Mplex":
         check s.closed
 
       await readLoop
-      await allFuturesThrowing((dialStreams & listenStreams).mapIt(it.join()))
+      await allFuturesRaising((dialStreams & listenStreams).mapIt(it.join()))
 
       checkTracker(LPChannelTrackerName)
 
       await conn.close()
       await mplexDialFut
-      await allFuturesThrowing(transport1.stop(), transport2.stop())
+      await allFuturesRaising(transport1.stop(), transport2.stop())
       await acceptFut
 
     asyncTest "dialing mplex closes both ends":
@@ -849,13 +849,13 @@ suite "Mplex":
         unorderedCompare(dialStreams, mplexDial.getStreams())
 
       await mplexDial.close()
-      await allFuturesThrowing((dialStreams & listenStreams).mapIt(it.join()))
+      await allFuturesRaising((dialStreams & listenStreams).mapIt(it.join()))
 
       checkTracker(LPChannelTrackerName)
 
       await conn.close()
       await mplexDialFut
-      await allFuturesThrowing(transport1.stop(), transport2.stop())
+      await allFuturesRaising(transport1.stop(), transport2.stop())
       await acceptFut
 
     asyncTest "listening mplex closes both ends":
@@ -891,13 +891,13 @@ suite "Mplex":
         listenStreams.len == 10 and dialStreams.len == 10
 
       await mplexListen.close()
-      await allFuturesThrowing((dialStreams & listenStreams).mapIt(it.join()))
+      await allFuturesRaising((dialStreams & listenStreams).mapIt(it.join()))
 
       checkTracker(LPChannelTrackerName)
 
       await conn.close()
       await mplexDialFut
-      await allFuturesThrowing(transport1.stop(), transport2.stop())
+      await allFuturesRaising(transport1.stop(), transport2.stop())
       await acceptFut
 
     asyncTest "canceling mplex handler closes both ends":
@@ -934,13 +934,13 @@ suite "Mplex":
         listenStreams.len == 10 and dialStreams.len == 10
 
       mplexHandle.cancel()
-      await allFuturesThrowing((dialStreams & listenStreams).mapIt(it.join()))
+      await allFuturesRaising((dialStreams & listenStreams).mapIt(it.join()))
 
       checkTracker(LPChannelTrackerName)
 
       await conn.close()
       await mplexDialFut
-      await allFuturesThrowing(transport1.stop(), transport2.stop())
+      await allFuturesRaising(transport1.stop(), transport2.stop())
 
     asyncTest "closing dialing connection should close both ends":
       let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
@@ -974,13 +974,13 @@ suite "Mplex":
         listenStreams.len == 10 and dialStreams.len == 10
 
       await conn.close()
-      await allFuturesThrowing((dialStreams & listenStreams).mapIt(it.join()))
+      await allFuturesRaising((dialStreams & listenStreams).mapIt(it.join()))
 
       checkTracker(LPChannelTrackerName)
 
       await conn.closeWithEOF()
       await mplexDialFut
-      await allFuturesThrowing(transport1.stop(), transport2.stop())
+      await allFuturesRaising(transport1.stop(), transport2.stop())
       await acceptFut
 
     asyncTest "canceling listening connection should close both ends":
@@ -1016,13 +1016,13 @@ suite "Mplex":
         listenStreams.len == 10 and dialStreams.len == 10
 
       await listenConn.closeWithEOF()
-      await allFuturesThrowing((dialStreams & listenStreams).mapIt(it.join()))
+      await allFuturesRaising((dialStreams & listenStreams).mapIt(it.join()))
 
       checkTracker(LPChannelTrackerName)
 
       await conn.close()
       await mplexDialFut
-      await allFuturesThrowing(transport1.stop(), transport2.stop())
+      await allFuturesRaising(transport1.stop(), transport2.stop())
       await acceptFut
 
     suite "jitter":
@@ -1094,7 +1094,7 @@ suite "Mplex":
         await acceptFut
         await mplexDialFut
 
-        await allFuturesThrowing(transport1.stop(), transport2.stop())
+        await allFuturesRaising(transport1.stop(), transport2.stop())
         await listenFut
 
       asyncTest "channel should handle 1 byte read/write":
@@ -1154,5 +1154,5 @@ suite "Mplex":
         await conn.close()
         await acceptFut
         await mplexDialFut
-        await allFuturesThrowing(transport1.stop(), transport2.stop())
+        await allFuturesRaising(transport1.stop(), transport2.stop())
         await listenFut

--- a/tests/libp2p/protocols/test_autonat_service.nim
+++ b/tests/libp2p/protocols/test_autonat_service.nim
@@ -81,7 +81,7 @@ suite "Autonat Service":
     check autonatService.networkReachability == NetworkReachability.NotReachable
     check libp2p_autonat_reachability_confidence.value(["NotReachable"]) == 0.3
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       switch1.stop(), switch2.stop(), switch3.stop(), switch4.stop()
     )
 
@@ -125,7 +125,7 @@ suite "Autonat Service":
     check switch1.peerInfo.addrs ==
       switch1.peerInfo.addrs.mapIt(switch1.peerStore.guessDialableAddr(it))
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       switch1.stop(), switch2.stop(), switch3.stop(), switch4.stop()
     )
 
@@ -177,7 +177,7 @@ suite "Autonat Service":
     check autonatService.networkReachability == NetworkReachability.Reachable
     check libp2p_autonat_reachability_confidence.value(["Reachable"]) == 0.3
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       switch1.stop(), switch2.stop(), switch3.stop(), switch4.stop()
     )
 
@@ -219,7 +219,7 @@ suite "Autonat Service":
     check autonatService.networkReachability == NetworkReachability.Reachable
     check libp2p_autonat_reachability_confidence.value(["Reachable"]) == 1
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       switch1.stop(), switch2.stop(), switch3.stop(), switch4.stop()
     )
 
@@ -270,7 +270,7 @@ suite "Autonat Service":
     check autonatService.networkReachability == NetworkReachability.NotReachable
     check libp2p_autonat_reachability_confidence.value(["NotReachable"]) == 1 / 3
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       switch1.stop(), switch2.stop(), switch3.stop(), switch4.stop()
     )
 
@@ -286,7 +286,7 @@ suite "Autonat Service":
     check (await autonatService.stop(switch)) == true
     check (await autonatService.stop(switch)) == false
 
-    await allFuturesThrowing(switch.stop())
+    await allFuturesRaising(switch.stop())
 
   asyncTest "Must bypass maxConnectionsPerPeer limit":
     let autonatService = AutonatService.new(
@@ -329,7 +329,7 @@ suite "Autonat Service":
     check autonatService.networkReachability == NetworkReachability.Reachable
     check libp2p_autonat_reachability_confidence.value(["Reachable"]) == 1
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop())
 
   asyncTest "Must work when peers ask each other at the same time with max 1 conn per peer":
     let autonatService1 = AutonatService.new(
@@ -387,7 +387,7 @@ suite "Autonat Service":
     check autonatService2.networkReachability == NetworkReachability.Reachable
     check libp2p_autonat_reachability_confidence.value(["Reachable"]) == 1
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop(), switch3.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop(), switch3.stop())
 
   asyncTest "Must work for one peer when two peers ask each other at the same time with max 1 conn per peer":
     let autonatService1 = AutonatService.new(
@@ -436,7 +436,7 @@ suite "Autonat Service":
     # Make sure remote peer can't create a connection to us
     check switch1.connManager.connCount(switch2.peerInfo.peerId) == 1
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop())
 
   asyncTest "Must work with low maxConnections":
     let autonatService = AutonatService.new(
@@ -485,7 +485,7 @@ suite "Autonat Service":
     check autonatService.networkReachability == NetworkReachability.Reachable
     check libp2p_autonat_reachability_confidence.value(["Reachable"]) == 1
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       switch1.stop(), switch2.stop(), switch3.stop(), switch4.stop(), switch5.stop()
     )
 
@@ -511,4 +511,4 @@ suite "Autonat Service":
 
     await sleepAsync(250.milliseconds)
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop())

--- a/tests/libp2p/protocols/test_autonat_v2_service.nim
+++ b/tests/libp2p/protocols/test_autonat_v2_service.nim
@@ -57,10 +57,10 @@ proc createSwitches(n: int): seq[Switch] =
   switches
 
 proc startAll(switches: seq[Switch]) {.async.} =
-  await allFuturesThrowing(switches.mapIt(it.start()))
+  await allFuturesRaising(switches.mapIt(it.start()))
 
 proc stopAll(switches: seq[Switch]) {.async.} =
-  await allFuturesThrowing(switches.mapIt(it.stop()))
+  await allFuturesRaising(switches.mapIt(it.stop()))
 
 proc startAndConnect(switch: Switch, switches: seq[Switch]) {.async.} =
   await switch.start()
@@ -335,7 +335,7 @@ suite "AutonatV2 Service":
     await awaiter
     check service.networkReachability == NetworkReachability.Reachable
     check libp2p_autonat_v2_reachability_confidence.value(["Reachable"]) == 1
-    await allFuturesThrowing(switch1.stop(), switch2.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop())
 
   asyncTest "Must work when peers ask each other at the same time with max 1 conn per peer":
     let
@@ -400,7 +400,7 @@ suite "AutonatV2 Service":
     check service2.networkReachability == NetworkReachability.Reachable
     check libp2p_autonat_v2_reachability_confidence.value(["Reachable"]) == 1
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop(), switch3.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop(), switch3.stop())
 
   asyncTest "Must work for one peer when two peers ask each other at the same time with max 1 conn per peer":
     let
@@ -454,7 +454,7 @@ suite "AutonatV2 Service":
     # Make sure remote peer can't create a connection to us
     check switch1.connManager.connCount(switch2.peerInfo.peerId) == 1
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop())
 
   asyncTest "Must work with low maxConnections":
     let (service, client) = newService(
@@ -524,4 +524,4 @@ suite "AutonatV2 Service":
 
     await sleepAsync(250.milliseconds)
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop())

--- a/tests/libp2p/protocols/test_noise.nim
+++ b/tests/libp2p/protocols/test_noise.nim
@@ -274,7 +274,7 @@ suite "Noise":
     check "Hello!" == msg
     await conn.close()
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop())
 
   asyncTest "e2e test wrong secure negotiation":
     let ma1 = MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()
@@ -296,4 +296,4 @@ suite "Noise":
       let conn =
         await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, TestCodec)
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop())

--- a/tests/libp2p/pubsub/component/test_floodsub.nim
+++ b/tests/libp2p/pubsub/component/test_floodsub.nim
@@ -177,9 +177,9 @@ suite "FloodSub Component":
     var pubs: seq[Future[int]]
     for i in 0 ..< numberOfNodes:
       pubs &= nodes[i].publish(topic, ("Hello!" & $i).toBytes())
-    await allFuturesThrowing(pubs)
+    await allFuturesRaising(pubs)
 
-    await allFuturesThrowing(futs.mapIt(it[0]))
+    await allFuturesRaising(futs.mapIt(it[0]))
 
   asyncTest "FloodSub multiple peers, with self trigger":
     const numberOfNodes = 10
@@ -213,10 +213,10 @@ suite "FloodSub Component":
     var pubs: seq[Future[int]]
     for i in 0 ..< numberOfNodes:
       pubs &= nodes[i].publish(topic, ("Hello!" & $i).toBytes())
-    await allFuturesThrowing(pubs)
+    await allFuturesRaising(pubs)
 
     # wait the test task
-    await allFuturesThrowing(futs.mapIt(it[0]))
+    await allFuturesRaising(futs.mapIt(it[0]))
 
     # test calling unsubscribeAll for coverage
     for node in nodes:

--- a/tests/libp2p/pubsub/component/test_gossipsub_mesh_management.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_mesh_management.nim
@@ -322,7 +322,7 @@ suite "GossipSub Component - Mesh Management":
 
     startNodesAndDeferStop(nodes)
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       connectNodes(nodes[0], nodes[1]), # Out
       connectNodes(nodes[0], nodes[2]), # Out
       connectNodes(nodes[3], nodes[0]), # In

--- a/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
@@ -757,7 +757,7 @@ suite "GossipSub Component - Message Handling":
     node1.addObserver(PubSubObserver(onRecv: observer1))
 
     # Connect them as direct peers
-    await allFuturesThrowing(
+    await allFuturesRaising(
       node0.addDirectPeer(node1.peerInfo.peerId, node1.peerInfo.addrs),
       node1.addDirectPeer(node0.peerInfo.peerId, node0.peerInfo.addrs),
     )

--- a/tests/libp2p/pubsub/utils.nim
+++ b/tests/libp2p/pubsub/utils.nim
@@ -143,7 +143,7 @@ proc setupGossipSubWithPeers*(
   )
 
 proc teardownGossipSub*(gossipSub: TestGossipSub, conns: seq[Connection]) {.async.} =
-  await allFuturesThrowing(conns.mapIt(it.close()))
+  await allFuturesRaising(conns.mapIt(it.close()))
 
 func defaultMsgIdProvider*(m: Message): Result[MessageId, ValidationResult] =
   let mid =
@@ -310,7 +310,7 @@ proc connectNodesChain*[T: PubSub](nodes: seq[T]) {.async.} =
   for i in 0 ..< nodes.len - 1:
     futs.add(connectNodes(nodes[i], nodes[i + 1]))
 
-  await allFuturesThrowing(futs)
+  await allFuturesRaising(futs)
 
 proc connectNodesRing*[T: PubSub](nodes: seq[T]) {.async.} =
   ## Ring: 1-2-3-4-5-1
@@ -321,7 +321,7 @@ proc connectNodesRing*[T: PubSub](nodes: seq[T]) {.async.} =
     futs.add(connectNodes(nodes[i], nodes[i + 1]))
   futs.add(connectNodes(nodes[nodes.len - 1], nodes[0]))
 
-  await allFuturesThrowing(futs)
+  await allFuturesRaising(futs)
 
 proc connectNodesHub*[T: PubSub](hub: T, nodes: seq[T]) {.async.} =
   ## Hub: hub-1, hub-2, hub-3,...
@@ -331,7 +331,7 @@ proc connectNodesHub*[T: PubSub](hub: T, nodes: seq[T]) {.async.} =
   for i in 0 ..< nodes.len:
     futs.add(connectNodes(hub, nodes[i]))
 
-  await allFuturesThrowing(futs)
+  await allFuturesRaising(futs)
 
 proc connectNodesStar*[T: PubSub](nodes: seq[T]) {.async.} =
   ## Star: 1-2; 1-3; 2-1; 2-3, 3-1, 3-2
@@ -343,7 +343,7 @@ proc connectNodesStar*[T: PubSub](nodes: seq[T]) {.async.} =
       if dialer.switch.peerInfo.peerId != listener.switch.peerInfo.peerId:
         futs.add(connectNodes(dialer, listener))
 
-  await allFuturesThrowing(futs)
+  await allFuturesRaising(futs)
 
 proc connectNodesSparse*[T: PubSub](nodes: seq[T], degree: int = 2) {.async.} =
   doAssert nodes.len >= degree, "nodes count needs to be greater or equal to degree"
@@ -358,7 +358,7 @@ proc connectNodesSparse*[T: PubSub](nodes: seq[T], degree: int = 2) {.async.} =
       if dialer.switch.peerInfo.peerId != listener.switch.peerInfo.peerId:
         futs.add(connectNodes(dialer, listener))
 
-  await allFuturesThrowing(futs)
+  await allFuturesRaising(futs)
 
 template waitSubscribeChain*[T: PubSub](nodes: seq[T], topic: string): untyped =
   ## Chain: 1-2-3-4-5
@@ -437,10 +437,10 @@ proc waitSubGraph*[T: PubSub](nodes: seq[T], key: string) {.async.} =
     isGraphConnected()
 
 proc startNodes*[T: PubSub](nodes: seq[T]) {.async.} =
-  await allFuturesThrowing(nodes.mapIt(it.switch.start()))
+  await allFuturesRaising(nodes.mapIt(it.switch.start()))
 
 proc stopNodes*[T: PubSub](nodes: seq[T]) {.async.} =
-  await allFuturesThrowing(nodes.mapIt(it.switch.stop()))
+  await allFuturesRaising(nodes.mapIt(it.switch.stop()))
 
 template startNodesAndDeferStop*[T: PubSub](nodes: seq[T]): untyped =
   await startNodes(nodes)
@@ -620,4 +620,4 @@ proc addDirectPeerStar*[T: PubSub](nodes: seq[T]) {.async.} =
       if node.switch.peerInfo.peerId != target.switch.peerInfo.peerId:
         futs.add(addDirectPeer(node, target))
 
-  await allFuturesThrowing(futs)
+  await allFuturesRaising(futs)

--- a/tests/libp2p/services/test_hp.nim
+++ b/tests/libp2p/services/test_hp.nim
@@ -80,7 +80,7 @@ suite "Hole Punching":
     let peerSwitch = createSwitch()
     let switchRelay = createSwitch(Relay.new())
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       switchRelay.start(),
       privatePeerSwitch.start(),
       publicPeerSwitch.start(),
@@ -110,7 +110,7 @@ suite "Hole Punching":
         privatePeerSwitch.connManager.selectMuxer(publicPeerSwitch.peerInfo.peerId).connection
       )
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       privatePeerSwitch.stop(),
       publicPeerSwitch.stop(),
       switchRelay.stop(),
@@ -141,7 +141,7 @@ suite "Hole Punching":
     let peerSwitch = createSwitch()
     let switchRelay = createSwitch(Relay.new())
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       switchRelay.start(),
       privatePeerSwitch.start(),
       publicPeerSwitch.start(),
@@ -171,7 +171,7 @@ suite "Hole Punching":
         privatePeerSwitch.connManager.selectMuxer(publicPeerSwitch.peerInfo.peerId).connection
       )
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       privatePeerSwitch.stop(),
       publicPeerSwitch.stop(),
       switchRelay.stop(),
@@ -223,7 +223,7 @@ suite "Hole Punching":
 
     var awaiter = newFuture[void]()
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       switchRelay.start(),
       privatePeerSwitch1.start(),
       privatePeerSwitch2.start(),
@@ -271,7 +271,7 @@ suite "Hole Punching":
     # wait for hole punching to finish in the background
     await sleepAsync(300.millis)
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       privatePeerSwitch1.stop(),
       privatePeerSwitch2.stop(),
       switchRelay.stop(),

--- a/tests/libp2p/stream/test_bufferstream.nim
+++ b/tests/libp2p/stream/test_bufferstream.nim
@@ -154,7 +154,7 @@ suite "BufferStream":
     let readerFut = reader()
     let writerFut = writer()
 
-    await allFuturesThrowing(readerFut, writerFut)
+    await allFuturesRaising(readerFut, writerFut)
 
     check str == str2
     await buff.close()

--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -171,7 +171,7 @@ suite "Connection Manager":
 
     await connMngr.close()
 
-    await allFuturesThrowing(muxs.mapIt(it.close()))
+    await allFuturesRaising(muxs.mapIt(it.close()))
 
   asyncTest "expect connection from peer":
     # FIXME This should be 1 instead of 0, it will get fixed soon
@@ -208,7 +208,7 @@ suite "Connection Manager":
     checkUntilTimeout:
       waitedConn3.cancelled()
 
-    await allFuturesThrowing(muxs.mapIt(it.close()))
+    await allFuturesRaising(muxs.mapIt(it.close()))
 
   asyncTest "cleanup on connection close":
     let connMngr = ConnManager.new()
@@ -377,7 +377,7 @@ suite "Connection Manager":
 
     check (await incomingSlot.withTimeout(10.millis)) == false
 
-    await allFuturesThrowing(muxs.mapIt(it.close()))
+    await allFuturesRaising(muxs.mapIt(it.close()))
 
     check await incomingSlot.withTimeout(10.millis)
 

--- a/tests/libp2p/test_dialer.nim
+++ b/tests/libp2p/test_dialer.nim
@@ -55,4 +55,4 @@ suite "Dialer":
       1000.millis
     )
 
-    await allFuturesThrowing(switches.mapIt(it.stop()))
+    await allFuturesRaising(switches.mapIt(it.stop()))

--- a/tests/libp2p/test_switch.nim
+++ b/tests/libp2p/test_switch.nim
@@ -81,7 +81,7 @@ suite "Switch":
     check "Hello!" == msg
     await conn.close()
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       handleFinished.wait(5.seconds), switch1.stop(), switch2.stop()
     )
 
@@ -128,7 +128,7 @@ suite "Switch":
     check "Hello!" == msg
     await conn.close()
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       handleFinished.wait(5.seconds), switch1.stop(), switch2.stop()
     )
 
@@ -170,7 +170,7 @@ suite "Switch":
     check "Hello!" == msg
     await conn.close()
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       handleFinished.wait(5.seconds), switch1.stop(), switch2.stop()
     )
 
@@ -210,7 +210,7 @@ suite "Switch":
     let msg = string.fromBytes(await conn.readLp(1024))
     check "Hello!" == msg
 
-    await allFuturesThrowing(conn.close(), switch1.stop(), switch2.stop())
+    await allFuturesRaising(conn.close(), switch1.stop(), switch2.stop())
 
     check not switch1.isConnected(switch2.peerInfo.peerId)
     check not switch2.isConnected(switch1.peerInfo.peerId)
@@ -241,7 +241,7 @@ suite "Switch":
 
     await switch2.disconnect(switch1.peerInfo.peerId)
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop())
 
   asyncTest "e2e connect to peer with known PeerId":
     let switch1 = newStandardSwitch(secureManagers = [SecureProtocol.Noise])
@@ -271,7 +271,7 @@ suite "Switch":
 
     await switch2.disconnect(switch1.peerInfo.peerId)
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop())
 
   asyncTest "e2e should not leak on peer disconnect":
     let switch1 = newStandardSwitch()
@@ -310,7 +310,7 @@ suite "Switch":
           switch2.connManager.outSema.availableSlots,
         ]
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop())
 
   asyncTest "e2e should trigger connection events (remote)":
     let switch1 = newStandardSwitch()
@@ -358,7 +358,7 @@ suite "Switch":
     check:
       kinds == {ConnEventKind.Connected, ConnEventKind.Disconnected}
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop())
 
   asyncTest "e2e should trigger connection events (local)":
     let switch1 = newStandardSwitch()
@@ -406,7 +406,7 @@ suite "Switch":
     check:
       kinds == {ConnEventKind.Connected, ConnEventKind.Disconnected}
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop())
 
   asyncTest "e2e should trigger peer events (remote)":
     let switch1 = newStandardSwitch()
@@ -455,7 +455,7 @@ suite "Switch":
     check:
       kinds == {PeerEventKind.Joined, PeerEventKind.Left}
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop())
 
   asyncTest "e2e should trigger peer events (local)":
     let switch1 = newStandardSwitch()
@@ -504,7 +504,7 @@ suite "Switch":
     check:
       kinds == {PeerEventKind.Joined, PeerEventKind.Left}
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop())
 
   asyncTest "e2e should trigger peer events only once per peer":
     let switch1 = newStandardSwitch()
@@ -565,7 +565,7 @@ suite "Switch":
     check:
       kinds == {PeerEventKind.Joined, PeerEventKind.Left}
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop(), switch3.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop(), switch3.stop())
 
   asyncTest "e2e should allow dropping peer from connection events":
     # use same private keys to emulate two connection from same peer
@@ -601,7 +601,7 @@ suite "Switch":
 
     await onDisconnect.wait()
 
-    await allFuturesThrowing(switches.mapIt(it.stop()))
+    await allFuturesRaising(switches.mapIt(it.stop()))
 
   asyncTest "e2e should allow dropping multiple connections for peer from connection events":
     let privateKey = PrivateKey.random(rng[]).tryGet()
@@ -646,7 +646,7 @@ suite "Switch":
       not isCounterLeaked(LPChannelTrackerName)
       not isCounterLeaked(SecureConnTrackerName)
 
-    await allFuturesThrowing(switches[0].stop())
+    await allFuturesRaising(switches[0].stop())
 
   asyncTest "e2e closing remote conn should not leak":
     let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
@@ -673,7 +673,7 @@ suite "Switch":
     checkTracker(SecureConnTrackerName)
     checkTracker(ChronosStreamTrackerName)
 
-    await allFuturesThrowing(transport.stop(), switch.stop())
+    await allFuturesRaising(transport.stop(), switch.stop())
 
   asyncTest "e2e calling closeWithEOF on the same stream should not assert":
     proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
@@ -703,7 +703,7 @@ suite "Switch":
     for i in 0 .. 10:
       readers.add(closeReader())
 
-    await allFuturesThrowing(readers)
+    await allFuturesRaising(readers)
     await switch2.stop() #Otherwise this leaks
     checkUntilTimeout:
       not switch1.isConnected(switch2.peerInfo.peerId)
@@ -750,7 +750,7 @@ suite "Switch":
       )
     )
 
-    await allFuturesThrowing(switches.mapIt(it.stop()))
+    await allFuturesRaising(switches.mapIt(it.stop()))
 
   asyncTest "e2e total connection limits on incoming connections":
     var switches: seq[Switch]
@@ -775,7 +775,7 @@ suite "Switch":
     switches.add(srcSwitch)
     switches.add(dstSwitch)
 
-    await allFuturesThrowing(switches.mapIt(it.stop()))
+    await allFuturesRaising(switches.mapIt(it.stop()))
 
   asyncTest "e2e max incoming connection limits":
     var switches: seq[Switch]
@@ -803,7 +803,7 @@ suite "Switch":
       )
     )
 
-    await allFuturesThrowing(switches.mapIt(it.stop()))
+    await allFuturesRaising(switches.mapIt(it.stop()))
 
   asyncTest "e2e max outgoing connection limits":
     var switches: seq[Switch]
@@ -828,7 +828,7 @@ suite "Switch":
     switches.add(srcSwitch)
     switches.add(dstSwitch)
 
-    await allFuturesThrowing(switches.mapIt(it.stop()))
+    await allFuturesRaising(switches.mapIt(it.stop()))
 
   asyncTest "e2e peer store":
     let handleFinished = newWaitGroup(1)
@@ -865,7 +865,7 @@ suite "Switch":
     check "Hello!" == msg
     await conn.close()
 
-    await allFuturesThrowing(
+    await allFuturesRaising(
       handleFinished.wait(5.seconds), switch1.stop(), switch2.stop()
     )
 
@@ -916,7 +916,7 @@ suite "Switch":
     let switch3 =
       newStandardSwitch(addrs = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet())
 
-    await allFuturesThrowing(switch1.start(), switch2.start(), switch3.start())
+    await allFuturesRaising(switch1.start(), switch2.start(), switch3.start())
 
     check IP4.matchPartial(switch1.peerInfo.addrs[0])
     check IP6.matchPartial(switch1.peerInfo.addrs[1])
@@ -943,7 +943,7 @@ suite "Switch":
     check "Hello!" == string.fromBytes(await connv6.readLp(1024))
     await connv6.close()
 
-    await allFuturesThrowing(switch1.stop(), switch2.stop(), switch3.stop())
+    await allFuturesRaising(switch1.stop(), switch2.stop(), switch3.stop())
 
     check not switch1.isConnected(switch2.peerInfo.peerId)
     check not switch2.isConnected(switch1.peerInfo.peerId)
@@ -1170,4 +1170,4 @@ suite "Switch":
     await switch.start()
     await switch.start()
 
-    await allFuturesThrowing(switch.stop())
+    await allFuturesRaising(switch.stop())

--- a/tests/tools/futures.nim
+++ b/tests/tools/futures.nim
@@ -14,7 +14,9 @@ proc completedFuture*(): Future[void] =
   f.complete()
   f
 
-proc allFuturesThrowing*(args: varargs[FutureBase]): Future[void] =
+proc allFuturesRaising*(
+    args: varargs[FutureBase]
+): Future[void].Raising([CatchableError]) =
   # This proc is only meant for use in tests / not suitable for general use.
   # Swallowing errors arbitrarily instead of aggregating them is bad design
   # It raises `CatchableError` instead of the union of the `futs` errors,
@@ -35,10 +37,12 @@ proc allFuturesThrowing*(args: varargs[FutureBase]): Future[void] =
         raise firstErr
   )()
 
-proc allFuturesThrowing*[T](futs: varargs[Future[T]]): Future[void] =
-  allFuturesThrowing(futs.mapIt(FutureBase(it)))
+proc allFuturesRaising*[T](
+    futs: varargs[Future[T]]
+): Future[void].Raising([CatchableError]) =
+  allFuturesRaising(futs.mapIt(FutureBase(it)))
 
-proc allFuturesThrowing*[T, E]( # https://github.com/nim-lang/Nim/issues/23432
+proc allFuturesRaising*[T, E]( # https://github.com/nim-lang/Nim/issues/23432
     futs: varargs[InternalRaisesFuture[T, E]]
-): Future[void] =
-  allFuturesThrowing(futs.mapIt(FutureBase(it)))
+): Future[void].Raising([CatchableError]) =
+  allFuturesRaising(futs.mapIt(FutureBase(it)))


### PR DESCRIPTION
- rename `allFuturesThrowing` -> `allFuturesRaising`
  - initially PR's intention was to rename it to `allFuturesDiscarding`, but `Raising` has more sense based on https://github.com/vacp2p/nim-libp2p/pull/1934#discussion_r2592984943
- adding `Raising` to return type
- removed unnecessary call to `allFutures / allFinished` within `allFuturesThrowing`