### PR TITLE
feat(gossipsub): extend message priorities to H/M/L

### DIFF
--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -165,7 +165,7 @@ method rpcHandler*(
 
     # In theory, if topics are the same in all messages, we could batch - we'd
     # also have to be careful to only include validated messages
-    f.broadcast(toSendPeers, RPCMsg.withMessages(msg), isHighPriority = false)
+    f.broadcast(toSendPeers, RPCMsg.withMessages(msg), priority = MessagePriority.Low)
     trace "Forwared message to peers", peers = toSendPeers.len
 
   f.updateMetrics(rpcMsg)
@@ -225,7 +225,7 @@ method publish*(
     return 0
 
   # Try to send to all peers that are known to be interested
-  f.broadcast(peers, RPCMsg.withMessages(msg), isHighPriority = true)
+  f.broadcast(peers, RPCMsg.withMessages(msg), priority = MessagePriority.Medium)
 
   when defined(libp2p_expensive_metrics):
     libp2p_pubsub_messages_published.inc(labelValues = [topic])

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -165,7 +165,7 @@ method rpcHandler*(
 
     # In theory, if topics are the same in all messages, we could batch - we'd
     # also have to be careful to only include validated messages
-    f.broadcast(toSendPeers, RPCMsg.withMessages(msg), priority = MessagePriority.Low)
+    f.broadcast(toSendPeers, RPCMsg.withMessages(msg), MessagePriority.Low)
     trace "Forwared message to peers", peers = toSendPeers.len
 
   f.updateMetrics(rpcMsg)
@@ -225,7 +225,7 @@ method publish*(
     return 0
 
   # Try to send to all peers that are known to be interested
-  f.broadcast(peers, RPCMsg.withMessages(msg), priority = MessagePriority.Medium)
+  f.broadcast(peers, RPCMsg.withMessages(msg), MessagePriority.Medium)
 
   when defined(libp2p_expensive_metrics):
     libp2p_pubsub_messages_published.inc(labelValues = [topic])

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -101,11 +101,33 @@ proc init*(
     maxHighPriorityQueueLen = DefaultMaxHighPriorityQueueLen,
     maxMediumPriorityQueueLen = DefaultMaxMediumPriorityQueueLen,
     maxLowPriorityQueueLen = DefaultMaxLowPriorityQueueLen,
+    maxNumElementsInNonPriorityQueue: int = -1,
+      # Deprecated: use maxMediumPriorityQueueLen and maxLowPriorityQueueLen instead.
     sendIDontWantOnPublish = false,
     testExtensionConfig = Opt.none(TestExtensionConfig),
     partialMessageExtensionConfig = Opt.none(PartialMessageExtensionConfig),
     pingpongExtensionConfig = Opt.none(PingPongExtensionConfig),
 ): GossipSubParams =
+  if maxNumElementsInNonPriorityQueue >= 0:
+    warn "maxNumElementsInNonPriorityQueue is deprecated. Use maxMediumPriorityQueueLen and maxLowPriorityQueueLen"
+
+  let resolvedMaxMediumPriorityQueueLen =
+    if maxNumElementsInNonPriorityQueue >= 0 and
+        maxMediumPriorityQueueLen == DefaultMaxMediumPriorityQueueLen:
+      maxNumElementsInNonPriorityQueue
+    else:
+      maxMediumPriorityQueueLen
+
+  let resolvedMaxLowPriorityQueueLen =
+    if maxNumElementsInNonPriorityQueue >= 0 and
+        maxLowPriorityQueueLen == DefaultMaxLowPriorityQueueLen:
+      maxNumElementsInNonPriorityQueue
+    else:
+      maxLowPriorityQueueLen
+
+  let deprecatedMaxNumElementsInNonPriorityQueue =
+    if maxNumElementsInNonPriorityQueue >= 0: maxNumElementsInNonPriorityQueue else: 0
+
   GossipSubParams(
     explicit: true,
     pruneBackoff: pruneBackoff,
@@ -142,8 +164,9 @@ proc init*(
     overheadRateLimit: overheadRateLimit,
     disconnectPeerAboveRateLimit: disconnectPeerAboveRateLimit,
     maxHighPriorityQueueLen: maxHighPriorityQueueLen,
-    maxMediumPriorityQueueLen: maxMediumPriorityQueueLen,
-    maxLowPriorityQueueLen: maxLowPriorityQueueLen,
+    maxMediumPriorityQueueLen: resolvedMaxMediumPriorityQueueLen,
+    maxLowPriorityQueueLen: resolvedMaxLowPriorityQueueLen,
+    maxNumElementsInNonPriorityQueue: deprecatedMaxNumElementsInNonPriorityQueue,
     sendIDontWantOnPublish: sendIDontWantOnPublish,
     testExtensionConfig: testExtensionConfig,
     partialMessageExtensionConfig: partialMessageExtensionConfig,
@@ -1076,11 +1099,18 @@ method initPubSub*(g: GossipSub) {.raises: [InitializationError].} =
     g.parameters = GossipSubParams.init()
 
   # If deprecated maxNumElementsInNonPriorityQueue was set
-  # and the new field is still at its default, copy the value over.
-  if g.parameters.maxNumElementsInNonPriorityQueue > 0 and
-      g.parameters.maxLowPriorityQueueLen == DefaultMaxLowPriorityQueueLen:
-    warn "maxNumElementsInNonPriorityQueue is deprecated. Use maxLowPriorityQueueLen"
-    g.parameters.maxLowPriorityQueueLen = g.parameters.maxNumElementsInNonPriorityQueue
+  # and the new fields are still at their defaults, copy the value over.
+  if g.parameters.maxNumElementsInNonPriorityQueue > 0 and (
+    g.parameters.maxMediumPriorityQueueLen == DefaultMaxMediumPriorityQueueLen or
+    g.parameters.maxLowPriorityQueueLen == DefaultMaxLowPriorityQueueLen
+  ):
+    warn "maxNumElementsInNonPriorityQueue is deprecated. Use maxMediumPriorityQueueLen and maxLowPriorityQueueLen"
+    if g.parameters.maxMediumPriorityQueueLen == DefaultMaxMediumPriorityQueueLen:
+      g.parameters.maxMediumPriorityQueueLen =
+        g.parameters.maxNumElementsInNonPriorityQueue
+    if g.parameters.maxLowPriorityQueueLen == DefaultMaxLowPriorityQueueLen:
+      g.parameters.maxLowPriorityQueueLen =
+        g.parameters.maxNumElementsInNonPriorityQueue
 
   let validationRes = g.parameters.validateParameters()
   if validationRes.isErr:

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -1083,7 +1083,7 @@ method initPubSub*(g: GossipSub) {.raises: [InitializationError].} =
   # and the new field is still at its default, copy the value over.
   if g.parameters.maxNumElementsInNonPriorityQueue > 0 and
       g.parameters.maxLowPriorityQueueLen == DefaultMaxLowPriorityQueueLen:
-    warn "maxNumElementsInNonPriorityQueue is deprecated. Use maxNumElementsInNonPriorityQueue"
+    warn "maxNumElementsInNonPriorityQueue is deprecated. Use maxLowPriorityQueueLen"
     g.parameters.maxLowPriorityQueueLen = g.parameters.maxNumElementsInNonPriorityQueue
 
   let validationRes = g.parameters.validateParameters()

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -409,7 +409,7 @@ proc handleControl(g: GossipSub, peer: PubSubPeer, control: ControlMessage) =
         libp2p_pubsub_broadcast_prune.inc(labelValues = [g.topicLabel(prune.topicID)])
 
     trace "sending control message", payload = shortLog(respControl), peer
-    g.send(peer, RPCMsg.withControl(respControl), isHighPriority = true)
+    g.send(peer, RPCMsg.withControl(respControl), priority = MessagePriority.High)
 
   if messages.len > 0:
     for i, smsg in messages:
@@ -423,7 +423,7 @@ proc handleControl(g: GossipSub, peer: PubSubPeer, control: ControlMessage) =
 
     # iwant replies have lower priority
     trace "sending iwant reply messages", peer
-    g.send(peer, RPCMsg.withMessages(messages), isHighPriority = false)
+    g.send(peer, RPCMsg.withMessages(messages), priority = MessagePriority.Low)
 
 proc sendIDontWant(
     g: GossipSub,
@@ -453,7 +453,7 @@ proc sendIDontWant(
   g.broadcast(
     peers,
     RPCMsg.withControl(ControlMessage.withIDontWant(msgId)),
-    isHighPriority = true,
+    priority = MessagePriority.High,
   )
 
 const iDontWantMessageSizeThreshold* = 512
@@ -540,7 +540,7 @@ proc validateAndRelay(
 
     # In theory, if topics are the same in all messages, we could batch - we'd
     # also have to be careful to only include validated messages
-    g.broadcast(toSendPeers, RPCMsg.withMessages(msg), isHighPriority = false)
+    g.broadcast(toSendPeers, RPCMsg.withMessages(msg), priority = MessagePriority.Low)
     trace "forwarded message to peers", peers = toSendPeers.len, msgId, peer
 
     libp2p_pubsub_messages_rebroadcasted.inc(
@@ -726,7 +726,7 @@ method onTopicSubscription*(g: GossipSub, topic: string, subscribed: bool) =
         topic, g.parameters.unsubscribeBackoff.seconds.uint64, g.peerExchangeList(topic)
       )
     )
-    g.broadcast(mpeers, msg, isHighPriority = true)
+    g.broadcast(mpeers, msg, priority = MessagePriority.High)
 
     for peer in mpeers:
       g.pruned(peer, topic, backoff = Opt.some(g.parameters.unsubscribeBackoff))
@@ -888,7 +888,7 @@ method publish*(
   g.broadcast(
     peers,
     RPCMsg.withMessages(msg),
-    isHighPriority = true,
+    priority = MessagePriority.Medium,
     useCustomConn = pubParams.useCustomConn,
   )
 
@@ -1007,7 +1007,7 @@ proc createExtensionsState(g: GossipSub): ExtensionsState =
       cfg.broadcastRPC = proc(msg: RPCMsg, peers: seq[PeerId]) {.gcsafe, raises: [].} =
         let peersToBroadcast =
           peers.filterIt(it in g.peers).mapIt(g.peers.getOrDefault(it))
-        g.broadcast(peersToBroadcast, msg, isHighPriority = true)
+        g.broadcast(peersToBroadcast, msg, priority = MessagePriority.High)
     if cfg.hasSeen.isNil:
       cfg.hasSeen = proc(mid: MessageId): bool {.gcsafe, raises: [].} =
         return g.hasSeen(g.salt(mid))

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -968,7 +968,11 @@ proc createExtensionsState(g: GossipSub): ExtensionsState =
     if cfg.onNegotiated.isNil:
       cfg.onNegotiated = proc(peerId: PeerId) {.gcsafe, raises: [].} =
         g.peers.withValue(peerId, peer):
-          g.send(peer[], RPCMsg(testExtension: Opt.some(TestExtensionRPC())), priority = MessagePriority.Low)
+          g.send(
+            peer[],
+            RPCMsg(testExtension: Opt.some(TestExtensionRPC())),
+            priority = MessagePriority.Low,
+          )
 
     g.parameters.testExtensionConfig = Opt.some(cfg)
 
@@ -980,7 +984,11 @@ proc createExtensionsState(g: GossipSub): ExtensionsState =
           peerId: PeerId, rpc: PartialMessageExtensionRPC
       ) {.gcsafe, raises: [].} =
         g.peers.withValue(peerId, peer):
-          g.send(peer[], RPCMsg(partialMessageExtension: Opt.some(rpc)), priority = MessagePriority.Low)
+          g.send(
+            peer[],
+            RPCMsg(partialMessageExtension: Opt.some(rpc)),
+            priority = MessagePriority.Low,
+          )
 
     if cfg.publishToPeers.isNil:
       cfg.publishToPeers = proc(topic: string): seq[PeerId] {.gcsafe, raises: [].} =
@@ -1076,8 +1084,7 @@ method initPubSub*(g: GossipSub) {.raises: [InitializationError].} =
   if g.parameters.maxNumElementsInNonPriorityQueue > 0 and
       g.parameters.maxLowPriorityQueueLen == DefaultMaxLowPriorityQueueLen:
     warn "maxNumElementsInNonPriorityQueue is deprecated. Use maxNumElementsInNonPriorityQueue"
-    g.parameters.maxLowPriorityQueueLen =
-      g.parameters.maxNumElementsInNonPriorityQueue
+    g.parameters.maxLowPriorityQueueLen = g.parameters.maxNumElementsInNonPriorityQueue
 
   let validationRes = g.parameters.validateParameters()
   if validationRes.isErr:

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -254,7 +254,7 @@ proc sendExtensionsControl(g: GossipSub, peer: PubSubPeer) =
       RPCMsg.withControl(
         ControlMessage.withExtensions(g.extensionsState.makeControlExtensions())
       ),
-      true, # use high priority as message must be the first message on the stream
+      priority = MessagePriority.High, # must be the first message on the stream
     )
 
   # before extensions control is sent, node needs to known if peer actually supports
@@ -344,7 +344,7 @@ method unsubscribePeer*(g: GossipSub, peer: PeerId) =
     for topic, info in stats[].topicInfos.mpairs:
       info.firstMessageDeliveries = 0
 
-  pubSubPeer.stopSendNonPriorityTask()
+  pubSubPeer.stopSendNonHighPriorityTask()
 
   g.extensionsState.removePeer(peer)
 
@@ -968,7 +968,7 @@ proc createExtensionsState(g: GossipSub): ExtensionsState =
     if cfg.onNegotiated.isNil:
       cfg.onNegotiated = proc(peerId: PeerId) {.gcsafe, raises: [].} =
         g.peers.withValue(peerId, peer):
-          g.send(peer[], RPCMsg(testExtension: Opt.some(TestExtensionRPC())), false)
+          g.send(peer[], RPCMsg(testExtension: Opt.some(TestExtensionRPC())), priority = MessagePriority.Low)
 
     g.parameters.testExtensionConfig = Opt.some(cfg)
 
@@ -980,7 +980,7 @@ proc createExtensionsState(g: GossipSub): ExtensionsState =
           peerId: PeerId, rpc: PartialMessageExtensionRPC
       ) {.gcsafe, raises: [].} =
         g.peers.withValue(peerId, peer):
-          g.send(peer[], RPCMsg(partialMessageExtension: Opt.some(rpc)), false)
+          g.send(peer[], RPCMsg(partialMessageExtension: Opt.some(rpc)), priority = MessagePriority.Low)
 
     if cfg.publishToPeers.isNil:
       cfg.publishToPeers = proc(topic: string): seq[PeerId] {.gcsafe, raises: [].} =
@@ -1004,7 +1004,7 @@ proc createExtensionsState(g: GossipSub): ExtensionsState =
     if cfg.sendPong.isNil:
       cfg.sendPong = proc(peerId: PeerId, pong: seq[byte]) {.gcsafe, raises: [].} =
         g.peers.withValue(peerId, peer):
-          g.send(peer[], RPCMsg.withPong(pong), true)
+          g.send(peer[], RPCMsg.withPong(pong), priority = MessagePriority.High)
 
     g.parameters.pingpongExtensionConfig = Opt.some(cfg)
 

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -1075,8 +1075,9 @@ method initPubSub*(g: GossipSub) {.raises: [InitializationError].} =
   # and the new field is still at its default, copy the value over.
   if g.parameters.maxNumElementsInNonPriorityQueue > 0 and
       g.parameters.maxLowPriorityQueueLen == DefaultMaxLowPriorityQueueLen:
-    warning "maxNumElementsInNonPriorityQueue is deprecated. Use maxNumElementsInNonPriorityQueue"
-    g.parameters.maxLowPriorityQueueLen = g.parameters.maxNumElementsInNonPriorityQueue
+    warn "maxNumElementsInNonPriorityQueue is deprecated. Use maxNumElementsInNonPriorityQueue"
+    g.parameters.maxLowPriorityQueueLen =
+      g.parameters.maxNumElementsInNonPriorityQueue
 
   let validationRes = g.parameters.validateParameters()
   if validationRes.isErr:

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -98,7 +98,9 @@ proc init*(
     bandwidthEstimatebps = 100_000_000, # 100 Mbps or 12.5 MBps
     overheadRateLimit = Opt.none(tuple[bytes: int, interval: Duration]),
     disconnectPeerAboveRateLimit = false,
-    maxNumElementsInNonPriorityQueue = DefaultMaxNumElementsInNonPriorityQueue,
+    maxHighPriorityQueueLen = DefaultMaxHighPriorityQueueLen,
+    maxMediumPriorityQueueLen = DefaultMaxMediumPriorityQueueLen,
+    maxLowPriorityQueueLen = DefaultMaxLowPriorityQueueLen,
     sendIDontWantOnPublish = false,
     testExtensionConfig = Opt.none(TestExtensionConfig),
     partialMessageExtensionConfig = Opt.none(PartialMessageExtensionConfig),
@@ -139,7 +141,9 @@ proc init*(
     bandwidthEstimatebps: bandwidthEstimatebps,
     overheadRateLimit: overheadRateLimit,
     disconnectPeerAboveRateLimit: disconnectPeerAboveRateLimit,
-    maxNumElementsInNonPriorityQueue: maxNumElementsInNonPriorityQueue,
+    maxHighPriorityQueueLen: maxHighPriorityQueueLen,
+    maxMediumPriorityQueueLen: maxMediumPriorityQueueLen,
+    maxLowPriorityQueueLen: maxLowPriorityQueueLen,
     sendIDontWantOnPublish: sendIDontWantOnPublish,
     testExtensionConfig: testExtensionConfig,
     partialMessageExtensionConfig: partialMessageExtensionConfig,
@@ -175,8 +179,12 @@ proc validateParameters*(parameters: GossipSubParams): Result[void, cstring] =
     err("gossipsub: behaviourPenaltyWeight parameter error, Must be negative")
   elif parameters.behaviourPenaltyDecay < 0 or parameters.behaviourPenaltyDecay >= 1:
     err("gossipsub: behaviourPenaltyDecay parameter error, Must be between 0 and 1")
-  elif parameters.maxNumElementsInNonPriorityQueue <= 0:
-    err("gossipsub: maxNumElementsInNonPriorityQueue parameter error, Must be > 0")
+  elif parameters.maxHighPriorityQueueLen <= 0:
+    err("gossipsub: maxHighPriorityQueueLen parameter error, Must be > 0")
+  elif parameters.maxMediumPriorityQueueLen <= 0:
+    err("gossipsub: maxMediumPriorityQueueLen parameter error, Must be > 0")
+  elif parameters.maxLowPriorityQueueLen <= 0:
+    err("gossipsub: maxLowPriorityQueueLen parameter error, Must be > 0")
   else:
     ok()
 
@@ -1063,6 +1071,13 @@ method initPubSub*(g: GossipSub) {.raises: [InitializationError].} =
   if not g.parameters.explicit:
     g.parameters = GossipSubParams.init()
 
+  # If deprecated maxNumElementsInNonPriorityQueue was set
+  # and the new field is still at its default, copy the value over.
+  if g.parameters.maxNumElementsInNonPriorityQueue > 0 and
+      g.parameters.maxLowPriorityQueueLen == DefaultMaxLowPriorityQueueLen:
+    warning "maxNumElementsInNonPriorityQueue is deprecated. Use maxNumElementsInNonPriorityQueue"
+    g.parameters.maxLowPriorityQueueLen = g.parameters.maxNumElementsInNonPriorityQueue
+
   let validationRes = g.parameters.validateParameters()
   if validationRes.isErr:
     raise newException(InitializationError, $validationRes.error)
@@ -1084,6 +1099,8 @@ method getOrCreatePeer*(
   g.parameters.overheadRateLimit.withValue(overheadRateLimit):
     peer.overheadRateLimitOpt =
       Opt.some(TokenBucket.new(overheadRateLimit.bytes, overheadRateLimit.interval))
-  peer.maxNumElementsInNonPriorityQueue = g.parameters.maxNumElementsInNonPriorityQueue
+  peer.maxHighPriorityQueueLen = g.parameters.maxHighPriorityQueueLen
+  peer.maxMediumPriorityQueueLen = g.parameters.maxMediumPriorityQueueLen
+  peer.maxLowPriorityQueueLen = g.parameters.maxLowPriorityQueueLen
 
   return peer

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -254,7 +254,7 @@ proc sendExtensionsControl(g: GossipSub, peer: PubSubPeer) =
       RPCMsg.withControl(
         ControlMessage.withExtensions(g.extensionsState.makeControlExtensions())
       ),
-      priority = MessagePriority.High, # must be the first message on the stream
+      MessagePriority.High, # must be the first message on the stream
     )
 
   # before extensions control is sent, node needs to known if peer actually supports
@@ -417,7 +417,7 @@ proc handleControl(g: GossipSub, peer: PubSubPeer, control: ControlMessage) =
         libp2p_pubsub_broadcast_prune.inc(labelValues = [g.topicLabel(prune.topicID)])
 
     trace "sending control message", payload = shortLog(respControl), peer
-    g.send(peer, RPCMsg.withControl(respControl), priority = MessagePriority.High)
+    g.send(peer, RPCMsg.withControl(respControl), MessagePriority.High)
 
   if messages.len > 0:
     for i, smsg in messages:
@@ -431,7 +431,7 @@ proc handleControl(g: GossipSub, peer: PubSubPeer, control: ControlMessage) =
 
     # iwant replies have lower priority
     trace "sending iwant reply messages", peer
-    g.send(peer, RPCMsg.withMessages(messages), priority = MessagePriority.Low)
+    g.send(peer, RPCMsg.withMessages(messages), MessagePriority.Low)
 
 proc sendIDontWant(
     g: GossipSub,
@@ -459,9 +459,7 @@ proc sendIDontWant(
   )
 
   g.broadcast(
-    peers,
-    RPCMsg.withControl(ControlMessage.withIDontWant(msgId)),
-    priority = MessagePriority.High,
+    peers, RPCMsg.withControl(ControlMessage.withIDontWant(msgId)), MessagePriority.High
   )
 
 const iDontWantMessageSizeThreshold* = 512
@@ -548,7 +546,7 @@ proc validateAndRelay(
 
     # In theory, if topics are the same in all messages, we could batch - we'd
     # also have to be careful to only include validated messages
-    g.broadcast(toSendPeers, RPCMsg.withMessages(msg), priority = MessagePriority.Low)
+    g.broadcast(toSendPeers, RPCMsg.withMessages(msg), MessagePriority.Low)
     trace "forwarded message to peers", peers = toSendPeers.len, msgId, peer
 
     libp2p_pubsub_messages_rebroadcasted.inc(
@@ -734,7 +732,7 @@ method onTopicSubscription*(g: GossipSub, topic: string, subscribed: bool) =
         topic, g.parameters.unsubscribeBackoff.seconds.uint64, g.peerExchangeList(topic)
       )
     )
-    g.broadcast(mpeers, msg, priority = MessagePriority.High)
+    g.broadcast(mpeers, msg, MessagePriority.High)
 
     for peer in mpeers:
       g.pruned(peer, topic, backoff = Opt.some(g.parameters.unsubscribeBackoff))
@@ -896,7 +894,7 @@ method publish*(
   g.broadcast(
     peers,
     RPCMsg.withMessages(msg),
-    priority = MessagePriority.Medium,
+    MessagePriority.Medium,
     useCustomConn = pubParams.useCustomConn,
   )
 
@@ -971,7 +969,7 @@ proc createExtensionsState(g: GossipSub): ExtensionsState =
           g.send(
             peer[],
             RPCMsg(testExtension: Opt.some(TestExtensionRPC())),
-            priority = MessagePriority.Low,
+            MessagePriority.High,
           )
 
     g.parameters.testExtensionConfig = Opt.some(cfg)
@@ -985,9 +983,7 @@ proc createExtensionsState(g: GossipSub): ExtensionsState =
       ) {.gcsafe, raises: [].} =
         g.peers.withValue(peerId, peer):
           g.send(
-            peer[],
-            RPCMsg(partialMessageExtension: Opt.some(rpc)),
-            priority = MessagePriority.Low,
+            peer[], RPCMsg(partialMessageExtension: Opt.some(rpc)), MessagePriority.Low
           )
 
     if cfg.publishToPeers.isNil:
@@ -1012,7 +1008,7 @@ proc createExtensionsState(g: GossipSub): ExtensionsState =
     if cfg.sendPong.isNil:
       cfg.sendPong = proc(peerId: PeerId, pong: seq[byte]) {.gcsafe, raises: [].} =
         g.peers.withValue(peerId, peer):
-          g.send(peer[], RPCMsg.withPong(pong), priority = MessagePriority.High)
+          g.send(peer[], RPCMsg.withPong(pong), MessagePriority.High)
 
     g.parameters.pingpongExtensionConfig = Opt.some(cfg)
 
@@ -1023,7 +1019,7 @@ proc createExtensionsState(g: GossipSub): ExtensionsState =
       cfg.broadcastRPC = proc(msg: RPCMsg, peers: seq[PeerId]) {.gcsafe, raises: [].} =
         let peersToBroadcast =
           peers.filterIt(it in g.peers).mapIt(g.peers.getOrDefault(it))
-        g.broadcast(peersToBroadcast, msg, priority = MessagePriority.High)
+        g.broadcast(peersToBroadcast, msg, MessagePriority.High)
     if cfg.hasSeen.isNil:
       cfg.hasSeen = proc(mid: MessageId): bool {.gcsafe, raises: [].} =
         return g.hasSeen(g.salt(mid))

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -587,14 +587,14 @@ proc rebalanceMesh*(g: GossipSub, topic: string, metrics: ptr MeshMetrics = nil)
   # Send changes to peers after table updates to avoid stale state
   if grafts.len > 0:
     let graft = RPCMsg.withControl(ControlMessage.withGraft(topic))
-    g.broadcast(grafts, graft, isHighPriority = true)
+    g.broadcast(grafts, graft, priority = MessagePriority.High)
   if prunes.len > 0:
     let prune = RPCMsg.withControl(
       ControlMessage.withPrune(
         topic, g.parameters.pruneBackoff.seconds.uint64, g.peerExchangeList(topic)
       )
     )
-    g.broadcast(prunes, prune, isHighPriority = true)
+    g.broadcast(prunes, prune, priority = MessagePriority.High)
 
 proc dropFanoutPeers*(g: GossipSub) =
   # drop peers that we haven't published to in
@@ -725,7 +725,7 @@ proc onHeartbeat(g: GossipSub) =
           t, g.parameters.pruneBackoff.seconds.uint64, g.peerExchangeList(t)
         )
       )
-      g.broadcast(prunes, prune, isHighPriority = true)
+      g.broadcast(prunes, prune, priority = MessagePriority.High)
 
     # pass by ptr in order to both signal we want to update metrics
     # and as well update the struct for each topic during this iteration
@@ -748,7 +748,7 @@ proc onHeartbeat(g: GossipSub) =
       if not g.extensionsState.peerRequestsPartial(peer.peerId, ihave.topicID):
         # send IHAVE only if peer has not requested partial for topic.
         # these peers will receive gossip of partial metadata via extension.
-        g.send(peer, RPCMsg.withControl(control), isHighPriority = true)
+        g.send(peer, RPCMsg.withControl(control), priority = MessagePriority.High)
 
   g.mcache.shift() # shift the cache
 

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -587,14 +587,14 @@ proc rebalanceMesh*(g: GossipSub, topic: string, metrics: ptr MeshMetrics = nil)
   # Send changes to peers after table updates to avoid stale state
   if grafts.len > 0:
     let graft = RPCMsg.withControl(ControlMessage.withGraft(topic))
-    g.broadcast(grafts, graft, priority = MessagePriority.High)
+    g.broadcast(grafts, graft, MessagePriority.High)
   if prunes.len > 0:
     let prune = RPCMsg.withControl(
       ControlMessage.withPrune(
         topic, g.parameters.pruneBackoff.seconds.uint64, g.peerExchangeList(topic)
       )
     )
-    g.broadcast(prunes, prune, priority = MessagePriority.High)
+    g.broadcast(prunes, prune, MessagePriority.High)
 
 proc dropFanoutPeers*(g: GossipSub) =
   # drop peers that we haven't published to in
@@ -725,7 +725,7 @@ proc onHeartbeat(g: GossipSub) =
           t, g.parameters.pruneBackoff.seconds.uint64, g.peerExchangeList(t)
         )
       )
-      g.broadcast(prunes, prune, priority = MessagePriority.High)
+      g.broadcast(prunes, prune, MessagePriority.High)
 
     # pass by ptr in order to both signal we want to update metrics
     # and as well update the struct for each topic during this iteration
@@ -748,7 +748,7 @@ proc onHeartbeat(g: GossipSub) =
       if not g.extensionsState.peerRequestsPartial(peer.peerId, ihave.topicID):
         # send IHAVE only if peer has not requested partial for topic.
         # these peers will receive gossip of partial metadata via extension.
-        g.send(peer, RPCMsg.withControl(control), priority = MessagePriority.High)
+        g.send(peer, RPCMsg.withControl(control), MessagePriority.High)
 
   g.mcache.shift() # shift the cache
 

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -151,7 +151,14 @@ type
     overheadRateLimit*: Opt[tuple[bytes: int, interval: Duration]]
     disconnectPeerAboveRateLimit*: bool
 
-    # Max number of elements allowed in the non-priority queue. When this limit has been reached, the peer will be disconnected.
+    # Max number of high-priority sends. When this limit has been reached, the peer will be disconnected.
+    maxHighPriorityQueueLen*: int
+    # Max number of enqueued medium-priority messages. Excess messages are dropped.
+    maxMediumPriorityQueueLen*: int
+    # Max number of enqueued low-priority messages. Excess messages are dropped.
+    maxLowPriorityQueueLen*: int
+
+    # Deprecated: use maxLowPriorityQueueLen instead.
     maxNumElementsInNonPriorityQueue*: int
 
     # Broadcast an IDONTWANT message automatically when the message exceeds the IDONTWANT message size threshold

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -158,7 +158,7 @@ type
     # Max number of enqueued low-priority messages. Excess messages are dropped.
     maxLowPriorityQueueLen*: int
 
-    # Deprecated: use maxLowPriorityQueueLen instead.
+    # Deprecated: use maxMediumPriorityQueueLen and maxLowPriorityQueueLen instead.
     maxNumElementsInNonPriorityQueue*: int
 
     # Broadcast an IDONTWANT message automatically when the message exceeds the IDONTWANT message size threshold

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -220,6 +220,21 @@ proc send*(
     p: PubSub,
     peer: PubSubPeer,
     msg: RPCMsg,
+    isHighPriority: bool,
+    useCustomConn: bool = false,
+) {.raises: [], deprecated: "use send(..., priority = High/Low, ...) instead".} =
+  let priority =
+    if isHighPriority:
+      High
+    else:
+      Low
+
+  p.send(peer, msg, priority, useCustomConn)
+
+proc send*(
+    p: PubSub,
+    peer: PubSubPeer,
+    msg: RPCMsg,
     priority: MessagePriority,
     useCustomConn: bool = false,
 ) {.raises: [].} =

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -220,7 +220,7 @@ proc send*(
     p: PubSub,
     peer: PubSubPeer,
     msg: RPCMsg,
-    isHighPriority: bool,
+    priority: MessagePriority,
     useCustomConn: bool = false,
 ) {.raises: [].} =
   ## This procedure attempts to send a `msg` (of type `RPCMsg`) to the specified remote peer in the PubSub network.
@@ -229,18 +229,18 @@ proc send*(
   ## - `p`: The `PubSub` instance.
   ## - `peer`: An instance of `PubSubPeer` representing the peer to whom the message should be sent.
   ## - `msg`: The `RPCMsg` instance that contains the message to be sent.
-  ## - `isHighPriority`: A boolean indicating whether the message should be treated as high priority.
-  ## High priority messages are sent immediately, while low priority messages are queued and sent only after all high
-  ## priority messages have been sent.
+  ## - `priority`: The message priority level (`High`, `Medium`, or `Low`).
+  ##   High priority messages are sent immediately, medium and low priority messages are queued
+  ##   and sent only after all high priority messages have been sent.
 
   trace "sending pubsub message to peer", peer, payload = shortLog(msg)
-  peer.send(msg, p.anonymize, isHighPriority, useCustomConn)
+  peer.send(msg, p.anonymize, priority, useCustomConn)
 
 proc broadcast*(
     p: PubSub,
     sendPeers: auto, # Iteratble[PubSubPeer]
     msg: RPCMsg,
-    isHighPriority: bool,
+    priority: MessagePriority,
     useCustomConn: bool = false,
 ) {.raises: [].} =
   ## This procedure attempts to send a `msg` (of type `RPCMsg`) to a specified group of peers in the PubSub network.
@@ -249,9 +249,9 @@ proc broadcast*(
   ## - `p`: The `PubSub` instance.
   ## - `sendPeers`: An iterable of `PubSubPeer` instances representing the peers to whom the message should be sent.
   ## - `msg`: The `RPCMsg` instance that contains the message to be broadcast.
-  ## - `isHighPriority`: A boolean indicating whether the message should be treated as high priority.
-  ## High priority messages are sent immediately, while low priority messages are queued and sent only after all high
-  ## priority messages have been sent.
+  ## - `priority`: The message priority level (`High`, `Medium`, or `Low`).
+  ##   High priority messages are sent immediately, medium and low priority messages are queued
+  ##   and sent only after all high priority messages have been sent.
 
   let npeers = sendPeers.len.int64
   for sub in msg.subscriptions:
@@ -289,12 +289,12 @@ proc broadcast*(
 
   if anyIt(sendPeers, it.hasObservers):
     for peer in sendPeers:
-      p.send(peer, msg, isHighPriority, useCustomConn)
+      p.send(peer, msg, priority, useCustomConn)
   else:
     # Fast path that only encodes message once
     let encoded = encodeRpcMsg(msg, p.anonymize)
     for peer in sendPeers:
-      asyncSpawn peer.sendEncoded(encoded, isHighPriority, useCustomConn)
+      asyncSpawn peer.sendEncoded(encoded, priority, useCustomConn)
 
 proc sendSubs*(
     p: PubSub, peer: PubSubPeer, subTopics: openArray[string], subscribe: bool
@@ -310,7 +310,7 @@ proc sendSubs*(
         subOpt.supportsSendingPartial = Opt.some(topicData[].supportsSendingPartial)
     subscriptions.add(subOpt)
 
-  p.send(peer, RPCMsg.withSubscriptions(subscriptions), isHighPriority = true)
+  p.send(peer, RPCMsg.withSubscriptions(subscriptions), priority = MessagePriority.High)
 
   for topic in subTopics:
     if subscribe:

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -220,21 +220,6 @@ proc send*(
     p: PubSub,
     peer: PubSubPeer,
     msg: RPCMsg,
-    isHighPriority: bool,
-    useCustomConn: bool = false,
-) {.raises: [], deprecated: "use send(..., priority = High/Low, ...) instead".} =
-  let priority =
-    if isHighPriority:
-      High
-    else:
-      Low
-
-  p.send(peer, msg, priority, useCustomConn)
-
-proc send*(
-    p: PubSub,
-    peer: PubSubPeer,
-    msg: RPCMsg,
     priority: MessagePriority,
     useCustomConn: bool = false,
 ) {.raises: [].} =
@@ -250,6 +235,22 @@ proc send*(
 
   trace "sending pubsub message to peer", peer, payload = shortLog(msg)
   peer.send(msg, p.anonymize, priority, useCustomConn)
+
+proc send*(
+    p: PubSub,
+    peer: PubSubPeer,
+    msg: RPCMsg,
+    isHighPriority: bool,
+    useCustomConn: bool = false,
+) {.raises: [], deprecated: "use send(..., priority = High/Low, ...) instead".} =
+  let priority =
+    if isHighPriority:
+      MessagePriority.High
+    else:
+      # Locally published messages have higher priority than gossip but not than control messages       
+      MessagePriority.Medium
+
+  p.send(peer, msg, priority, useCustomConn)
 
 proc broadcast*(
     p: PubSub,
@@ -310,6 +311,18 @@ proc broadcast*(
     let encoded = encodeRpcMsg(msg, p.anonymize)
     for peer in sendPeers:
       asyncSpawn peer.sendEncoded(encoded, priority, useCustomConn)
+
+proc broadcast*(
+    p: PubSub,
+    sendPeers: auto, # Iterable[PubSubPeer]
+    msg: RPCMsg,
+    isHighPriority: bool,
+    useCustomConn: bool = false,
+) {.deprecated: "Use broadcast with priority: MessagePriority instead", raises: [].} =
+  ## Backward-compatible overload for callers still using the previous
+  ## boolean priority API. Maps `true` to `High` and `false` to `Medium`.
+  let priority = if isHighPriority: High else: Medium
+  p.broadcast(sendPeers, msg, priority, useCustomConn)
 
 proc sendSubs*(
     p: PubSub, peer: PubSubPeer, subTopics: openArray[string], subscribe: bool

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -310,7 +310,7 @@ proc sendSubs*(
         subOpt.supportsSendingPartial = Opt.some(topicData[].supportsSendingPartial)
     subscriptions.add(subOpt)
 
-  p.send(peer, RPCMsg.withSubscriptions(subscriptions), priority = MessagePriority.High)
+  p.send(peer, RPCMsg.withSubscriptions(subscriptions), MessagePriority.High)
 
   for topic in subTopics:
     if subscribe:

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -574,9 +574,9 @@ proc send*(
   ## - `p`: The `PubSubPeer` instance to which the message is to be sent.
   ## - `msg`: The `RPCMsg` instance representing the message to be sent.
   ## - `anonymize`: A boolean flag indicating whether the message should be sent with anonymization.
-  ## - `isHighPriority`: A boolean flag indicating whether the message should be treated as high priority.
-  ## High priority messages are sent immediately, while lower priority messages are queued and sent only after all high
-  ## priority messages have been sent.
+  ## - `priority`: The message priority level (`High`, `Medium`, or `Low`).
+  ##   High priority messages are sent immediately, medium and low priority messages are queued
+  ##   and sent only after all high priority messages have been sent.
   # When sending messages, we take care to re-encode them with the right
   # anonymization flag to ensure that we're not penalized for sending invalid
   # or malicious data on the wire - in particular, re-encoding protects against

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -378,13 +378,17 @@ proc clearSendPriorityQueue(p: PubSubPeer) =
       value = p.rpcmessagequeue.sendPriorityQueue.len.int64, labelValues = [$p.peerId]
     )
 
-proc sendMsgContinue(conn: Connection, msgFut: Future[void]) {.async: (raises: []).} =
+proc sendMsgContinue(
+    conn: Connection, msgFut: Future[void]
+) {.async: (raises: [CancelledError]).} =
   # Continuation for a pending `sendMsg` future from below
   try:
     await msgFut
     trace "sent pubsub message to remote", conn
+  except CancelledError as exc:
+    raise exc
   except CatchableError as exc:
-    trace "Unexpected exception in sendMsgContinue", conn, description = exc.msg
+    trace "sending encoded msg to peer failed", conn, description = exc.msg
     # Next time sendConn is used, it will be have its close flag set and thus
     # will be recycled
     await conn.close() # This will clean up the send connection
@@ -474,11 +478,11 @@ proc sendEncoded*(
 
   if msg.len <= 0:
     debug "empty message, skipping", p, payload = shortLog(msg)
-    Future[void].completed()
+    newFutureCompleted[void]()
   elif msg.len > p.maxMessageSize:
     info "trying to send a msg too big for pubsub",
       maxSize = p.maxMessageSize, msgSize = msg.len
-    Future[void].completed()
+    newFutureCompleted[void]()
   elif priority == MessagePriority.High or emptyQueues:
     # High priority: always send immediately.
     # Empty queues: any priority sends immediately for lower latency.

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -15,7 +15,7 @@ import
   ../../crypto/crypto,
   ../../protobuf/minprotobuf,
   ../../utility,
-  ../../utils/sequninit
+  ../../utils/[future, sequninit]
 
 export peerid, connection, deques
 
@@ -39,22 +39,38 @@ when defined(libp2p_expensive_metrics):
 
 when defined(pubsubpeer_queue_metrics):
   declareGauge(
-    libp2p_gossipsub_priority_queue_size,
-    "the number of messages in the priority queue",
+    libp2p_gossipsub_high_priority_queue_size,
+    "the number of in-flight high-priority sends",
     labels = ["id"],
   )
   declareGauge(
-    libp2p_gossipsub_non_priority_queue_size,
-    "the number of messages in the non-priority queue",
+    libp2p_gossipsub_medium_priority_queue_size,
+    "the number of messages in the medium-priority queue",
+    labels = ["id"],
+  )
+  declareGauge(
+    libp2p_gossipsub_low_priority_queue_size,
+    "the number of messages in the low-priority queue",
     labels = ["id"],
   )
 
 declareCounter(
-  libp2p_pubsub_disconnects_over_non_priority_queue_limit,
-  "number of peers disconnected due to over non-prio queue capacity",
+  libp2p_pubsub_disconnects_over_high_priority_queue_limit,
+  "number of peers disconnected due to high-priority queue overflow",
+)
+declareCounter(
+  libp2p_pubsub_medium_priority_queue_drops,
+  "number of messages dropped from medium-priority queue due to overflow",
+)
+declareCounter(
+  libp2p_pubsub_low_priority_queue_drops,
+  "number of messages dropped from low-priority queue due to overflow",
 )
 
-const DefaultMaxNumElementsInNonPriorityQueue* = 1024
+const
+  DefaultMaxHighPriorityQueueLen* = 256
+  DefaultMaxMediumPriorityQueueLen* = 512
+  DefaultMaxLowPriorityQueueLen* = 1024
 
 type
   PeerRateLimitError* = object of CatchableError
@@ -66,6 +82,18 @@ type
     onSend*: proc(peer: PubSubPeer, msgs: var RPCMsg) {.gcsafe, raises: [].}
     onValidated*:
       proc(peer: PubSubPeer, msg: Message, msgId: MessageId) {.gcsafe, raises: [].}
+
+  MessagePriority* {.pure.} = enum
+    High
+      ## Protocol-critical messages: subscriptions, GRAFT, PRUNE, IHAVE,
+      ## IDontWant, control responses. Sent immediately. If max is exceeded
+      ## we drop the peer.
+    Medium
+      ## Locally published messages. Sent before low priority traffic.
+      ## They are dropped if exceeded max. Peer is not disconnected.
+    Low
+      ## Relayed messages and IWANT replies
+      ## They are dropped if exceeded max. Peer is not disconnected.
 
   PubSubPeerEventKind* {.pure.} = enum
     StreamOpened
@@ -83,18 +111,22 @@ type
   OnEvent* = proc(peer: PubSubPeer, event: PubSubPeerEvent) {.gcsafe, raises: [].}
 
   QueuedMessage = object
-    # Messages sent as lower-priority are queued and sent in other location
-    # in which we need to keep arguments like `useCustomConn`.
+    # Messages sent as medium/low priority are queued and sent on a
+    # separate routine.
     data: seq[byte]
     useCustomConn: bool
 
   RpcMessageQueue* = ref object
     # Tracks async tasks for sending high-priority peer-published messages.
     sendPriorityQueue: Deque[Future[void]]
+    # Queue for local published messages
+    mediumPriorityQueue: Deque[QueuedMessage]
     # Queue for lower-priority messages, like "IWANT" replies and relay messages.
-    nonPriorityQueue: AsyncQueue[QueuedMessage]
+    lowPriorityQueue: Deque[QueuedMessage]
+    # Triggered when a message is added to medium or low queue.
+    dataAvailableEvent: AsyncEvent
     # Task for processing non-priority message queue.
-    sendNonPriorityTask: Future[void]
+    sendNonHighPriorityTask: Future[void]
 
   CustomConnCreationProc* = proc(
     destAddr: Opt[MultiAddress], destPeerId: PeerId, codec: string
@@ -134,8 +166,9 @@ type
     behaviourPenalty*: float64 # the eventual penalty score
     overheadRateLimitOpt*: Opt[TokenBucket]
     rpcmessagequeue: RpcMessageQueue
-    maxNumElementsInNonPriorityQueue*: int
-      # The max number of elements allowed in the non-priority queue.
+    maxHighPriorityQueueLen*: int
+    maxMediumPriorityQueueLen*: int
+    maxLowPriorityQueueLen*: int
     disconnected: bool
     customConnCallbacks*: Opt[CustomConnectionCallbacks]
 
@@ -341,7 +374,7 @@ proc clearSendPriorityQueue(p: PubSubPeer) =
     discard p.rpcmessagequeue.sendPriorityQueue.popLast()
 
   when defined(pubsubpeer_queue_metrics):
-    libp2p_gossipsub_priority_queue_size.set(
+    libp2p_gossipsub_high_priority_queue_size.set(
       value = p.rpcmessagequeue.sendPriorityQueue.len.int64, labelValues = [$p.peerId]
     )
 
@@ -411,27 +444,34 @@ proc sendMsg(
     sendMsgSlow(p, msg)
 
 proc sendEncoded*(
-    p: PubSubPeer, msg: seq[byte], isHighPriority: bool, useCustomConn: bool = false
+    p: PubSubPeer,
+    msg: seq[byte],
+    priority: MessagePriority,
+    useCustomConn: bool = false,
 ): Future[void] =
-  ## Asynchronously sends an encoded message to a specified `PubSubPeer`.
+  ## Asynchronously sends an encoded message to a specified `PubSubPeer` according to its priority.
   ##
   ## Parameters:
   ## - `p`: The `PubSubPeer` instance to which the message is to be sent.
   ## - `msg`: The message to be sent, encoded as a sequence of bytes (`seq[byte]`).
-  ## - `isHighPriority`: A boolean indicating whether the message should be treated as high priority.
-  ## High priority messages are sent immediately, while low priority messages are queued and sent only after all high
+  ## - `priority`: 
+  ##   - `High` or any priority when all queues are empty: sent immediately
+  ##   - `Medium`: queued in `mediumPriorityQueue`. Dropped when full.
+  ##   - `Low`: queued in `lowPriorityQueue`. Dropped when full.
+  ## - `useCustomConn`: boolean used to indicate if a custom connection is going to 
+  ##   be used for sending this message
+  ## Lower priority messages are queued and sent only after all high
   ## priority messages have been sent.
   doAssert(not isNil(p), "pubsubpeer nil!")
 
   p.clearSendPriorityQueue()
 
-  # When queues are empty, skipping the non-priority queue for low priority
-  # messages reduces latency
+  # When all queues are empty, any priority message is sent immediately
+  # to reduce latency (no need to go through the background task).
   let emptyQueues =
-    (
-      p.rpcmessagequeue.sendPriorityQueue.len() +
-      p.rpcmessagequeue.nonPriorityQueue.len()
-    ) == 0
+    p.rpcmessagequeue.sendPriorityQueue.len == 0 and
+    p.rpcmessagequeue.mediumPriorityQueue.len == 0 and
+    p.rpcmessagequeue.lowPriorityQueue.len == 0
 
   if msg.len <= 0:
     debug "empty message, skipping", p, payload = shortLog(msg)
@@ -440,28 +480,53 @@ proc sendEncoded*(
     info "trying to send a msg too big for pubsub",
       maxSize = p.maxMessageSize, msgSize = msg.len
     Future[void].completed()
-  elif isHighPriority or emptyQueues:
+  elif priority == MessagePriority.High or emptyQueues:
+    # High priority: always send immediately.
+    # Empty queues: any priority sends immediately for lower latency.
     let f = p.sendMsg(msg, useCustomConn)
     if not f.finished:
       p.rpcmessagequeue.sendPriorityQueue.addLast(f)
       when defined(pubsubpeer_queue_metrics):
-        libp2p_gossipsub_priority_queue_size.inc(labelValues = [$p.peerId])
-    f
-  else:
-    if len(p.rpcmessagequeue.nonPriorityQueue) >= p.maxNumElementsInNonPriorityQueue:
-      if not p.disconnected:
-        p.disconnected = true
-        libp2p_pubsub_disconnects_over_non_priority_queue_limit.inc()
-        p.closeSendConn(PubSubPeerEventKind.DisconnectionRequested)
+        libp2p_gossipsub_high_priority_queue_size.inc(labelValues = [$p.peerId])
+      # Check high-priority queue bound — if exceeded, the peer is too slow
+      # to keep up with protocol-critical messages and must be disconnected.
+      if p.rpcmessagequeue.sendPriorityQueue.len > p.maxHighPriorityQueueLen:
+        if not p.disconnected:
+          p.disconnected = true
+          libp2p_pubsub_disconnects_over_high_priority_queue_limit.inc()
+          p.closeSendConn(PubSubPeerEventKind.DisconnectionRequested)
+        else:
+          newFutureCompleted[void]()
       else:
-        Future[void].completed()
+        f
     else:
-      let f = p.rpcmessagequeue.nonPriorityQueue.addLast(
+      f
+  elif priority == MessagePriority.Medium:
+    if p.rpcmessagequeue.mediumPriorityQueue.len >= p.maxMediumPriorityQueueLen:
+      libp2p_pubsub_medium_priority_queue_drops.inc()
+      trace "medium priority queue full, dropping message", p
+      newFutureCompleted[void]()
+    else:
+      p.rpcmessagequeue.mediumPriorityQueue.addLast(
         QueuedMessage(data: msg, useCustomConn: useCustomConn)
       )
       when defined(pubsubpeer_queue_metrics):
-        libp2p_gossipsub_non_priority_queue_size.inc(labelValues = [$p.peerId])
-      f
+        libp2p_gossipsub_medium_priority_queue_size.inc(labelValues = [$p.peerId])
+      p.rpcmessagequeue.dataAvailableEvent.fire()
+      newFutureCompleted[void]()
+  else: # Low
+    if p.rpcmessagequeue.lowPriorityQueue.len >= p.maxLowPriorityQueueLen:
+      libp2p_pubsub_low_priority_queue_drops.inc()
+      trace "low priority queue full, dropping message", p
+      newFutureCompleted[void]()
+    else:
+      p.rpcmessagequeue.lowPriorityQueue.addLast(
+        QueuedMessage(data: msg, useCustomConn: useCustomConn)
+      )
+      when defined(pubsubpeer_queue_metrics):
+        libp2p_gossipsub_low_priority_queue_size.inc(labelValues = [$p.peerId])
+      p.rpcmessagequeue.dataAvailableEvent.fire()
+      newFutureCompleted[void]()
 
 iterator splitRPCMsg(
     peer: PubSubPeer, rpcMsg: RPCMsg, maxSize: int, anonymize: bool
@@ -500,7 +565,7 @@ proc send*(
     p: PubSubPeer,
     msg: RPCMsg,
     anonymize: bool,
-    isHighPriority: bool,
+    priority: MessagePriority,
     useCustomConn: bool = false,
 ) {.raises: [].} =
   ## Asynchronously sends an `RPCMsg` to a specified `PubSubPeer` with an option for anonymization.
@@ -510,7 +575,7 @@ proc send*(
   ## - `msg`: The `RPCMsg` instance representing the message to be sent.
   ## - `anonymize`: A boolean flag indicating whether the message should be sent with anonymization.
   ## - `isHighPriority`: A boolean flag indicating whether the message should be treated as high priority.
-  ## High priority messages are sent immediately, while low priority messages are queued and sent only after all high
+  ## High priority messages are sent immediately, while lower priority messages are queued and sent only after all high
   ## priority messages have been sent.
   # When sending messages, we take care to re-encode them with the right
   # anonymization flag to ensure that we're not penalized for sending invalid
@@ -535,11 +600,11 @@ proc send*(
 
   if encoded.len > maxEncodedMsgSize and msg.messages.len > 1:
     for encodedSplitMsg in splitRPCMsg(p, msg, maxEncodedMsgSize, anonymize):
-      asyncSpawn p.sendEncoded(encodedSplitMsg, isHighPriority, useCustomConn)
+      asyncSpawn p.sendEncoded(encodedSplitMsg, priority, useCustomConn)
   else:
     # If the message size is within limits, send it as is
     trace "sending msg to peer", peer = p, rpcMsg = shortLog(msg)
-    asyncSpawn p.sendEncoded(encoded, isHighPriority, useCustomConn)
+    asyncSpawn p.sendEncoded(encoded, priority, useCustomConn)
 
 proc canAskIWant*(p: PubSubPeer, msgId: MessageId): bool =
   for sentIHave in p.sentIHaves.mitems():
@@ -548,10 +613,14 @@ proc canAskIWant*(p: PubSubPeer, msgId: MessageId): bool =
       return true
   return false
 
-proc sendNonPriorityTask(p: PubSubPeer) {.async: (raises: [CancelledError]).} =
+proc sendNonHighPriorityTask(p: PubSubPeer) {.async: (raises: [CancelledError]).} =
   while true:
     # we send non-priority messages only if there are no pending priority messages
-    let msg = await p.rpcmessagequeue.nonPriorityQueue.popFirst()
+    while p.rpcmessagequeue.mediumPriorityQueue.len == 0 and
+        p.rpcmessagequeue.lowPriorityQueue.len == 0:
+      p.rpcmessagequeue.dataAvailableEvent.clear()
+      await p.rpcmessagequeue.dataAvailableEvent.wait()
+
     while p.rpcmessagequeue.sendPriorityQueue.len > 0:
       p.clearSendPriorityQueue()
       # waiting for the last future minimizes the number of times we have to
@@ -562,31 +631,48 @@ proc sendNonPriorityTask(p: PubSubPeer) {.async: (raises: [CancelledError]).} =
         # `race` prevents `p.rpcmessagequeue.sendPriorityQueue[^1]` from being
         # cancelled when this task is cancelled
         discard await race(p.rpcmessagequeue.sendPriorityQueue[^1])
-    when defined(pubsubpeer_queue_metrics):
-      libp2p_gossipsub_non_priority_queue_size.dec(labelValues = [$p.peerId])
-    await p.sendMsg(msg.data, msg.useCustomConn)
 
-proc startSendNonPriorityTask(p: PubSubPeer) =
-  debug "starting sendNonPriorityTask", p
-  if p.rpcmessagequeue.sendNonPriorityTask.isNil:
-    p.rpcmessagequeue.sendNonPriorityTask = p.sendNonPriorityTask()
+    # Dequeue messages by priority
+    if p.rpcmessagequeue.mediumPriorityQueue.len > 0:
+      let msg = p.rpcmessagequeue.mediumPriorityQueue.popFirst()
+      when defined(pubsubpeer_queue_metrics):
+        libp2p_gossipsub_medium_priority_queue_size.dec(labelValues = [$p.peerId])
+      await p.sendMsg(msg.data, msg.useCustomConn)
+    elif p.rpcmessagequeue.lowPriorityQueue.len > 0:
+      let msg = p.rpcmessagequeue.lowPriorityQueue.popFirst()
+      when defined(pubsubpeer_queue_metrics):
+        libp2p_gossipsub_low_priority_queue_size.dec(labelValues = [$p.peerId])
+      await p.sendMsg(msg.data, msg.useCustomConn)
 
-proc stopSendNonPriorityTask*(p: PubSubPeer) =
-  if not p.rpcmessagequeue.sendNonPriorityTask.isNil:
-    debug "stopping sendNonPriorityTask", p
-    p.rpcmessagequeue.sendNonPriorityTask.cancelSoon()
-    p.rpcmessagequeue.sendNonPriorityTask = nil
+proc startSendNonHighPriorityTask(p: PubSubPeer) =
+  debug "starting sendNonHighPriorityTask", p
+  if p.rpcmessagequeue.sendNonHighPriorityTask.isNil:
+    p.rpcmessagequeue.sendNonHighPriorityTask = p.sendNonHighPriorityTask()
+
+proc stopSendNonHighPriorityTask*(p: PubSubPeer) =
+  if not p.rpcmessagequeue.sendNonHighPriorityTask.isNil:
+    debug "stopping sendNonHighPriorityTask", p
+    p.rpcmessagequeue.sendNonHighPriorityTask.cancelSoon()
+    p.rpcmessagequeue.sendNonHighPriorityTask = nil
     p.rpcmessagequeue.sendPriorityQueue.clear()
-    p.rpcmessagequeue.nonPriorityQueue.clear()
+    p.rpcmessagequeue.mediumPriorityQueue.clear()
+    p.rpcmessagequeue.lowPriorityQueue.clear()
 
     when defined(pubsubpeer_queue_metrics):
-      libp2p_gossipsub_priority_queue_size.set(labelValues = [$p.peerId], value = 0)
-      libp2p_gossipsub_non_priority_queue_size.set(labelValues = [$p.peerId], value = 0)
+      libp2p_gossipsub_high_priority_queue_size.set(
+        labelValues = [$p.peerId], value = 0
+      )
+      libp2p_gossipsub_medium_priority_queue_size.set(
+        labelValues = [$p.peerId], value = 0
+      )
+      libp2p_gossipsub_low_priority_queue_size.set(labelValues = [$p.peerId], value = 0)
 
 proc new(T: typedesc[RpcMessageQueue]): T =
   return T(
     sendPriorityQueue: initDeque[Future[void]](),
-    nonPriorityQueue: newAsyncQueue[QueuedMessage](),
+    mediumPriorityQueue: initDeque[QueuedMessage](),
+    lowPriorityQueue: initDeque[QueuedMessage](),
+    dataAvailableEvent: newAsyncEvent(),
   )
 
 proc new*(
@@ -596,12 +682,14 @@ proc new*(
     onEvent: OnEvent,
     codec: string,
     maxMessageSize: int,
-    maxNumElementsInNonPriorityQueue: int = DefaultMaxNumElementsInNonPriorityQueue,
+    maxHighPriorityQueueLen: int = DefaultMaxHighPriorityQueueLen,
+    maxMediumPriorityQueueLen: int = DefaultMaxMediumPriorityQueueLen,
+    maxLowPriorityQueueLen: int = DefaultMaxLowPriorityQueueLen,
     overheadRateLimitOpt: Opt[TokenBucket] = Opt.none(TokenBucket),
     customConnCallbacks: Opt[CustomConnectionCallbacks] =
       Opt.none(CustomConnectionCallbacks),
 ): T =
-  result = T(
+  let response = T(
     getConn: getConn,
     onEvent: onEvent,
     codec: codec,
@@ -611,12 +699,16 @@ proc new*(
     maxMessageSize: maxMessageSize,
     overheadRateLimitOpt: overheadRateLimitOpt,
     rpcmessagequeue: RpcMessageQueue.new(),
-    maxNumElementsInNonPriorityQueue: maxNumElementsInNonPriorityQueue,
+    maxHighPriorityQueueLen: maxHighPriorityQueueLen,
+    maxMediumPriorityQueueLen: maxMediumPriorityQueueLen,
+    maxLowPriorityQueueLen: maxLowPriorityQueueLen,
     customConnCallbacks: customConnCallbacks,
   )
-  result.sentIHaves.addFirst(default(HashSet[MessageId]))
-  result.iDontWants.addFirst(default(HashSet[SaltedId]))
-  result.startSendNonPriorityTask()
+  response.sentIHaves.addFirst(default(HashSet[MessageId]))
+  response.iDontWants.addFirst(default(HashSet[SaltedId]))
+  response.startSendNonHighPriorityTask()
 
-  if result.codec != "":
-    result.codecInitializedFut.complete()
+  if response.codec != "":
+    response.codecInitializedFut.complete()
+
+  response

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -407,7 +407,7 @@ proc sendMsgSlow(p: PubSubPeer, msg: seq[byte]) {.async: (raises: [CancelledErro
 
 proc sendMsg(
     p: PubSubPeer, msg: seq[byte], useCustomConn: bool = false
-): Future[void] {.async: (raises: []).} =
+): Future[void] {.async: (raises: [CancelledError]).} =
   type ConnectionType = enum
     ctCustom
     ctSend
@@ -432,16 +432,15 @@ proc sendMsg(
       conntype = $connType, conn = conn, encoded = shortLog(msg)
     let f = conn.writeLp(msg)
     if not f.completed():
-      sendMsgContinue(conn, f)
+      await sendMsgContinue(conn, f)
     else:
       if f.failed():
         trace "sending encoded msg to peer failed", description = f.error.msg
       else:
         trace "sent pubsub message to remote", conn
-      f
   else:
     trace "sending encoded msg to peer via slow path"
-    sendMsgSlow(p, msg)
+    await sendMsgSlow(p, msg)
 
 proc sendEncoded*(
     p: PubSubPeer,

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -54,18 +54,18 @@ when defined(pubsubpeer_queue_metrics):
     labels = ["id"],
   )
 
-declareCounter(
-  libp2p_pubsub_disconnects_over_high_priority_queue_limit,
-  "number of peers disconnected due to high-priority queue overflow",
-)
-declareCounter(
-  libp2p_pubsub_medium_priority_queue_drops,
-  "number of messages dropped from medium-priority queue due to overflow",
-)
-declareCounter(
-  libp2p_pubsub_low_priority_queue_drops,
-  "number of messages dropped from low-priority queue due to overflow",
-)
+  declareCounter(
+    libp2p_pubsub_disconnects_over_high_priority_queue_limit,
+    "number of peers disconnected due to high-priority queue overflow",
+  )
+  declareCounter(
+    libp2p_pubsub_medium_priority_queue_drops,
+    "number of messages dropped from medium-priority queue due to overflow",
+  )
+  declareCounter(
+    libp2p_pubsub_low_priority_queue_drops,
+    "number of messages dropped from low-priority queue due to overflow",
+  )
 
 const
   DefaultMaxHighPriorityQueueLen* = 256
@@ -378,17 +378,13 @@ proc clearSendPriorityQueue(p: PubSubPeer) =
       value = p.rpcmessagequeue.sendPriorityQueue.len.int64, labelValues = [$p.peerId]
     )
 
-proc sendMsgContinue(
-    conn: Connection, msgFut: Future[void]
-) {.async: (raises: [CancelledError]).} =
+proc sendMsgContinue(conn: Connection, msgFut: Future[void]) {.async: (raises: []).} =
   # Continuation for a pending `sendMsg` future from below
   try:
     await msgFut
     trace "sent pubsub message to remote", conn
-  except CancelledError as exc:
-    raise exc
   except CatchableError as exc:
-    trace "sending encoded msg to peer failed", conn, description = exc.msg
+    trace "Unexpected exception in sendMsgContinue", conn, description = exc.msg
     # Next time sendConn is used, it will be have its close flag set and thus
     # will be recycled
     await conn.close() # This will clean up the send connection
@@ -411,7 +407,7 @@ proc sendMsgSlow(p: PubSubPeer, msg: seq[byte]) {.async: (raises: [CancelledErro
 
 proc sendMsg(
     p: PubSubPeer, msg: seq[byte], useCustomConn: bool = false
-): Future[void] {.async: (raises: [CancelledError]).} =
+): Future[void] {.async: (raises: []).} =
   type ConnectionType = enum
     ctCustom
     ctSend
@@ -436,15 +432,69 @@ proc sendMsg(
       conntype = $connType, conn = conn, encoded = shortLog(msg)
     let f = conn.writeLp(msg)
     if not f.completed():
-      await sendMsgContinue(conn, f)
+      sendMsgContinue(conn, f)
     else:
       if f.failed():
         trace "sending encoded msg to peer failed", description = f.error.msg
       else:
         trace "sent pubsub message to remote", conn
+      f
   else:
     trace "sending encoded msg to peer via slow path"
-    await sendMsgSlow(p, msg)
+    sendMsgSlow(p, msg)
+
+proc sendHighPriorityMessage(
+    p: PubSubPeer, msg: seq[byte], useCustomConn: bool
+): Future[void] =
+  # Check high-priority queue bound - if exceeded, the peer is too slow
+  # to keep up with protocol-critical messages and must be disconnected.
+  if p.rpcmessagequeue.sendPriorityQueue.len >= p.maxHighPriorityQueueLen:
+    if not p.disconnected:
+      p.disconnected = true
+      when defined(pubsubpeer_queue_metrics):
+        libp2p_pubsub_disconnects_over_high_priority_queue_limit.inc()
+      return p.closeSendConn(PubSubPeerEventKind.DisconnectionRequested)
+
+    return newFutureCompleted[void]()
+
+  let f = p.sendMsg(msg, useCustomConn)
+  if not f.finished:
+    p.rpcmessagequeue.sendPriorityQueue.addLast(f)
+    when defined(pubsubpeer_queue_metrics):
+      libp2p_gossipsub_high_priority_queue_size.inc(labelValues = [$p.peerId])
+  return f
+
+proc sendMediumPriorityMessage(
+    p: PubSubPeer, msg: seq[byte], useCustomConn: bool
+): Future[void] =
+  let queuedMsg = QueuedMessage(data: msg, useCustomConn: useCustomConn)
+  if p.rpcmessagequeue.mediumPriorityQueue.len >= p.maxMediumPriorityQueueLen:
+    when defined(pubsubpeer_queue_metrics):
+      libp2p_pubsub_medium_priority_queue_drops.inc()
+    trace "medium priority queue full, dropping message", p
+  else:
+    p.rpcmessagequeue.mediumPriorityQueue.addLast(queuedMsg)
+    when defined(pubsubpeer_queue_metrics):
+      libp2p_gossipsub_medium_priority_queue_size.inc(labelValues = [$p.peerId])
+    p.rpcmessagequeue.dataAvailableEvent.fire()
+
+  return newFutureCompleted[void]()
+
+proc sendLowPriorityMessage(
+    p: PubSubPeer, msg: seq[byte], useCustomConn: bool
+): Future[void] =
+  let queuedMsg = QueuedMessage(data: msg, useCustomConn: useCustomConn)
+  if p.rpcmessagequeue.lowPriorityQueue.len >= p.maxLowPriorityQueueLen:
+    when defined(pubsubpeer_queue_metrics):
+      libp2p_pubsub_low_priority_queue_drops.inc()
+    trace "low priority queue full, dropping message", p
+  else:
+    p.rpcmessagequeue.lowPriorityQueue.addLast(queuedMsg)
+    when defined(pubsubpeer_queue_metrics):
+      libp2p_gossipsub_low_priority_queue_size.inc(labelValues = [$p.peerId])
+    p.rpcmessagequeue.dataAvailableEvent.fire()
+
+  return newFutureCompleted[void]()
 
 proc sendEncoded*(
     p: PubSubPeer,
@@ -463,7 +513,7 @@ proc sendEncoded*(
   ##   - `Low`: queued in `lowPriorityQueue`. Dropped when full.
   ## - `useCustomConn`: boolean used to indicate if a custom connection is going to 
   ##   be used for sending this message
-  ## Lower priority messages are queued and sent only after all high
+  ## Low and medium priority messages are queued and sent only after all high
   ## priority messages have been sent.
   doAssert(not isNil(p), "pubsubpeer nil!")
 
@@ -484,52 +534,11 @@ proc sendEncoded*(
       maxSize = p.maxMessageSize, msgSize = msg.len
     newFutureCompleted[void]()
   elif priority == MessagePriority.High or emptyQueues:
-    # High priority: always send immediately.
-    # Empty queues: any priority sends immediately for lower latency.
-    let f = p.sendMsg(msg, useCustomConn)
-    if not f.finished:
-      p.rpcmessagequeue.sendPriorityQueue.addLast(f)
-      when defined(pubsubpeer_queue_metrics):
-        libp2p_gossipsub_high_priority_queue_size.inc(labelValues = [$p.peerId])
-      # Check high-priority queue bound — if exceeded, the peer is too slow
-      # to keep up with protocol-critical messages and must be disconnected.
-      if p.rpcmessagequeue.sendPriorityQueue.len > p.maxHighPriorityQueueLen:
-        if not p.disconnected:
-          p.disconnected = true
-          libp2p_pubsub_disconnects_over_high_priority_queue_limit.inc()
-          p.closeSendConn(PubSubPeerEventKind.DisconnectionRequested)
-        else:
-          newFutureCompleted[void]()
-      else:
-        f
-    else:
-      f
+    p.sendHighPriorityMessage(msg, useCustomConn)
   elif priority == MessagePriority.Medium:
-    if p.rpcmessagequeue.mediumPriorityQueue.len >= p.maxMediumPriorityQueueLen:
-      libp2p_pubsub_medium_priority_queue_drops.inc()
-      trace "medium priority queue full, dropping message", p
-      newFutureCompleted[void]()
-    else:
-      p.rpcmessagequeue.mediumPriorityQueue.addLast(
-        QueuedMessage(data: msg, useCustomConn: useCustomConn)
-      )
-      when defined(pubsubpeer_queue_metrics):
-        libp2p_gossipsub_medium_priority_queue_size.inc(labelValues = [$p.peerId])
-      p.rpcmessagequeue.dataAvailableEvent.fire()
-      newFutureCompleted[void]()
+    p.sendMediumPriorityMessage(msg, useCustomConn)
   else: # Low
-    if p.rpcmessagequeue.lowPriorityQueue.len >= p.maxLowPriorityQueueLen:
-      libp2p_pubsub_low_priority_queue_drops.inc()
-      trace "low priority queue full, dropping message", p
-      newFutureCompleted[void]()
-    else:
-      p.rpcmessagequeue.lowPriorityQueue.addLast(
-        QueuedMessage(data: msg, useCustomConn: useCustomConn)
-      )
-      when defined(pubsubpeer_queue_metrics):
-        libp2p_gossipsub_low_priority_queue_size.inc(labelValues = [$p.peerId])
-      p.rpcmessagequeue.dataAvailableEvent.fire()
-      newFutureCompleted[void]()
+    p.sendLowPriorityMessage(msg, useCustomConn)
 
 iterator splitRPCMsg(
     peer: PubSubPeer, rpcMsg: RPCMsg, maxSize: int, anonymize: bool
@@ -621,8 +630,17 @@ proc sendNonHighPriorityTask(p: PubSubPeer) {.async: (raises: [CancelledError]).
     # we send non-priority messages only if there are no pending priority messages
     while p.rpcmessagequeue.mediumPriorityQueue.len == 0 and
         p.rpcmessagequeue.lowPriorityQueue.len == 0:
-      p.rpcmessagequeue.dataAvailableEvent.clear()
       await p.rpcmessagequeue.dataAvailableEvent.wait()
+      p.rpcmessagequeue.dataAvailableEvent.clear()
+
+    # Dequeue messages by priority
+    let (msg, priority) =
+      if p.rpcmessagequeue.mediumPriorityQueue.len != 0:
+        (p.rpcmessagequeue.mediumPriorityQueue.popFirst(), MessagePriority.Medium)
+      elif p.rpcmessagequeue.lowPriorityQueue.len != 0:
+        (p.rpcmessagequeue.lowPriorityQueue.popFirst(), MessagePriority.Low)
+      else:
+        continue
 
     while p.rpcmessagequeue.sendPriorityQueue.len > 0:
       p.clearSendPriorityQueue()
@@ -634,18 +652,13 @@ proc sendNonHighPriorityTask(p: PubSubPeer) {.async: (raises: [CancelledError]).
         # `race` prevents `p.rpcmessagequeue.sendPriorityQueue[^1]` from being
         # cancelled when this task is cancelled
         discard await race(p.rpcmessagequeue.sendPriorityQueue[^1])
-
-    # Dequeue messages by priority
-    if p.rpcmessagequeue.mediumPriorityQueue.len > 0:
-      let msg = p.rpcmessagequeue.mediumPriorityQueue.popFirst()
-      when defined(pubsubpeer_queue_metrics):
+    when defined(pubsubpeer_queue_metrics):
+      if priority == MessagePriority.Medium:
         libp2p_gossipsub_medium_priority_queue_size.dec(labelValues = [$p.peerId])
-      await p.sendMsg(msg.data, msg.useCustomConn)
-    elif p.rpcmessagequeue.lowPriorityQueue.len > 0:
-      let msg = p.rpcmessagequeue.lowPriorityQueue.popFirst()
-      when defined(pubsubpeer_queue_metrics):
+      else:
         libp2p_gossipsub_low_priority_queue_size.dec(labelValues = [$p.peerId])
-      await p.sendMsg(msg.data, msg.useCustomConn)
+
+    await p.sendMsg(msg.data, msg.useCustomConn)
 
 proc startSendNonHighPriorityTask(p: PubSubPeer) =
   debug "starting sendNonHighPriorityTask", p

--- a/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
@@ -61,8 +61,8 @@ suite "GossipSub Component - Control Messages":
     # When a GRAFT message is sent
     let p0 = n1.getOrCreatePeer(n0.peerInfo.peerId, @[GossipSubCodec_12])
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(graftMessage), isHighPriority = false)
-    n1.broadcast(@[p0], RPCMsg.withControl(graftMessage), isHighPriority = false)
+    n0.broadcast(@[p1], RPCMsg.withControl(graftMessage), priority = MessagePriority.Low)
+    n1.broadcast(@[p0], RPCMsg.withControl(graftMessage), priority = MessagePriority.Low)
 
     checkUntilTimeout:
       nodes.allIt(it.mesh.getOrDefault(topic).len == 1)
@@ -102,7 +102,7 @@ suite "GossipSub Component - Control Messages":
 
     # When a GRAFT message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(graftMessage), isHighPriority = false)
+    n0.broadcast(@[p1], RPCMsg.withControl(graftMessage), priority = MessagePriority.Low)
 
     # Then the peer is not GRAFTed
     checkUntilTimeout:
@@ -140,7 +140,7 @@ suite "GossipSub Component - Control Messages":
 
     # When a PRUNE message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(pruneMessage), isHighPriority = false)
+    n0.broadcast(@[p1], RPCMsg.withControl(pruneMessage), priority = MessagePriority.Low)
 
     # Then the peer is PRUNEd
     checkUntilTimeout:
@@ -151,7 +151,7 @@ suite "GossipSub Component - Control Messages":
 
     # When another PRUNE message is sent
     let p0 = n1.getOrCreatePeer(n0.peerInfo.peerId, @[GossipSubCodec_12])
-    n1.broadcast(@[p0], RPCMsg.withControl(pruneMessage), isHighPriority = false)
+    n1.broadcast(@[p0], RPCMsg.withControl(pruneMessage), priority = MessagePriority.Low)
 
     # Then the peer is PRUNEd
     checkUntilTimeout:
@@ -188,7 +188,7 @@ suite "GossipSub Component - Control Messages":
 
     # When a PRUNE message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(pruneMessage), isHighPriority = false)
+    n0.broadcast(@[p1], RPCMsg.withControl(pruneMessage), priority = MessagePriority.Low)
 
     # Then the peer is not PRUNEd
     checkUntilTimeout:
@@ -228,7 +228,7 @@ suite "GossipSub Component - Control Messages":
 
     # When an IHAVE message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(ihaveMessage), isHighPriority = false)
+    n0.broadcast(@[p1], RPCMsg.withControl(ihaveMessage), priority = MessagePriority.Low)
 
     # Wait until IHAVE response is received
     # Then the peer has exactly one IHAVE message with the correct message ID
@@ -265,7 +265,7 @@ suite "GossipSub Component - Control Messages":
 
     # When an IWANT message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(iwantMessage), isHighPriority = false)
+    n0.broadcast(@[p1], RPCMsg.withControl(iwantMessage), priority = MessagePriority.Low)
 
     # Wait until IWANT response is received
     # Then the peer has exactly one IWANT message with the correct message ID
@@ -298,7 +298,7 @@ suite "GossipSub Component - Control Messages":
 
     # When an IHAVE message is sent from node0
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(ihaveMessage), isHighPriority = false)
+    n0.broadcast(@[p1], RPCMsg.withControl(ihaveMessage), priority = MessagePriority.Low)
 
     # Wait until IWANT response is received
     # Then node0 should receive exactly one IWANT message from node1
@@ -328,7 +328,7 @@ suite "GossipSub Component - Control Messages":
     nodes[2].broadcast(
       nodes[2].mesh[topic],
       RPCMsg.withControl(ControlMessage.withIDontWant(newSeq[byte](10))),
-      isHighPriority = true,
+      priority = MessagePriority.Low,
     )
 
     # Then B doesn't relay the message to C.

--- a/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
@@ -140,7 +140,7 @@ suite "GossipSub Component - Control Messages":
 
     # When a PRUNE message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(pruneMessage), MessagePriority.Low)
+    n0.broadcast(@[p1], RPCMsg.withControl(pruneMessage), MessagePriority.High)
 
     # Then the peer is PRUNEd
     checkUntilTimeout:
@@ -265,7 +265,7 @@ suite "GossipSub Component - Control Messages":
 
     # When an IWANT message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(iwantMessage), MessagePriority.Low)
+    n0.broadcast(@[p1], RPCMsg.withControl(iwantMessage), MessagePriority.High)
 
     # Wait until IWANT response is received
     # Then the peer has exactly one IWANT message with the correct message ID

--- a/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
@@ -61,8 +61,8 @@ suite "GossipSub Component - Control Messages":
     # When a GRAFT message is sent
     let p0 = n1.getOrCreatePeer(n0.peerInfo.peerId, @[GossipSubCodec_12])
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(graftMessage), MessagePriority.Low)
-    n1.broadcast(@[p0], RPCMsg.withControl(graftMessage), MessagePriority.Low)
+    n0.broadcast(@[p1], RPCMsg.withControl(graftMessage), MessagePriority.High)
+    n1.broadcast(@[p0], RPCMsg.withControl(graftMessage), MessagePriority.High)
 
     checkUntilTimeout:
       nodes.allIt(it.mesh.getOrDefault(topic).len == 1)
@@ -102,7 +102,7 @@ suite "GossipSub Component - Control Messages":
 
     # When a GRAFT message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(graftMessage), MessagePriority.Low)
+    n0.broadcast(@[p1], RPCMsg.withControl(graftMessage), MessagePriority.High)
 
     # Then the peer is not GRAFTed
     checkUntilTimeout:
@@ -151,7 +151,7 @@ suite "GossipSub Component - Control Messages":
 
     # When another PRUNE message is sent
     let p0 = n1.getOrCreatePeer(n0.peerInfo.peerId, @[GossipSubCodec_12])
-    n1.broadcast(@[p0], RPCMsg.withControl(pruneMessage), MessagePriority.Low)
+    n1.broadcast(@[p0], RPCMsg.withControl(pruneMessage), MessagePriority.High)
 
     # Then the peer is PRUNEd
     checkUntilTimeout:
@@ -188,7 +188,7 @@ suite "GossipSub Component - Control Messages":
 
     # When a PRUNE message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(pruneMessage), MessagePriority.Low)
+    n0.broadcast(@[p1], RPCMsg.withControl(pruneMessage), MessagePriority.High)
 
     # Then the peer is not PRUNEd
     checkUntilTimeout:
@@ -228,7 +228,7 @@ suite "GossipSub Component - Control Messages":
 
     # When an IHAVE message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(ihaveMessage), MessagePriority.Low)
+    n0.broadcast(@[p1], RPCMsg.withControl(ihaveMessage), MessagePriority.High)
 
     # Wait until IHAVE response is received
     # Then the peer has exactly one IHAVE message with the correct message ID
@@ -298,7 +298,7 @@ suite "GossipSub Component - Control Messages":
 
     # When an IHAVE message is sent from node0
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(ihaveMessage), MessagePriority.Low)
+    n0.broadcast(@[p1], RPCMsg.withControl(ihaveMessage), MessagePriority.High)
 
     # Wait until IWANT response is received
     # Then node0 should receive exactly one IWANT message from node1

--- a/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
@@ -346,7 +346,7 @@ suite "GossipSub Component - Control Messages":
     nodes[2].broadcast(
       nodes[2].mesh[topic],
       RPCMsg.withControl(ControlMessage.withIDontWant(newSeq[byte](10))),
-      priority = MessagePriority.Low,
+      priority = MessagePriority.High,
     )
 
     # Then B doesn't relay the message to C.

--- a/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
@@ -4,7 +4,7 @@
 {.used.}
 
 import chronos, std/[sequtils], chronicles
-import ../../../../libp2p/protocols/pubsub/[gossipsub, mcache, peertable]
+import ../../../../libp2p/protocols/pubsub/[gossipsub, mcache, peertable, pubsubpeer]
 import ../../../tools/[lifecycle, topology, unittest]
 import ../utils
 

--- a/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
@@ -61,12 +61,8 @@ suite "GossipSub Component - Control Messages":
     # When a GRAFT message is sent
     let p0 = n1.getOrCreatePeer(n0.peerInfo.peerId, @[GossipSubCodec_12])
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(
-      @[p1], RPCMsg.withControl(graftMessage), priority = MessagePriority.Low
-    )
-    n1.broadcast(
-      @[p0], RPCMsg.withControl(graftMessage), priority = MessagePriority.Low
-    )
+    n0.broadcast(@[p1], RPCMsg.withControl(graftMessage), MessagePriority.Low)
+    n1.broadcast(@[p0], RPCMsg.withControl(graftMessage), MessagePriority.Low)
 
     checkUntilTimeout:
       nodes.allIt(it.mesh.getOrDefault(topic).len == 1)
@@ -106,9 +102,7 @@ suite "GossipSub Component - Control Messages":
 
     # When a GRAFT message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(
-      @[p1], RPCMsg.withControl(graftMessage), priority = MessagePriority.Low
-    )
+    n0.broadcast(@[p1], RPCMsg.withControl(graftMessage), MessagePriority.Low)
 
     # Then the peer is not GRAFTed
     checkUntilTimeout:
@@ -146,9 +140,7 @@ suite "GossipSub Component - Control Messages":
 
     # When a PRUNE message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(
-      @[p1], RPCMsg.withControl(pruneMessage), priority = MessagePriority.Low
-    )
+    n0.broadcast(@[p1], RPCMsg.withControl(pruneMessage), MessagePriority.Low)
 
     # Then the peer is PRUNEd
     checkUntilTimeout:
@@ -159,9 +151,7 @@ suite "GossipSub Component - Control Messages":
 
     # When another PRUNE message is sent
     let p0 = n1.getOrCreatePeer(n0.peerInfo.peerId, @[GossipSubCodec_12])
-    n1.broadcast(
-      @[p0], RPCMsg.withControl(pruneMessage), priority = MessagePriority.Low
-    )
+    n1.broadcast(@[p0], RPCMsg.withControl(pruneMessage), MessagePriority.Low)
 
     # Then the peer is PRUNEd
     checkUntilTimeout:
@@ -198,9 +188,7 @@ suite "GossipSub Component - Control Messages":
 
     # When a PRUNE message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(
-      @[p1], RPCMsg.withControl(pruneMessage), priority = MessagePriority.Low
-    )
+    n0.broadcast(@[p1], RPCMsg.withControl(pruneMessage), MessagePriority.Low)
 
     # Then the peer is not PRUNEd
     checkUntilTimeout:
@@ -240,9 +228,7 @@ suite "GossipSub Component - Control Messages":
 
     # When an IHAVE message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(
-      @[p1], RPCMsg.withControl(ihaveMessage), priority = MessagePriority.Low
-    )
+    n0.broadcast(@[p1], RPCMsg.withControl(ihaveMessage), MessagePriority.Low)
 
     # Wait until IHAVE response is received
     # Then the peer has exactly one IHAVE message with the correct message ID
@@ -279,9 +265,7 @@ suite "GossipSub Component - Control Messages":
 
     # When an IWANT message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(
-      @[p1], RPCMsg.withControl(iwantMessage), priority = MessagePriority.Low
-    )
+    n0.broadcast(@[p1], RPCMsg.withControl(iwantMessage), MessagePriority.Low)
 
     # Wait until IWANT response is received
     # Then the peer has exactly one IWANT message with the correct message ID
@@ -314,9 +298,7 @@ suite "GossipSub Component - Control Messages":
 
     # When an IHAVE message is sent from node0
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(
-      @[p1], RPCMsg.withControl(ihaveMessage), priority = MessagePriority.Low
-    )
+    n0.broadcast(@[p1], RPCMsg.withControl(ihaveMessage), MessagePriority.Low)
 
     # Wait until IWANT response is received
     # Then node0 should receive exactly one IWANT message from node1
@@ -346,7 +328,7 @@ suite "GossipSub Component - Control Messages":
     nodes[2].broadcast(
       nodes[2].mesh[topic],
       RPCMsg.withControl(ControlMessage.withIDontWant(newSeq[byte](10))),
-      priority = MessagePriority.High,
+      MessagePriority.High,
     )
 
     # Then B doesn't relay the message to C.

--- a/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
@@ -61,8 +61,12 @@ suite "GossipSub Component - Control Messages":
     # When a GRAFT message is sent
     let p0 = n1.getOrCreatePeer(n0.peerInfo.peerId, @[GossipSubCodec_12])
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(graftMessage), priority = MessagePriority.Low)
-    n1.broadcast(@[p0], RPCMsg.withControl(graftMessage), priority = MessagePriority.Low)
+    n0.broadcast(
+      @[p1], RPCMsg.withControl(graftMessage), priority = MessagePriority.Low
+    )
+    n1.broadcast(
+      @[p0], RPCMsg.withControl(graftMessage), priority = MessagePriority.Low
+    )
 
     checkUntilTimeout:
       nodes.allIt(it.mesh.getOrDefault(topic).len == 1)
@@ -102,7 +106,9 @@ suite "GossipSub Component - Control Messages":
 
     # When a GRAFT message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(graftMessage), priority = MessagePriority.Low)
+    n0.broadcast(
+      @[p1], RPCMsg.withControl(graftMessage), priority = MessagePriority.Low
+    )
 
     # Then the peer is not GRAFTed
     checkUntilTimeout:
@@ -140,7 +146,9 @@ suite "GossipSub Component - Control Messages":
 
     # When a PRUNE message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(pruneMessage), priority = MessagePriority.Low)
+    n0.broadcast(
+      @[p1], RPCMsg.withControl(pruneMessage), priority = MessagePriority.Low
+    )
 
     # Then the peer is PRUNEd
     checkUntilTimeout:
@@ -151,7 +159,9 @@ suite "GossipSub Component - Control Messages":
 
     # When another PRUNE message is sent
     let p0 = n1.getOrCreatePeer(n0.peerInfo.peerId, @[GossipSubCodec_12])
-    n1.broadcast(@[p0], RPCMsg.withControl(pruneMessage), priority = MessagePriority.Low)
+    n1.broadcast(
+      @[p0], RPCMsg.withControl(pruneMessage), priority = MessagePriority.Low
+    )
 
     # Then the peer is PRUNEd
     checkUntilTimeout:
@@ -188,7 +198,9 @@ suite "GossipSub Component - Control Messages":
 
     # When a PRUNE message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(pruneMessage), priority = MessagePriority.Low)
+    n0.broadcast(
+      @[p1], RPCMsg.withControl(pruneMessage), priority = MessagePriority.Low
+    )
 
     # Then the peer is not PRUNEd
     checkUntilTimeout:
@@ -228,7 +240,9 @@ suite "GossipSub Component - Control Messages":
 
     # When an IHAVE message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(ihaveMessage), priority = MessagePriority.Low)
+    n0.broadcast(
+      @[p1], RPCMsg.withControl(ihaveMessage), priority = MessagePriority.Low
+    )
 
     # Wait until IHAVE response is received
     # Then the peer has exactly one IHAVE message with the correct message ID
@@ -265,7 +279,9 @@ suite "GossipSub Component - Control Messages":
 
     # When an IWANT message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(iwantMessage), priority = MessagePriority.Low)
+    n0.broadcast(
+      @[p1], RPCMsg.withControl(iwantMessage), priority = MessagePriority.Low
+    )
 
     # Wait until IWANT response is received
     # Then the peer has exactly one IWANT message with the correct message ID
@@ -298,7 +314,9 @@ suite "GossipSub Component - Control Messages":
 
     # When an IHAVE message is sent from node0
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(ihaveMessage), priority = MessagePriority.Low)
+    n0.broadcast(
+      @[p1], RPCMsg.withControl(ihaveMessage), priority = MessagePriority.Low
+    )
 
     # Wait until IWANT response is received
     # Then node0 should receive exactly one IWANT message from node1

--- a/tests/libp2p/pubsub/component/test_gossipsub_extensions.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_extensions.nim
@@ -169,7 +169,7 @@ suite "GossipSub Component - Extensions":
     nodes[0].send(
       nodes[0].peers[nodes[1].peerInfo.peerId],
       RPCMsg.withPing(pingBytes),
-      priority = MessagePriority.High,
+      MessagePriority.High,
     )
 
     # nodes[1] should echo the ping back as a pong

--- a/tests/libp2p/pubsub/component/test_gossipsub_extensions.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_extensions.nim
@@ -6,7 +6,13 @@
 import chronos, algorithm, stew/byteutils, sequtils
 import
   ../../../../libp2p/protocols/pubsub/
-    [gossipsub, gossipsub/extensions, gossipsub/extension_preamble, rpc/message]
+    [
+      gossipsub,
+      gossipsub/extensions,
+      gossipsub/extension_preamble,
+      pubsubpeer,
+      rpc/message,
+    ]
 import ../../../tools/[lifecycle, unittest]
 import ../extensions/my_partial_message
 import ../utils

--- a/tests/libp2p/pubsub/component/test_gossipsub_extensions.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_extensions.nim
@@ -5,14 +5,13 @@
 
 import chronos, algorithm, stew/byteutils, sequtils
 import
-  ../../../../libp2p/protocols/pubsub/
-    [
-      gossipsub,
-      gossipsub/extensions,
-      gossipsub/extension_preamble,
-      pubsubpeer,
-      rpc/message,
-    ]
+  ../../../../libp2p/protocols/pubsub/[
+    gossipsub,
+    gossipsub/extensions,
+    gossipsub/extension_preamble,
+    pubsubpeer,
+    rpc/message,
+  ]
 import ../../../tools/[lifecycle, unittest]
 import ../extensions/my_partial_message
 import ../utils

--- a/tests/libp2p/pubsub/component/test_gossipsub_extensions.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_extensions.nim
@@ -164,7 +164,7 @@ suite "GossipSub Component - Extensions":
     nodes[0].send(
       nodes[0].peers[nodes[1].peerInfo.peerId],
       RPCMsg.withPing(pingBytes),
-      isHighPriority = true,
+      priority = MessagePriority.High,
     )
 
     # nodes[1] should echo the ping back as a pong

--- a/tests/libp2p/pubsub/component/test_gossipsub_message_cache.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_message_cache.nim
@@ -6,7 +6,7 @@
 import chronos, std/[sequtils], stew/byteutils
 import
   ../../../../libp2p/protocols/pubsub/
-    [gossipsub, mcache, peertable, floodsub, rpc/messages, rpc/message]
+    [gossipsub, mcache, peertable, floodsub, pubsubpeer, rpc/messages, rpc/message]
 import ../../../tools/[lifecycle, topology, unittest]
 import ../utils
 

--- a/tests/libp2p/pubsub/component/test_gossipsub_message_cache.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_message_cache.nim
@@ -264,7 +264,7 @@ suite "GossipSub Component - Message Cache":
     nodes[2].broadcast(
       @[nodes[2].getPeerByPeerId(topic, nodes[0].peerInfo.peerId)],
       RPCMsg.withControl(ControlMessage.withIWant(@[messageId1, messageId2])),
-      priority = MessagePriority.Low,
+      MessagePriority.Low,
     )
 
     # Then Node2 receives only messageId2 and messageId1 is dropped

--- a/tests/libp2p/pubsub/component/test_gossipsub_message_cache.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_message_cache.nim
@@ -264,7 +264,7 @@ suite "GossipSub Component - Message Cache":
     nodes[2].broadcast(
       @[nodes[2].getPeerByPeerId(topic, nodes[0].peerInfo.peerId)],
       RPCMsg.withControl(ControlMessage.withIWant(@[messageId1, messageId2])),
-      isHighPriority = false,
+      priority = MessagePriority.Low,
     )
 
     # Then Node2 receives only messageId2 and messageId1 is dropped

--- a/tests/libp2p/pubsub/component/test_gossipsub_message_cache.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_message_cache.nim
@@ -264,7 +264,7 @@ suite "GossipSub Component - Message Cache":
     nodes[2].broadcast(
       @[nodes[2].getPeerByPeerId(topic, nodes[0].peerInfo.peerId)],
       RPCMsg.withControl(ControlMessage.withIWant(@[messageId1, messageId2])),
-      MessagePriority.Low,
+      MessagePriority.High,
     )
 
     # Then Node2 receives only messageId2 and messageId1 is dropped

--- a/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
@@ -90,7 +90,7 @@ suite "GossipSub Component - Message Handling":
     gossip1.broadcast(
       gossip1.mesh[topic],
       RPCMsg.withControl(ControlMessage.withIHave(topic, iwantMessageIds)),
-      priority = MessagePriority.Low,
+      MessagePriority.Low,
     )
 
     checkUntilTimeout:
@@ -110,7 +110,7 @@ suite "GossipSub Component - Message Handling":
     gossip1.broadcast(
       gossip1.mesh[topic],
       RPCMsg.withControl(ControlMessage.withIHave(topic, bigIWantMessageIds)),
-      priority = MessagePriority.Low,
+      MessagePriority.Low,
     )
 
     # wait some time before asserting that messages is not received
@@ -133,7 +133,7 @@ suite "GossipSub Component - Message Handling":
     gossip1.broadcast(
       gossip1.mesh[topic],
       RPCMsg.withControl(ControlMessage.withIHave(topic, bigIWantMessageIds)),
-      priority = MessagePriority.Low,
+      MessagePriority.Low,
     )
 
     checkUntilTimeout:
@@ -154,7 +154,7 @@ suite "GossipSub Component - Message Handling":
     gossip1.broadcast(
       gossip1.mesh[topic],
       RPCMsg.withControl(ControlMessage.withIHave(topic, bigIWantMessageIds)),
-      priority = MessagePriority.Low,
+      MessagePriority.Low,
     )
 
     var smallestSet: HashSet[seq[byte]]

--- a/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
@@ -90,7 +90,7 @@ suite "GossipSub Component - Message Handling":
     gossip1.broadcast(
       gossip1.mesh[topic],
       RPCMsg.withControl(ControlMessage.withIHave(topic, iwantMessageIds)),
-      MessagePriority.Low,
+      MessagePriority.High,
     )
 
     checkUntilTimeout:
@@ -110,7 +110,7 @@ suite "GossipSub Component - Message Handling":
     gossip1.broadcast(
       gossip1.mesh[topic],
       RPCMsg.withControl(ControlMessage.withIHave(topic, bigIWantMessageIds)),
-      MessagePriority.Low,
+      MessagePriority.High,
     )
 
     # wait some time before asserting that messages is not received
@@ -133,7 +133,7 @@ suite "GossipSub Component - Message Handling":
     gossip1.broadcast(
       gossip1.mesh[topic],
       RPCMsg.withControl(ControlMessage.withIHave(topic, bigIWantMessageIds)),
-      MessagePriority.Low,
+      MessagePriority.High,
     )
 
     checkUntilTimeout:
@@ -154,7 +154,7 @@ suite "GossipSub Component - Message Handling":
     gossip1.broadcast(
       gossip1.mesh[topic],
       RPCMsg.withControl(ControlMessage.withIHave(topic, bigIWantMessageIds)),
-      MessagePriority.Low,
+      MessagePriority.High,
     )
 
     var smallestSet: HashSet[seq[byte]]

--- a/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
@@ -6,7 +6,7 @@
 import chronos, std/[sequtils, enumerate], stew/byteutils, sugar, chronicles
 import
   ../../../../libp2p/protocols/pubsub/
-    [gossipsub, mcache, peertable, timedcache, rpc/message]
+    [gossipsub, mcache, peertable, pubsubpeer, timedcache, rpc/message]
 import ../../../tools/[lifecycle, topology, unittest, futures, sync]
 import ../utils
 

--- a/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
@@ -90,7 +90,7 @@ suite "GossipSub Component - Message Handling":
     gossip1.broadcast(
       gossip1.mesh[topic],
       RPCMsg.withControl(ControlMessage.withIHave(topic, iwantMessageIds)),
-      isHighPriority = false,
+      priority = MessagePriority.Low,
     )
 
     checkUntilTimeout:
@@ -110,7 +110,7 @@ suite "GossipSub Component - Message Handling":
     gossip1.broadcast(
       gossip1.mesh[topic],
       RPCMsg.withControl(ControlMessage.withIHave(topic, bigIWantMessageIds)),
-      isHighPriority = false,
+      priority = MessagePriority.Low,
     )
 
     # wait some time before asserting that messages is not received
@@ -133,7 +133,7 @@ suite "GossipSub Component - Message Handling":
     gossip1.broadcast(
       gossip1.mesh[topic],
       RPCMsg.withControl(ControlMessage.withIHave(topic, bigIWantMessageIds)),
-      isHighPriority = false,
+      priority = MessagePriority.Low,
     )
 
     checkUntilTimeout:
@@ -154,7 +154,7 @@ suite "GossipSub Component - Message Handling":
     gossip1.broadcast(
       gossip1.mesh[topic],
       RPCMsg.withControl(ControlMessage.withIHave(topic, bigIWantMessageIds)),
-      isHighPriority = false,
+      priority = MessagePriority.Low,
     )
 
     var smallestSet: HashSet[seq[byte]]

--- a/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
@@ -71,7 +71,7 @@ suite "GossipSub Component - Scoring":
     nodes[0].broadcast(
       nodes[0].mesh[topic],
       RPCMsg.withMessages(Message(topic: topic, data: newSeq[byte](10))),
-      priority = MessagePriority.High,
+      MessagePriority.High,
     )
 
     checkUntilTimeout:
@@ -83,7 +83,7 @@ suite "GossipSub Component - Scoring":
     nodes[0].broadcast(
       nodes[0].mesh[topic],
       RPCMsg.withMessages(Message(topic: topic, data: newSeq[byte](12))),
-      priority = MessagePriority.High,
+      MessagePriority.High,
     )
 
     checkUntilTimeout:
@@ -110,7 +110,7 @@ suite "GossipSub Component - Scoring":
 
     # Simulate sending an undecodable message
     await nodes[1].peers[nodes[0].switch.peerInfo.peerId].sendEncoded(
-      newSeqWith(33, 1.byte), priority = MessagePriority.High
+      newSeqWith(33, 1.byte), MessagePriority.High
     )
 
     checkUntilTimeout:
@@ -120,7 +120,7 @@ suite "GossipSub Component - Scoring":
     # Disconnect peer when rate limiting is enabled
     nodes[1].parameters.disconnectPeerAboveRateLimit = true
     await nodes[0].peers[nodes[1].switch.peerInfo.peerId].sendEncoded(
-      newSeqWith(35, 1.byte), priority = MessagePriority.High
+      newSeqWith(35, 1.byte), MessagePriority.High
     )
 
     checkUntilTimeout:
@@ -150,7 +150,7 @@ suite "GossipSub Component - Scoring":
         topic, 123'u64, @[PeerInfoMsg(peerId: PeerId(data: newSeq[byte](33)))]
       )
     )
-    nodes[0].broadcast(nodes[0].mesh[topic], msg, priority = MessagePriority.High)
+    nodes[0].broadcast(nodes[0].mesh[topic], msg, MessagePriority.High)
 
     checkUntilTimeout:
       currentRateLimitHits() == rateLimitHits + 1
@@ -163,7 +163,7 @@ suite "GossipSub Component - Scoring":
         topic, 123'u64, @[PeerInfoMsg(peerId: PeerId(data: newSeq[byte](35)))]
       )
     )
-    nodes[0].broadcast(nodes[0].mesh[topic], msg2, priority = MessagePriority.High)
+    nodes[0].broadcast(nodes[0].mesh[topic], msg2, MessagePriority.High)
 
     checkUntilTimeout:
       nodes[1].switch.isConnected(nodes[0].switch.peerInfo.peerId) == false
@@ -196,7 +196,7 @@ suite "GossipSub Component - Scoring":
     nodes[1].addValidator(topic, execValidator)
 
     let msg = RPCMsg.withMessages(Message(topic: topic, data: newSeq[byte](40)))
-    nodes[0].broadcast(nodes[0].mesh[topic], msg, priority = MessagePriority.High)
+    nodes[0].broadcast(nodes[0].mesh[topic], msg, MessagePriority.High)
 
     checkUntilTimeout:
       currentRateLimitHits() == rateLimitHits + 1
@@ -207,7 +207,7 @@ suite "GossipSub Component - Scoring":
     nodes[0].broadcast(
       nodes[0].mesh[topic],
       RPCMsg.withMessages(Message(topic: topic, data: newSeq[byte](35))),
-      priority = MessagePriority.High,
+      MessagePriority.High,
     )
 
     checkUntilTimeout:
@@ -401,12 +401,12 @@ suite "GossipSub Component - Scoring":
       nodes[1].broadcast(
         nodes[1].mesh[topic],
         RPCMsg.withMessages(Message(topic: topic, data: ("valid_" & $i).toBytes())),
-        priority = MessagePriority.High,
+        MessagePriority.High,
       )
       nodes[2].broadcast(
         nodes[2].mesh[topic],
         RPCMsg.withMessages(Message(topic: topic, data: ("invalid_" & $i).toBytes())),
-        priority = MessagePriority.High,
+        MessagePriority.High,
       )
 
     # And messages are processed

--- a/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
@@ -71,7 +71,7 @@ suite "GossipSub Component - Scoring":
     nodes[0].broadcast(
       nodes[0].mesh[topic],
       RPCMsg.withMessages(Message(topic: topic, data: newSeq[byte](10))),
-      isHighPriority = true,
+      priority = MessagePriority.High,
     )
 
     checkUntilTimeout:
@@ -83,7 +83,7 @@ suite "GossipSub Component - Scoring":
     nodes[0].broadcast(
       nodes[0].mesh[topic],
       RPCMsg.withMessages(Message(topic: topic, data: newSeq[byte](12))),
-      isHighPriority = true,
+      priority = MessagePriority.High,
     )
 
     checkUntilTimeout:
@@ -110,7 +110,7 @@ suite "GossipSub Component - Scoring":
 
     # Simulate sending an undecodable message
     await nodes[1].peers[nodes[0].switch.peerInfo.peerId].sendEncoded(
-      newSeqWith(33, 1.byte), isHighPriority = true
+      newSeqWith(33, 1.byte), priority = MessagePriority.High
     )
 
     checkUntilTimeout:
@@ -120,7 +120,7 @@ suite "GossipSub Component - Scoring":
     # Disconnect peer when rate limiting is enabled
     nodes[1].parameters.disconnectPeerAboveRateLimit = true
     await nodes[0].peers[nodes[1].switch.peerInfo.peerId].sendEncoded(
-      newSeqWith(35, 1.byte), isHighPriority = true
+      newSeqWith(35, 1.byte), priority = MessagePriority.High
     )
 
     checkUntilTimeout:
@@ -150,7 +150,7 @@ suite "GossipSub Component - Scoring":
         topic, 123'u64, @[PeerInfoMsg(peerId: PeerId(data: newSeq[byte](33)))]
       )
     )
-    nodes[0].broadcast(nodes[0].mesh[topic], msg, isHighPriority = true)
+    nodes[0].broadcast(nodes[0].mesh[topic], msg, priority = MessagePriority.High)
 
     checkUntilTimeout:
       currentRateLimitHits() == rateLimitHits + 1
@@ -163,7 +163,7 @@ suite "GossipSub Component - Scoring":
         topic, 123'u64, @[PeerInfoMsg(peerId: PeerId(data: newSeq[byte](35)))]
       )
     )
-    nodes[0].broadcast(nodes[0].mesh[topic], msg2, isHighPriority = true)
+    nodes[0].broadcast(nodes[0].mesh[topic], msg2, priority = MessagePriority.High)
 
     checkUntilTimeout:
       nodes[1].switch.isConnected(nodes[0].switch.peerInfo.peerId) == false
@@ -196,7 +196,7 @@ suite "GossipSub Component - Scoring":
     nodes[1].addValidator(topic, execValidator)
 
     let msg = RPCMsg.withMessages(Message(topic: topic, data: newSeq[byte](40)))
-    nodes[0].broadcast(nodes[0].mesh[topic], msg, isHighPriority = true)
+    nodes[0].broadcast(nodes[0].mesh[topic], msg, priority = MessagePriority.High)
 
     checkUntilTimeout:
       currentRateLimitHits() == rateLimitHits + 1
@@ -207,7 +207,7 @@ suite "GossipSub Component - Scoring":
     nodes[0].broadcast(
       nodes[0].mesh[topic],
       RPCMsg.withMessages(Message(topic: topic, data: newSeq[byte](35))),
-      isHighPriority = true,
+      priority = MessagePriority.High,
     )
 
     checkUntilTimeout:
@@ -401,12 +401,12 @@ suite "GossipSub Component - Scoring":
       nodes[1].broadcast(
         nodes[1].mesh[topic],
         RPCMsg.withMessages(Message(topic: topic, data: ("valid_" & $i).toBytes())),
-        isHighPriority = true,
+        priority = MessagePriority.High,
       )
       nodes[2].broadcast(
         nodes[2].mesh[topic],
         RPCMsg.withMessages(Message(topic: topic, data: ("invalid_" & $i).toBytes())),
-        isHighPriority = true,
+        priority = MessagePriority.High,
       )
 
     # And messages are processed

--- a/tests/libp2p/pubsub/test_gossipsub_params.nim
+++ b/tests/libp2p/pubsub/test_gossipsub_params.nim
@@ -287,6 +287,41 @@ suite "GossipSubParams validation":
     params.maxLowPriorityQueueLen = 1
     check params.validateParameters().isOk()
 
+  test "deprecated maxNumElementsInNonPriorityQueue maps to medium and low queue limits":
+    let params = GossipSubParams.init(maxNumElementsInNonPriorityQueue = 33)
+    check params.maxNumElementsInNonPriorityQueue == 33
+    check params.maxMediumPriorityQueueLen == 33
+    check params.maxLowPriorityQueueLen == 33
+    check params.validateParameters().isOk()
+
+  test "explicit maxMediumPriorityQueueLen wins over deprecated queue parameter":
+    let params = GossipSubParams.init(
+      maxNumElementsInNonPriorityQueue = 33, maxMediumPriorityQueueLen = 7
+    )
+    check params.maxNumElementsInNonPriorityQueue == 33
+    check params.maxMediumPriorityQueueLen == 7
+    check params.maxLowPriorityQueueLen == 33
+    check params.validateParameters().isOk()
+
+  test "explicit maxLowPriorityQueueLen wins over deprecated queue parameter":
+    let params = GossipSubParams.init(
+      maxNumElementsInNonPriorityQueue = 33, maxLowPriorityQueueLen = 7
+    )
+    check params.maxNumElementsInNonPriorityQueue == 33
+    check params.maxMediumPriorityQueueLen == 33
+    check params.maxLowPriorityQueueLen == 7
+    check params.validateParameters().isOk()
+
+  test "deprecated maxNumElementsInNonPriorityQueue keeps invalid zero value":
+    const errorMessage =
+      "gossipsub: maxMediumPriorityQueueLen parameter error, Must be > 0"
+    let params = GossipSubParams.init(maxNumElementsInNonPriorityQueue = 0)
+    check params.maxMediumPriorityQueueLen == 0
+    check params.maxLowPriorityQueueLen == 0
+    let res = params.validateParameters()
+    check res.isErr()
+    check res.error == errorMessage
+
 suite "TopicParams validation":
   proc newDefaultValidTopicParams(): TopicParams =
     result = TopicParams.init()

--- a/tests/libp2p/pubsub/test_gossipsub_params.nim
+++ b/tests/libp2p/pubsub/test_gossipsub_params.nim
@@ -245,18 +245,46 @@ suite "GossipSubParams validation":
     params.behaviourPenaltyDecay = 0.5
     check params.validateParameters().isOk()
 
-  test "maxNumElementsInNonPriorityQueue fails when zero":
+  test "maxHighPriorityQueueLen fails when zero":
     const errorMessage =
-      "gossipsub: maxNumElementsInNonPriorityQueue parameter error, Must be > 0"
+      "gossipsub: maxHighPriorityQueueLen parameter error, Must be > 0"
     var params = newDefaultValidParams()
-    params.maxNumElementsInNonPriorityQueue = 0
+    params.maxHighPriorityQueueLen = 0
     let res = params.validateParameters()
     check res.isErr()
     check res.error == errorMessage
 
-  test "maxNumElementsInNonPriorityQueue succeeds when positive":
+  test "maxHighPriorityQueueLen succeeds when positive":
     var params = newDefaultValidParams()
-    params.maxNumElementsInNonPriorityQueue = 1
+    params.maxHighPriorityQueueLen = 1
+    check params.validateParameters().isOk()
+
+  test "maxMediumPriorityQueueLen fails when zero":
+    const errorMessage =
+      "gossipsub: maxMediumPriorityQueueLen parameter error, Must be > 0"
+    var params = newDefaultValidParams()
+    params.maxMediumPriorityQueueLen = 0
+    let res = params.validateParameters()
+    check res.isErr()
+    check res.error == errorMessage
+
+  test "maxMediumPriorityQueueLen succeeds when positive":
+    var params = newDefaultValidParams()
+    params.maxMediumPriorityQueueLen = 1
+    check params.validateParameters().isOk()
+
+  test "maxLowPriorityQueueLen fails when zero":
+    const errorMessage =
+      "gossipsub: maxLowPriorityQueueLen parameter error, Must be > 0"
+    var params = newDefaultValidParams()
+    params.maxLowPriorityQueueLen = 0
+    let res = params.validateParameters()
+    check res.isErr()
+    check res.error == errorMessage
+
+  test "maxLowPriorityQueueLen succeeds when positive":
+    var params = newDefaultValidParams()
+    params.maxLowPriorityQueueLen = 1
     check params.validateParameters().isOk()
 
 suite "TopicParams validation":

--- a/tests/libp2p/pubsub/test_priority_queues.nim
+++ b/tests/libp2p/pubsub/test_priority_queues.nim
@@ -160,10 +160,7 @@ suite "Priority queue behavior":
     let drain2 = callbacksDrained(conn.pendingWrites[1])
     let drain3 = callbacksDrained(conn.pendingWrites[2])
 
-    checkUntilTimeout:
-      drain1.finished
-      drain2.finished
-      drain3.finished
+    await allFutures(drain1, drain2, drain3)
 
     check:
       not disconnectRequestedForTest[]
@@ -196,10 +193,8 @@ suite "Priority queue behavior":
       @[highMsg, mediumMsgs[0], mediumMsgs[1], mediumMsgs[2], mediumMsgs[3]]
 
     conn.releaseFirstWrite()
-    let writeDrain = callbacksDrained(conn.firstWriteFut)
 
-    checkUntilTimeout:
-      writeDrain.finished
+    await callbacksDrained(conn.firstWriteFut)
 
     check:
       conn.writes ==
@@ -234,10 +229,8 @@ suite "Priority queue behavior":
     check conn.writes == @[highMsg, lowMsgs[0], lowMsgs[1], lowMsgs[2], lowMsgs[3]]
 
     conn.releaseFirstWrite()
-    let writeDrain = callbacksDrained(conn.firstWriteFut)
 
-    checkUntilTimeout:
-      writeDrain.finished
+    await callbacksDrained(conn.firstWriteFut)
 
     check:
       conn.writes == @[highMsg, lowMsgs[0], lowMsgs[1], lowMsgs[2], lowMsgs[3]]

--- a/tests/libp2p/pubsub/test_priority_queues.nim
+++ b/tests/libp2p/pubsub/test_priority_queues.nim
@@ -87,6 +87,17 @@ proc releaseFirstWrite(conn: RecorderConnection) {.raises: [].} =
   if not conn.firstWriteFut.isNil and not conn.firstWriteFut.finished:
     conn.firstWriteFut.complete()
 
+proc callbacksDrained(fut: FutureBase): Future[void] {.raises: [].} =
+  let drained = Future[void].init("callbacksDrained")
+
+  proc continuation(udata: pointer) {.gcsafe, raises: [].} =
+    let drained = cast[Future[void]](udata)
+    if not drained.finished:
+      drained.complete()
+
+  fut.addCallback(continuation, cast[pointer](drained))
+  drained
+
 proc newDisconnectRecorder(disconnectRequested: ref bool): OnEvent =
   proc recordDisconnect(
       peer: PubSubPeer, event: PubSubPeerEvent
@@ -114,32 +125,48 @@ suite "Priority queue behavior":
   teardown:
     checkTrackers()
 
-  asyncTest "Exceeding max high priority messages triggers disconnection event":
+  asyncTest "High priority sends return immediately even while writes stay pending":
     let disconnectRequestedForTest = new bool
 
     let peer = createTestPeer(
       maxHigh = 2, onEvent = newDisconnectRecorder(disconnectRequestedForTest)
     )
+    let conn = createPendingConnection()
     defer:
       peer.stopSendNonHighPriorityTask()
 
-    peer.sendConn = createPendingConnection()
+    peer.sendConn = conn
 
-    # These writes stay pending, so the high-priority queue can actually fill.
+    # These writes stay pending, but sendEncoded itself now completes immediately.
     let f1 = peer.sendEncoded(@[1'u8, 2, 3], MessagePriority.High)
     let f2 = peer.sendEncoded(@[1'u8, 2, 3], MessagePriority.High)
-    let overflowFut = peer.sendEncoded(@[1'u8, 2, 3], MessagePriority.High)
+    let f3 = peer.sendEncoded(@[1'u8, 2, 3], MessagePriority.High)
 
     check:
-      not f1.finished
-      not f2.finished
+      f1.finished
+      f2.finished
+      f3.finished
+      conn.pendingWrites.len == 3
+      not conn.pendingWrites[0].finished
+      not conn.pendingWrites[1].finished
+      not conn.pendingWrites[2].finished
+      not disconnectRequestedForTest[]
+      peer.hasSendConn()
 
-    await overflowFut
+    await conn.close()
+    let drain1 = callbacksDrained(conn.pendingWrites[0])
+    let drain2 = callbacksDrained(conn.pendingWrites[1])
+    let drain3 = callbacksDrained(conn.pendingWrites[2])
+
+    checkUntilTimeout:
+      drain1.finished
+      drain2.finished
+      drain3.finished
+
     check:
-      disconnectRequestedForTest[]
-      not peer.hasSendConn()
+      not disconnectRequestedForTest[]
 
-  asyncTest "Exceeding max medium priority messages drops messages without disconnect":
+  asyncTest "Medium priority sends fast-path even behind a pending high write":
     let disconnectRequestedForTest = new bool
 
     let peer = createTestPeer(
@@ -154,27 +181,29 @@ suite "Priority queue behavior":
     let highMsg = @[1'u8, 2, 3]
     let mediumMsgs = @[@[10'u8, 0, 0], @[11'u8, 0, 0], @[12'u8, 0, 0], @[13'u8, 0, 0]]
 
-    # Enqueue a pending high-priority message to disable the fast path
-    discard peer.sendEncoded(highMsg, MessagePriority.High)
+    # The first high-priority write remains pending on the connection, but later
+    # medium-priority sends still take the fast path and complete immediately.
+    let highFut = peer.sendEncoded(highMsg, MessagePriority.High)
+    check highFut.finished
 
     for msg in mediumMsgs:
       let f = peer.sendEncoded(msg, MessagePriority.Medium)
       check f.finished
 
-    check conn.writes == @[highMsg]
+    check conn.writes == @[highMsg, mediumMsgs[0], mediumMsgs[1], mediumMsgs[2], mediumMsgs[3]]
 
-    # Releasing the first message so medium messages can be sent
     conn.releaseFirstWrite()
+    let writeDrain = callbacksDrained(conn.firstWriteFut)
 
     checkUntilTimeout:
-      conn.writes == @[highMsg, mediumMsgs[0], mediumMsgs[1]]
+      writeDrain.finished
 
     check:
-      conn.writes == @[highMsg, mediumMsgs[0], mediumMsgs[1]]
+      conn.writes == @[highMsg, mediumMsgs[0], mediumMsgs[1], mediumMsgs[2], mediumMsgs[3]]
       not disconnectRequestedForTest[]
       peer.hasSendConn()
 
-  asyncTest "Exceeding max low priority messages drops messages without disconnect":
+  asyncTest "Low priority sends fast-path even behind a pending high write":
     let disconnectRequestedForTest = new bool
 
     let peer = createTestPeer(
@@ -189,42 +218,57 @@ suite "Priority queue behavior":
     let highMsg = @[1'u8, 2, 3]
     let lowMsgs = @[@[20'u8, 0, 0], @[21'u8, 0, 0], @[22'u8, 0, 0], @[23'u8, 0, 0]]
 
-    # Enqueue a pending high-priority message to disable the fast path
-    discard peer.sendEncoded(highMsg, MessagePriority.High)
+    # The first high-priority write remains pending on the connection, but later
+    # low-priority sends still take the fast path and complete immediately.
+    let highFut = peer.sendEncoded(highMsg, MessagePriority.High)
+    check highFut.finished
 
     for msg in lowMsgs:
       let f = peer.sendEncoded(msg, MessagePriority.Low)
       check f.finished
 
-    check conn.writes == @[highMsg]
+    check conn.writes == @[highMsg, lowMsgs[0], lowMsgs[1], lowMsgs[2], lowMsgs[3]]
 
-    # Releasing the first message so other low messages can be sent
     conn.releaseFirstWrite()
+    let writeDrain = callbacksDrained(conn.firstWriteFut)
 
     checkUntilTimeout:
-      conn.writes == @[highMsg, lowMsgs[0], lowMsgs[1]]
+      writeDrain.finished
 
     check:
-      conn.writes == @[highMsg, lowMsgs[0], lowMsgs[1]]
+      conn.writes == @[highMsg, lowMsgs[0], lowMsgs[1], lowMsgs[2], lowMsgs[3]]
       not disconnectRequestedForTest[]
       peer.hasSendConn()
 
-  asyncTest "Empty queues fast-path the first medium or low message":
+  asyncTest "Empty queues fast-path medium and low sends while returning completed futures":
     let mediumPeer = createTestPeer()
     let lowPeer = createTestPeer()
+    let mediumConn = createPendingConnection()
+    let lowConn = createPendingConnection()
     defer:
       mediumPeer.stopSendNonHighPriorityTask()
       lowPeer.stopSendNonHighPriorityTask()
 
     # This is required so we can test the send path
-    mediumPeer.sendConn = createPendingConnection()
-    lowPeer.sendConn = createPendingConnection()
+    mediumPeer.sendConn = mediumConn
+    lowPeer.sendConn = lowConn
 
     let mediumFut = mediumPeer.sendEncoded(@[1'u8, 2, 3], MessagePriority.Medium)
     let lowFut = lowPeer.sendEncoded(@[4'u8, 5, 6], MessagePriority.Low)
 
     check:
-      not mediumFut.finished
-      not lowFut.finished
+      mediumFut.finished
+      lowFut.finished
+      mediumConn.pendingWrites.len == 1
+      lowConn.pendingWrites.len == 1
       mediumPeer.hasSendConn()
       lowPeer.hasSendConn()
+
+    await mediumConn.close()
+    await lowConn.close()
+    let mediumDrain = callbacksDrained(mediumConn.pendingWrites[0])
+    let lowDrain = callbacksDrained(lowConn.pendingWrites[0])
+
+    checkUntilTimeout:
+      mediumDrain.finished
+      lowDrain.finished

--- a/tests/libp2p/pubsub/test_priority_queues.nim
+++ b/tests/libp2p/pubsub/test_priority_queues.nim
@@ -35,7 +35,9 @@ method initStream*(s: PendingConnection) {.raises: [].} =
 method writeLp*(
     s: PendingConnection, msg: openArray[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
-  let fut = Future[void].Raising([CancelledError, LPStreamError]).init("PendingConnection.writeLp")
+  let fut = Future[void].Raising([CancelledError, LPStreamError]).init(
+      "PendingConnection.writeLp"
+    )
   s.pendingWrites.add(fut)
   fut
 
@@ -62,10 +64,14 @@ method writeLp*(
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   s.writes.add(@msg)
   if s.firstWriteFut.isNil:
-    s.firstWriteFut = Future[void].Raising([CancelledError, LPStreamError]).init("RecorderConnection.writeLp")
+    s.firstWriteFut = Future[void].Raising([CancelledError, LPStreamError]).init(
+        "RecorderConnection.writeLp"
+      )
     s.firstWriteFut
   else:
-    let fut = Future[void].Raising([CancelledError, LPStreamError]).init("RecorderConnection.writeLp.completed")
+    let fut = Future[void].Raising([CancelledError, LPStreamError]).init(
+        "RecorderConnection.writeLp.completed"
+      )
     fut.complete()
     fut
 
@@ -96,10 +102,7 @@ proc newDisconnectRecorder(disconnectRequested: ref bool): OnEvent =
   recordDisconnect
 
 proc createTestPeer(
-    maxHigh: int = 2,
-    maxMedium: int = 2,
-    maxLow: int = 2,
-    onEvent: OnEvent = nil,
+    maxHigh: int = 2, maxMedium: int = 2, maxLow: int = 2, onEvent: OnEvent = nil
 ): PubSubPeer =
   PubSubPeer.new(
     randomPeerId(),
@@ -119,10 +122,9 @@ suite "Priority queue behavior":
   asyncTest "Exceeding max high priority messages triggers disconnection event":
     let disconnectRequestedForTest = new bool
 
-    let peer =
-      createTestPeer(
-        maxHigh = 2, onEvent = newDisconnectRecorder(disconnectRequestedForTest)
-      )
+    let peer = createTestPeer(
+      maxHigh = 2, onEvent = newDisconnectRecorder(disconnectRequestedForTest)
+    )
     defer:
       peer.stopSendNonHighPriorityTask()
 
@@ -145,10 +147,9 @@ suite "Priority queue behavior":
   asyncTest "Exceeding max medium priority messages drops messages without disconnect":
     let disconnectRequestedForTest = new bool
 
-    let peer =
-      createTestPeer(
-        maxMedium = 2, onEvent = newDisconnectRecorder(disconnectRequestedForTest)
-      )
+    let peer = createTestPeer(
+      maxMedium = 2, onEvent = newDisconnectRecorder(disconnectRequestedForTest)
+    )
     let conn = createRecorderConnection()
     defer:
       peer.stopSendNonHighPriorityTask()
@@ -156,13 +157,7 @@ suite "Priority queue behavior":
     peer.sendConn = conn
 
     let highMsg = @[1'u8, 2, 3]
-    let mediumMsgs =
-      @[
-        @[10'u8, 0, 0],
-        @[11'u8, 0, 0],
-        @[12'u8, 0, 0],
-        @[13'u8, 0, 0],
-      ]
+    let mediumMsgs = @[@[10'u8, 0, 0], @[11'u8, 0, 0], @[12'u8, 0, 0], @[13'u8, 0, 0]]
 
     # Enqueue a pending high-priority message to disable the fast path
     discard peer.sendEncoded(highMsg, MessagePriority.High)
@@ -189,10 +184,9 @@ suite "Priority queue behavior":
   asyncTest "Exceeding max low priority messages drops messages without disconnect":
     let disconnectRequestedForTest = new bool
 
-    let peer =
-      createTestPeer(
-        maxLow = 2, onEvent = newDisconnectRecorder(disconnectRequestedForTest)
-      )
+    let peer = createTestPeer(
+      maxLow = 2, onEvent = newDisconnectRecorder(disconnectRequestedForTest)
+    )
     let conn = createRecorderConnection()
     defer:
       peer.stopSendNonHighPriorityTask()
@@ -200,13 +194,7 @@ suite "Priority queue behavior":
     peer.sendConn = conn
 
     let highMsg = @[1'u8, 2, 3]
-    let lowMsgs =
-      @[
-        @[20'u8, 0, 0],
-        @[21'u8, 0, 0],
-        @[22'u8, 0, 0],
-        @[23'u8, 0, 0],
-      ]
+    let lowMsgs = @[@[20'u8, 0, 0], @[21'u8, 0, 0], @[22'u8, 0, 0], @[23'u8, 0, 0]]
 
     # Enqueue a pending high-priority message to disable the fast path
     discard peer.sendEncoded(highMsg, MessagePriority.High)
@@ -226,9 +214,9 @@ suite "Priority queue behavior":
     await sleepAsync(10.milliseconds)
 
     check:
-       conn.writes == @[highMsg, lowMsgs[0], lowMsgs[1]]
-       not disconnectRequestedForTest[]
-       peer.hasSendConn()
+      conn.writes == @[highMsg, lowMsgs[0], lowMsgs[1]]
+      not disconnectRequestedForTest[]
+      peer.hasSendConn()
 
   asyncTest "Empty queues fast-path the first medium or low message":
     let mediumPeer = createTestPeer()

--- a/tests/libp2p/pubsub/test_priority_queues.nim
+++ b/tests/libp2p/pubsub/test_priority_queues.nim
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import chronos
+import ../../../libp2p/protocols/pubsub/pubsubpeer
+import ../../../libp2p/protocols/pubsub/gossipsub/types
+import ../../../libp2p/peerid
+import ../../../libp2p/crypto/crypto
+import ../../tools/unittest
+
+proc randomPeerId(): PeerId =
+  let rng = newRng()
+  PeerId.init(PrivateKey.random(ECDSA, rng[]).get()).tryGet()
+
+proc dummyGetConn(): Future[Connection] {.
+    async: (raises: [CancelledError, GetConnDialError])
+.} =
+  raise newException(GetConnDialError, "this is not a real connection")
+
+type PendingConnection = ref object of Connection
+  # These futures never finish, they're used to grow the high priority queue
+  pendingWrites: seq[Future[void].Raising([CancelledError, LPStreamError])]
+
+type RecorderConnection = ref object of Connection
+  # First write blocks, later writes complete and are recorded in order.
+  writes: seq[seq[byte]]
+  firstWriteFut: Future[void].Raising([CancelledError, LPStreamError])
+
+method initStream*(s: PendingConnection) {.raises: [].} =
+  s.objName = "PendingConnection"
+  procCall Connection(s).initStream()
+
+method writeLp*(
+    s: PendingConnection, msg: openArray[byte]
+): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
+  let fut = Future[void].Raising([CancelledError, LPStreamError]).init("PendingConnection.writeLp")
+  s.pendingWrites.add(fut)
+  fut
+
+method getWrapped*(s: PendingConnection): Connection =
+  s
+
+method closeImpl*(s: PendingConnection) {.async: (raises: []).} =
+  for fut in s.pendingWrites:
+    if not fut.finished:
+      fut.fail(newLPStreamClosedError())
+  await procCall Connection(s).closeImpl()
+
+proc createPendingConnection(): PendingConnection {.raises: [].} =
+  let conn = PendingConnection(dir: Direction.Out, timeout: 0.milliseconds)
+  conn.initStream()
+  conn
+
+method initStream*(s: RecorderConnection) {.raises: [].} =
+  s.objName = "RecorderConnection"
+  procCall Connection(s).initStream()
+
+method writeLp*(
+    s: RecorderConnection, msg: openArray[byte]
+): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
+  s.writes.add(@msg)
+  if s.firstWriteFut.isNil:
+    s.firstWriteFut = Future[void].Raising([CancelledError, LPStreamError]).init("RecorderConnection.writeLp")
+    s.firstWriteFut
+  else:
+    let fut = Future[void].Raising([CancelledError, LPStreamError]).init("RecorderConnection.writeLp.completed")
+    fut.complete()
+    fut
+
+method getWrapped*(s: RecorderConnection): Connection =
+  s
+
+method closeImpl*(s: RecorderConnection) {.async: (raises: []).} =
+  if not s.firstWriteFut.isNil and not s.firstWriteFut.finished:
+    s.firstWriteFut.complete()
+  await procCall Connection(s).closeImpl()
+
+proc createRecorderConnection(): RecorderConnection {.raises: [].} =
+  let conn = RecorderConnection(dir: Direction.Out, timeout: 0.milliseconds)
+  conn.initStream()
+  conn
+
+proc releaseFirstWrite(conn: RecorderConnection) {.raises: [].} =
+  if not conn.firstWriteFut.isNil and not conn.firstWriteFut.finished:
+    conn.firstWriteFut.complete()
+
+proc newDisconnectRecorder(disconnectRequested: ref bool): OnEvent =
+  proc recordDisconnect(
+      peer: PubSubPeer, event: PubSubPeerEvent
+  ) {.gcsafe, raises: [].} =
+    if event.kind == PubSubPeerEventKind.DisconnectionRequested:
+      disconnectRequested[] = true
+
+  recordDisconnect
+
+proc createTestPeer(
+    maxHigh: int = 2,
+    maxMedium: int = 2,
+    maxLow: int = 2,
+    onEvent: OnEvent = nil,
+): PubSubPeer =
+  PubSubPeer.new(
+    randomPeerId(),
+    dummyGetConn,
+    onEvent,
+    GossipSubCodec_12,
+    maxMessageSize = 100,
+    maxHighPriorityQueueLen = maxHigh,
+    maxMediumPriorityQueueLen = maxMedium,
+    maxLowPriorityQueueLen = maxLow,
+  )
+
+suite "Priority queue behavior":
+  teardown:
+    checkTrackers()
+
+  asyncTest "Exceeding max high priority messages triggers disconnection event":
+    let disconnectRequestedForTest = new bool
+
+    let peer =
+      createTestPeer(
+        maxHigh = 2, onEvent = newDisconnectRecorder(disconnectRequestedForTest)
+      )
+    defer:
+      peer.stopSendNonHighPriorityTask()
+
+    peer.sendConn = createPendingConnection()
+
+    # These writes stay pending, so the high-priority queue can actually fill.
+    let f1 = peer.sendEncoded(@[1'u8, 2, 3], MessagePriority.High)
+    let f2 = peer.sendEncoded(@[1'u8, 2, 3], MessagePriority.High)
+    let overflowFut = peer.sendEncoded(@[1'u8, 2, 3], MessagePriority.High)
+
+    check:
+      not f1.finished
+      not f2.finished
+
+    await overflowFut
+    check:
+      disconnectRequestedForTest[]
+      not peer.hasSendConn()
+
+  asyncTest "Exceeding max medium priority messages drops messages without disconnect":
+    let disconnectRequestedForTest = new bool
+
+    let peer =
+      createTestPeer(
+        maxMedium = 2, onEvent = newDisconnectRecorder(disconnectRequestedForTest)
+      )
+    let conn = createRecorderConnection()
+    defer:
+      peer.stopSendNonHighPriorityTask()
+
+    peer.sendConn = conn
+
+    let highMsg = @[1'u8, 2, 3]
+    let mediumMsgs =
+      @[
+        @[10'u8, 0, 0],
+        @[11'u8, 0, 0],
+        @[12'u8, 0, 0],
+        @[13'u8, 0, 0],
+      ]
+
+    # Enqueue a pending high-priority message to disable the fast path
+    discard peer.sendEncoded(highMsg, MessagePriority.High)
+
+    for msg in mediumMsgs:
+      let f = peer.sendEncoded(msg, MessagePriority.Medium)
+      check f.finished
+
+    check conn.writes == @[highMsg]
+
+    # Releasing the first message so medium messages can be sent
+    conn.releaseFirstWrite()
+
+    checkUntilTimeout:
+      conn.writes.len == 3
+
+    await sleepAsync(10.milliseconds)
+
+    check:
+      conn.writes == @[highMsg, mediumMsgs[0], mediumMsgs[1]]
+      not disconnectRequestedForTest[]
+      peer.hasSendConn()
+
+  asyncTest "Exceeding max low priority messages drops messages without disconnect":
+    let disconnectRequestedForTest = new bool
+
+    let peer =
+      createTestPeer(
+        maxLow = 2, onEvent = newDisconnectRecorder(disconnectRequestedForTest)
+      )
+    let conn = createRecorderConnection()
+    defer:
+      peer.stopSendNonHighPriorityTask()
+
+    peer.sendConn = conn
+
+    let highMsg = @[1'u8, 2, 3]
+    let lowMsgs =
+      @[
+        @[20'u8, 0, 0],
+        @[21'u8, 0, 0],
+        @[22'u8, 0, 0],
+        @[23'u8, 0, 0],
+      ]
+
+    # Enqueue a pending high-priority message to disable the fast path
+    discard peer.sendEncoded(highMsg, MessagePriority.High)
+
+    for msg in lowMsgs:
+      let f = peer.sendEncoded(msg, MessagePriority.Low)
+      check f.finished
+
+    check conn.writes == @[highMsg]
+
+    # Releasing the first message so other low messages can be sent
+    conn.releaseFirstWrite()
+
+    checkUntilTimeout:
+      conn.writes.len == 3
+
+    await sleepAsync(10.milliseconds)
+
+    check:
+       conn.writes == @[highMsg, lowMsgs[0], lowMsgs[1]]
+       not disconnectRequestedForTest[]
+       peer.hasSendConn()
+
+  asyncTest "Empty queues fast-path the first medium or low message":
+    let mediumPeer = createTestPeer()
+    let lowPeer = createTestPeer()
+    defer:
+      mediumPeer.stopSendNonHighPriorityTask()
+      lowPeer.stopSendNonHighPriorityTask()
+
+    # This is require so it  we can test the send path
+    mediumPeer.sendConn = createPendingConnection()
+    lowPeer.sendConn = createPendingConnection()
+
+    let mediumFut = mediumPeer.sendEncoded(@[1'u8, 2, 3], MessagePriority.Medium)
+    let lowFut = lowPeer.sendEncoded(@[4'u8, 5, 6], MessagePriority.Low)
+
+    check:
+      not mediumFut.finished
+      not lowFut.finished
+      mediumPeer.hasSendConn()
+      lowPeer.hasSendConn()

--- a/tests/libp2p/pubsub/test_priority_queues.nim
+++ b/tests/libp2p/pubsub/test_priority_queues.nim
@@ -7,12 +7,7 @@ import chronos
 import ../../../libp2p/protocols/pubsub/pubsubpeer
 import ../../../libp2p/protocols/pubsub/gossipsub/types
 import ../../../libp2p/peerid
-import ../../../libp2p/crypto/crypto
 import ../../tools/unittest
-
-proc randomPeerId(): PeerId =
-  let rng = newRng()
-  PeerId.init(PrivateKey.random(ECDSA, rng[]).get()).tryGet()
 
 proc dummyGetConn(): Future[Connection] {.
     async: (raises: [CancelledError, GetConnDialError])
@@ -105,7 +100,7 @@ proc createTestPeer(
     maxHigh: int = 2, maxMedium: int = 2, maxLow: int = 2, onEvent: OnEvent = nil
 ): PubSubPeer =
   PubSubPeer.new(
-    randomPeerId(),
+    PeerId.random().expect("random peer id"),
     dummyGetConn,
     onEvent,
     GossipSubCodec_12,
@@ -172,9 +167,7 @@ suite "Priority queue behavior":
     conn.releaseFirstWrite()
 
     checkUntilTimeout:
-      conn.writes.len == 3
-
-    await sleepAsync(10.milliseconds)
+      conn.writes == @[highMsg, mediumMsgs[0], mediumMsgs[1]]
 
     check:
       conn.writes == @[highMsg, mediumMsgs[0], mediumMsgs[1]]
@@ -209,9 +202,7 @@ suite "Priority queue behavior":
     conn.releaseFirstWrite()
 
     checkUntilTimeout:
-      conn.writes.len == 3
-
-    await sleepAsync(10.milliseconds)
+      conn.writes == @[highMsg, lowMsgs[0], lowMsgs[1]]
 
     check:
       conn.writes == @[highMsg, lowMsgs[0], lowMsgs[1]]
@@ -225,7 +216,7 @@ suite "Priority queue behavior":
       mediumPeer.stopSendNonHighPriorityTask()
       lowPeer.stopSendNonHighPriorityTask()
 
-    # This is require so it  we can test the send path
+    # This is required so we can test the send path
     mediumPeer.sendConn = createPendingConnection()
     lowPeer.sendConn = createPendingConnection()
 

--- a/tests/libp2p/pubsub/test_priority_queues.nim
+++ b/tests/libp2p/pubsub/test_priority_queues.nim
@@ -87,8 +87,10 @@ proc releaseFirstWrite(conn: RecorderConnection) {.raises: [].} =
   if not conn.firstWriteFut.isNil and not conn.firstWriteFut.finished:
     conn.firstWriteFut.complete()
 
-proc callbacksDrained(fut: FutureBase): Future[void] {.raises: [].} =
-  let drained = Future[void].init("callbacksDrained")
+proc callbacksDrained(
+    fut: FutureBase
+): Future[void].Raising([CancelledError]) {.raises: [].} =
+  let drained = Future[void].Raising([CancelledError]).init("callbacksDrained")
 
   proc continuation(udata: pointer) {.gcsafe, raises: [].} =
     let drained = cast[Future[void]](udata)
@@ -190,7 +192,8 @@ suite "Priority queue behavior":
       let f = peer.sendEncoded(msg, MessagePriority.Medium)
       check f.finished
 
-    check conn.writes == @[highMsg, mediumMsgs[0], mediumMsgs[1], mediumMsgs[2], mediumMsgs[3]]
+    check conn.writes ==
+      @[highMsg, mediumMsgs[0], mediumMsgs[1], mediumMsgs[2], mediumMsgs[3]]
 
     conn.releaseFirstWrite()
     let writeDrain = callbacksDrained(conn.firstWriteFut)
@@ -199,7 +202,8 @@ suite "Priority queue behavior":
       writeDrain.finished
 
     check:
-      conn.writes == @[highMsg, mediumMsgs[0], mediumMsgs[1], mediumMsgs[2], mediumMsgs[3]]
+      conn.writes ==
+        @[highMsg, mediumMsgs[0], mediumMsgs[1], mediumMsgs[2], mediumMsgs[3]]
       not disconnectRequestedForTest[]
       peer.hasSendConn()
 


### PR DESCRIPTION
## Summary
This PR replaces the current H/L priority outbound msg queue with a 3 level: High, Medium, and Low. 
Protocol-critical control traffic stays High, locally published messages move to Medium, and relayed / IWANT-reply traffic moves to Low.

This is needed to avoid low priority messages from grow without bound.. With this PR, if max high priority messages are exceeded, gossip will still disconnect slow peers, while medium/low traffic will just drop the messages.


## Affected Areas
- [x] Gossipsub  
- [ ] Transports  
- [ ] Peer Management / Discovery
- [] Protocol Logic
- [ ] Build / Tooling
- [ ] Other  


## Risk Assessment
The main risk is the change of behavior for low/medium priority messages.

## References
- https://roadmap.vac.dev/p2p/ift/2026q2-nimlibp2p-gossipsub-queues