### PR TITLE
refactor(mix): variables now have Duration type

### DIFF
--- a/libp2p/protocols/mix/delay_strategy.nim
+++ b/libp2p/protocols/mix/delay_strategy.nim
@@ -54,6 +54,16 @@ const DefaultSpamProtectionDelayFloor*: Duration = milliseconds(100)
   ## Recommended default lower bound when per-hop spam protection is enabled.
   ## Use `SpamProtectionDelayStrategy` to apply this floor explicitly.
 
+proc doAssertDelay*(delay: Duration) {.raises: [].} =
+  ## Asserts that a delay value is valid for use in the Mix protocol.
+  ## A valid delay must be non-negative and encodable in the 2-byte on-wire
+  ## delay field (<=65535ms).
+  doAssert(delay.milliseconds >= 0, "delay must be non-negative")
+  doAssert(
+    delay.milliseconds <= high(uint16).int,
+    "delay must be encodable in 2 bytes (<=65535ms)",
+  )
+
 type ExponentialDelayStrategy* = ref object of DelayStrategy
   ## Recommended strategy: encodes mean delay, samples from exponential distribution.
   ## Samples are drawn directly from the exponential distribution conditioned on
@@ -79,6 +89,8 @@ proc new*(
   doAssert(
     negligibleProb > 0.0 and negligibleProb < 1.0, "negligibleProb must be in (0, 1)"
   )
+  doAssertDelay(meanDelay)
+  doAssertDelay(minimumDelay)
   T(
     meanDelay: meanDelay,
     rng: rng,
@@ -97,6 +109,8 @@ proc new*(
   doAssert(
     negligibleProb > 0.0 and negligibleProb < 1.0, "negligibleProb must be in (0, 1)"
   )
+  doAssertDelay(meanDelay)
+  doAssertDelay(minimumDelay)
   T(
     meanDelay: meanDelay,
     rng: rng,

--- a/libp2p/protocols/mix/delay_strategy.nim
+++ b/libp2p/protocols/mix/delay_strategy.nim
@@ -4,20 +4,21 @@
 ## Pluggable delay strategy interface for the Mix Protocol.
 
 import std/math
+import chronos
 import bearssl/rand
 import ../../crypto/crypto
 
 type DelayStrategy* = ref object of RootObj ## Abstract interface for delay strategies.
   rng: ref HmacDrbgContext
 
-method generateForEntry*(self: DelayStrategy): uint16 {.base, gcsafe, raises: [].} =
+method generateForEntry*(self: DelayStrategy): Duration {.base, gcsafe, raises: [].} =
   ## Generate delay value to encode in packet (called by sender/entry node).
   ## implementation should return some default value in case of errors
   raiseAssert "generateForEntry must be implemented by concrete delay strategy types"
 
 method generateForIntermediate*(
-    self: DelayStrategy, encodedDelayMs: uint16
-): uint16 {.base, gcsafe, raises: [].} =
+    self: DelayStrategy, encodedDelay: Duration
+): Duration {.base, gcsafe, raises: [].} =
   ## Generate actual delay from encoded value (called by intermediate node).
   ## implementation should return some default value in case of errors
   raiseAssert "generateForIntermediate must be implemented by concrete delay strategy types"
@@ -29,35 +30,38 @@ proc new*(T: typedesc[NoSamplingDelayStrategy], rng: ref HmacDrbgContext): T =
   doAssert(rng != nil, "random is not set")
   T(rng: rng)
 
-method generateForEntry*(self: NoSamplingDelayStrategy): uint16 {.gcsafe, raises: [].} =
-  self.rng[].generate(uint16) mod 3
+method generateForEntry*(
+    self: NoSamplingDelayStrategy
+): Duration {.gcsafe, raises: [].} =
+  milliseconds(self.rng[].generate(uint16) mod 3)
 
 method generateForIntermediate*(
-    self: NoSamplingDelayStrategy, encodedDelayMs: uint16
-): uint16 {.gcsafe, raises: [].} =
-  encodedDelayMs
+    self: NoSamplingDelayStrategy, encodedDelay: Duration
+): Duration {.gcsafe, raises: [].} =
+  encodedDelay
 
-const DefaultMeanDelayMs* = 100
+const NoDelay*: Duration = milliseconds(0)
+const DefaultMeanDelay*: Duration = milliseconds(100)
 const DefaultNegligibleProb* = 1e-6
   ## Probability below which the tail of the exponential distribution is
   ## excluded from the practical sampling window.
   ## Yields a maximum delay of mean * -ln(negligibleProb) ≈ mean * 13.8.
-const DefaultMinimumDelayMs* = 0
+const DefaultMinimumDelay*: Duration = milliseconds(0)
   ## Optional lower bound for sampled delays. This is useful when auxiliary work
   ## such as proof generation runs in parallel with the delay timer and would
   ## otherwise collapse the lower tail into a predictable floor.
-const DefaultSpamProtectionDelayFloorMs* = 100'u16
+const DefaultSpamProtectionDelayFloor*: Duration = milliseconds(100)
   ## Recommended default lower bound when per-hop spam protection is enabled.
   ## Use `SpamProtectionDelayStrategy` to apply this floor explicitly.
 
 type ExponentialDelayStrategy* = ref object of DelayStrategy
   ## Recommended strategy: encodes mean delay, samples from exponential distribution.
   ## Samples are drawn directly from the exponential distribution conditioned on
-  ## the configured [minimumDelayMs, practicalMaxDelayMs] window. This preserves
+  ## the configured [minimumDelay, practicalMaxDelay] window. This preserves
   ## a smooth bounded distribution without fixed spikes at either bound.
-  meanDelayMs: uint16
+  meanDelay: Duration
   negligibleProb: float64
-  minimumDelayMs: uint16
+  minimumDelay: Duration
 
 type SpamProtectionDelayStrategy* = ref object of ExponentialDelayStrategy
   ## Recommended strategy when `MixProtocol` is configured with per-hop spam
@@ -66,38 +70,38 @@ type SpamProtectionDelayStrategy* = ref object of ExponentialDelayStrategy
 
 proc new*(
     T: typedesc[ExponentialDelayStrategy],
-    meanDelayMs: uint16 = DefaultMeanDelayMs,
+    meanDelay: Duration = DefaultMeanDelay,
     rng: ref HmacDrbgContext,
     negligibleProb: float64 = DefaultNegligibleProb,
-    minimumDelayMs: uint16 = DefaultMinimumDelayMs,
+    minimumDelay: Duration = DefaultMinimumDelay,
 ): T {.raises: [].} =
   doAssert(rng != nil, "random is not set")
   doAssert(
     negligibleProb > 0.0 and negligibleProb < 1.0, "negligibleProb must be in (0, 1)"
   )
   T(
-    meanDelayMs: meanDelayMs,
+    meanDelay: meanDelay,
     rng: rng,
     negligibleProb: negligibleProb,
-    minimumDelayMs: minimumDelayMs,
+    minimumDelay: minimumDelay,
   )
 
 proc new*(
     T: typedesc[SpamProtectionDelayStrategy],
-    meanDelayMs: uint16 = DefaultMeanDelayMs,
+    meanDelay: Duration = DefaultMeanDelay,
     rng: ref HmacDrbgContext,
     negligibleProb: float64 = DefaultNegligibleProb,
-    minimumDelayMs: uint16 = DefaultSpamProtectionDelayFloorMs,
+    minimumDelay: Duration = DefaultSpamProtectionDelayFloor,
 ): T {.raises: [].} =
   doAssert(rng != nil, "random is not set")
   doAssert(
     negligibleProb > 0.0 and negligibleProb < 1.0, "negligibleProb must be in (0, 1)"
   )
   T(
-    meanDelayMs: meanDelayMs,
+    meanDelay: meanDelay,
     rng: rng,
     negligibleProb: negligibleProb,
-    minimumDelayMs: minimumDelayMs,
+    minimumDelay: minimumDelay,
   )
 
 proc sampleOpenUnitInterval(self: DelayStrategy): float64 {.inline, raises: [].} =
@@ -105,43 +109,43 @@ proc sampleOpenUnitInterval(self: DelayStrategy): float64 {.inline, raises: [].}
   let rand53 = self.rng[].generate(uint64) shr (64 - Float64MantissaBits)
   (float64(rand53) + 0.5) / float64(1'u64 shl Float64MantissaBits)
 
-proc practicalMaxDelayMs(
-    meanDelayMs: uint16, negligibleProb: float64
+proc practicalMaxDelay(
+    meanDelay: Duration, negligibleProb: float64
 ): float64 {.inline.} =
-  min(-float64(meanDelayMs) * ln(negligibleProb), float64(high(uint16)))
+  min(-float64(meanDelay.milliseconds) * ln(negligibleProb), float64(high(uint16)))
 
-proc sampleTruncatedExponentialDelayMs(
-    self: DelayStrategy, meanDelayMs: uint16, minDelayMs, maxDelayMs: float64
-): uint16 {.inline, raises: [].} =
+proc sampleTruncatedExponentialDelay(
+    self: DelayStrategy, meanDelay: Duration, minDelayMs, maxDelayMs: float64
+): Duration {.inline, raises: [].} =
   let
-    meanDelay = float64(meanDelayMs)
-    minBound = exp(-minDelayMs / meanDelay)
-    maxBound = exp(-maxDelayMs / meanDelay)
+    meanMs = float64(meanDelay.milliseconds)
+    minBound = exp(-minDelayMs / meanMs)
+    maxBound = exp(-maxDelayMs / meanMs)
     sample = self.sampleOpenUnitInterval()
-    delay = -meanDelay * ln(minBound - sample * (minBound - maxBound))
+    delay = -meanMs * ln(minBound - sample * (minBound - maxBound))
     boundedDelay = clamp(delay, minDelayMs, min(maxDelayMs, float64(high(uint16))))
-  boundedDelay.uint16
+  milliseconds(boundedDelay.int64)
 
 method generateForEntry*(
     self: ExponentialDelayStrategy
-): uint16 {.gcsafe, raises: [].} =
-  self.meanDelayMs
+): Duration {.gcsafe, raises: [].} =
+  self.meanDelay
 
 method generateForIntermediate*(
-    self: ExponentialDelayStrategy, encodedDelayMs: uint16
-): uint16 {.gcsafe, raises: [].} =
+    self: ExponentialDelayStrategy, encodedDelay: Duration
+): Duration {.gcsafe, raises: [].} =
   ## Samples directly from the exponential distribution conditioned on the
   ## configured practical window. If the configured minimum delay already
   ## exceeds the practical maximum for the encoded mean, the configured minimum
   ## is returned as a deterministic fallback.
-  if encodedDelayMs == 0:
-    return 0u16
+  if encodedDelay == NoDelay:
+    return encodedDelay
 
   let
-    minDelayMs = float64(self.minimumDelayMs)
-    maxDelayMs = practicalMaxDelayMs(encodedDelayMs, self.negligibleProb)
+    minDelayMs = float64(self.minimumDelay.milliseconds)
+    maxDelayMs = practicalMaxDelay(encodedDelay, self.negligibleProb)
 
   if minDelayMs >= maxDelayMs:
-    return self.minimumDelayMs
+    return self.minimumDelay
 
-  self.sampleTruncatedExponentialDelayMs(encodedDelayMs, minDelayMs, maxDelayMs)
+  self.sampleTruncatedExponentialDelay(encodedDelay, minDelayMs, maxDelayMs)

--- a/libp2p/protocols/mix/delay_strategy.nim
+++ b/libp2p/protocols/mix/delay_strategy.nim
@@ -111,13 +111,18 @@ proc sampleOpenUnitInterval(self: DelayStrategy): float64 {.inline, raises: [].}
 
 proc practicalMaxDelay(
     meanDelay: Duration, negligibleProb: float64
-): float64 {.inline.} =
-  min(-float64(meanDelay.milliseconds) * ln(negligibleProb), float64(high(uint16)))
+): Duration {.inline.} =
+  let maxDelay = min(
+    -float64(meanDelay.milliseconds) * ln(negligibleProb), float64(high(uint16))
+  ).uint64
+  return maxDelay.int.milliseconds
 
 proc sampleTruncatedExponentialDelay(
-    self: DelayStrategy, meanDelay: Duration, minDelayMs, maxDelayMs: float64
+    self: DelayStrategy, meanDelay: Duration, minDelay, maxDelay: Duration
 ): Duration {.inline, raises: [].} =
   let
+    minDelayMs = minDelay.milliseconds.float64
+    maxDelayMs = maxDelay.milliseconds.float64
     meanMs = float64(meanDelay.milliseconds)
     minBound = exp(-minDelayMs / meanMs)
     maxBound = exp(-maxDelayMs / meanMs)
@@ -141,11 +146,8 @@ method generateForIntermediate*(
   if encodedDelay == NoDelay:
     return encodedDelay
 
-  let
-    minDelayMs = float64(self.minimumDelay.milliseconds)
-    maxDelayMs = practicalMaxDelay(encodedDelay, self.negligibleProb)
-
-  if minDelayMs >= maxDelayMs:
+  let maxDelay = practicalMaxDelay(encodedDelay, self.negligibleProb)
+  if self.minimumDelay >= maxDelay:
     return self.minimumDelay
 
-  self.sampleTruncatedExponentialDelay(encodedDelay, minDelayMs, maxDelayMs)
+  self.sampleTruncatedExponentialDelay(encodedDelay, self.minimumDelay, maxDelay)

--- a/libp2p/protocols/mix/mix_protocol.nim
+++ b/libp2p/protocols/mix/mix_protocol.nim
@@ -9,7 +9,6 @@ import
     tag_manager, mix_metrics, exit_layer, multiaddr, exit_connection, spam_protection,
     delay_strategy, pool,
   ]
-import stew/endians2
 import ../protocol
 import ../../utils/[sequninit, future]
 import ../../stream/[connection, lpstream]
@@ -342,9 +341,8 @@ method handleMixMessages*(
     trace "Intermediate node processing",
       peerId = mixProto.mixNodeInfo.peerId, multiAddr = mixProto.mixNodeInfo.multiAddr
     mix_messages_recvd.inc(labelValues = ["Intermediate"])
-    let actualDelayMs =
-      mixProto.delayStrategy.generateForIntermediate(processedSP.delayMs.uint16)
-    trace "Computed delay", encodedDelayMs = processedSP.delayMs, actualDelayMs
+    let actualDelay = mixProto.delayStrategy.generateForIntermediate(processedSP.delay)
+    trace "Computed delay", encodedDelay = processedSP.delay, actualDelay
 
     # Forward to next hop
     let nextHopBytes = processedSP.nextHop.get()
@@ -367,7 +365,7 @@ method handleMixMessages*(
     # exponential delays, a lower sampling floor can be applied so this overlap
     # does not collapse short samples into a fixed processing-time spike.
     let proofGenStartTime = Moment.now()
-    let delayFut = sleepAsync(milliseconds(actualDelayMs.int))
+    let delayFut = sleepAsync(actualDelay)
 
     let proofGenFut = (
       proc(): Future[Result[seq[byte], string]] {.async.} =
@@ -379,11 +377,11 @@ method handleMixMessages*(
     await allFutures(proofGenFut, delayFut)
 
     if mixProto.spamProtection.isSome():
-      let proofGenTimeMs = (Moment.now() - proofGenStartTime).milliseconds
-      if proofGenTimeMs > actualDelayMs.int64:
+      let proofGenTime = Moment.now() - proofGenStartTime
+      if proofGenTime > actualDelay:
         warn "Proof generation time exceeds sampled delay",
-          proofGenTimeMs,
-          sampledDelayMs = actualDelayMs,
+          proofGenTime,
+          sampledDelay = actualDelay,
           hint = "Increase the minimum delay floor or reduce proof generation time"
 
     let outgoingPacket = proofGenFut.value().valueOr:
@@ -450,7 +448,7 @@ method buildSurb*(
   var
     publicKeys: seq[FieldElement] = @[]
     hops: seq[Hop] = @[]
-    delay: seq[seq[byte]] = @[]
+    delay: seq[Duration] = @[]
 
   if mixProto.nodePool.len < PathLength:
     return err("No. of public mix nodes less than path length")
@@ -462,7 +460,7 @@ method buildSurb*(
 
   # Select L mix nodes at random
   for i in 0 ..< PathLength:
-    let (peerId, multiAddr, mixPubKey, delayMillisec) =
+    let (peerId, multiAddr, mixPubKey, delayForHop) =
       if i < PathLength - 1:
         let randomIndexPosition = cryptoRandomInt(mixProto.rng, availableIndices.len).valueOr:
           return err("failed to generate random num: " & error)
@@ -481,7 +479,7 @@ method buildSurb*(
       else:
         (
           mixProto.mixNodeInfo.peerId, mixProto.mixNodeInfo.multiAddr,
-          mixProto.mixNodeInfo.mixPubKey, 0.uint16,
+          mixProto.mixNodeInfo.mixPubKey, NoDelay,
         ) # No delay for last hop
 
     publicKeys.add(mixPubKey)
@@ -492,7 +490,7 @@ method buildSurb*(
 
     hops.add(Hop.init(multiAddrBytes))
 
-    delay.add(@(delayMillisec.uint16.toBytesBE()))
+    delay.add(delayForHop)
 
   return createSURB(publicKeys, delay, hops, id)
 
@@ -656,7 +654,7 @@ proc anonymizeLocalProtocolSend*(
   var
     publicKeys: seq[FieldElement] = @[]
     hop: seq[Hop] = @[]
-    delay: seq[seq[byte]] = @[]
+    delay: seq[Duration] = @[]
     exitPeerId: PeerId
 
   # Select L mix nodes at random
@@ -745,13 +743,13 @@ proc anonymizeLocalProtocolSend*(
       nextHopAddr = multiAddr
       nextHopPeerId = peerId
 
-    let delayMillisec =
+    let delayForHop =
       if hop.len != PathLength - 1:
         mixProto.delayStrategy.generateForEntry()
       else:
-        0.uint16 # No delay for exit node
+        NoDelay # No delay for exit node
 
-    delay.add(@(delayMillisec.toBytesBE()))
+    delay.add(delayForHop)
 
     hop.add(Hop.init(multiAddrBytes))
 

--- a/libp2p/protocols/mix/serialization.nim
+++ b/libp2p/protocols/mix/serialization.nim
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH 
 
-import results
+import results, chronos, stew/endians2
 import std/sequtils
 import ../../utility
 
@@ -112,36 +112,45 @@ proc deserialize*(T: typedesc[Hop], data: openArray[byte]): Result[T, string] =
     )
   )
 
+proc dealyFromBytes*(data: openArray[byte]): Duration {.inline.} =
+  return milliseconds(uint16.fromBytesBE(data).int)
+
+proc dealyToBytes*(delay: Duration): seq[byte] {.inline.} =
+  return delay.milliseconds.uint16.toBytesBE().toSeq()
+
 type RoutingInfo* = object
   Addr: Hop
-  Delay: seq[byte]
+  Delay: Duration
   Gamma: seq[byte]
   Beta: seq[byte]
 
 proc init*(
     T: typedesc[RoutingInfo],
     address: Hop,
-    delay: seq[byte],
+    delay: Duration,
     gamma: seq[byte],
     beta: seq[byte],
 ): T =
   return T(Addr: address, Delay: delay, Gamma: gamma, Beta: beta)
 
-proc getRoutingInfo*(info: RoutingInfo): (Hop, seq[byte], seq[byte], seq[byte]) =
+proc getRoutingInfo*(info: RoutingInfo): (Hop, Duration, seq[byte], seq[byte]) =
   (info.Addr, info.Delay, info.Gamma, info.Beta)
 
 proc serialize*(info: RoutingInfo): seq[byte] =
-  doAssert info.Delay.len() == DelaySize,
-    "Delay must be exactly " & $DelaySize & " bytes"
   doAssert info.Gamma.len() == GammaSize,
     "Gamma must be exactly " & $GammaSize & " bytes"
+
   let expectedBetaLen = ((r * (t + 1)) - t) * k
   doAssert info.Beta.len() == expectedBetaLen,
     "Beta must be exactly " & $expectedBetaLen & " bytes"
 
+  let delayBytes = dealyToBytes(info.Delay)
+  doAssert delayBytes.len() == DelaySize,
+    "Delay must be exactly " & $DelaySize & " bytes"
+
   let addrBytes = info.Addr.serialize()
 
-  return addrBytes & info.Delay & info.Gamma & info.Beta
+  return addrBytes & delayBytes & info.Gamma & info.Beta
 
 proc readBytes(
     data: openArray[byte], offset: var int, readSize: Opt[int] = Opt.none(int)
@@ -168,12 +177,12 @@ proc deserialize*(T: typedesc[RoutingInfo], data: openArray[byte]): Result[T, st
     return err("Deserialize hop error: " & error)
 
   var offset: int = AddrSize
+  let delayBytes = ?data.readBytes(offset, Opt.some(DelaySize))
+  let gamaBytes = ?data.readBytes(offset, Opt.some(GammaSize))
+  let betaBytes = ?data.readBytes(offset, Opt.some(BetaSize))
   return ok(
     RoutingInfo(
-      Addr: hop,
-      Delay: ?data.readBytes(offset, Opt.some(DelaySize)),
-      Gamma: ?data.readBytes(offset, Opt.some(GammaSize)),
-      Beta: ?data.readBytes(offset, Opt.some(BetaSize)),
+      Addr: hop, Delay: dealyFromBytes(delayBytes), Gamma: gamaBytes, Beta: betaBytes
     )
   )
 

--- a/libp2p/protocols/mix/serialization.nim
+++ b/libp2p/protocols/mix/serialization.nim
@@ -112,11 +112,19 @@ proc deserialize*(T: typedesc[Hop], data: openArray[byte]): Result[T, string] =
     )
   )
 
-proc dealyFromBytes*(data: openArray[byte]): Duration {.inline.} =
+proc delayFromBytes*(data: openArray[byte]): Duration {.inline.} =
   return milliseconds(uint16.fromBytesBE(data).int)
 
-proc dealyToBytes*(delay: Duration): seq[byte] {.inline.} =
-  return delay.milliseconds.uint16.toBytesBE().toSeq()
+proc delayToBytes*(delay: Duration): seq[byte] {.inline.} =
+  let ms = delay.milliseconds
+  let clampedMs =
+    if ms < 0:
+      0
+    elif ms > high(uint16).int:
+      high(uint16).int
+    else:
+      ms
+  return clampedMs.uint16.toBytesBE().toSeq()
 
 type RoutingInfo* = object
   Addr: Hop
@@ -144,10 +152,7 @@ proc serialize*(info: RoutingInfo): seq[byte] =
   doAssert info.Beta.len() == expectedBetaLen,
     "Beta must be exactly " & $expectedBetaLen & " bytes"
 
-  let delayBytes = dealyToBytes(info.Delay)
-  doAssert delayBytes.len() == DelaySize,
-    "Delay must be exactly " & $DelaySize & " bytes"
-
+  let delayBytes = delayToBytes(info.Delay)
   let addrBytes = info.Addr.serialize()
 
   return addrBytes & delayBytes & info.Gamma & info.Beta
@@ -178,11 +183,11 @@ proc deserialize*(T: typedesc[RoutingInfo], data: openArray[byte]): Result[T, st
 
   var offset: int = AddrSize
   let delayBytes = ?data.readBytes(offset, Opt.some(DelaySize))
-  let gamaBytes = ?data.readBytes(offset, Opt.some(GammaSize))
+  let gammaBytes = ?data.readBytes(offset, Opt.some(GammaSize))
   let betaBytes = ?data.readBytes(offset, Opt.some(BetaSize))
   return ok(
     RoutingInfo(
-      Addr: hop, Delay: dealyFromBytes(delayBytes), Gamma: gamaBytes, Beta: betaBytes
+      Addr: hop, Delay: delayFromBytes(delayBytes), Gamma: gammaBytes, Beta: betaBytes
     )
   )
 

--- a/libp2p/protocols/mix/sphinx.nim
+++ b/libp2p/protocols/mix/sphinx.nim
@@ -126,10 +126,7 @@ proc computeBetaGamma(
       beta = aes & filler
     else:
       let routingInfo = RoutingInfo.init(
-        hops[i + 1],
-        delay[i],
-        gamma,
-        beta[0 .. (((r * (t + 1)) - t) * k) - 1],
+        hops[i + 1], delay[i], gamma, beta[0 .. (((r * (t + 1)) - t) * k) - 1]
       )
 
       let serializedRoutingInfo = routingInfo.serialize()

--- a/libp2p/protocols/mix/sphinx.nim
+++ b/libp2p/protocols/mix/sphinx.nim
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH 
 
-import results, sequtils, stew/endians2
+import results, sequtils
+import chronos
 import ./[crypto, curve25519, serialization, tag_manager]
 import ../../crypto/crypto
 import ../../utils/sequninit
@@ -91,7 +92,7 @@ proc computeFillerStrings(s: seq[seq[byte]]): Result[seq[byte], string] =
 proc computeBetaGamma(
     s: seq[seq[byte]],
     hops: openArray[Hop],
-    delay: openArray[seq[byte]],
+    delay: openArray[Duration],
     destHop: Hop,
     id: SURBIdentifier,
 ): Result[tuple[beta: seq[byte], gamma: seq[byte]], string] =
@@ -117,14 +118,18 @@ proc computeBetaGamma(
     # Compute Beta and Gamma
     if i == sLen - 1:
       let destBytes = destHop.serialize()
-      let destPadding = destBytes & delay[i] & @id & newSeq[byte](PaddingLength)
+      let delayBytes = dealyToBytes(delay[i])
+      let destPadding = destBytes & delayBytes & @id & newSeq[byte](PaddingLength)
 
       let aes = aes_ctr(beta_aes_key, beta_iv, destPadding)
 
       beta = aes & filler
     else:
       let routingInfo = RoutingInfo.init(
-        hops[i + 1], delay[i], gamma, beta[0 .. (((r * (t + 1)) - t) * k) - 1]
+        hops[i + 1],
+        delay[i],
+        gamma,
+        beta[0 .. (((r * (t + 1)) - t) * k) - 1],
       )
 
       let serializedRoutingInfo = routingInfo.serialize()
@@ -156,7 +161,7 @@ proc computeDelta(s: seq[seq[byte]], msg: Message): Result[seq[byte], string] =
 
 proc createSURB*(
     publicKeys: openArray[FieldElement],
-    delay: openArray[seq[byte]],
+    delay: openArray[Duration],
     hops: openArray[Hop],
     id: SURBIdentifier,
     rng: ref HmacDrbgContext = newRng(),
@@ -221,7 +226,7 @@ proc processReply*(
 proc wrapInSphinxPacket*(
     msg: Message,
     publicKeys: openArray[FieldElement],
-    delay: openArray[seq[byte]],
+    delay: openArray[Duration],
     hop: openArray[Hop],
     destHop: Hop,
 ): Result[SphinxPacket, string] =
@@ -251,7 +256,7 @@ type ProcessedSphinxPacket* = object
     messageChunk*: seq[byte]
   of ProcessingStatus.Intermediate:
     nextHop*: Hop
-    delayMs*: int
+    delay*: Duration
     serializedSphinxPacket*: seq[byte]
   of ProcessingStatus.Reply:
     id*: SURBIdentifier
@@ -402,7 +407,7 @@ proc processSphinxPacket*(
       ProcessedSphinxPacket(
         status: Intermediate,
         nextHop: address,
-        delayMs: uint16.fromBytesBE(delay).int,
+        delay: delay,
         serializedSphinxPacket: sphinxPkt.serialize(),
       )
     )

--- a/libp2p/protocols/mix/sphinx.nim
+++ b/libp2p/protocols/mix/sphinx.nim
@@ -118,7 +118,7 @@ proc computeBetaGamma(
     # Compute Beta and Gamma
     if i == sLen - 1:
       let destBytes = destHop.serialize()
-      let delayBytes = dealyToBytes(delay[i])
+      let delayBytes = delayToBytes(delay[i])
       let destPadding = destBytes & delayBytes & @id & newSeq[byte](PaddingLength)
 
       let aes = aes_ctr(beta_aes_key, beta_iv, destPadding)

--- a/tests/libp2p/mix/component/test_message_delivery.nim
+++ b/tests/libp2p/mix/component/test_message_delivery.nim
@@ -191,8 +191,8 @@ suite "Mix Protocol - Message Delivery":
     check response == testPayload
 
   asyncTest "intermediate nodes apply delay":
-    let delayMs: uint16 = 300
-    let delayStrategy: DelayStrategy = FixedDelayStrategy(delayMs: delayMs)
+    let delay = milliseconds(300)
+    let delayStrategy: DelayStrategy = FixedDelayStrategy(delay: delay)
     let nodes = await setupMixNodes(10, delayStrategy = Opt.some(delayStrategy))
     startAndDeferStop(nodes)
 
@@ -216,7 +216,7 @@ suite "Mix Protocol - Message Delivery":
     # Path == 3, 2 intermediate hops apply delay, exit node does not.
     check:
       receivedMsg.data == data
-      elapsed >= milliseconds(int64(delayMs) * 2)
+      elapsed >= delay * 2
 
   asyncTest "concurrent messages with SURB replies":
     let echoProto = EchoProtocol.new()

--- a/tests/libp2p/mix/component/test_node_failures.nim
+++ b/tests/libp2p/mix/component/test_node_failures.nim
@@ -170,7 +170,7 @@ suite "Mix Protocol - Node Failures":
 
     ## The high delay ensures intermediaries hold the packet long enough
     ## to stop the target node before it is forwarded.
-    let delayStrategy: DelayStrategy = FixedDelayStrategy(delayMs: 1000)
+    let delayStrategy: DelayStrategy = FixedDelayStrategy(delay: milliseconds(1000))
 
     let nodes = await setupMixNodes(4, delayStrategy = Opt.some(delayStrategy))
     startAndDeferStop(nodes)

--- a/tests/libp2p/mix/test_delay_strategy.nim
+++ b/tests/libp2p/mix/test_delay_strategy.nim
@@ -4,6 +4,7 @@
 {.used.}
 
 import std/[math, sets]
+import chronos
 import ../../../libp2p/protocols/mix/delay_strategy
 import ../../tools/[unittest, crypto]
 
@@ -16,129 +17,132 @@ const
   MinBoundaryHitRatePct = 5
   ## Boundary-hit tests use large sample counts to make accidental spikes at the
   ## configured min/max easy to detect while leaving room for normal rounding
-  ## into the boundary bucket after float -> uint16 conversion.
+  ## into the boundary bucket after float -> Duration conversion.
 
 proc sampleUpperBoundStats(
-    strategy: DelayStrategy, encodedDelayMs, maximumDelayMs: uint16, sampleCount: int
+    strategy: DelayStrategy, encodedDelay, maximumDelay: Duration, sampleCount: int
 ): tuple[maximumDelayHits: int, sawDelayBelowMaximum: bool] =
   var
     maximumDelayHits = 0
     sawDelayBelowMaximum = false
 
   for _ in 0 ..< sampleCount:
-    let delay = strategy.generateForIntermediate(encodedDelayMs)
-    check delay <= maximumDelayMs
-    if delay == maximumDelayMs:
+    let delay = strategy.generateForIntermediate(encodedDelay)
+    check delay <= maximumDelay
+    if delay == maximumDelay:
       inc maximumDelayHits
-    elif delay < maximumDelayMs:
+    elif delay < maximumDelay:
       sawDelayBelowMaximum = true
 
   (maximumDelayHits, sawDelayBelowMaximum)
 
 proc sampleLowerBoundStats(
-    strategy: DelayStrategy, encodedDelayMs, minimumDelayMs: uint16, sampleCount: int
+    strategy: DelayStrategy, encodedDelay, minimumDelay: Duration, sampleCount: int
 ): tuple[minimumDelayHits: int, sawDelayAboveMinimum: bool] =
   var
     minimumDelayHits = 0
     sawDelayAboveMinimum = false
 
   for _ in 0 ..< sampleCount:
-    let delay = strategy.generateForIntermediate(encodedDelayMs)
-    check delay >= minimumDelayMs
-    if delay == minimumDelayMs:
+    let delay = strategy.generateForIntermediate(encodedDelay)
+    check delay >= minimumDelay
+    if delay == minimumDelay:
       inc minimumDelayHits
-    elif delay > minimumDelayMs:
+    elif delay > minimumDelay:
       sawDelayAboveMinimum = true
 
   (minimumDelayHits, sawDelayAboveMinimum)
 
 suite "DelayStrategy":
-  test "NoSamplingDelayStrategy generateForEntry returns values in [0, 2]":
+  test "NoSamplingDelayStrategy generateForEntry returns values in [0, 2]ms":
     let strategy = NoSamplingDelayStrategy.new(rng())
 
     for _ in 0 ..< NumIterations:
-      check strategy.generateForEntry() <= 2
+      check strategy.generateForEntry() <= milliseconds(2)
 
   test "NoSamplingDelayStrategy generateForIntermediate returns encoded value":
     let strategy = NoSamplingDelayStrategy.new(rng())
 
     check:
-      strategy.generateForIntermediate(100) == 100
-      strategy.generateForIntermediate(200) == 200
+      strategy.generateForIntermediate(milliseconds(100)) == milliseconds(100)
+      strategy.generateForIntermediate(milliseconds(200)) == milliseconds(200)
 
   test "ExponentialDelayStrategy generateForEntry returns configured mean":
     let rng = rng()
 
     check:
-      ExponentialDelayStrategy.new(50, rng).generateForEntry() == 50
-      ExponentialDelayStrategy.new(100, rng).generateForEntry() == 100
+      ExponentialDelayStrategy.new(milliseconds(50), rng).generateForEntry() ==
+        milliseconds(50)
+      ExponentialDelayStrategy.new(milliseconds(100), rng).generateForEntry() ==
+        milliseconds(100)
 
   test "ExponentialDelayStrategy generateForIntermediate returns 0 for mean 0":
-    let strategy = ExponentialDelayStrategy.new(0, rng())
+    let strategy = ExponentialDelayStrategy.new(milliseconds(0), rng())
 
-    check strategy.generateForIntermediate(0) == 0
+    check strategy.generateForIntermediate(milliseconds(0)) == milliseconds(0)
 
   test "ExponentialDelayStrategy generateForIntermediate samples from exponential distribution":
     let
-      strategy = ExponentialDelayStrategy.new(100, rng())
-      meanDelayMs: uint16 = 100
+      meanDelay = milliseconds(100)
+      strategy = ExponentialDelayStrategy.new(meanDelay, rng())
       numSamples = 1000
     var sum: float64 = 0
 
     for _ in 0 ..< numSamples:
-      let delay = strategy.generateForIntermediate(meanDelayMs)
-      sum += float64(delay)
+      let delay = strategy.generateForIntermediate(meanDelay)
+      sum += float64(delay.milliseconds)
 
     let empiricalMean = sum / float64(numSamples)
     # Allow 20% tolerance for statistical variation
     check:
-      empiricalMean > float64(meanDelayMs) * (1 - Tolerance)
-      empiricalMean < float64(meanDelayMs) * (1 + Tolerance)
+      empiricalMean > float64(meanDelay.milliseconds) * (1 - Tolerance)
+      empiricalMean < float64(meanDelay.milliseconds) * (1 + Tolerance)
 
   test "ExponentialDelayStrategy produces variable delays":
     let
-      strategy = ExponentialDelayStrategy.new(100, rng())
-      meanDelayMs: uint16 = 100
+      meanDelay = milliseconds(100)
+      strategy = ExponentialDelayStrategy.new(meanDelay, rng())
 
-    var delays = initHashSet[uint16]()
+    var delays = initHashSet[Duration]()
     for _ in 0 ..< NumSamples:
-      let delay = strategy.generateForIntermediate(meanDelayMs)
+      let delay = strategy.generateForIntermediate(meanDelay)
       delays.incl(delay)
 
     check delays.len > NumSamples div 2
 
   test "ExponentialDelayStrategy never samples above the practical maximum":
     let
-      meanDelayMs: uint16 = 100
+      meanDelay = milliseconds(100)
       negligibleProb = 0.01
-      strategy = ExponentialDelayStrategy.new(meanDelayMs, rng(), negligibleProb)
+      strategy = ExponentialDelayStrategy.new(meanDelay, rng(), negligibleProb)
       # maxDelay = -mean * ln(negligibleProb)
-      maxDelayMs = uint16(-float64(meanDelayMs) * ln(negligibleProb))
+      maxDelay =
+        milliseconds(int64(-float64(meanDelay.milliseconds) * ln(negligibleProb)))
       (maxDelayHits, sawDelayBelowMaximum) =
-        sampleUpperBoundStats(strategy, meanDelayMs, maxDelayMs, BoundarySamples)
+        sampleUpperBoundStats(strategy, meanDelay, maxDelay, BoundarySamples)
 
     check sawDelayBelowMaximum
     check maxDelayHits * 100 < BoundarySamples * MaxBoundaryHitRatePct
 
   test "ExponentialDelayStrategy respects custom negligibleProb":
     let
-      meanDelayMs: uint16 = 100
+      meanDelay = milliseconds(100)
       negligibleProb = 0.01 # aggressive truncation: max ≈ mean * 4.6
-      strategy = ExponentialDelayStrategy.new(meanDelayMs, rng(), negligibleProb)
-      maxDelayMs = uint16(-float64(meanDelayMs) * ln(negligibleProb))
+      strategy = ExponentialDelayStrategy.new(meanDelay, rng(), negligibleProb)
+      maxDelay =
+        milliseconds(int64(-float64(meanDelay.milliseconds) * ln(negligibleProb)))
 
     for _ in 0 ..< 10000:
-      check strategy.generateForIntermediate(meanDelayMs) <= maxDelayMs
+      check strategy.generateForIntermediate(meanDelay) <= maxDelay
 
   test "ExponentialDelayStrategy never samples below the configured minimum":
     let
-      meanDelayMs: uint16 = 100
-      minimumDelayMs: uint16 = 100
-      strategy = ExponentialDelayStrategy.new(
-        meanDelayMs, rng(), minimumDelayMs = minimumDelayMs
-      )
+      meanDelay = milliseconds(100)
+      minimumDelay = milliseconds(100)
+      strategy =
+        ExponentialDelayStrategy.new(meanDelay, rng(), minimumDelay = minimumDelay)
       (minimumDelayHits, sawDelayAboveMinimum) =
-        sampleLowerBoundStats(strategy, meanDelayMs, minimumDelayMs, BoundarySamples)
+        sampleLowerBoundStats(strategy, meanDelay, minimumDelay, BoundarySamples)
 
     check minimumDelayHits > 0
     check sawDelayAboveMinimum
@@ -146,24 +150,21 @@ suite "DelayStrategy":
 
   test "ExponentialDelayStrategy falls back to minimum when floor exceeds practical maximum":
     let
-      meanDelayMs: uint16 = 100
+      meanDelay = milliseconds(100)
       negligibleProb = 0.01
-      minimumDelayMs: uint16 = 500
+      minimumDelay = milliseconds(500)
       strategy = ExponentialDelayStrategy.new(
-        meanDelayMs,
-        rng(),
-        negligibleProb = negligibleProb,
-        minimumDelayMs = minimumDelayMs,
+        meanDelay, rng(), negligibleProb = negligibleProb, minimumDelay = minimumDelay
       )
 
-    check strategy.generateForIntermediate(meanDelayMs) == minimumDelayMs
+    check strategy.generateForIntermediate(meanDelay) == minimumDelay
 
   test "SpamProtectionDelayStrategy applies the default delay floor":
     let
-      meanDelayMs: uint16 = 100
-      strategy = SpamProtectionDelayStrategy.new(meanDelayMs, rng())
+      meanDelay = milliseconds(100)
+      strategy = SpamProtectionDelayStrategy.new(meanDelay, rng())
       (minimumDelayHits, sawDelayAboveMinimum) = sampleLowerBoundStats(
-        strategy, meanDelayMs, DefaultSpamProtectionDelayFloorMs, BoundarySamples
+        strategy, meanDelay, DefaultSpamProtectionDelayFloor, BoundarySamples
       )
 
     check minimumDelayHits > 0
@@ -172,13 +173,12 @@ suite "DelayStrategy":
 
   test "SpamProtectionDelayStrategy allows overriding the default delay floor":
     let
-      meanDelayMs: uint16 = 100
-      minimumDelayMs: uint16 = 250
-      strategy = SpamProtectionDelayStrategy.new(
-        meanDelayMs, rng(), minimumDelayMs = minimumDelayMs
-      )
+      meanDelay = milliseconds(100)
+      minimumDelay = milliseconds(250)
+      strategy =
+        SpamProtectionDelayStrategy.new(meanDelay, rng(), minimumDelay = minimumDelay)
       (minimumDelayHits, sawDelayAboveMinimum) =
-        sampleLowerBoundStats(strategy, meanDelayMs, minimumDelayMs, BoundarySamples)
+        sampleLowerBoundStats(strategy, meanDelay, minimumDelay, BoundarySamples)
 
     check minimumDelayHits > 0
     check sawDelayAboveMinimum

--- a/tests/libp2p/mix/test_serialization.nim
+++ b/tests/libp2p/mix/test_serialization.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import results, std/sequtils
+import results, std/sequtils, chronos
 import ../../../libp2p/protocols/mix/serialization
 import ../../tools/[unittest]
 
@@ -45,7 +45,7 @@ suite "serialization_tests":
   test "serialize_and_deserialize_routing_info":
     let routingInfo = RoutingInfo.init(
       Hop.init(newSeq[byte](AddrSize)),
-      newSeq[byte](DelaySize),
+      30.milliseconds,
       newSeq[byte](GammaSize),
       newSeq[byte](((r * (t + 1)) - t) * k),
     )

--- a/tests/libp2p/mix/test_sphinx.nim
+++ b/tests/libp2p/mix/test_sphinx.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import random, results, chronicles, bearssl/rand
+import random, results, chronicles, bearssl/rand, chronos
 import ../../../libp2p/crypto/crypto
 import ../../../libp2p/protocols/mix/[curve25519, serialization, sphinx, tag_manager]
 import ../../tools/[unittest, crypto]
@@ -19,7 +19,7 @@ proc addPadding(message: openArray[byte], size: int): seq[byte] =
 
 # Helper function to create dummy data
 proc createDummyData(): (
-  Message, seq[FieldElement], seq[FieldElement], seq[seq[byte]], seq[Hop], Hop
+  Message, seq[FieldElement], seq[FieldElement], seq[Duration], seq[Hop], Hop
 ) =
   let (privateKey1, publicKey1) = generateKeyPair().expect("generate keypair error")
   let (privateKey2, publicKey2) = generateKeyPair().expect("generate keypair error")
@@ -29,7 +29,7 @@ proc createDummyData(): (
     privateKeys = @[privateKey1, privateKey2, privateKey3]
     publicKeys = @[publicKey1, publicKey2, publicKey3]
 
-    delay = @[newSeq[byte](DelaySize), newSeq[byte](DelaySize), newSeq[byte](DelaySize)]
+    delay = @[0.milliseconds, 0.milliseconds, 0.milliseconds]
 
     hops =
       @[

--- a/tests/libp2p/mix/utils.nim
+++ b/tests/libp2p/mix/utils.nim
@@ -48,7 +48,7 @@ proc setupMixNode[T: MixProtocol](
       Opt.none(SpamProtection)
   let actualDelayStrategy = delayStrategy.valueOr:
     if spamProtectionRateLimit.isSome():
-      DelayStrategy(SpamProtectionDelayStrategy.new(DefaultMeanDelayMs, rng()))
+      DelayStrategy(SpamProtectionDelayStrategy.new(DefaultMeanDelay, rng()))
     else:
       DelayStrategy(NoSamplingDelayStrategy.new(rng()))
 
@@ -188,12 +188,12 @@ proc new*(T: typedesc[EchoProtocol]): EchoProtocol =
 ###
 
 type FixedDelayStrategy* = ref object of DelayStrategy
-  delayMs*: uint16
+  delay*: Duration
 
-method generateForEntry*(self: FixedDelayStrategy): uint16 =
-  self.delayMs
+method generateForEntry*(self: FixedDelayStrategy): Duration =
+  self.delay
 
 method generateForIntermediate*(
-    self: FixedDelayStrategy, encodedDelayMs: uint16
-): uint16 =
-  self.delayMs
+    self: FixedDelayStrategy, encodedDelay: Duration
+): Duration =
+  self.delay


### PR DESCRIPTION
## Summary
In Mix code there were many instances where variable names encoded time units (e.g., `delayMs`). Instead of encoding units in names, variables are now typed as `Duration`, which eliminates ambiguity (ms vs seconds vs minutes), prevents misuse, and is self-documenting.

## Affected Areas


- [x] Mix  


## Compatibility & Downstream Validation


Reference PRs / branches / commits demonstrating successful integration:

- **Nimbus:**  
n/a

- **Waku:**  
breaking change for them because they use mix.

- **Codex:**  
n/a


## Impact on Library Users


Mix API has changed; it now utilizes the `Duration` type.
Change should be trivial because users will just have to change code like:
`someDelayMs` to `someDelayMs.milliseconds` to convert to `Duration`.


## Risk Assessment

Changes can be fully asserted with unit tests. The added `doAssertDelay` validation ensures invalid `Duration` values are caught at construction time, preventing runtime crashes or silent overflow during packet serialization.

## References

closes #2206