### PR TITLE
fix: make storeMuxer async and not use asyncSpawn to trigger the connection events

### DIFF
--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -224,7 +224,7 @@ proc internalConnect(
   slot.trackMuxer(muxed)
 
   try:
-    self.connManager.storeMuxer(muxed)
+    await self.connManager.storeMuxer(muxed)
     await self.peerStore.identify(muxed, dir)
     await self.connManager.triggerPeerEvents(
       muxed.connection.peerId,

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -221,7 +221,7 @@ proc upgrader(
 ) {.async: (raises: [CancelledError, UpgradeError]).} =
   try:
     let muxed = await trans.upgrade(conn, Opt.none(PeerId))
-    switch.connManager.storeMuxer(muxed)
+    await switch.connManager.storeMuxer(muxed)
     await switch.peerStore.identify(muxed, conn.transportDir)
     await switch.connManager.triggerPeerEvents(
       muxed.connection.peerId,

--- a/tests/libp2p/pubsub/test_gossipsub.nim
+++ b/tests/libp2p/pubsub/test_gossipsub.nim
@@ -36,7 +36,7 @@ suite "GossipSub":
     gossipSub.peerStats[peer.peerId] = peerStats
 
     # And the peer is connected
-    gossipSub.switch.connManager.storeMuxer(Muxer(connection: conns[0]))
+    await gossipSub.switch.connManager.storeMuxer(Muxer(connection: conns[0]))
     check:
       gossipSub.switch.isConnected(peer.peerId)
 
@@ -93,7 +93,7 @@ suite "GossipSub":
       await teardownGossipSub(gossipSub, conns)
 
     # And the peer is connected
-    gossipSub.switch.connManager.storeMuxer(Muxer(connection: conns[0]))
+    await gossipSub.switch.connManager.storeMuxer(Muxer(connection: conns[0]))
     check:
       gossipSub.switch.isConnected(peer.peerId)
       gossipSub.mesh.hasPeerId(topic, peer.peerId)

--- a/tests/libp2p/pubsub/test_scoring.nim
+++ b/tests/libp2p/pubsub/test_scoring.nim
@@ -28,7 +28,7 @@ suite "GossipSub Scoring":
     for i, peer in peers:
       peer.appScore = gossipSub.parameters.graylistThreshold - 1
       let conn = conns[i]
-      gossipSub.switch.connManager.storeMuxer(Muxer(connection: conn))
+      await gossipSub.switch.connManager.storeMuxer(Muxer(connection: conn))
 
     gossipSub.updateScores()
 

--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -28,7 +28,7 @@ suite "Connection Manager":
     let peerId = PeerId.init(PrivateKey.random(ECDSA, (newRng())[]).tryGet()).tryGet()
     let mux = getMuxer(peerId)
 
-    connMngr.storeMuxer(mux)
+    await connMngr.storeMuxer(mux)
     check mux in connMngr
 
     let peerMux = connMngr.selectMuxer(peerId)
@@ -43,7 +43,7 @@ suite "Connection Manager":
     let peers = toSeq(0 ..< 2).mapIt(PeerId.random.tryGet())
     let muxs = toSeq(0 ..< 2).mapIt(getMuxer(peers[it]))
     for mux in muxs:
-      connMngr.storeMuxer(mux)
+      await connMngr.storeMuxer(mux)
 
     let conns = connMngr.getConnections()
     let connsMux = toSeq(conns.values).mapIt(it[0])
@@ -58,7 +58,7 @@ suite "Connection Manager":
     await mux.connection.close()
 
     expect LPError:
-      connMngr.storeMuxer(mux)
+      await connMngr.storeMuxer(mux)
 
     await connMngr.close()
 
@@ -69,7 +69,7 @@ suite "Connection Manager":
     mux.connection.isEof = true
 
     expect LPError:
-      connMngr.storeMuxer(mux)
+      await connMngr.storeMuxer(mux)
 
     await mux.close()
     await connMngr.close()
@@ -82,7 +82,7 @@ suite "Connection Manager":
     muxer.connection = nil
 
     expect LPError:
-      connMngr.storeMuxer(muxer)
+      await connMngr.storeMuxer(muxer)
 
     await conn.close()
     await muxer.close()
@@ -95,8 +95,8 @@ suite "Connection Manager":
     let mux1 = getMuxer(peerId, Direction.Out)
     let mux2 = getMuxer(peerId)
 
-    connMngr.storeMuxer(mux1)
-    connMngr.storeMuxer(mux2)
+    await connMngr.storeMuxer(mux1)
+    await connMngr.storeMuxer(mux2)
     check mux1 in connMngr
     check mux2 in connMngr
 
@@ -120,7 +120,7 @@ suite "Connection Manager":
     muxer.peerId = peerId
     muxer.connection = connection
 
-    connMngr.storeMuxer(muxer)
+    await connMngr.storeMuxer(muxer)
     check muxer in connMngr
 
     let stream = await connMngr.getStream(peerId)
@@ -140,7 +140,7 @@ suite "Connection Manager":
     muxer.peerId = peerId
     muxer.connection = connection
 
-    connMngr.storeMuxer(muxer)
+    await connMngr.storeMuxer(muxer)
     check muxer in connMngr
 
     let stream1 = await connMngr.getStream(peerId, Direction.In)
@@ -156,12 +156,12 @@ suite "Connection Manager":
     let connMngr = ConnManager.new(maxConnsPerPeer = 0)
     let peerId = PeerId.init(PrivateKey.random(ECDSA, (newRng())[]).tryGet()).tryGet()
 
-    connMngr.storeMuxer(getMuxer(peerId))
+    await connMngr.storeMuxer(getMuxer(peerId))
 
     let muxs = @[getMuxer(peerId)]
 
     expect TooManyConnectionsError:
-      connMngr.storeMuxer(muxs[0])
+      await connMngr.storeMuxer(muxs[0])
 
     await connMngr.close()
 
@@ -172,12 +172,12 @@ suite "Connection Manager":
     let connMngr = ConnManager.new(maxConnsPerPeer = 0)
     let peerId = PeerId.init(PrivateKey.random(ECDSA, (newRng())[]).tryGet()).tryGet()
 
-    connMngr.storeMuxer(getMuxer(peerId))
+    await connMngr.storeMuxer(getMuxer(peerId))
 
     let muxs = @[getMuxer(peerId), getMuxer(peerId)]
 
     expect TooManyConnectionsError:
-      connMngr.storeMuxer(muxs[0])
+      await connMngr.storeMuxer(muxs[0])
 
     let waitedConn1 = connMngr.expectConnection(peerId, In)
 
@@ -191,11 +191,11 @@ suite "Connection Manager":
         PeerId.init(PrivateKey.random(ECDSA, (newRng())[]).tryGet()).tryGet(), In
       )
       conn = getMuxer(peerId)
-    connMngr.storeMuxer(conn)
+    await connMngr.storeMuxer(conn)
     check (await waitedConn2) == conn
 
     expect TooManyConnectionsError:
-      connMngr.storeMuxer(muxs[1])
+      await connMngr.storeMuxer(muxs[1])
 
     await connMngr.close()
 
@@ -209,7 +209,7 @@ suite "Connection Manager":
     let peerId = PeerId.init(PrivateKey.random(ECDSA, (newRng())[]).tryGet()).tryGet()
     let muxer = getMuxer(peerId)
 
-    connMngr.storeMuxer(muxer)
+    await connMngr.storeMuxer(muxer)
 
     check muxer in connMngr
 
@@ -229,7 +229,7 @@ suite "Connection Manager":
 
       let muxer = getMuxer(peerId, dir)
 
-      connMngr.storeMuxer(muxer)
+      await connMngr.storeMuxer(muxer)
 
       check muxer in connMngr
       check not (isNil(connMngr.selectMuxer(peerId, dir)))


### PR DESCRIPTION
This is to ensure a sequential order of events (i.e. in nimbus the stream handler is being executed first before the connection events)