### PR TITLE
docs: Improve Development section visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,12 @@ You'll find the nim-libp2p documentation [here](https://vacp2p.github.io/nim-lib
 
 ## Development
 
-Read the [development](docs/development.md) guide to get started with the project and testing the code. Additionally, check the [compile time flags](docs/compile_time_flags.md) page, where all available compile-time flags are documented. Reading [common hurdles](docs/common_hurdles.md) for frequently encountered issues can be helpfull to prevent painfull time loss in advance.
+Read the [development guide](docs/development.md) to get started with the project and testing.
+
+Additional resources:
+
+- [Compile time flags](docs/compile_time_flags.md) - all available compile-time options
+- [Common hurdles](docs/common_hurdles.md) - frequently encountered issues and solutions
 
 ## Contributors
 

--- a/docs/compile_time_flags.md
+++ b/docs/compile_time_flags.md
@@ -1,4 +1,4 @@
-# Compile time flags|
+# Compile time flags
 
 Enable autotls support
 ```bash


### PR DESCRIPTION
The Development section links to additional documentation, but in its previous form as a single paragraph, these links were easy to overlook.

This PR adds some visual separation to make the resources easier to discover.