### PR TITLE
chore(kad): add k closest to randomRecords proc

### DIFF
--- a/libp2p/protocols/kademlia_discovery/randomfind.nim
+++ b/libp2p/protocols/kademlia_discovery/randomfind.nim
@@ -22,13 +22,14 @@ proc randomRecords*(
 
   let randomKey = randomPeerId.toKey()
 
-  let queue = newAsyncQueue[(PeerId, Opt[Message])](disco.config.replication)
+  let queue = newAsyncQueue[(PeerId, Opt[Message])]()
 
   let peers = disco.rtable.findClosestPeerIds(randomKey, disco.config.replication)
   for peer in peers:
-    # ignore errors, queue capacity is the same as peer count
-    let _ = catch:
+    let addRes = catch:
       queue.addFirstNoWait((peer, Opt.none(Message)))
+    if addRes.isErr:
+      error "cannot enqueue peer", error = addRes.error.msg
 
   let findRes = catch:
     await disco.findNode(randomKey, queue)


### PR DESCRIPTION
If we don't add the K closest peers when initiating `randomRecords` we might not get any records in small networks.

This PR fixes this.