### PR TITLE
fix(kad-dht): stop condition on find_node and track whether node responded succesfully or not

### DIFF
--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -16,11 +16,15 @@ import ./[routingtable, protobuf, types]
 logScope:
   topics = "kad-dht find"
 
+type RespondedStatus* = enum
+  Failed
+  Success
+
 type LookupState* = object
   kad: KadDHT
   target*: Key
   shortlist*: Table[PeerId, XorDistance]
-  responded*: HashSet[PeerId]
+  responded*: Table[PeerId, RespondedStatus]
   attempts: Table[PeerId, int]
 
 type DispatchProc* = proc(kad: KadDHT, peer: PeerId, target: Key): Future[Opt[Message]] {.
@@ -88,8 +92,28 @@ proc selectCloserPeers*(
     # take at most alpha peers
     .take(amount)
 
+proc hasResponsesFromClosestAvailable(state: LookupState): bool {.raises: [], gcsafe.} =
+  ## True when all closest k AVAILABLE peers have responded.
+  let candidates = state.sortedShortlist(excludeResponded = false)
+  if candidates.len == 0:
+    return true
+
+  var closetsRespondedCnt = 0
+  for (c, _) in candidates:
+    if state.responded.hasKey(c):
+      try:
+        if state.responded[c] == RespondedStatus.Success:
+          closetsRespondedCnt.inc(1)
+      except KeyError:
+        raiseAssert "checked with hasKey"
+    else:
+      # It's a close peer but has not been queried yet
+      break
+
+  return closetsRespondedCnt >= state.kad.config.replication
+
 proc init*(T: type LookupState, kad: KadDHT, target: Key): T =
-  var res = LookupState(kad: kad, target: target, responded: initHashSet[PeerId]())
+  var res = LookupState(kad: kad, target: target)
   for pid in kad.rtable.findClosestPeerIds(target, kad.config.replication):
     res.shortlist[pid] = xorDistance(pid, target, kad.rtable.config.hasher)
 
@@ -132,7 +156,6 @@ proc iterativeLookup*(
     dispatch: DispatchProc,
     onReply: ReplyHandler,
     stopCond: StopCond,
-    countFailedAsResponded: bool = true,
 ): Future[LookupState] {.async: (raises: [CancelledError]).} =
   var state = LookupState.init(kad, target)
 
@@ -164,8 +187,8 @@ proc iterativeLookup*(
     for (fut, peerId) in zip(rpcBatch, toQuery):
       if not fut.completed():
         continue
-      if countFailedAsResponded or not fut.failed():
-        state.responded.incl(peerId)
+      state.responded[peerId] =
+        if fut.failed(): RespondedStatus.Failed else: RespondedStatus.Success
 
     for (peerId, msg) in completedRPCBatch:
       msg.withValue(reply):
@@ -186,9 +209,7 @@ method findNode*(
     discard
 
   let stop = proc(state: LookupState): bool {.raises: [], gcsafe.} =
-    # findNode does not have a stop condition per se except 
-    # for when there's no more nodes to query to traverse the DHT
-    false
+    state.hasResponsesFromClosestAvailable()
 
   let dispatchFind = proc(
       kad: KadDHT, peer: PeerId, target: Key
@@ -197,9 +218,7 @@ method findNode*(
   .} =
     return await dispatchFindNode(kad, peer, target)
 
-  let state = await kad.iterativeLookup(
-    target, dispatchFind, ignoreReply, stop, countFailedAsResponded = true
-  )
+  let state = await kad.iterativeLookup(target, dispatchFind, ignoreReply, stop)
 
   return state.selectCloserPeers(kad.config.replication, excludeResponded = false)
 

--- a/libp2p/protocols/kademlia/get.nim
+++ b/libp2p/protocols/kademlia/get.nim
@@ -95,9 +95,7 @@ proc getValue*(
   let stop = proc(state: LookupState): bool {.gcsafe.} =
     received.len >= quorum
 
-  discard await kad.iterativeLookup(
-    key, dispatchGetVal, onReply, stop, countFailedAsResponded = false
-  )
+  discard await kad.iterativeLookup(key, dispatchGetVal, onReply, stop)
 
   let best = ?kad.bestValidRecord(key, received, quorum)
 

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -228,9 +228,7 @@ proc getProviders*(
   let stop = proc(state: LookupState): bool {.gcsafe.} =
     allProviders.len() >= kad.config.replication
 
-  discard await kad.iterativeLookup(
-    key, dispatchGetProviders, onReply, stop, countFailedAsResponded = false
-  )
+  discard await kad.iterativeLookup(key, dispatchGetProviders, onReply, stop)
 
   return allProviders
 

--- a/tests/libp2p/kademlia/test_find.nim
+++ b/tests/libp2p/kademlia/test_find.nim
@@ -9,7 +9,7 @@
 
 {.used.}
 
-import chronos, std/[enumerate, sets], sequtils, tables
+import chronos, std/[enumerate, sequtils, tables]
 import ../../../libp2p/[protocols/kademlia, switch, builders]
 import ../../tools/[unittest]
 import ./utils.nim
@@ -488,8 +488,8 @@ suite "KadDHT Find":
     state.shortlist[peer3] = xorDistance(peer3, targetKey, kad.rtable.config.hasher)
 
     # Mark peer1 and peer2 as responded
-    state.responded.incl(peer1)
-    state.responded.incl(peer2)
+    state.responded[peer1] = RespondedStatus.Success
+    state.responded[peer2] = RespondedStatus.Success
 
     # Only peer3 should be selectable
     let selected = state.selectCloserPeers(10)


### PR DESCRIPTION
Current code can potentially query the whole network. With this change it should stop when there are no unqueried peers left in the short list (as it  drop those whole  xor distance is greater than alpha), or, did queries and didnt discover anything closer than the best we already had.

h/t to Vlado for reporting this issue!