### PR TITLE
fix(mix): crash during connection cleanup

### DIFF
--- a/libp2p/protocols/mix/mix_protocol.nim
+++ b/libp2p/protocols/mix/mix_protocol.nim
@@ -81,11 +81,9 @@ proc removeClosedConnections(
   peersToGC.incl(pid)
 
   for p in peersToGC:
-    try:
-      await mixProto.connPool[p].close()
-      mixProto.connPool.del(p)
-    except KeyError:
-      discard # peer already removed from connPool, nothing to clean up
+    var conn: Connection
+    if mixProto.connPool.pop(p, conn):
+      await conn.close()
 
 proc getConn(
     mixProto: MixProtocol,


### PR DESCRIPTION
remove assertion check as well as it is just cleanup.

the await conn.close() yields, and another coroutine could remove the peer from connPool in the meantime, invalidating any prior hasKey result.
A missing key is not a bug here — it just means the peer was already cleaned up, which is perfectly fine for a GC routine.
