### PR TITLE
test(interop): fix partial message flakines

### DIFF
--- a/interop/partial-message/go-peer/peer.go
+++ b/interop/partial-message/go-peer/peer.go
@@ -126,6 +126,7 @@ func publishPartialMessage(ps *pubsub.PubSub, doneC chan struct{}) {
 	if err != nil {
 		log.Fatalf("Failed to join topic: %v", err)
 	}
+	defer topic.Close()
 
 	subs, err := topic.Subscribe()
 	if err != nil {
@@ -145,8 +146,6 @@ func publishPartialMessage(ps *pubsub.PubSub, doneC chan struct{}) {
 
 	time.Sleep(2 * time.Second)
 
-	defer topic.Close()
-
 	pm := MyPartialMessage{
 		groupID:  []byte("interop-group"),
 		metadata: []byte{1, 'h', 2, 'h', 3, 'h'},
@@ -158,6 +157,10 @@ func publishPartialMessage(ps *pubsub.PubSub, doneC chan struct{}) {
 	} else {
 		log.Printf("Partial message published")
 	}
+
+	// give some time for peer to process data before
+	// terminating the program
+	time.Sleep(2 * time.Second)
 }
 
 type connectionNotifiee struct {


### PR DESCRIPTION
go peer was terminating right after message has be published. this could cause flakiness because data might not have be transmitted over network in time when program terminates.