### PR TITLE
feat: v1.15.1

### DIFF
--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName = "libp2p"
-version = "1.15.0"
+version = "1.15.1"
 author = "Status Research & Development GmbH"
 description = "LibP2P implementation"
 license = "MIT"


### PR DESCRIPTION
Creating this version to fix an issue reported by @Ivansete-status in which lsquic fork was not being loaded; and also, so compile constants from lsquic and boringssl use localpassc instead of passc