### PR TITLE
fix(kad): add configurable option to purge stale entries on bucketrefreshInterval

### DIFF
--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -21,6 +21,8 @@ proc bootstrap*(
   ## Sends a findNode to find itself to keep nearby peers up to date
   ## Also sends a findNode to find a random key for each non-empty k-bucket
 
+  kad.rtable.purgeExpired()
+
   discard await kad.findNode(kad.rtable.selfId)
 
   # Snapshot bucket count. findNode() can grow buckets and mutate length.
@@ -55,7 +57,9 @@ proc new*(
 ): T {.raises: [].} =
   var rtable = RoutingTable.new(
     switch.peerInfo.peerId.toKey(),
-    config = RoutingTableConfig.new(replication = config.replication),
+    config = RoutingTableConfig.new(
+      replication = config.replication, purgeStaleEntries = config.purgeStaleEntries
+    ),
   )
   let kad = T(
     rng: rng,

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -167,6 +167,7 @@ type
     replication*: int
     hasher*: Opt[XorDHasher]
     maxBuckets*: int
+    purgeStaleEntries*: bool
 
   RoutingTable* = ref object
     selfId*: Key
@@ -296,6 +297,10 @@ type KadDHTConfig* = ref object
   republishProvidedKeysInterval*: chronos.Duration
   cleanupProvidersInterval*: chronos.Duration
   providerExpirationInterval*: chronos.Duration
+  purgeStaleEntries*: bool
+    ## When true, routing table entries not refreshed within
+    ## DefaultBucketStaleTime are removed during each bootstrap cycle.
+    ## Defaults to false to preserve existing behaviour.
 
 proc new*(
     T: typedesc[KadDHTConfig],
@@ -312,6 +317,7 @@ proc new*(
     republishProvidedKeysInterval: chronos.Duration = DefaultRepublishInterval,
     cleanupProvidersInterval: chronos.Duration = DefaultCleanupProvidersInterval,
     providerExpirationInterval: chronos.Duration = DefaultProviderExpirationInterval,
+    purgeStaleEntries: bool = false,
 ): T {.raises: [].} =
   KadDHTConfig(
     validator: validator,
@@ -327,6 +333,7 @@ proc new*(
     republishProvidedKeysInterval: republishProvidedKeysInterval,
     cleanupProvidersInterval: cleanupProvidersInterval,
     providerExpirationInterval: providerExpirationInterval,
+    purgeStaleEntries: purgeStaleEntries,
   )
 
 type KadDHT* = ref object of LPProtocol


### PR DESCRIPTION
## Summary

Nodes such as logos-delivery/waku that don't have persistent node-keys would cause DHT bloat due to restarts. This happens especially apps that are running kademlia as each restart creates a new peerID. 

Added config flag for users to define this behaviour of purging stale entries on bucketRefreshInterval with default behaviour being not do do anything.

@SionoiS , @tinniaru3005  @jm-clius  wdyt? Does this solve the issue observed while testing with fleet or we need to do something else?

## Affected Areas
- [x] Peer Management / Discovery


## Compatibility & Downstream Validation

Reference PRs / branches / commits demonstrating successful integration:

- **Waku:**  https://github.com/logos-messaging/logos-delivery/pull/3739


