### PR TITLE
fix(ci): failures on devel or in unpinned deps wont fail the github action

### DIFF
--- a/.github/workflows/daily_amd64.yml
+++ b/.github/workflows/daily_amd64.yml
@@ -14,6 +14,8 @@ jobs:
     name: Daily test amd64 (latest dependencies)
     uses: ./.github/workflows/daily_common.yml
     with:
+      allow_failure: ${{ github.event_name == 'schedule' }}
+      allow_devel_failure: ${{ github.event_name == 'schedule' }}
       nim: "[
           {'ref': 'v2.0.16', 'memory_management': 'refc'},
           {'ref': 'v2.2.6', 'memory_management': 'refc'},
@@ -30,6 +32,7 @@ jobs:
     uses: ./.github/workflows/daily_common.yml
     with:
       pinned_deps: true
+      allow_devel_failure: ${{ github.event_name == 'schedule' }}
       nim: "[
           {'ref': 'v2.0.16', 'memory_management': 'refc'},
           {'ref': 'v2.2.6', 'memory_management': 'refc'},

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -9,6 +9,16 @@ on:
         required: false
         type: boolean
         default: false
+      allow_failure:
+        description: "Allow the daily test job to fail without failing the workflow"
+        required: false
+        type: boolean
+        default: false
+      allow_devel_failure:
+        description: "Allow Nim devel matrix entries to fail without failing the workflow"
+        required: false
+        type: boolean
+        default: false
       nim:
         description: "Nim Configuration"
         required: true
@@ -31,6 +41,7 @@ jobs:
     env:
       NIMBLE_COMMIT: 9207e8b2bbdf66b5a4d1020214cff44d2d30df92 # v0.20.1
     timeout-minutes: 45
+    continue-on-error: ${{ inputs.allow_failure || (inputs.allow_devel_failure && matrix.nim.ref == 'devel') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/daily_i386.yml
+++ b/.github/workflows/daily_i386.yml
@@ -14,6 +14,8 @@ jobs:
     name: Daily i386 (latest dependencies)
     uses: ./.github/workflows/daily_common.yml
     with:
+      allow_failure: ${{ github.event_name == 'schedule' }}
+      allow_devel_failure: ${{ github.event_name == 'schedule' }}
       nim: "[
           {'ref': 'v2.0.16', 'memory_management': 'refc'},
           {'ref': 'v2.2.6', 'memory_management': 'refc'},
@@ -27,6 +29,7 @@ jobs:
     uses: ./.github/workflows/daily_common.yml
     with:
       pinned_deps: true
+      allow_devel_failure: ${{ github.event_name == 'schedule' }}
       nim: "[
           {'ref': 'v2.0.16', 'memory_management': 'refc'},
           {'ref': 'v2.2.6', 'memory_management': 'refc'},


### PR DESCRIPTION
Scheduled daily runs stay green if only nim devel fails, but still fail on v2.0.16 or v2.2.6 failures.
Scheduled daily runs stay green as well if only latest dependencies daily jobs fail
Keeps manual workflow_dispatch runs strict.