### PR TITLE
feat(cbind): add transport, conn limits

### DIFF
--- a/cbind/examples/cbindings.c
+++ b/cbind/examples/cbindings.c
@@ -84,6 +84,11 @@ int main(int argc, char **argv) {
   cfg1.muxer = LIBP2P_MUXER_MPLEX;
   cfg1.transport = LIBP2P_TRANSPORT_TCP;
 
+  // connection limits
+  cfg1.max_connections = 50;
+  cfg1.max_in = 25;
+  cfg1.max_out = 25;
+  cfg1.max_conns_per_peer = 1;
   // enable circuit relay
   cfg1.circuit_relay = 1;
 

--- a/cbind/ffi_types.nim
+++ b/cbind/ffi_types.nim
@@ -138,6 +138,10 @@ type Libp2pConfig* {.bycopy.} = object
   kadSelector*: KadEntrySelector
   kadUserData*: pointer
   privKey*: Libp2pPrivateKey
+  maxConnections*: cint
+  maxIn*: cint
+  maxOut*: cint
+  maxConnsPerPeer*: cint
   circuitRelay*: cint
   autonat*: cint
   autonatV2*: cint

--- a/cbind/libp2p.h
+++ b/cbind/libp2p.h
@@ -175,6 +175,14 @@ typedef struct {
   // Optional private key bytes (only used if is not nil).
   libp2p_private_key_t priv_key;
 
+  // Maximum number of connections (in + out)
+  int max_connections;
+  // Maximum number of incoming connections
+  int max_in;
+  // Maximum number of outgoing connections
+  int max_out;
+  // Maximum number of connections per peer
+  int max_conns_per_peer;
   // Enable circuit relay
   int circuit_relay;
 

--- a/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_lifecycle_requests.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_lifecycle_requests.nim
@@ -23,7 +23,10 @@ import ../../../../libp2p/protocols/mix
 import ../../../../libp2p/protocols/mix/mix_protocol
 import ../../../../libp2p/protocols/mix/mix_node
 
-const DefaultDnsResolver = "1.1.1.1:53"
+const
+  DefaultDnsResolver = "1.1.1.1:53"
+  DefaultMaxConnections = MaxConnections
+  DefaultMaxConnectionsPerPeer = MaxConnectionsPerPeer
 
 type LifecycleMsgType* = enum
   CREATE_LIBP2P
@@ -247,8 +250,12 @@ proc createLibp2p(appCallbacks: AppCallbacks, config: Libp2pConfig): LibP2P =
   var switchBuilder = newStandardSwitchBuilder(
     privKey = privKey,
     addrs = addrs,
-    transport = transport,
     muxer = muxer,
+    transport = transport,
+    maxConnections = config.maxConnections,
+    maxIn = config.maxIn,
+    maxOut = config.maxOut,
+    maxConnsPerPeer = config.maxConnsPerPeer,
     nameResolver = dnsResolver,
   )
 
@@ -294,6 +301,10 @@ proc init*(T: typedesc[Libp2pConfig]): T =
     transport: ord(TransportType.TCP),
     kadBootstrapNodes: nil,
     kadBootstrapNodesLen: 0,
+    maxConnections: DefaultMaxConnections,
+    maxIn: -1,
+    maxOut: -1,
+    maxConnsPerPeer: DefaultMaxConnectionsPerPeer,
     circuitRelay: 0,
     autonat: 0,
     autonatV2: 0,
@@ -306,7 +317,7 @@ proc copyCstring(src: cstring, dst: ptr cstring) =
   dst[] = src.alloc()
 
 proc copyConfig(config: ptr Libp2pConfig): Libp2pConfig =
-  var resolved = Libp2pConfig.default()
+  var resolved = Libp2pConfig.init()
 
   if config.isNil():
     return resolved
@@ -318,6 +329,10 @@ proc copyConfig(config: ptr Libp2pConfig): Libp2pConfig =
   resolved.mountKadDiscovery = config[].mountKadDiscovery
   resolved.muxer = config[].muxer
   resolved.transport = config[].transport
+  resolved.maxConnections = config[].maxConnections
+  resolved.maxIn = config[].maxIn
+  resolved.maxOut = config[].maxOut
+  resolved.maxConnsPerPeer = config[].maxConnsPerPeer
   resolved.circuitRelay = config[].circuitRelay
   resolved.autonat = config[].autonat
   resolved.autonatV2 = config[].autonatV2


### PR DESCRIPTION
## Summary
- Add `transport` field to cbindings config (analog to `withTransport`, `withTCP`, etc. in switch builder)

## Affected Areas

- [ x ] Cbindings  