### PR TITLE
test(interop): update transport script for unified-testing

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -13,29 +13,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  run-transport-interop:
-    name: Run transport interoperability tests
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Free Disk Space
-        # For some reason we have space issues while running this action. Likely while building the image.
-        # This action will free up some space to avoid the issue.
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: true
+  # run-transport-interop:
+  #   name: Run transport interoperability tests
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - name: Free Disk Space
+  #       # For some reason we have space issues while running this action. Likely while building the image.
+  #       # This action will free up some space to avoid the issue.
+  #       uses: jlumbroso/free-disk-space@v1.3.1
+  #       with:
+  #         tool-cache: true
 
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - name: Build image
-        run: docker buildx build --load -t nim-libp2p-transport-head -f interop/transport/Dockerfile .
-      - name: Run tests
-        uses: libp2p/test-plans/.github/actions/run-transport-interop-test@master
-        with:
-          test-filter: nim-libp2p-transport-head
-          # without suffix action fails because "hole-punching-interop" artifacts have 
-          # the same name as "transport-interop" artifacts
-          test-results-suffix: transport-interop
-          extra-versions: ${{ github.workspace }}/interop/transport/version.json
+  #     - uses: actions/checkout@v4
+  #     - uses: docker/setup-buildx-action@v3
+  #     - name: Build image
+  #       run: docker buildx build --load -t nim-libp2p-transport-head -f interop/transport/Dockerfile .
+  #     - name: Run tests
+  #       uses: libp2p/test-plans/.github/actions/run-transport-interop-test@f58b7472d85aa053ce2ba8e9135bcc126a6fed3e
+  #       with:
+  #         test-filter: nim-libp2p-transport-head
+  #         # without suffix action fails because "hole-punching-interop" artifacts have 
+  #         # the same name as "transport-interop" artifacts
+  #         test-results-suffix: transport-interop
+  #         extra-versions: ${{ github.workspace }}/interop/transport/version.json
+  #         s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
+  #         s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
+  #         s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
+  #         aws-region: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_REGION }}
 
   # run-hole-punching-interop:
   #   name: Run hole punching interoperability tests

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -29,17 +29,13 @@ jobs:
       - name: Build image
         run: docker buildx build --load -t nim-libp2p-transport-head -f interop/transport/Dockerfile .
       - name: Run tests
-        uses: libp2p/test-plans/.github/actions/run-transport-interop-test@f58b7472d85aa053ce2ba8e9135bcc126a6fed3e
+        uses: libp2p/test-plans/.github/actions/run-transport-interop-test@master
         with:
           test-filter: nim-libp2p-transport-head
           # without suffix action fails because "hole-punching-interop" artifacts have 
           # the same name as "transport-interop" artifacts
           test-results-suffix: transport-interop
           extra-versions: ${{ github.workspace }}/interop/transport/version.json
-          s3-cache-bucket: ${{ vars.S3_LIBP2P_BUILD_CACHE_BUCKET_NAME }}
-          s3-access-key-id: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_ACCESS_KEY_ID }}
-          s3-secret-access-key: ${{ secrets.S3_LIBP2P_BUILD_CACHE_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ vars.S3_LIBP2P_BUILD_CACHE_AWS_REGION }}
 
   # run-hole-punching-interop:
   #   name: Run hole punching interoperability tests

--- a/interop/transport/main.nim
+++ b/interop/transport/main.nim
@@ -1,26 +1,23 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH 
 
-import std/[os, strutils, sequtils], chronos, redis, serialization, json_serialization
+import std/[os, strutils, sequtils], chronos, redis
 import ../../libp2p/[builders, protocols/ping, transports/wstransport]
-
-type ResultJson = object
-  handshakePlusOneRTTMillis: float
-  pingRTTMilllis: float
 
 let testTimeout =
   try:
-    seconds(parseInt(getEnv("test_timeout_seconds")))
+    seconds(parseInt(getEnv("TEST_TIMEOUT_SECS")))
   except CatchableError:
     3.minutes
 
 proc main() {.async.} =
   let
-    transport = getEnv("transport")
-    muxer = getEnv("muxer")
-    secureChannel = getEnv("security")
-    isDialer = getEnv("is_dialer") == "true"
-    envIp = getEnv("ip", "0.0.0.0")
+    transport = getEnv("TRANSPORT")
+    muxer = getEnv("MUXER")
+    secureChannel = getEnv("SECURE_CHANNEL")
+    isDialer = getEnv("IS_DIALER") == "true"
+    testKey = getEnv("TEST_KEY")
+    envIp = getEnv("LISTENER_IP", "0.0.0.0")
     ip =
       # nim-libp2p doesn't do snazzy ip expansion
       if envIp == "0.0.0.0":
@@ -32,7 +29,7 @@ proc main() {.async.} =
           ($addresses[0][0].host).split(":")[0]
       else:
         envIp
-    redisAddr = getEnv("redis_addr", "redis:6379").split(":")
+    redisAddr = getEnv("REDIS_ADDR", "redis:6379").split(":")
 
     # using synchronous redis because async redis is based on
     # asyncdispatch instead of chronos
@@ -76,12 +73,16 @@ proc main() {.async.} =
     await switch.stop()
 
   if not isDialer:
-    discard redisClient.rPush("listenerAddr", $switch.peerInfo.fullAddrs.tryGet()[0])
+    discard redisClient.rPush(
+      testKey & "_listener_multiaddr", $switch.peerInfo.fullAddrs.tryGet()[0]
+    )
     await sleepAsync(100.hours) # will get cancelled
   else:
     let listenerAddr =
       try:
-        redisClient.bLPop(@["listenerAddr"], testTimeout.seconds.int)[1]
+        redisClient.bLPop(@[testKey & "_listener_multiaddr"], testTimeout.seconds.int)[
+          1
+        ]
       except Exception as e:
         raise newException(CatchableError, "Exception calling bLPop: " & e.msg, e)
     let
@@ -93,12 +94,10 @@ proc main() {.async.} =
       totalDelay = Moment.now() - dialingStart
     await stream.close()
 
-    echo Json.encode(
-      ResultJson(
-        handshakePlusOneRTTMillis: float(totalDelay.milliseconds),
-        pingRTTMilllis: float(pingDelay.milliseconds),
-      )
-    )
+    echo "latency:"
+    echo "  handshake_plus_one_rtt: " & $float(totalDelay.milliseconds)
+    echo "  ping_rtt: " & $float(pingDelay.milliseconds)
+    echo "  unit: ms"
 
 try:
   proc mainAsync(): Future[string] {.async.} =


### PR DESCRIPTION
## Summary
Update Transport interop test script to be compatible with new [Unified testing](https://github.com/libp2p/unified-testing) repo (see https://github.com/libp2p/unified-testing/blob/master/docs/write-a-transport-test-app.md). 

Tested against a fork https://github.com/rlve/unified-testing/pull/1 for now. Currently `python-v0.x` (ws) is failing against `nim-v1.15`.

```
╲ Collecting results...
 ▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔
  → Results:
    → Total: 55
    ✓ Passed: 52
    ✗ Failed: 3
    - python-v0.x x nim-v1.15 (ws, noise, mplex)
    - nim-v1.15 x python-v0.x (ws, noise, yamux)
    - nim-v1.15 x python-v0.x (ws, noise, mplex)

  → Total time: 00:17:05

  ✗ 3 test(s) failed
```

> [!WARNING]
>  Currently the new repo doesn't support using their actions on the implementation side, that's why `run-transport-interop` job has to be disabled and the required check turned off. 

## Affected Areas
- [x] Tests  