### PR TITLE
fix(cbind): libp2p_kad_random_records - add missing import

### DIFF
--- a/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_lifecycle_requests.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_lifecycle_requests.nim
@@ -17,6 +17,7 @@ import ../../../../libp2p/crypto/secp
 import ../../../../libp2p/nameresolving/[dnsresolver, nameresolver]
 import ../../../../libp2p/protocols/pubsub/gossipsub
 import ../../../../libp2p/protocols/kademlia
+import ../../../../libp2p/protocols/kad_disco
 import ../../../../libp2p/protocols/kademlia_discovery/types
 import ../../../../libp2p/protocols/ping
 import ../../../../libp2p/protocols/mix


### PR DESCRIPTION
## Summary
The `cbind` only imported the `KademliaDiscovery` type but not `kad_disco` file, which defines its `start()` method override. Without that import, Nim never linked the override into the binary, so the base `KadDHT.start()` ran instead, which doesn't store self-signed peer records. That's why `randomRecords` always returned empty. 

Fix: add the missing import

## Affected Areas
- [x] cbind  
  
## Compatibility & Downstream Validation
- **Logos Libp2p Module:**  
https://github.com/logos-co/logos-libp2p-module/pull/37