### PR TITLE
chore(mix): make delay strategy pluggable

### DIFF
--- a/libp2p/protocols/mix/delay_strategy.nim
+++ b/libp2p/protocols/mix/delay_strategy.nim
@@ -10,31 +10,27 @@ import ../../crypto/crypto
 type DelayStrategy* = ref object of RootObj ## Abstract interface for delay strategies.
   rng: ref HmacDrbgContext
 
-import results
-
-method generateForEntry*(
-    self: DelayStrategy
-): Result[uint16, string] {.base, gcsafe, raises: [].} =
+method generateForEntry*(self: DelayStrategy): uint16 {.base, gcsafe, raises: [].} =
   ## Generate delay value to encode in packet (called by sender/entry node).
+  ## implementation should return some default value in case of errors
+  raiseAssert "generateForEntry must be implemented by concrete delay strategy types"
 
 method generateForIntermediate*(
     self: DelayStrategy, encodedDelayMs: uint16
 ): uint16 {.base, gcsafe, raises: [].} =
   ## Generate actual delay from encoded value (called by intermediate node).
   ## implementation should return some default value in case of errors
+  raiseAssert "generateForIntermediate must be implemented by concrete delay strategy types"
 
 type NoSamplingDelayStrategy* = ref object of DelayStrategy
   ## Default strategy: generates random delays [0-2]ms, uses them directly.
 
 proc new*(T: typedesc[NoSamplingDelayStrategy], rng: ref HmacDrbgContext): T =
+  doAssert(rng != nil, "random is not set")
   T(rng: rng)
 
-method generateForEntry*(
-    self: NoSamplingDelayStrategy
-): Result[uint16, string] {.gcsafe, raises: [].} =
-  if self.rng.isNil:
-    return err("RNG is nil")
-  ok((self.rng[].generate(uint64) mod 3).uint16)
+method generateForEntry*(self: NoSamplingDelayStrategy): uint16 {.gcsafe, raises: [].} =
+  self.rng[].generate(uint16) mod 3
 
 method generateForIntermediate*(
     self: NoSamplingDelayStrategy, encodedDelayMs: uint16
@@ -52,12 +48,13 @@ proc new*(
     meanDelayMs: uint16 = DefaultMeanDelayMs,
     rng: ref HmacDrbgContext,
 ): T =
+  doAssert(rng != nil, "random is not set")
   T(meanDelayMs: meanDelayMs, rng: rng)
 
 method generateForEntry*(
     self: ExponentialDelayStrategy
-): Result[uint16, string] {.gcsafe, raises: [].} =
-  ok(self.meanDelayMs)
+): uint16 {.gcsafe, raises: [].} =
+  self.meanDelayMs
 
 method generateForIntermediate*(
     self: ExponentialDelayStrategy, meanDelayMs: uint16
@@ -66,15 +63,7 @@ method generateForIntermediate*(
   ## Fall back to no delay in case of errors
   if meanDelayMs == 0:
     return 0u16
-  if self.rng.isNil:
-    return 0u16
   let randVal = self.rng[].generate(uint64)
   let u = (float64(randVal) + 1.0) / (float64(high(uint64)) + 1.0)
   let delay = -float64(meanDelayMs) * ln(u)
   min(delay, float64(high(uint16))).uint16
-
-proc exponentialDelayStrategy*(
-    meanDelayMs: uint16 = DefaultMeanDelayMs, rng: ref HmacDrbgContext
-): DelayStrategy =
-  ## Returns ExponentialDelayStrategy (recommended per spec).
-  ExponentialDelayStrategy.new(meanDelayMs, rng)

--- a/tests/libp2p/mix/test_delay_strategy.nim
+++ b/tests/libp2p/mix/test_delay_strategy.nim
@@ -4,7 +4,6 @@
 {.used.}
 
 import std/[sets]
-import ../../../libp2p/crypto/crypto
 import ../../../libp2p/protocols/mix/delay_strategy
 import ../../tools/[unittest, crypto]
 
@@ -15,19 +14,13 @@ const
 
 suite "DelayStrategy":
   test "NoSamplingDelayStrategy generateForEntry returns values in [0, 2]":
-    let
-      rng = rng()
-      strategy = NoSamplingDelayStrategy.new(rng)
+    let strategy = NoSamplingDelayStrategy.new(rng())
 
     for _ in 0 ..< NumIterations:
-      let delay = strategy.generateForEntry().valueOr:
-        raiseAssert error
-      check delay <= 2
+      check strategy.generateForEntry() <= 2
 
   test "NoSamplingDelayStrategy generateForIntermediate returns encoded value":
-    let
-      rng = rng()
-      strategy = NoSamplingDelayStrategy.new(rng)
+    let strategy = NoSamplingDelayStrategy.new(rng())
 
     check:
       strategy.generateForIntermediate(100) == 100
@@ -37,20 +30,17 @@ suite "DelayStrategy":
     let rng = rng()
 
     check:
-      ExponentialDelayStrategy.new(50, rng).generateForEntry().get() == 50
-      ExponentialDelayStrategy.new(100, rng).generateForEntry().get() == 100
+      ExponentialDelayStrategy.new(50, rng).generateForEntry() == 50
+      ExponentialDelayStrategy.new(100, rng).generateForEntry() == 100
 
   test "ExponentialDelayStrategy generateForIntermediate returns 0 for mean 0":
-    let
-      strategy = ExponentialDelayStrategy.new(0, rng)
-      rng = rng()
+    let strategy = ExponentialDelayStrategy.new(0, rng())
 
     check strategy.generateForIntermediate(0) == 0
 
   test "ExponentialDelayStrategy generateForIntermediate samples from exponential distribution":
     let
-      rng = rng()
-      strategy = ExponentialDelayStrategy.new(100, rng)
+      strategy = ExponentialDelayStrategy.new(100, rng())
       meanDelayMs: uint16 = 100
       numSamples = 1000
     var sum: float64 = 0
@@ -67,8 +57,7 @@ suite "DelayStrategy":
 
   test "ExponentialDelayStrategy produces variable delays":
     let
-      rng = rng()
-      strategy = ExponentialDelayStrategy.new(100, rng)
+      strategy = ExponentialDelayStrategy.new(100, rng())
       meanDelayMs: uint16 = 100
 
     var delays = initHashSet[uint16]()


### PR DESCRIPTION
As per mix spec [delay strategy](https://lip.logos.co/ift-ts/raw/mix.html#62-delay-strategy) is supposed to be pluggable to make instantiations choose the type they want and configure it. 
- Made delay strategy pluggable with default being same as before
- provided a exponential strategy as well.