### PR TITLE
feat(mix): cover traffic with constant rate

### DIFF
--- a/libp2p/protocols/mix/cover_traffic.nim
+++ b/libp2p/protocols/mix/cover_traffic.nim
@@ -1,0 +1,408 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## Pluggable cover traffic interface and strategies for the Mix Protocol.
+##
+## Cover traffic ensures sender unobservability by emitting dummy Sphinx packets
+## at a constant rate, making it impossible for an observer to distinguish cover
+## traffic from locally originated messages.
+##
+## See Mix Cover Traffic specification sections 3-7.
+
+import std/deques
+import chronicles, chronos, results, metrics
+import ../../[multiaddress, peerid]
+import ../../utils/heartbeat
+import ./mix_metrics, ./sphinx
+
+logScope:
+  topics = "libp2p mix covertraffic"
+
+# Callback types injected by MixProtocol to avoid circular dependency.
+# CoverTraffic lives in a separate module and cannot import MixProtocol
+# (that would create a circular import). The callbacks are the only way
+# to break this cycle while letting CoverTraffic build and send packets
+# through MixProtocol's infrastructure (nodePool, sphinx, spam protection).
+type
+  CoverPacketBuild* = object
+    packet*: seq[byte]
+    firstHopPeerId*: PeerId
+    firstHopAddr*: MultiAddress
+    proofToken*: seq[byte]
+
+  BuildCoverPacketProc* =
+    proc(): Result[CoverPacketBuild, string] {.gcsafe, raises: [].}
+
+  SendCoverPacketProc* = proc(
+    peerId: PeerId, multiAddr: MultiAddress, packet: seq[byte]
+  ): Future[Result[void, string]] {.async: (raises: [CancelledError]).}
+
+type
+  CoverPacket* = object
+    packet*: seq[byte]
+    firstHopPeerId*: PeerId
+    firstHopAddr*: MultiAddress
+    proofToken*: seq[byte] ## Opaque token from spam protection proof generation
+
+  ClaimResult* = object
+    success*: bool
+    reclaimedToken*: seq[byte] ## Proof token from discarded cover packet (empty if none)
+
+type SlotPool* = ref object
+  ## Manages the R-slot budget per epoch. All traffic types (cover, local
+  ## origination, forwarding) draw from the same pool.
+  epoch*: uint64
+  totalSlots: int
+  coverQueue: Deque[CoverPacket]
+  coverClaimed*: int
+  nonCoverClaimed*: int
+
+proc new*(T: typedesc[SlotPool], totalSlots: int): T =
+  doAssert totalSlots > 0, "SlotPool totalSlots must be greater than zero"
+  T(epoch: 0, totalSlots: totalSlots, coverQueue: initDeque[CoverPacket]())
+
+proc beginEpoch*(pool: SlotPool, epoch: uint64) =
+  ## Clear stale cover packets and refill slots for the new epoch.
+  ## Precomputed packets from the previous epoch are discarded because
+  ## their proofs belong to the old epoch.
+  pool.epoch = epoch
+  pool.coverQueue = initDeque[CoverPacket]()
+  pool.coverClaimed = 0
+  pool.nonCoverClaimed = 0
+
+func availableSlots*(pool: SlotPool): int {.inline.} =
+  pool.totalSlots - pool.coverClaimed - pool.nonCoverClaimed
+
+func hasAvailableSlots*(pool: SlotPool): bool {.inline.} =
+  pool.availableSlots > 0
+
+proc claimSlotForCover*(pool: SlotPool): bool =
+  if not pool.hasAvailableSlots():
+    return false
+  pool.coverClaimed += 1
+  true
+
+proc claimSlot*(pool: SlotPool): ClaimResult =
+  ## Claim a slot for non-cover use. Discards one pre-built cover packet
+  ## and returns its proof token for potential reuse (Mix Cover Traffic spec §5.2).
+  if not pool.hasAvailableSlots():
+    return ClaimResult(success: false)
+
+  pool.nonCoverClaimed += 1
+  var token: seq[byte]
+  if pool.coverQueue.len > 0:
+    let discarded = pool.coverQueue.popFirst()
+    token = discarded.proofToken
+  ClaimResult(success: true, reclaimedToken: token)
+
+func totalSlots*(pool: SlotPool): int {.inline.} =
+  pool.totalSlots
+
+proc updateTotalSlots*(pool: SlotPool, r: int) =
+  pool.totalSlots = r
+
+proc addPacket*(pool: SlotPool, pkt: CoverPacket) =
+  pool.coverQueue.addLast(pkt)
+
+func queuedCount*(pool: SlotPool): int {.inline.} =
+  pool.coverQueue.len
+
+proc dequeue*(pool: SlotPool): Opt[CoverPacket] {.inline.} =
+  if pool.coverQueue.len == 0:
+    return Opt.none(CoverPacket)
+  Opt.some(pool.coverQueue.popFirst())
+
+type
+  ValidateProofTokenProc* = proc(token: seq[byte]): bool {.gcsafe, raises: [].}
+    ## Callback to check if a prebuilt proof is still valid (e.g., Merkle root
+    ## still in the acceptable window). Returns true if valid, false if stale.
+
+  ReclaimProofTokenProc* = proc(token: seq[byte]) {.gcsafe, raises: [].}
+    ## Callback to return a proof token for reuse when a prebuilt cover packet
+    ## is discarded (e.g., due to stale Merkle root).
+
+  CoverTraffic* = ref object of RootObj
+    ## Abstract base to allow alternate emission strategies (e.g. Poisson-Rate).
+    ## MixProtocol injects packet building and sending via callback procs.
+    slotPool*: SlotPool
+    buildPacket: BuildCoverPacketProc
+    sendPacket: SendCoverPacketProc
+    validateProofToken: ValidateProofTokenProc
+    reclaimProofToken: ReclaimProofTokenProc
+
+method start*(ct: CoverTraffic) {.base, async: (raises: [CancelledError]).} =
+  raiseAssert "start must be implemented by concrete cover traffic types"
+
+method stop*(ct: CoverTraffic) {.base, async: (raises: []).} =
+  raiseAssert "stop must be implemented by concrete cover traffic types"
+
+method onEpochChange*(ct: CoverTraffic, epoch: uint64) {.base, gcsafe, raises: [].} =
+  ct.slotPool.beginEpoch(epoch)
+
+method onCoverReceived*(ct: CoverTraffic) {.base, gcsafe, raises: [].} =
+  ## Diagnostics hook when a cover packet loops back (Mix Cover Traffic spec §11.2).
+  discard
+
+proc setCoverPacketBuilder*(ct: CoverTraffic, builder: BuildCoverPacketProc) =
+  ct.buildPacket = builder
+
+proc setProofTokenValidator*(ct: CoverTraffic, validator: ValidateProofTokenProc) =
+  ct.validateProofToken = validator
+
+proc setProofTokenReclaimer*(ct: CoverTraffic, reclaimer: ReclaimProofTokenProc) =
+  ct.reclaimProofToken = reclaimer
+
+proc setCoverPacketSender*(ct: CoverTraffic, sender: SendCoverPacketProc) =
+  ct.sendPacket = sender
+
+type ConstantRateCoverTraffic* = ref object of CoverTraffic
+  ## Emits cover packets at a fixed interval of ((1+L)*P)/R seconds.
+  ## RECOMMENDED as the default strategy (Mix Cover Traffic spec §7.1).
+  emissionInterval: Duration
+  epochDuration: Duration
+  enablePrecomputation: bool
+  precomputeBatchSize: int
+  emissionLoop: Future[void]
+  precomputeLoop: Future[void]
+  epochTimerLoop: Future[void]
+  emissionEpochEvent: AsyncEvent
+  precomputeEpochEvent: AsyncEvent
+  useInternalEpochTimer: bool
+  running: bool
+
+proc new*(
+    T: typedesc[ConstantRateCoverTraffic],
+    totalSlots: int = 100,
+    epochDuration: Duration = 60.seconds,
+    enablePrecomputation: bool = false,
+    precomputeBatchSize: int = 0,
+    useInternalEpochTimer: bool = true,
+): T =
+  ## Parameters:
+  ##   totalSlots: R (rate limit budget per epoch)
+  ##   epochDuration: P (epoch duration)
+  ##   enablePrecomputation: whether to pre-build cover packets in batches
+  ##   precomputeBatchSize: packets per batch (0 = auto: R / (1+L) / 10)
+  ##   useInternalEpochTimer: false when SpamProtection provides OnEpochChange
+  doAssert totalSlots > 0, "totalSlots (R) must be positive"
+  doAssert epochDuration > Duration.default, "epochDuration (P) must be positive"
+
+  let emissionInterval =
+    max(1.milliseconds, epochDuration * (1 + PathLength) div totalSlots)
+  let targetCount = totalSlots div (1 + PathLength)
+  let batchSize =
+    if precomputeBatchSize > 0:
+      precomputeBatchSize
+    else:
+      max(1, targetCount div 10)
+
+  T(
+    slotPool: SlotPool.new(totalSlots),
+    emissionInterval: emissionInterval,
+    epochDuration: epochDuration,
+    enablePrecomputation: enablePrecomputation,
+    precomputeBatchSize: batchSize,
+    emissionEpochEvent: newAsyncEvent(),
+    precomputeEpochEvent: newAsyncEvent(),
+    useInternalEpochTimer: useInternalEpochTimer,
+    running: false,
+  )
+
+proc unclaimCoverSlot(ct: ConstantRateCoverTraffic) =
+  ## Return a cover slot on build failure so it can be retried within the
+  ## same epoch. Send failures do NOT unclaim — the proof/messageId was
+  ## already consumed and cannot be reused.
+  if ct.slotPool.coverClaimed > 0:
+    ct.slotPool.coverClaimed -= 1
+
+proc buildAndSendOnDemand(
+    ct: ConstantRateCoverTraffic
+) {.async: (raises: [CancelledError]).} =
+  ## Build and send a cover packet on-demand. Assumes slot is already claimed.
+  let buildRes = ct.buildPacket()
+  if buildRes.isErr:
+    trace "Failed to build cover packet", err = buildRes.error
+    mix_cover_error.inc(labelValues = ["BUILD_FAILED"])
+    ct.unclaimCoverSlot()
+    return
+
+  let built = buildRes.get()
+  let sendRes =
+    await ct.sendPacket(built.firstHopPeerId, built.firstHopAddr, built.packet)
+  if sendRes.isErr:
+    debug "Failed to send cover packet", err = sendRes.error
+    mix_cover_error.inc(labelValues = ["SEND_FAILED"])
+  else:
+    mix_cover_emitted.inc(labelValues = ["on_demand"])
+
+proc emitCoverPacket*(
+    ct: ConstantRateCoverTraffic
+) {.async: (raises: [CancelledError]).} =
+  doAssert ct.buildPacket != nil, "buildPacket callback must be set before emitting"
+  doAssert ct.sendPacket != nil, "sendPacket callback must be set before emitting"
+
+  if ct.enablePrecomputation and ct.slotPool.queuedCount > 0:
+    if not ct.slotPool.claimSlotForCover():
+      mix_slot_claim_rejected.inc(labelValues = ["cover"])
+      return
+    ct.slotPool.dequeue().withValue(pkt):
+      # Check if the prebuilt proof is still valid (e.g., Merkle root not stale)
+      if ct.validateProofToken != nil and pkt.proofToken.len > 0 and
+          not ct.validateProofToken(pkt.proofToken):
+        trace "Prebuilt cover packet has stale proof, rebuilding on-demand"
+        mix_cover_error.inc(labelValues = ["STALE_PROOF"])
+        # Reclaim the stale proof's messageId so it can be reused
+        if ct.reclaimProofToken != nil:
+          ct.reclaimProofToken(pkt.proofToken)
+        await ct.buildAndSendOnDemand()
+        return
+      else:
+        let sendRes =
+          await ct.sendPacket(pkt.firstHopPeerId, pkt.firstHopAddr, pkt.packet)
+        if sendRes.isErr:
+          debug "Failed to send pre-built cover packet", err = sendRes.error
+          mix_cover_error.inc(labelValues = ["SEND_FAILED"])
+        else:
+          mix_cover_emitted.inc(labelValues = ["prebuilt"])
+        return
+
+  if ct.slotPool.claimSlotForCover():
+    await ct.buildAndSendOnDemand()
+
+proc runEmissionLoop(
+    ct: ConstantRateCoverTraffic
+) {.async: (raises: [CancelledError]).} =
+  var nextTick = Moment.now() + ct.emissionInterval
+  while ct.running:
+    if not ct.slotPool.hasAvailableSlots():
+      ct.emissionEpochEvent.clear()
+      await ct.emissionEpochEvent.wait()
+      nextTick = Moment.now()
+
+    let now = Moment.now()
+    if now < nextTick:
+      await sleepAsync(nextTick - now)
+
+    await ct.emitCoverPacket()
+    nextTick = nextTick + ct.emissionInterval
+
+proc runPrecomputeLoop(
+    ct: ConstantRateCoverTraffic
+) {.async: (raises: [CancelledError]).} =
+  ## Builds cover packets in batches and adds them to the coverQueue for the
+  ## current epoch (same-epoch precomputation).
+  ##
+  ## Packets are built with proofs for the current epoch so their proof tokens
+  ## can be reclaimed if the packet is discarded before sending.
+  while ct.running:
+    let currentEpoch = ct.slotPool.epoch
+    let targetCount = ct.slotPool.totalSlots div (1 + PathLength)
+    var built = 0
+
+    while built + ct.slotPool.queuedCount < targetCount and ct.running:
+      if ct.slotPool.epoch != currentEpoch:
+        trace "Epoch changed during pre-computation, aborting",
+          startedEpoch = currentEpoch, currentEpoch = ct.slotPool.epoch
+        break
+
+      let batchEnd =
+        min(built + ct.precomputeBatchSize, targetCount - ct.slotPool.queuedCount)
+      var batchFailed = false
+      while built < batchEnd:
+        let buildRes = ct.buildPacket()
+        if buildRes.isErr:
+          debug "Pre-computation: failed to build cover packet", err = buildRes.error
+          mix_cover_error.inc(labelValues = ["BUILD_FAILED"])
+          batchFailed = true
+          break
+
+        let coverBuild = buildRes.get()
+        ct.slotPool.addPacket(
+          CoverPacket(
+            packet: coverBuild.packet,
+            firstHopPeerId: coverBuild.firstHopPeerId,
+            firstHopAddr: coverBuild.firstHopAddr,
+            proofToken: coverBuild.proofToken,
+          )
+        )
+        built += 1
+        mix_cover_precomputed.inc()
+        # Yield per packet so other async tasks can proceed
+        await sleepAsync(1.milliseconds)
+
+      if batchFailed:
+        break
+
+      # Longer yield between batches
+      await sleepAsync(10.milliseconds)
+
+    trace "Pre-computation complete", epoch = currentEpoch, totalBuilt = built
+
+    # If epoch changed during precomputation, the event was already fired
+    # (via onEpochChange → fire). Don't clear+wait or we'd skip an epoch.
+    if ct.slotPool.epoch != currentEpoch:
+      continue
+
+    ct.precomputeEpochEvent.clear()
+    await ct.precomputeEpochEvent.wait()
+
+proc runEpochTimer(ct: ConstantRateCoverTraffic) {.async: (raises: [CancelledError]).} =
+  ## Fallback epoch timer when no SpamProtection provides OnEpochChange.
+  var epochCounter: uint64 = 0
+  heartbeat "Cover traffic epoch timer", ct.epochDuration, sleepFirst = true:
+    epochCounter += 1
+    ct.onEpochChange(epochCounter)
+
+method onEpochChange*(
+    ct: ConstantRateCoverTraffic, epoch: uint64
+) {.gcsafe, raises: [].} =
+  procCall CoverTraffic(ct).onEpochChange(epoch)
+  ct.emissionEpochEvent.fire()
+  ct.precomputeEpochEvent.fire()
+
+method start*(ct: ConstantRateCoverTraffic) {.async: (raises: [CancelledError]).} =
+  if ct.running:
+    return
+
+  doAssert ct.buildPacket != nil, "buildPacket callback must be set before start"
+  doAssert ct.sendPacket != nil, "sendPacket callback must be set before start"
+
+  ct.running = true
+
+  ct.emissionLoop = ct.runEmissionLoop()
+
+  if ct.enablePrecomputation:
+    ct.precomputeLoop = ct.runPrecomputeLoop()
+
+  if ct.useInternalEpochTimer:
+    ct.epochTimerLoop = ct.runEpochTimer()
+
+  debug "Cover traffic started",
+    interval = ct.emissionInterval,
+    precomputation = ct.enablePrecomputation,
+    internalEpochTimer = ct.useInternalEpochTimer
+
+proc cancelIfNotNil(fut: Future[void]) {.async: (raises: []).} =
+  if not fut.isNil:
+    await fut.cancelAndWait()
+
+method stop*(ct: ConstantRateCoverTraffic) {.async: (raises: []).} =
+  if not ct.running:
+    return
+  ct.running = false
+  await cancelIfNotNil(ct.emissionLoop)
+  await cancelIfNotNil(ct.precomputeLoop)
+  await cancelIfNotNil(ct.epochTimerLoop)
+  ct.emissionLoop = nil
+  ct.precomputeLoop = nil
+  ct.epochTimerLoop = nil
+  trace "Cover traffic stopped"
+
+func emissionInterval*(ct: ConstantRateCoverTraffic): Duration =
+  ct.emissionInterval
+
+func precomputeBatchSize*(ct: ConstantRateCoverTraffic): int =
+  ct.precomputeBatchSize
+
+func isRunning*(ct: ConstantRateCoverTraffic): bool =
+  ct.running

--- a/libp2p/protocols/mix/mix_metrics.nim
+++ b/libp2p/protocols/mix/mix_metrics.nim
@@ -14,3 +14,16 @@ declarePublicCounter mix_messages_error,
   "number of mix messages failed processing", ["type", "error"]
 
 declarePublicGauge mix_pool_size, "number of nodes in the pool"
+
+declarePublicCounter mix_cover_emitted, "number of cover packets emitted", ["type"]
+
+declarePublicCounter mix_cover_received,
+  "number of cover packets received at exit (loop return)"
+
+declarePublicCounter mix_slot_claim_rejected,
+  "number of slot claim rejections", ["type"]
+
+declarePublicCounter mix_cover_error, "number of cover traffic errors", ["error"]
+
+declarePublicCounter mix_cover_precomputed,
+  "number of cover packets pre-computed per epoch"

--- a/libp2p/protocols/mix/mix_protocol.nim
+++ b/libp2p/protocols/mix/mix_protocol.nim
@@ -7,13 +7,13 @@ import
   ./[
     curve25519, delay, fragmentation, mix_message, mix_node, sphinx, serialization,
     tag_manager, mix_metrics, exit_layer, multiaddr, exit_connection, spam_protection,
-    delay_strategy, pool,
+    delay_strategy, pool, cover_traffic,
   ]
 import ../protocol
 import ../../utils/[sequninit]
 import ../../stream/[connection, lpstream]
 import ../../[switch, multicodec, peerinfo, varint]
-import ../../peerstore
+import ../../crypto/crypto
 
 export pool
 
@@ -25,6 +25,14 @@ when defined(libp2p_mix_experimental_exit_is_dest):
   {.warning: "experimental support for mix exit == destination is enabled!".}
 
 const MixProtocolID* = "/mix/1.0.0"
+
+const CoverTrafficCodec* = "/mix/cover/1.0.0"
+  ## Reserved codec for cover traffic packets. Cover packets use this codec
+  ## so the exit node can identify and silently discard returning cover traffic.
+
+func isCoverTraffic*(msg: MixMessage): bool =
+  ## Returns true if the message is a cover traffic packet.
+  msg.codec == CoverTrafficCodec
 
 type
   SURBIdentifierGroup = ref object
@@ -54,6 +62,7 @@ type MixProtocol* = ref object of LPProtocol
   connPool: Table[PeerId, Connection]
   spamProtection: Opt[SpamProtection]
   delayStrategy: DelayStrategy
+  coverTraffic*: Opt[CoverTraffic]
   ongoingMixMessages: seq[Future[void]]
     ## Tracks all in-flight handleMixMessages futures so they can be
     ## cancelled on stop and waited for during teardown.
@@ -121,14 +130,15 @@ proc writeLp(
 
 proc generateAndAppendProof(
     mixProto: MixProtocol, packet: seq[byte], label: string
-): Result[seq[byte], string] =
+): Result[tuple[packet: seq[byte], proofToken: seq[byte]], string] =
   ## Generate spam protection proof and append it to the packet.
-  ## Returns the packet with proof appended if spam protection is enabled, or an error.
+  ## Returns the packet with proof appended and an opaque proof token
+  ## for proof slot tracking.
   let spamProtection = mixProto.spamProtection.valueOr:
-    return ok(packet)
+    return ok((packet, newSeq[byte]()))
 
   let bindingData = packet
-  let proof = spamProtection
+  let proofResult = spamProtection
     .generateProof(bindingData)
     .mapErr(
       proc(e: string): string =
@@ -137,7 +147,7 @@ proc generateAndAppendProof(
     ).valueOr:
       return err(error)
 
-  let packetWithProof = appendProofToPacket(packet, proof)
+  let packetWithProof = appendProofToPacket(packet, proofResult.proof)
     .mapErr(
       proc(e: string): string =
         mix_messages_error.inc(labelValues = [label, "SPAM_PROOF_EMBED_FAILED"])
@@ -145,7 +155,7 @@ proc generateAndAppendProof(
     ).valueOr:
       return err(error)
 
-  ok(packetWithProof)
+  ok((packetWithProof, proofResult.token))
 
 proc extractProof(
     mixProto: MixProtocol, packetWithProof: var seq[byte], label: string
@@ -269,6 +279,14 @@ method handleMixMessages*(
       mix_messages_error.inc(labelValues = ["Exit", "INVALID_SPHINX"])
       return
 
+    if isCoverTraffic(deserialized):
+      trace "Cover packet received (loop), discarding",
+        peerId = mixProto.mixNodeInfo.peerId
+      mix_cover_received.inc()
+      mixProto.coverTraffic.withValue(ct):
+        ct.onCoverReceived()
+      return
+
     let (surbs, message) = extractSURBs(deserialized.message).valueOr:
       error "Extracting surbs from payload failed", err = error
       mix_messages_error.inc(labelValues = ["Exit", "INVALID_MSG_SURBS"])
@@ -344,6 +362,20 @@ method handleMixMessages*(
     trace "Intermediate node processing",
       peerId = mixProto.mixNodeInfo.peerId, multiAddr = mixProto.mixNodeInfo.multiAddr
     mix_messages_recvd.inc(labelValues = ["Intermediate"])
+
+    # Claim a slot for forwarding (Mix Cover Traffic spec §6.4)
+    mixProto.coverTraffic.withValue(ct):
+      let claim = ct.slotPool.claimSlot()
+      if not claim.success:
+        warn "Slot exhaustion, dropping forwarded packet"
+        mix_messages_error.inc(labelValues = ["Intermediate", "SLOT_EXHAUSTED"])
+        mix_slot_claim_rejected.inc(labelValues = ["forward"])
+        return
+      # Reclaim proof token from discarded cover packet for messageId reuse
+      if claim.reclaimedToken.len > 0:
+        mixProto.spamProtection.withValue(sp):
+          sp.reclaimProofToken(claim.reclaimedToken)
+
     let actualDelay = mixProto.delayStrategy.generateForIntermediate(processedSP.delay)
     trace "Computed delay", encodedDelay = processedSP.delay, actualDelay
 
@@ -371,7 +403,9 @@ method handleMixMessages*(
     let delayFut = sleepAsync(actualDelay.toDuration)
 
     let proofGenFut = (
-      proc(): Future[Result[seq[byte], string]] {.async.} =
+      proc(): Future[Result[tuple[packet: seq[byte], proofToken: seq[byte]], string]] {.
+          async
+      .} =
         return mixProto.generateAndAppendProof(
           processedSP.serializedSphinxPacket, "Intermediate"
         )
@@ -379,7 +413,7 @@ method handleMixMessages*(
 
     await allFutures(proofGenFut, delayFut)
 
-    if mixProto.spamProtection.isSome():
+    mixProto.spamProtection.withValue(sp):
       let proofGenTimeMs = (Moment.now() - proofGenStartTime).milliseconds
       if proofGenTimeMs > actualDelay.int64:
         warn "Proof generation time exceeds sampled delay",
@@ -387,7 +421,7 @@ method handleMixMessages*(
           sampledDelay = actualDelay,
           hint = "Increase the minimum delay floor or reduce proof generation time"
 
-    let outgoingPacket = proofGenFut.value().valueOr:
+    let (outgoingPacket, _) = proofGenFut.value().valueOr:
       error "Failed to generate spam protection proof for next hop", err = error
       return
 
@@ -487,9 +521,9 @@ method buildSurb*(
     return err("No. of public mix nodes less than path length")
 
   # Remove exit and dest node from nodes to consider for surbs
-  var pubNodeInfoKeys =
+  var poolPeerIds =
     mixProto.nodePool.peerIds().filterIt(it != exitPeerId and it != destPeerId)
-  var availableIndices = toSeq(0 ..< pubNodeInfoKeys.len)
+  var availableIndices = toSeq(0 ..< poolPeerIds.len)
 
   # Select L mix nodes at random
   for i in 0 ..< PathLength:
@@ -498,7 +532,7 @@ method buildSurb*(
         let randomIndexPosition = cryptoRandomInt(mixProto.rng, availableIndices.len).valueOr:
           return err("failed to generate random num: " & error)
         let selectedIndex = availableIndices[randomIndexPosition]
-        let randPeerId = pubNodeInfoKeys[selectedIndex]
+        let randPeerId = poolPeerIds[selectedIndex]
         availableIndices.del(randomIndexPosition)
         debug "Selected mix node for surbs: ", indexInPath = i, peerId = randPeerId
         let mixPubInfo = mixProto.nodePool.get(randPeerId).valueOr:
@@ -586,7 +620,9 @@ proc sendPacket(
   let label = $logConfig.logType
 
   # Per-hop spam protection: Generate initial proof and append to packet
-  let packetToSend = mixProto.generateAndAppendProof(sphinxPacket.serialize(), label).valueOr:
+  let (packetToSend, _) = mixProto.generateAndAppendProof(
+    sphinxPacket.serialize(), label
+  ).valueOr:
     return err(error)
 
   when defined(enable_mix_benchmarks):
@@ -677,9 +713,20 @@ proc anonymizeLocalProtocolSend*(
 
   mix_messages_recvd.inc(labelValues = ["Entry"])
 
+  # Claim a slot for local origination (Mix Cover Traffic spec §6.3)
+  mixProto.coverTraffic.withValue(ct):
+    let claim = ct.slotPool.claimSlot()
+    if not claim.success:
+      mix_slot_claim_rejected.inc(labelValues = ["send"])
+      return err("No slots available in current epoch")
+    # Reclaim proof token from discarded cover packet for messageId reuse
+    if claim.reclaimedToken.len > 0:
+      mixProto.spamProtection.withValue(sp):
+        sp.reclaimProofToken(claim.reclaimedToken)
+
   var logConfig = SendPacketLogConfig(logType: Entry)
   when defined(enable_mix_benchmarks):
-    # Assumes a fixed message layout whose first 16 bytes are the time at 
+    # Assumes a fixed message layout whose first 16 bytes are the time at
     # origin and msgId
     logConfig.startTime = getTime()
     logConfig.metadata = Metadata.deserialize(msg)
@@ -706,10 +753,10 @@ proc anonymizeLocalProtocolSend*(
     )
 
   # Skip the destination peer
-  var pubNodeInfoKeys = mixProto.nodePool.peerIds()
-  var availableIndices = toSeq(0 ..< pubNodeInfoKeys.len)
+  var poolPeerIds = mixProto.nodePool.peerIds()
+  var availableIndices = toSeq(0 ..< poolPeerIds.len)
 
-  let index = pubNodeInfoKeys.find(destination.peerId)
+  let index = poolPeerIds.find(destination.peerId)
   if index != -1:
     availableIndices.del(index)
   elif destination.kind == MixNode:
@@ -726,7 +773,7 @@ proc anonymizeLocalProtocolSend*(
       mix_messages_error.inc(labelValues = ["Entry", "NON_RECOVERABLE"])
       return err(fmt"Failed to generate random number: {error}")
     let selectedIndex = availableIndices[randomIndexPosition]
-    var randPeerId = pubNodeInfoKeys[selectedIndex]
+    var randPeerId = poolPeerIds[selectedIndex]
     availableIndices.del(randomIndexPosition)
 
     if destination.kind == ForwardAddr and randPeerId == destination.peerId:
@@ -833,13 +880,127 @@ proc reply(
   if sendRes.isErr:
     error "could not send reply", peerId, multiAddr, err = sendRes.error
 
-method stop*(mixProto: MixProtocol): Future[void] {.async: (raises: []).} =
-  ## Stop the MixProtocol background tasks and cancels all in-flight handleMixMessages futures.
-  ## 
+type PathNode = object
+  peerId: PeerId
+  multiAddr: MultiAddress
+  mixPubKey: FieldElement
 
+proc selectRandomNodes(
+    mixProto: MixProtocol, count: int, excludePeerIds: HashSet[PeerId]
+): Result[seq[PathNode], string] {.raises: [].} =
+  ## Select `count` random mix nodes from the pool, excluding specified peers.
+  let available = mixProto.nodePool.peerIds().filterIt(it notin excludePeerIds)
+
+  if available.len < count:
+    return err(
+      "Not enough mix nodes in pool (available=" & $available.len & ", needed=" & $count &
+        ")"
+    )
+
+  let selectedPeerIds = mixProto.rng.pick(available, count).valueOr:
+    return err("No mix nodes available in pool")
+
+  var selected: seq[PathNode] = @[]
+  for peerId in selectedPeerIds:
+    let mixPubInfo = mixProto.nodePool.get(peerId).valueOr:
+      return err("Could not get mix pub info for peer: " & $peerId)
+    selected.add(
+      PathNode(
+        peerId: mixPubInfo.peerId,
+        multiAddr: mixPubInfo.multiAddr,
+        mixPubKey: mixPubInfo.mixPubKey,
+      )
+    )
+
+  ok(selected)
+
+proc buildCoverPacket*(
+    mixProto: MixProtocol
+): Result[CoverPacketBuild, string] {.raises: [].} =
+  ## Build a cover Sphinx packet with a loop path (self = exit node),
+  ## random payload .
+  let nodes = mixProto.selectRandomNodes(
+    PathLength - 1, [mixProto.mixNodeInfo.peerId].toHashSet
+  ).valueOr:
+    return err(error)
+
+  var
+    publicKeys: seq[FieldElement] = @[]
+    hops: seq[Hop] = @[]
+    delays: seq[Delay] = @[]
+
+  for node in nodes:
+    let addrBytes = multiAddrToBytes(node.peerId, node.multiAddr).valueOr:
+      return err("Failed to convert multiaddress to bytes: " & error)
+    publicKeys.add(node.mixPubKey)
+    hops.add(Hop.init(addrBytes))
+    delays.add(mixProto.delayStrategy.generateForEntry())
+
+  let selfAddrBytes = multiAddrToBytes(
+    mixProto.mixNodeInfo.peerId, mixProto.mixNodeInfo.multiAddr
+  ).valueOr:
+    return err("Failed to convert self multiaddress to bytes: " & error)
+  publicKeys.add(mixProto.mixNodeInfo.mixPubKey)
+  hops.add(Hop.init(selfAddrBytes))
+  delays.add(NoDelay)
+
+  # Identify cover packets at exit processing
+  let maxMsgSize = getMaxMessageSizeForCodec(CoverTrafficCodec).valueOr:
+    return err("Failed to get max message size for cover codec: " & error)
+  var randomPayload = newSeq[byte](maxMsgSize)
+  mixProto.rng[].generate(randomPayload)
+
+  let message = buildMessage(
+    randomPayload, CoverTrafficCodec, mixProto.mixNodeInfo.peerId
+  ).valueOr:
+    return err("Error building cover message: " & error[0])
+
+  let sphinxPacket = wrapInSphinxPacket(message, publicKeys, delays, hops, Hop()).valueOr:
+    return err("Failed to wrap cover sphinx packet: " & error)
+
+  let (packetToSend, proofToken) = mixProto.generateAndAppendProof(
+    sphinxPacket.serialize(), "Cover"
+  ).valueOr:
+    return err("Failed to generate proof for cover packet: " & error)
+
+  let firstNode = nodes[0]
+  ok(
+    CoverPacketBuild(
+      packet: packetToSend,
+      firstHopPeerId: firstNode.peerId,
+      firstHopAddr: firstNode.multiAddr,
+      proofToken: proofToken,
+    )
+  )
+
+proc sendCoverPacket*(
+    mixProto: MixProtocol, peerId: PeerId, multiAddr: MultiAddress, packet: seq[byte]
+): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
+  try:
+    await mixProto.writeLp(peerId, @[multiAddr], @[MixProtocolID], packet)
+    mix_messages_forwarded.inc(labelValues = ["Cover"])
+    return ok()
+  except DialFailedError as exc:
+    mix_messages_error.inc(labelValues = ["Cover", "SEND_FAILED"])
+    return err("Failed to dial for cover packet: " & exc.msg)
+  except LPStreamError as exc:
+    mix_messages_error.inc(labelValues = ["Cover", "SEND_FAILED"])
+    return err("Failed to write cover packet: " & exc.msg)
+
+method start*(mixProto: MixProtocol) {.async: (raises: [CancelledError]).} =
+  await procCall LPProtocol(mixProto).start()
+  mixProto.coverTraffic.withValue(ct):
+    await ct.start()
+
+method stop*(mixProto: MixProtocol) {.async: (raises: []).} =
+  ## Stop the MixProtocol background tasks and cancel all in-flight
+  ## handleMixMessages futures.
   mixProto.started = false
 
   await mixProto.tagManager.stop()
+
+  mixProto.coverTraffic.withValue(ct):
+    await ct.stop()
 
   # Snapshot the list and clear it before cancelling.
   let pending = mixProto.ongoingMixMessages
@@ -854,6 +1015,7 @@ proc init*(
     tagManager: TagManager = TagManager.new(),
     spamProtection: Opt[SpamProtection] = default(Opt[SpamProtection]),
     delayStrategy: Opt[DelayStrategy] = Opt.none(DelayStrategy),
+    coverTraffic: Opt[CoverTraffic] = Opt.none(CoverTraffic),
 ) {.raises: [].} =
   ## Initialize a MixProtocol instance.
   ##
@@ -864,21 +1026,47 @@ proc init*(
   ## `SpamProtectionDelayStrategy` to avoid timing correlation between proof
   ## generation and short exponential delays.
 
-  var rng = switch.rng
-  if rng.isNil:
-    rng = newRng()
-  doAssert(not rng.isNil, "MixProtocol could not create random")
+  doAssert not switch.rng.isNil, "Switch must have RNG initialized"
 
   mixProto.mixNodeInfo = mixNodeInfo
   mixProto.switch = switch
-  mixProto.rng = rng
+  mixProto.rng = switch.rng
   mixProto.nodePool = MixNodePool.new(switch.peerStore)
   mixProto.tagManager = tagManager
   mixProto.destReadBehavior = newTable[string, DestReadBehavior]()
 
   mixProto.spamProtection = spamProtection
   mixProto.delayStrategy = delayStrategy.valueOr:
-    NoSamplingDelayStrategy.new(rng)
+    NoSamplingDelayStrategy.new(switch.rng)
+
+  mixProto.coverTraffic = coverTraffic
+  coverTraffic.withValue(ct):
+    ct.setCoverPacketBuilder(
+      proc(): Result[CoverPacketBuild, string] {.gcsafe, raises: [].} =
+        mixProto.buildCoverPacket()
+    )
+    ct.setCoverPacketSender(
+      proc(
+          peerId: PeerId, multiAddr: MultiAddress, packet: seq[byte]
+      ): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
+        await mixProto.sendCoverPacket(peerId, multiAddr, packet)
+    )
+    # Note: useInternalEpochTimer must be set to false when SpamProtection is
+    # present, as SpamProtection provides epoch change notifications via
+    # notifyEpochChange. Having both active would cause double epoch advances.
+    spamProtection.withValue(sp):
+      sp.registerOnEpochChange(
+        proc(epoch: uint64) {.gcsafe, raises: [].} =
+          ct.onEpochChange(epoch)
+      )
+      ct.setProofTokenValidator(
+        proc(token: seq[byte]): bool {.gcsafe, raises: [].} =
+          sp.isProofTokenValid(token)
+      )
+      ct.setProofTokenReclaimer(
+        proc(token: seq[byte]) {.gcsafe, raises: [].} =
+          sp.reclaimProofToken(token)
+      )
 
   let onReplyDialer = proc(
       surb: SURB, message: seq[byte]
@@ -903,6 +1091,7 @@ proc new*(
     tagManager: TagManager = TagManager.new(),
     spamProtection: Opt[SpamProtection] = default(Opt[SpamProtection]),
     delayStrategy: Opt[DelayStrategy] = Opt.none(DelayStrategy),
+    coverTraffic: Opt[CoverTraffic] = Opt.none(CoverTraffic),
 ): T {.raises: [].} =
   ## Create a new MixProtocol instance.
   ##
@@ -913,5 +1102,7 @@ proc new*(
   ## `SpamProtectionDelayStrategy` to avoid timing correlation between proof
   ## generation and short exponential delays.
   let mixProto = new(T)
-  mixProto.init(mixNodeInfo, switch, tagManager, spamProtection, delayStrategy)
+  mixProto.init(
+    mixNodeInfo, switch, tagManager, spamProtection, delayStrategy, coverTraffic
+  )
   mixProto

--- a/libp2p/protocols/mix/spam_protection.nim
+++ b/libp2p/protocols/mix/spam_protection.nim
@@ -8,15 +8,28 @@
 
 import results
 
-type SpamProtection* = ref object of RootObj
-  ## Abstract interface that spam protection mechanisms must implement
-  ## to integrate with the Mix Protocol.
-  ## Uses per-hop proof generation architecture.
-  proofSize*: int
+type
+  EpochChangeCallback* = proc(epoch: uint64) {.gcsafe, raises: [].}
+    ## Callback invoked when the DoS protection mechanism detects an epoch transition.
+    ## See Mix DoS Protection spec §8.2.3.
+
+  ProofResult* = object ## Result of spam protection proof generation.
+    proof*: seq[byte] ## Serialized proof bytes
+    token*: seq[byte]
+      ## Opaque token for proof slot tracking.
+      ## Only meaningful to the concrete implementation.
+      ## Used to reclaim proof slots when precomputed cover packets are discarded.
+
+  SpamProtection* = ref object of RootObj
+    ## Abstract interface that spam protection mechanisms must implement
+    ## to integrate with the Mix Protocol.
+    ## Uses per-hop proof generation architecture.
+    proofSize*: int
+    epochChangeCallbacks: seq[EpochChangeCallback]
 
 method generateProof*(
     self: SpamProtection, bindingData: seq[byte]
-): Result[seq[byte], string] {.base, gcsafe, raises: [].} =
+): Result[ProofResult, string] {.base, gcsafe, raises: [].} =
   ## Generate a spam protection proof bound to specific packet data.
   ##
   ## Parameters:
@@ -25,15 +38,33 @@ method generateProof*(
   ##                outgoing Sphinx packet state.
   ##
   ## Returns:
-  ##   Serialized bytes containing proof and verification metadata
-  ##   (opaque to Mix Protocol layer).
+  ##   ProofResult containing serialized proof bytes and an opaque token
+  ##   for proof slot tracking.
   ##
   ## Requirements:
-  ##   - Must produce output with length == self.proofSize
+  ##   - Must produce proof with length == self.proofSize
   ##   - Mechanism manages its own runtime state independently
   ##
   ## Note: This base implementation should be overridden by concrete types.
   raiseAssert "generateProof must be implemented by concrete spam protection types"
+
+method reclaimProofToken*(
+    self: SpamProtection, token: seq[byte]
+) {.base, gcsafe, raises: [].} =
+  ## Return an opaque proof token for potential reuse.
+  ## Called when a precomputed cover packet is discarded without being sent.
+  ## The concrete implementation may reclaim internal resources (e.g., rate limit slots).
+  ## Default: no-op.
+  discard
+
+method isProofTokenValid*(
+    self: SpamProtection, token: seq[byte]
+): bool {.base, gcsafe, raises: [].} =
+  ## Check if a precomputed proof is still valid (e.g., its Merkle root
+  ## is still in the acceptable window). Called before sending a prebuilt
+  ## cover packet. If false, the packet should be discarded and rebuilt.
+  ## Default: always valid.
+  true
 
 method verifyProof*(
     self: SpamProtection, encodedProofData: seq[byte], bindingData: seq[byte]
@@ -55,6 +86,16 @@ method verifyProof*(
   ##
   ## Note: This base implementation should be overridden by concrete types.
   raiseAssert "verifyProof must be implemented by concrete spam protection types"
+
+method registerOnEpochChange*(
+    self: SpamProtection, cb: EpochChangeCallback
+) {.base, gcsafe, raises: [].} =
+  self.epochChangeCallbacks.add(cb)
+
+proc notifyEpochChange*(self: SpamProtection, epoch: uint64) {.raises: [].} =
+  ## Fire all registered epoch change callbacks.
+  for cb in self.epochChangeCallbacks:
+    cb(epoch)
 
 # Note: To disable spam protection, pass nil as the spamProtection parameter
 # when initializing MixProtocol. No no-op implementation is needed.

--- a/tests/libp2p/mix/component/test_cover_traffic.nim
+++ b/tests/libp2p/mix/component/test_cover_traffic.nim
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import chronos, results
+import
+  ../../../../libp2p/[
+    protocols/mix,
+    protocols/mix/mix_protocol,
+    protocols/mix/cover_traffic,
+    protocols/mix/delay_strategy,
+    protocols/mix/serialization,
+    protocols/mix/mix_node,
+    protocols/mix/spam_protection,
+    peerid,
+    multiaddress,
+    switch,
+    builders,
+  ]
+
+import metrics
+import ../../../../libp2p/protocols/mix/mix_metrics
+import ../../../tools/[lifecycle, unittest, crypto]
+import ../[utils, spam_protection_impl]
+
+suite "Cover Traffic - Integration":
+  asyncTeardown:
+    checkTrackers()
+
+  asyncTest "buildCoverPacket produces valid Sphinx that can be processed by each hop":
+    let nodes = await setupMixNodes(5)
+    startAndDeferStop(nodes)
+
+    let node = nodes[0]
+    let buildRes = node.buildCoverPacket()
+    check buildRes.isOk
+    let built = buildRes.get()
+
+    check built.packet.len == PacketSize
+    check built.firstHopPeerId != node.switch.peerInfo.peerId
+
+    # Verify the packet can be deserialized as a valid Sphinx packet
+    let sphinxPacket = SphinxPacket.deserialize(built.packet)
+    check sphinxPacket.isOk
+
+  asyncTest "cover packet traverses network and is silently discarded at exit":
+    let nodes = await setupMixNodes(
+      5, delayStrategy = Opt.some(DelayStrategy(FixedDelayStrategy(delay: 0)))
+    )
+    startAndDeferStop(nodes)
+
+    let ct = ConstantRateCoverTraffic.new(
+      totalSlots = 10, epochDuration = 100.seconds, useInternalEpochTimer = false
+    )
+
+    ct.setCoverPacketBuilder(
+      proc(): Result[CoverPacketBuild, string] {.gcsafe, raises: [].} =
+        nodes[0].buildCoverPacket()
+    )
+    ct.setCoverPacketSender(
+      proc(
+          peerId: PeerId, multiAddr: MultiAddress, packet: seq[byte]
+      ): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
+        return await nodes[0].sendCoverPacket(peerId, multiAddr, packet)
+    )
+    ct.onEpochChange(1)
+
+    let coverReceivedBefore = mix_cover_received.value()
+
+    await ct.emitCoverPacket()
+    check ct.slotPool.coverClaimed == 1
+
+    # Verify cover packet was received at exit and silently discarded
+    checkUntilTimeout:
+      mix_cover_received.value() > coverReceivedBefore
+
+  asyncTest "slot exhaustion blocks local send, epoch reset unblocks":
+    let nodes = await setupMixNodes(5)
+    startAndDeferStop(nodes)
+
+    let ct = ConstantRateCoverTraffic.new(totalSlots = 2, useInternalEpochTimer = false)
+    ct.onEpochChange(1)
+    nodes[0].coverTraffic = Opt.some(CoverTraffic(ct))
+
+    let (destNode, _) = await setupDestNode(NoReplyProtocol.new())
+    defer:
+      await stopDestNode(destNode)
+
+    let incoming = newAsyncQueue[seq[byte]]()
+
+    # First send succeeds (claims 1 of 2 slots)
+    let res1 = await nodes[0].anonymizeLocalProtocolSend(
+      incoming, @[1.byte], "/test/1.0.0", destNode.toMixDestination(), 0
+    )
+    check res1.isOk
+
+    # Second send succeeds (claims 2 of 2 slots)
+    let res2 = await nodes[0].anonymizeLocalProtocolSend(
+      incoming, @[2.byte], "/test/1.0.0", destNode.toMixDestination(), 0
+    )
+    check res2.isOk
+
+    # Third send fails — slots exhausted
+    let res3 = await nodes[0].anonymizeLocalProtocolSend(
+      incoming, @[3.byte], "/test/1.0.0", destNode.toMixDestination(), 0
+    )
+    check res3.isErr
+    check res3.error == "No slots available in current epoch"
+
+    # Epoch reset unblocks
+    ct.onEpochChange(2)
+    let res4 = await nodes[0].anonymizeLocalProtocolSend(
+      incoming, @[4.byte], "/test/1.0.0", destNode.toMixDestination(), 0
+    )
+    check res4.isOk
+
+  asyncTest "MixProtocol wires SpamProtection epoch changes to cover traffic":
+    let nodeInfos = MixNodeInfo.generateRandomMany(5)
+    let mixNodeInfo = nodeInfos[0]
+    let switch =
+      createSwitch(mixNodeInfo.multiAddr, Opt.some(mixNodeInfo.libp2pPrivKey))
+
+    let sp = newRateLimitSpamProtection(100)
+    let ct = ConstantRateCoverTraffic.new(totalSlots = 5)
+
+    discard MixProtocol.new(
+      mixNodeInfo,
+      switch,
+      spamProtection = Opt.some(SpamProtection(sp)),
+      delayStrategy = Opt.some(DelayStrategy(NoSamplingDelayStrategy.new(rng()))),
+      coverTraffic = Opt.some(CoverTraffic(ct)),
+    )
+
+    # Exhaust slots
+    for _ in 0 ..< 5:
+      discard ct.slotPool.claimSlot()
+    check ct.slotPool.availableSlots == 0
+
+    # SpamProtection epoch change should propagate to cover traffic
+    sp.notifyEpochChange(42)
+    check ct.slotPool.epoch == 42
+    check ct.slotPool.availableSlots == 5
+
+  asyncTest "no cover traffic configured — send works without slot claiming":
+    let nodes = await setupMixNodes(5)
+    startAndDeferStop(nodes)
+
+    check nodes[0].coverTraffic.isNone
+
+    let (destNode, nrProto) = await setupDestNode(NoReplyProtocol.new())
+    defer:
+      await stopDestNode(destNode)
+
+    let incoming = newAsyncQueue[seq[byte]]()
+    let sendRes = await nodes[0].anonymizeLocalProtocolSend(
+      incoming, @[1.byte, 2, 3], "/test/1.0.0", destNode.toMixDestination(), 0
+    )
+    check sendRes.isOk
+
+    let receivedMsg = await nrProto.receivedMessages.get().wait(2.seconds)
+    check receivedMsg.data.len > 0

--- a/tests/libp2p/mix/spam_protection_impl.nim
+++ b/tests/libp2p/mix/spam_protection_impl.nim
@@ -24,7 +24,7 @@ proc newPoWSpamProtection*(difficulty: int = 2): PoWSpamProtection =
 
 method generateProof*(
     self: PoWSpamProtection, bindingData: seq[byte]
-): Result[seq[byte], string] =
+): Result[ProofResult, string] =
   # Simplified PoW: find nonce where last byte of hash has 'difficulty' leading zeros
   let bindingBytes = bindingData
   var nonce: uint64 = 0
@@ -49,16 +49,19 @@ method generateProof*(
     # Check if hash meets difficulty (leading zeros in binary representation)
     if (hash and byte((1 shl self.difficulty) - 1)) == 0:
       return ok(
-        @[
-          byte(nonce shr 56),
-          byte(nonce shr 48),
-          byte(nonce shr 40),
-          byte(nonce shr 32),
-          byte(nonce shr 24),
-          byte(nonce shr 16),
-          byte(nonce shr 8),
-          byte(nonce),
-        ]
+        ProofResult(
+          proof: @[
+            byte(nonce shr 56),
+            byte(nonce shr 48),
+            byte(nonce shr 40),
+            byte(nonce shr 32),
+            byte(nonce shr 24),
+            byte(nonce shr 16),
+            byte(nonce shr 8),
+            byte(nonce),
+          ],
+          token: @[],
+        )
       )
     nonce += 1
 
@@ -105,16 +108,19 @@ proc newRateLimitSpamProtection*(
 
 method generateProof*(
     self: RateLimitSpamProtection, bindingData: seq[byte]
-): Result[seq[byte], string] =
+): Result[ProofResult, string] =
   # Generate timestamp-based proof
   let timestamp = 12345 # Simplified timestamp
   ok(
-    @[
-      byte(timestamp shr 24),
-      byte(timestamp shr 16),
-      byte(timestamp shr 8),
-      byte(timestamp),
-    ]
+    ProofResult(
+      proof: @[
+        byte(timestamp shr 24),
+        byte(timestamp shr 16),
+        byte(timestamp shr 8),
+        byte(timestamp),
+      ],
+      token: @[],
+    )
   )
 
 method verifyProof*(

--- a/tests/libp2p/mix/test_cover_traffic.nim
+++ b/tests/libp2p/mix/test_cover_traffic.nim
@@ -1,0 +1,269 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import chronos
+import results
+import ../../../libp2p/protocols/mix/[cover_traffic, serialization, spam_protection]
+import ../../../libp2p/[multiaddress, peerid]
+import ../../../libp2p/crypto/[crypto, secp]
+import ../../tools/[unittest, crypto]
+
+proc makePeerInfo(): (PeerId, MultiAddress) =
+  let kp = SkKeyPair.random(rng()[])
+  let pubKeyProto = PublicKey(scheme: Secp256k1, skkey: kp.pubkey)
+  let pid = PeerId.init(pubKeyProto).expect("PeerId init")
+  let ma = MultiAddress.init("/ip4/127.0.0.1/tcp/5000").tryGet()
+  (pid, ma)
+
+proc mockBuildCoverPacket(): BuildCoverPacketProc =
+  let (pid, ma) = makePeerInfo()
+  return proc(): Result[CoverPacketBuild, string] {.gcsafe, raises: [].} =
+    ok(
+      CoverPacketBuild(
+        packet: newSeq[byte](PacketSize),
+        firstHopPeerId: pid,
+        firstHopAddr: ma,
+        proofToken: @[0x42.byte],
+      )
+    )
+
+proc mockBuildCoverPacketFailing(): BuildCoverPacketProc =
+  return proc(): Result[CoverPacketBuild, string] {.gcsafe, raises: [].} =
+    err("mock build failure")
+
+proc mockSendCoverPacket(sentPackets: ref seq[seq[byte]]): SendCoverPacketProc =
+  return proc(
+      peerId: PeerId, multiAddr: MultiAddress, packet: seq[byte]
+  ): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
+    sentPackets[].add(packet)
+    return ok()
+
+proc mockSendCoverPacketFailing(): SendCoverPacketProc =
+  return proc(
+      peerId: PeerId, multiAddr: MultiAddress, packet: seq[byte]
+  ): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
+    return err("mock send failure")
+
+suite "SlotPool":
+  test "exhaustion returns false for both claim types":
+    let pool = SlotPool.new(2)
+    check pool.claimSlot().success == true
+    check pool.claimSlotForCover() == true
+    check pool.claimSlot().success == false
+    check pool.claimSlotForCover() == false
+
+  test "beginEpoch refills pool and clears stale packets":
+    let pool = SlotPool.new(10)
+    let (pid, ma) = makePeerInfo()
+    discard pool.claimSlot()
+    discard pool.claimSlotForCover()
+    pool.addPacket(
+      CoverPacket(packet: @[1.byte], firstHopPeerId: pid, firstHopAddr: ma)
+    )
+    pool.beginEpoch(42)
+    check:
+      pool.epoch == 42
+      pool.availableSlots == 10
+      pool.coverClaimed == 0
+      pool.nonCoverClaimed == 0
+      pool.queuedCount == 0 # Stale packets cleared on epoch change
+
+  test "claimSlot discards a pre-built packet and returns its proof token":
+    let pool = SlotPool.new(10)
+    let (pid, ma) = makePeerInfo()
+    pool.addPacket(
+      CoverPacket(
+        packet: @[0xAA.byte],
+        firstHopPeerId: pid,
+        firstHopAddr: ma,
+        proofToken: @[0x01.byte],
+      )
+    )
+    pool.addPacket(
+      CoverPacket(
+        packet: @[0xBB.byte],
+        firstHopPeerId: pid,
+        firstHopAddr: ma,
+        proofToken: @[0x02.byte],
+      )
+    )
+    let claim = pool.claimSlot()
+    check claim.success == true
+    check claim.reclaimedToken == @[0x01.byte]
+    check pool.queuedCount == 1
+    check pool.dequeue().get().packet == @[0xBB.byte]
+
+  test "mixed traffic draws from same pool":
+    let pool = SlotPool.new(3)
+    check pool.claimSlot().success == true
+    check pool.claimSlotForCover() == true
+    check pool.claimSlot().success == true
+    check pool.claimSlot().success == false
+    check pool.claimSlotForCover() == false
+    check:
+      pool.nonCoverClaimed == 2
+      pool.coverClaimed == 1
+
+suite "ConstantRateCoverTraffic":
+  test "emission sends packet and claims slot":
+    let sentPackets = new seq[seq[byte]]
+    sentPackets[] = @[]
+
+    let ct = ConstantRateCoverTraffic.new(totalSlots = 10, epochDuration = 1.seconds)
+    ct.setCoverPacketBuilder(mockBuildCoverPacket())
+    ct.setCoverPacketSender(mockSendCoverPacket(sentPackets))
+    ct.onEpochChange(1)
+
+    waitFor ct.emitCoverPacket()
+    check sentPackets[].len == 1
+    check ct.slotPool.coverClaimed == 1
+
+  test "emission stops when exhausted, resumes after epoch change":
+    let sentPackets = new seq[seq[byte]]
+    sentPackets[] = @[]
+
+    let ct = ConstantRateCoverTraffic.new(totalSlots = 1, epochDuration = 1.seconds)
+    ct.setCoverPacketBuilder(mockBuildCoverPacket())
+    ct.setCoverPacketSender(mockSendCoverPacket(sentPackets))
+    ct.onEpochChange(1)
+
+    waitFor ct.emitCoverPacket()
+    check sentPackets[].len == 1
+
+    waitFor ct.emitCoverPacket()
+    check sentPackets[].len == 1
+
+    ct.onEpochChange(2)
+    waitFor ct.emitCoverPacket()
+    check sentPackets[].len == 2
+
+  test "build failure does not crash emission and returns slot":
+    let ct = ConstantRateCoverTraffic.new(totalSlots = 10, epochDuration = 1.seconds)
+    ct.setCoverPacketBuilder(mockBuildCoverPacketFailing())
+    ct.setCoverPacketSender(mockSendCoverPacket(new seq[seq[byte]]))
+    ct.onEpochChange(1)
+
+    waitFor ct.emitCoverPacket()
+    check ct.slotPool.coverClaimed == 0 # Slot returned on build failure
+
+  test "send failure does not crash emission":
+    let ct = ConstantRateCoverTraffic.new(totalSlots = 10, epochDuration = 1.seconds)
+    ct.setCoverPacketBuilder(mockBuildCoverPacket())
+    ct.setCoverPacketSender(mockSendCoverPacketFailing())
+    ct.onEpochChange(1)
+
+    waitFor ct.emitCoverPacket()
+    check ct.slotPool.coverClaimed == 1
+
+  asyncTest "start and stop":
+    let ct = ConstantRateCoverTraffic.new(
+      totalSlots = 10, epochDuration = 100.seconds, useInternalEpochTimer = false
+    )
+    ct.setCoverPacketBuilder(mockBuildCoverPacket())
+    ct.setCoverPacketSender(mockSendCoverPacket(new seq[seq[byte]]))
+    ct.onEpochChange(1)
+
+    await ct.start()
+    check ct.isRunning == true
+
+    await ct.stop()
+    check ct.isRunning == false
+
+suite "CoverTraffic Pre-computation":
+  test "pre-built packets used before on-demand, falls back when empty":
+    let sentPackets = new seq[seq[byte]]
+    sentPackets[] = @[]
+
+    let ct = ConstantRateCoverTraffic.new(
+      totalSlots = 10, epochDuration = 1.seconds, enablePrecomputation = true
+    )
+    ct.setCoverPacketBuilder(mockBuildCoverPacket())
+    ct.setCoverPacketSender(mockSendCoverPacket(sentPackets))
+    ct.onEpochChange(1)
+
+    let (pid, ma) = makePeerInfo()
+    let prebuiltPacket = @[0xAA.byte]
+    ct.slotPool.addPacket(
+      CoverPacket(packet: prebuiltPacket, firstHopPeerId: pid, firstHopAddr: ma)
+    )
+
+    # First: uses pre-built
+    waitFor ct.emitCoverPacket()
+    check sentPackets[][0] == prebuiltPacket
+
+    # Second: queue empty, falls back to on-demand
+    waitFor ct.emitCoverPacket()
+    check sentPackets[][1].len == PacketSize
+
+  test "epoch change clears stale cover packets":
+    let ct = ConstantRateCoverTraffic.new(
+      totalSlots = 10, epochDuration = 1.seconds, enablePrecomputation = true
+    )
+    let (pid, ma) = makePeerInfo()
+    ct.slotPool.addPacket(
+      CoverPacket(packet: @[0xAA.byte], firstHopPeerId: pid, firstHopAddr: ma)
+    )
+    ct.onEpochChange(2)
+    check ct.slotPool.queuedCount == 0 # Stale packets cleared
+
+  test "stale prebuilt proof consumes only one slot":
+    ## Verify that when a prebuilt proof is stale, only ONE slot is consumed
+    ## (the initial claimSlotForCover), not two.
+    let sentPackets = new seq[seq[byte]]
+    sentPackets[] = @[]
+
+    let ct = ConstantRateCoverTraffic.new(
+      totalSlots = 2, epochDuration = 1.seconds, enablePrecomputation = true
+    )
+    ct.setCoverPacketBuilder(mockBuildCoverPacket())
+    ct.setCoverPacketSender(mockSendCoverPacket(sentPackets))
+    ct.setProofTokenValidator(
+      proc(token: seq[byte]): bool {.gcsafe, raises: [].} =
+        false # All proofs are stale
+    )
+    ct.onEpochChange(1)
+
+    let (pid, ma) = makePeerInfo()
+    ct.slotPool.addPacket(
+      CoverPacket(
+        packet: @[0xAA.byte],
+        firstHopPeerId: pid,
+        firstHopAddr: ma,
+        proofToken: @[0x01.byte],
+      )
+    )
+
+    waitFor ct.emitCoverPacket()
+    # Stale proof: should rebuild on-demand but consume only 1 slot
+    check ct.slotPool.coverClaimed == 1
+    check sentPackets[].len == 1
+    # The sent packet should be on-demand (PacketSize), not the prebuilt one
+    check sentPackets[][0].len == PacketSize
+
+    # Second emission should still succeed (1 of 2 slots used)
+    waitFor ct.emitCoverPacket()
+    check ct.slotPool.coverClaimed == 2
+    check sentPackets[].len == 2
+
+suite "CoverTraffic DoS Protection Independence":
+  test "SpamProtection epoch change propagates to cover traffic":
+    let sp = SpamProtection(proofSize: 0)
+    let ct = ConstantRateCoverTraffic.new(totalSlots = 5)
+    ct.setCoverPacketBuilder(mockBuildCoverPacket())
+    ct.setCoverPacketSender(mockSendCoverPacket(new seq[seq[byte]]))
+
+    sp.registerOnEpochChange(
+      proc(epoch: uint64) {.gcsafe, raises: [].} =
+        ct.onEpochChange(epoch)
+    )
+
+    for _ in 0 ..< 5:
+      discard ct.slotPool.claimSlot()
+    check ct.slotPool.availableSlots == 0
+
+    sp.notifyEpochChange(10)
+    check:
+      ct.slotPool.epoch == 10
+      ct.slotPool.availableSlots == 5

--- a/tests/libp2p/mix/test_spam_protection_interface.nim
+++ b/tests/libp2p/mix/test_spam_protection_interface.nim
@@ -16,11 +16,11 @@ suite "Spam Protection - Per Hop Proof Generation":
 
     # Simulate node generating proof for packet
     let packetData = testPacketData
-    let proof = spamProtection.generateProof(packetData).get()
-    check proof.len == 8
+    let proofResult = spamProtection.generateProof(packetData).get()
+    check proofResult.proof.len == 8
 
     # Simulate next node verifying proof with same packet
-    let verifyResult = spamProtection.verifyProof(proof, packetData)
+    let verifyResult = spamProtection.verifyProof(proofResult.proof, packetData)
 
     check verifyResult.isOk()
     check verifyResult.get() == true
@@ -30,11 +30,11 @@ suite "Spam Protection - Per Hop Proof Generation":
     let spamProtection = newPoWSpamProtection(2)
 
     let originalPacket = testPacketData
-    let proof = spamProtection.generateProof(originalPacket).get()
+    let proofResult = spamProtection.generateProof(originalPacket).get()
 
     # Try to verify with different packet
     let differentPacket = @[1.byte, 2, 3, 4, 6]
-    let verifyResult = spamProtection.verifyProof(proof, differentPacket)
+    let verifyResult = spamProtection.verifyProof(proofResult.proof, differentPacket)
 
     check verifyResult.isOk()
     check verifyResult.get() == false
@@ -57,16 +57,16 @@ suite "Spam Protection - Per Hop Proof Generation":
     let packet1 = testPacketData
     let packet2 = @[4.byte, 5, 6]
 
-    let proof1 = spamProtection.generateProof(packet1).get()
-    let proof2 = spamProtection.generateProof(packet2).get()
+    let pr1 = spamProtection.generateProof(packet1).get()
+    let pr2 = spamProtection.generateProof(packet2).get()
 
     # Each proof should verify with its corresponding packet
-    check spamProtection.verifyProof(proof1, packet1).get() == true
-    check spamProtection.verifyProof(proof2, packet2).get() == true
+    check spamProtection.verifyProof(pr1.proof, packet1).get() == true
+    check spamProtection.verifyProof(pr2.proof, packet2).get() == true
 
     # But not with the other packet
-    check spamProtection.verifyProof(proof1, packet2).get() == false
-    check spamProtection.verifyProof(proof2, packet1).get() == false
+    check spamProtection.verifyProof(pr1.proof, packet2).get() == false
+    check spamProtection.verifyProof(pr2.proof, packet1).get() == false
 
   test "Rate limiting blocks packets exceeding limit":
     let spamProtection = newRateLimitSpamProtection(3)
@@ -75,13 +75,13 @@ suite "Spam Protection - Per Hop Proof Generation":
 
     # First 3 packets should be accepted
     for i in 0 ..< 3:
-      let proof = spamProtection.generateProof(packetData).get()
-      let valid = spamProtection.verifyProof(proof, packetData).get()
+      let pr = spamProtection.generateProof(packetData).get()
+      let valid = spamProtection.verifyProof(pr.proof, packetData).get()
       check valid == true
 
     # 4th packet should be rejected
-    let proof4 = spamProtection.generateProof(packetData).get()
-    let valid4 = spamProtection.verifyProof(proof4, packetData).get()
+    let pr4 = spamProtection.generateProof(packetData).get()
+    let valid4 = spamProtection.verifyProof(pr4.proof, packetData).get()
     check valid4 == false
 
   test "Per-hop proofs are independently generated":
@@ -91,12 +91,12 @@ suite "Spam Protection - Per Hop Proof Generation":
     let packet2 = @[4.byte, 5, 6]
 
     # Generate fresh proofs for each packet
-    let proof1 = spamProtection.generateProof(packet1).get()
-    let proof2 = spamProtection.generateProof(packet2).get()
+    let pr1 = spamProtection.generateProof(packet1).get()
+    let pr2 = spamProtection.generateProof(packet2).get()
 
     # Both should verify successfully (rate limit not exceeded)
-    check spamProtection.verifyProof(proof1, packet1).get() == true
-    check spamProtection.verifyProof(proof2, packet2).get() == true
+    check spamProtection.verifyProof(pr1.proof, packet1).get() == true
+    check spamProtection.verifyProof(pr2.proof, packet2).get() == true
 
 suite "Spam Protection - Packet Integration":
   test "Proof can be appended and extracted from packet":


### PR DESCRIPTION
 ## Summary                                                                                                                                                             
                                                                                                                                                                         
  Implements the cover traffic mechanism for the Mix Protocol as a pluggable component, following the same pattern as `DelayStrategy`. 
Cover traffic ensures sender unobservability by emitting dummy Sphinx packets at a constant rate, making it impossible for an observer to distinguish cover traffic from locally originated messages.                                                                                                                                                              
                                                            
  This PR:
  - Adds the `CoverTraffic` abstract base type and `ConstantRateCoverTraffic` strategy (spec §7.1 RECOMMENDED)
  - Introduces `SlotPool` to manage the per-epoch R-slot budget shared across cover, local origination, and forwarding traffic
  - Integrates cover traffic into `MixProtocol` at four spec-defined touch points: cover packet transmission, non-cover slot claiming, epoch boundary handling, and cover packet reception at exit                                                                                                                                              
  - Adds `OnEpochChange` callback support to `SpamProtection` for epoch boundary notifications (spec: mix-dos-protection §8.2.3)                                         
  - Supports configurable batch pre-computation of cover packets staged for the next epoch                                                                               
                                                                                                                                                                          
  The spec this implements: [vacp2p/rfc-index#311](https://github.com/vacp2p/rfc-index/pull/311)                                                                         
                                                                                                                                                                                                                                                                                                   
  ## Affected Areas                                         
  - [x] Protocol Logic                                                                                                                                                   
    - Mix protocol: new `cover_traffic.nim` module, integration into `mix_protocol.nim` (exit handler codec check, slot claiming in send/forward paths, init/stop
  wiring), epoch change support in `spam_protection.nim`                                                                                                                 
                                                                                                                                                                                                                                                                                                              
  ## Compatibility & Downstream Validation                  

  Cover traffic is opt-in. When not configured existing behavior is fully preserved.
                                                                                                                                                                         
  The `SpamProtection` interface gains new methods (`registerOnEpochChange`, `epochDurationSeconds`, `rateLimitBudget`) with base implementations that are no-ops/return 
  defaults, so existing concrete implementations (e.g. RLN plugin) continue to compile without changes.
                                                                                                                                                                         
  - **Waku (logos-delivery):** follow-up [PR](https://github.com/logos-messaging/logos-delivery/pull/3807) to wire `CoverTraffic` into `WakuMix.init` and [update the RLN plugin](https://github.com/logos-co/mix-rln-spam-protection-plugin/pull/5) to call `notifyEpochChange`
  
  ## Impact on Library Users                                

  - **New optional parameter**: `MixProtocol.new` and `MixProtocol.init` accept `coverTraffic: Opt[CoverTraffic]` (default `Opt.none`) — no migration required           
  - **New public types**: `CoverTraffic`, `ConstantRateCoverTraffic`, `SlotPool`, `PrebuiltCoverPacket`, `BuildCoverPacketProc`, `SendCoverPacketProc` — all in
  `libp2p/protocols/mix/cover_traffic`                                                                                                                                   
  - **SpamProtection interface extended**: Three new base methods added with default implementations — existing subclasses are unaffected
  - **No breaking changes**                                                                                                                                
                                                            
  ## Risk Assessment                                        

  - **Network behavior**: When enabled, cover traffic consumes slots from the shared R-budget. Forwarded packets are dropped and locally originated messages fail when slots are exhausted (TODO: queue for next epoch)                                                                                                                       
  - **Performance**: Cover packet construction involves Sphinx wrapping and optional proof generation per emission. Pre-computation (configurable) amortizes this cost  
                                                                                                                                                                                                                                                                                          
  ## Additional Notes                                                                                                                                                                                                                                                                                                                                         
  - The RLN spam protection plugin [mix-rln-spam-protection-plugin](https://github.com/logos-co/mix-rln-spam-protection-plugin) needs a separate [PR](https://github.com/logos-co/mix-rln-spam-protection-plugin/pull/5) to override `epochDurationSeconds`/`rateLimitBudget` and call
  `notifyEpochChange` on epoch transitions.                                                                                                                              
  - Cover traffic works independently of DoS protection with sensible defaults (R=100, P=60s) and an internal epoch timer fallback.