### PR TITLE
test(kad): provider 1 - refactor

### DIFF
--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -14,6 +14,9 @@ import ../../utils/heartbeat
 import ../protocol
 import ./[protobuf, types, find]
 
+logScope:
+  topics = "kad-dht provider"
+
 proc `==`*(a, b: ProviderRecord): bool {.inline.} =
   a.provider.id == b.provider.id and a.key == b.key
 


### PR DESCRIPTION
Changes:
- refactor `provider` tests:
  - use common helpers
  - use `checkUntilTimeout` instead of `sleepAsync`that can be flaky
  - rewrite "Get providers" test
- add log scope