### PR TITLE
feat(cbind): kad validator and selectors

### DIFF
--- a/cbind/examples/cbindings.c
+++ b/cbind/examples/cbindings.c
@@ -36,6 +36,12 @@ static void get_providers_handler(int callerRet,
                                   const Libp2pPeerInfo *providers,
                                   size_t providersLen, const char *msg,
                                   size_t len, void *userData);
+static int permissive_kad_validator(const uint8_t *key, size_t keyLen,
+                                    libp2p_kad_entry_record_t record,
+                                    void *userData);
+static int permissive_kad_selector(const uint8_t *key, size_t keyLen,
+                                   const libp2p_kad_entry_record_t *records,
+                                   size_t recordsLen, void *userData);
 static void peerinfo_handler(int callerret, const Libp2pPeerInfo *info,
                              const char *msg, size_t len, void *userdata);
 
@@ -65,6 +71,9 @@ int main(int argc, char **argv) {
   cfg1.mount_gossipsub = 1;
   cfg1.gossipsub_trigger_self = 1;
   cfg1.mount_kad_discovery = 1;
+  cfg1.kad_validator = permissive_kad_validator;
+  cfg1.kad_selector = permissive_kad_selector;
+  cfg1.kad_user_data = NULL;
 
   libp2p_private_key_t priv_key = {0};
   libp2p_new_private_key(LIBP2P_PK_RSA, private_key_handler, &priv_key);
@@ -85,6 +94,9 @@ int main(int argc, char **argv) {
   cfg2.mount_gossipsub = 1;
   cfg2.gossipsub_trigger_self = 1;
   cfg2.mount_kad_discovery = 1;
+  cfg2.kad_validator = permissive_kad_validator;
+  cfg2.kad_selector = permissive_kad_selector;
+  cfg2.kad_user_data = NULL;
   libp2p_bootstrap_node_t bootstrap_nodes[1] = {
       {.peerId = pInfo1.peerId,
        .multiaddrs = pInfo1.addrs,
@@ -224,6 +236,31 @@ static void event_handler(int callerRet, const char *msg, size_t len,
   }
 
   signal_callback_executed();
+}
+
+static int permissive_kad_validator(const uint8_t *key, size_t keyLen,
+                                    libp2p_kad_entry_record_t record,
+                                    void *userData) {
+  (void)key;
+  (void)keyLen;
+  (void)record;
+  (void)userData;
+  return 1; // everything is considered valid.
+}
+
+static int permissive_kad_selector(const uint8_t *key, size_t keyLen,
+                                   const libp2p_kad_entry_record_t *records,
+                                   size_t recordsLen, void *userData) {
+  // Always pick the first candidate whenever possible. No ordering between
+  // records is assumed or required.
+  (void)key;
+  (void)keyLen;
+  (void)records;
+  (void)userData;
+  if (recordsLen == 0) {
+    return -1;
+  }
+  return 0;
 }
 
 static void topic_handler(const char *topic, uint8_t *data, size_t len,

--- a/cbind/ffi_types.nim
+++ b/cbind/ffi_types.nim
@@ -62,6 +62,24 @@ type Libp2pServiceInfo* {.bycopy.} = object
   data*: ptr byte
   dataLen*: csize_t
 
+type Libp2pKadEntryRecord* {.bycopy.} = object
+  value*: ptr byte
+  valueLen*: csize_t
+  time*: cstring
+  timeLen*: csize_t
+
+type KadEntryValidator* = proc(
+  key: ptr byte, keyLen: csize_t, record: Libp2pKadEntryRecord, userData: pointer
+): cint {.cdecl, gcsafe, raises: [].}
+
+type KadEntrySelector* = proc(
+  key: ptr byte,
+  keyLen: csize_t,
+  records: ptr Libp2pKadEntryRecord,
+  recordsLen: csize_t,
+  userData: pointer,
+): cint {.cdecl, gcsafe, raises: [].}
+
 type Libp2pExtendedPeerRecord* {.bycopy.} = object
   peerId*: cstring
   seqNo*: uint64
@@ -113,6 +131,9 @@ type Libp2pConfig* {.bycopy.} = object
   kadBootstrapNodes*: ptr Libp2pBootstrapNode
   kadBootstrapNodesLen*: csize_t
   privKey*: Libp2pPrivateKey
+  kadValidator*: KadEntryValidator
+  kadSelector*: KadEntrySelector
+  kadUserData*: pointer
 
 type RetCode* {.size: sizeof(cint).} = enum
   RET_OK = 0

--- a/cbind/libp2p.h
+++ b/cbind/libp2p.h
@@ -101,6 +101,22 @@ typedef struct libp2p_private_key {
 } libp2p_private_key_t;
 
 typedef struct {
+  const uint8_t *value;
+  size_t valueLen;
+  const char *time;
+  size_t timeLen;
+} libp2p_kad_entry_record_t;
+
+// Return nonzero to accept a key/value record, 0 to reject.
+typedef int (*KadEntryValidator)(const uint8_t *key, size_t keyLen,
+                                 libp2p_kad_entry_record_t record,
+                                 void *userData);
+
+// Return selected record index in [0, recordsLen), or -1 to reject.
+typedef int (*KadEntrySelector)(const uint8_t *key, size_t keyLen,
+                                const libp2p_kad_entry_record_t *records,
+                                size_t recordsLen, void *userData);
+typedef struct {
   // Enable/disable gossipsub (default on).
   int mount_gossipsub;
   // If nonzero, deliver published messages to self subscribers too.
@@ -119,6 +135,12 @@ typedef struct {
   size_t kad_bootstrap_nodes_len;
   // Optional private key bytes (only used if is not nil).
   libp2p_private_key_t priv_key;
+  // Optional Kademlia value validator callback.
+  KadEntryValidator kad_validator;
+  // Optional Kademlia value selector callback.
+  KadEntrySelector kad_selector;
+  // Opaque user data passed to kad_validator/kad_selector callbacks.
+  void *kad_user_data;
 } libp2p_config_t;
 
 typedef struct {

--- a/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_lifecycle_requests.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_lifecycle_requests.nim
@@ -36,6 +36,74 @@ type LifecycleRequest* = object
   appCallbacks: AppCallbacks
   config: Libp2pConfig
 
+type CEntryValidator = ref object of EntryValidator
+  cb: KadEntryValidator
+  userData: pointer
+
+type CEntrySelector = ref object of EntrySelector
+  cb: KadEntrySelector
+  userData: pointer
+
+proc toCRecord(record: EntryRecord): Libp2pKadEntryRecord =
+  Libp2pKadEntryRecord(
+    value:
+      if record.value.len > 0:
+        record.value[0].addr
+      else:
+        nil,
+    valueLen: record.value.len.csize_t,
+    time: record.time.cstring,
+    timeLen: record.time.len.csize_t,
+  )
+
+method isValid(
+    self: CEntryValidator, key: Key, record: EntryRecord
+): bool {.raises: [], gcsafe.} =
+  let keyPtr =
+    if key.len > 0:
+      key[0].addr
+    else:
+      nil
+  self.cb(keyPtr, key.len.csize_t, toCRecord(record), self.userData) != 0
+
+method select(
+    self: CEntrySelector, key: Key, records: seq[EntryRecord]
+): Result[int, string] {.raises: [], gcsafe.} =
+  if records.len == 0:
+    return err("No records to choose from")
+
+  var cRecords = newSeqUninit[Libp2pKadEntryRecord](records.len)
+  for i in 0 ..< records.len:
+    cRecords[i] = toCRecord(records[i])
+
+  let keyPtr =
+    if key.len > 0:
+      key[0].addr
+    else:
+      nil
+  let selected = self.cb(
+    keyPtr, key.len.csize_t, cRecords[0].addr, cRecords.len.csize_t, self.userData
+  ).int
+
+  if selected == -1:
+    return err("Selector rejected all entries")
+  if selected < 0 or selected >= records.len:
+    return err("Selector returned invalid index")
+
+  ok(selected)
+
+proc buildKadDhtConfig(config: Libp2pConfig): KadDHTConfig =
+  var validator: EntryValidator = DefaultEntryValidator()
+  var selector: EntrySelector = DefaultEntrySelector()
+
+  if not config.kadValidator.isNil():
+    validator = CEntryValidator(cb: config.kadValidator, userData: config.kadUserData)
+
+  if not config.kadSelector.isNil():
+    selector = CEntrySelector(cb: config.kadSelector, userData: config.kadUserData)
+
+  KadDHTConfig.new(validator = validator, selector = selector)
+
 proc parseBootstrapNodes(config: Libp2pConfig): seq[(PeerId, seq[MultiAddress])] =
   if config.kadBootstrapNodesLen == 0:
     return @[]
@@ -92,16 +160,19 @@ proc mountKad(libp2p: var LibP2P, config: Libp2pConfig) =
   var kad = Opt.none(KadDHT)
   if config.mountKad != 0 or config.mountKadDiscovery != 0:
     let bootstrapNodes = parseBootstrapNodes(config)
+    let kadCfg = buildKadDhtConfig(config)
     if config.mountKadDiscovery != 0:
       let k = KademliaDiscovery.new(
         libp2p.switch,
         bootstrapNodes = bootstrapNodes,
+        config = kadCfg,
         codec = ExtendedKademliaDiscoveryCodec,
       )
       libp2p.switch.mount(k)
       kad = Opt.some(KadDHT(k))
     else:
-      let k = KadDHT.new(libp2p.switch, bootstrapNodes = bootstrapNodes)
+      let k =
+        KadDHT.new(libp2p.switch, bootstrapNodes = bootstrapNodes, config = kadCfg)
       libp2p.switch.mount(k)
       kad = Opt.some(k)
   libp2p.kad = kad
@@ -139,7 +210,6 @@ proc createLibp2p(appCallbacks: AppCallbacks, config: Libp2pConfig): LibP2P =
       privKey = Opt.some(copyKey)
 
   let switch = newStandardSwitch(privKey = privKey, nameResolver = dnsResolver)
-
   var ret = LibP2P(
     switch: switch,
     gossipSub: Opt.none(GossipSub),
@@ -193,6 +263,10 @@ proc copyConfig(config: ptr Libp2pConfig): Libp2pConfig =
     resolved.privKey.dataLen = srcKey.dataLen
     resolved.privKey.data = allocShared(srcKey.dataLen.int)
     copyMem(resolved.privKey.data, srcKey.data, srcKey.dataLen.int)
+
+  resolved.kadValidator = config[].kadValidator
+  resolved.kadSelector = config[].kadSelector
+  resolved.kadUserData = config[].kadUserData
 
   resolved.kadBootstrapNodesLen = config[].kadBootstrapNodesLen
   if not config[].kadBootstrapNodes.isNil() and config[].kadBootstrapNodesLen > 0:


### PR DESCRIPTION
Updates kad-dht c-bindings so they have a way to setup the validator and selector to use to determine whether a record is considered valid or not as well as the criteria to use to check if an existing record should be replaced