### PR TITLE
feat(peerstore): add LastSeenOutboundBook for outbound-only address 

### DIFF
--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -231,7 +231,7 @@ proc internalConnect(
 
   try:
     self.connManager.storeMuxer(muxed)
-    await self.peerStore.identify(muxed)
+    await self.peerStore.identify(muxed, dir)
     await self.connManager.triggerPeerEvents(
       muxed.connection.peerId,
       PeerEvent(kind: PeerEventKind.Identified, initiator: true),

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -228,7 +228,7 @@ proc upgrader(
   try:
     let muxed = await trans.upgrade(conn, Opt.none(PeerId))
     switch.connManager.storeMuxer(muxed)
-    await switch.peerStore.identify(muxed)
+    await switch.peerStore.identify(muxed, conn.transportDir)
     await switch.connManager.triggerPeerEvents(
       muxed.connection.peerId,
       PeerEvent(kind: PeerEventKind.Identified, initiator: false),


### PR DESCRIPTION
…racking

Add LastSeenOutboundBook to track observed addresses only for outbound connections. This complements LastSeenBook which stores addresses for all connections (both inbound and outbound).

Changes:
- Add LastSeenOutboundBook type to peerstore
- Update identify() to accept Direction parameter
- Update updatePeerInfo() to track direction and populate LastSeenOutboundBook only for outbound connections
- Update dialer and switch to pass connection direction to identify
- Add comprehensive test to verify outbound-only tracking

The implementation ensures:
- LastSeenBook continues to store addresses for ALL connections (backward compatible)
- LastSeenOutboundBook stores addresses ONLY for outbound connections
- Direction checking logic is centralized in updatePeerInfo