### PR TITLE
chore(crypto): add pick utilities

### DIFF
--- a/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_kademlia_requests.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_kademlia_requests.nim
@@ -7,7 +7,7 @@ import ../../../[alloc, ffi_types]
 import ../../../../libp2p
 import ../../../../libp2p/extended_peer_record
 import ../../../../libp2p/protocols/kademlia
-import ../../../../libp2p/protocols/kademlia_discovery/[randomfind, types]
+import ../../../../libp2p/protocols/kademlia_discovery/[random_find, types]
 import ./libp2p_peer_manager_requests
 
 type KademliaMsgType* = enum

--- a/libp2p/crypto/crypto.nim
+++ b/libp2p/crypto/crypto.nim
@@ -180,6 +180,45 @@ proc shuffle*[T](rng: ref HmacDrbgContext, x: var openArray[T]) =
       y = rand mod i
     swap(x[i], x[y])
 
+proc randBelow(rng: ref HmacDrbgContext, max: uint32): int =
+  ## Returns a uniformly random integer in the range [0, max).
+  ## Uses 32-bit rejection sampling to eliminate modulo bias and to
+  ## support max values larger than 65536.
+  # threshold = 2^32 mod max. In uint32 arithmetic: (0 - umax) mod umax.
+  # Values in [0, threshold) are rejected to eliminate modulo bias.
+  let threshold = (0'u32 - max) mod max
+  while true:
+    var bytes: array[4, byte]
+    hmacDrbgGenerate(rng[], bytes)
+    let r =
+      bytes[0].uint32 or (bytes[1].uint32 shl 8) or (bytes[2].uint32 shl 16) or
+      (bytes[3].uint32 shl 24)
+    if r >= threshold:
+      return (r mod max).int
+
+proc pick*[T](rng: ref HmacDrbgContext, x: openArray[T], n: int): Opt[seq[T]] =
+  doAssert n >= 0, "n must be non-negative"
+  if x.len == 0:
+    return Opt.none(seq[T])
+  if n == 0:
+    return Opt.some(newSeq[T]())
+  var indices = newSeq[int](x.len)
+  for i in 0 ..< x.len:
+    indices[i] = i
+  let count = min(n, x.len)
+  var output = newSeq[T](count)
+  for i in 0 ..< count:
+    let j = i + rng.randBelow((x.len - i).uint32)
+    swap(indices[i], indices[j])
+    output[i] = x[indices[i]]
+  Opt.some(output)
+
+proc pickOne*[T](rng: ref HmacDrbgContext, x: openArray[T]): Opt[T] =
+  if x.len == 0:
+    return Opt.none(T)
+
+  Opt.some(x[rng.randBelow(x.len.uint32)])
+
 proc random*(
     T: typedesc[PrivateKey],
     scheme: PKScheme,

--- a/libp2p/crypto/crypto.nim
+++ b/libp2p/crypto/crypto.nim
@@ -202,9 +202,11 @@ proc pick*[T](rng: ref HmacDrbgContext, x: openArray[T], n: int): Opt[seq[T]] =
     return Opt.none(seq[T])
   if n == 0:
     return Opt.some(newSeq[T]())
+
   var indices = newSeq[int](x.len)
   for i in 0 ..< x.len:
     indices[i] = i
+
   let count = min(n, x.len)
   var output = newSeq[T](count)
   for i in 0 ..< count:

--- a/libp2p/protocols/kad_disco.nim
+++ b/libp2p/protocols/kad_disco.nim
@@ -5,9 +5,9 @@ import chronos, chronicles, results, sets, sequtils, std/times
 import ../utils/heartbeat
 import ../[peerid, switch, multihash, peerinfo, extended_peer_record]
 import ./kademlia
-import ./kademlia_discovery/[randomfind, types]
+import ./kademlia_discovery/[random_find, types]
 
-export randomfind, types
+export random_find, types
 
 logScope:
   topics = "kad-disco"

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -5,10 +5,10 @@ import chronos, chronicles, results
 import ../utils/heartbeat
 import ../[peerid, switch, multihash]
 import ./protocol
-import ./kademlia/[routingtable, protobuf, types, find, get, put, provider, ping]
+import ./kademlia/[routing_table, protobuf, types, find, get, put, provider, ping]
 import ./kademlia/kademlia_metrics
 
-export routingtable, protobuf, types, find, get, put, provider, ping, kademlia_metrics
+export routing_table, protobuf, types, find, get, put, provider, ping, kademlia_metrics
 
 logScope:
   topics = "kad-dht"
@@ -34,7 +34,7 @@ proc bootstrap*(
     if not (forceRefresh or bucket.isStale()):
       continue
 
-    let randomKey = randomKeyInBucket(kad.rtable.selfId, i, kad.rng[])
+    let randomKey = randomKeyInBucket(kad.rtable.selfId, i, kad.rng)
     discard await kad.findNode(randomKey)
 
   trace "Bootstrap complete"

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -5,7 +5,7 @@ import std/[tables, sequtils, sets, algorithm]
 import chronos, chronicles, results
 import ../../[peerid, peerinfo, switch, multihash]
 import ../protocol
-import ./[routingtable, protobuf, types, kademlia_metrics]
+import ./[routing_table, protobuf, types, kademlia_metrics]
 
 logScope:
   topics = "kad-dht find"

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -6,6 +6,7 @@ import bearssl/rand, chronos, chronicles, results
 import ./types
 import ./kademlia_metrics
 import ../../peerid
+import ../../crypto/crypto
 import ../../utils/sequninit
 
 logScope:
@@ -34,7 +35,7 @@ proc new*(
 proc bucketIndex*(selfId, key: Key, hasher: Opt[XorDHasher]): int =
   return xorDistance(selfId, key, hasher).leadingZeros
 
-proc peerIndexInBucket(bucket: var Bucket, nodeId: Key): Opt[int] =
+proc peerIndexInBucket(bucket: Bucket, nodeId: Key): Opt[int] =
   for i, p in bucket.peers:
     if p.nodeId == nodeId:
       return Opt.some(i)
@@ -74,7 +75,7 @@ proc updateRoutingTableMetrics*(rtable: RoutingTable) =
   kad_routing_table_peers.set(total.float64)
   kad_routing_table_buckets.set(rtable.buckets.len.float64)
 
-proc insert*(rtable: var RoutingTable, nodeId: Key): bool =
+proc insert*(rtable: RoutingTable, nodeId: Key): bool =
   if nodeId == rtable.selfId:
     debug "Cannot insert self in routing table", nodeId = nodeId
     return false # No self insertion
@@ -108,7 +109,7 @@ proc insert*(rtable: var RoutingTable, nodeId: Key): bool =
   updateRoutingTableMetrics(rtable)
   return true
 
-proc insert*(rtable: var RoutingTable, peerId: PeerId): bool =
+proc insert*(rtable: RoutingTable, peerId: PeerId): bool =
   insert(rtable, peerId.toKey())
 
 proc findClosest*(rtable: RoutingTable, targetId: Key, count: int): seq[Key] =
@@ -142,7 +143,7 @@ proc isStale*(bucket: Bucket): bool =
       return true
   return false
 
-proc randomKeyInBucket*(selfId: Key, bucketIndex: int, rng: var HmacDrbgContext): Key =
+proc randomKeyInBucket*(selfId: Key, bucketIndex: int, rng: ref HmacDrbgContext): Key =
   var raw = selfId
 
   # zero out higher bits
@@ -156,22 +157,21 @@ proc randomKeyInBucket*(selfId: Key, bucketIndex: int, rng: var HmacDrbgContext)
   let tgtBitInByte = 7 - (bucketIndex mod 8)
   raw[tgtByte] = raw[tgtByte] xor (1'u8 shl tgtBitInByte)
 
-  # randomize all less significant bits
-  let totalBits = raw.len * 8
-  let lsbStart = bucketIndex + 1
-  let lsbBytes = (totalBits - lsbStart + 7) div 8
-  var randomBuf = newSeqUninit[byte](lsbBytes)
-  rng.hmacDrbgGenerate(randomBuf)
+  # randomize lower bits of the boundary byte
+  let lsbMask = (1'u8 shl tgtBitInByte) - 1
+  if lsbMask != 0:
+    var rb: array[1, byte]
+    hmacDrbgGenerate(rng[], rb)
+    raw[tgtByte] = (raw[tgtByte] and not lsbMask) or (rb[0] and lsbMask)
 
-  for i in lsbStart ..< totalBits:
-    let byteIdx = i div 8
-    let bitInByte = 7 - (i mod 8)
-    let lsbByte = (i - lsbStart) div 8
-    let lsbBit = 7 - ((i - lsbStart) mod 8)
-    let randBit = (randomBuf[lsbByte] shr lsbBit) and 1
-    if randBit == 1:
-      raw[byteIdx] = raw[byteIdx] or (1'u8 shl bitInByte)
-    else:
-      raw[byteIdx] = raw[byteIdx] and not (1'u8 shl bitInByte)
+  # randomize remaining bytes
+  if tgtByte + 1 < raw.len:
+    hmacDrbgGenerate(rng[], raw.toOpenArray(tgtByte + 1, raw.len - 1))
 
   return raw
+
+proc randomPeer*(bucket: Bucket, rng: ref HmacDrbgContext): Opt[Key] =
+  rng.pickOne(bucket.peers).map(
+    proc(e: NodeEntry): Key =
+      e.nodeId
+  )

--- a/libp2p/protocols/kademlia_discovery/random_find.nim
+++ b/libp2p/protocols/kademlia_discovery/random_find.nim
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright (c) Status Research & Development GmbH 
+# Copyright (c) Status Research & Development GmbH
 
 import std/[sequtils, sets]
 import chronos, chronicles, results
 import ../../[peerid, peerinfo, switch, multihash, routing_record, extended_peer_record]
 import ../protocol
-import ../kademlia/[types, find, get, protobuf, routingtable]
+import ../kademlia/[types, find, get, protobuf, routing_table]
 import ./[types]
 
 logScope:

--- a/tests/libp2p/crypto/test_crypto.nim
+++ b/tests/libp2p/crypto/test_crypto.nim
@@ -3,6 +3,7 @@
 {.used.}
 
 from std/strutils import toUpper
+import std/[sequtils, algorithm]
 import bearssl/hash, nimcrypto/utils
 import ../../../libp2p/crypto/[crypto, chacha20poly1305, curve25519, hkdf]
 import ../../tools/[unittest, crypto]
@@ -631,3 +632,60 @@ suite "Key interface test suite":
     hmacDrbgInit(rng[], addr sha256Vtable, nil, 0)
     rng.shuffle(cards)
     check cards == ["King", "Ten", "Ace", "Queen", "Jack"]
+
+  test "pickOne returns none for empty sequence":
+    let x: seq[int] = @[]
+    check rng.pickOne(x).isNone()
+
+  test "pickOne returns the only element of a singleton":
+    check rng.pickOne(@[42]).get() == 42
+
+  test "pickOne returns an element from the sequence":
+    let xs = @[11, 22, 33, 44, 55]
+    let picked = rng.pickOne(xs).get()
+    check picked in xs
+
+  test "pick returns none for empty sequence":
+    check rng.pick(newSeq[int](), 3).isNone()
+
+  test "pick returns empty when n is zero":
+    check rng.pick(@[1, 2, 3], 0).get().len == 0
+
+  test "pick returns n distinct elements from the sequence":
+    let xs = @[11, 22, 33, 44, 55]
+    let picked = rng.pick(xs, 3).get()
+    check picked.len == 3
+    for x in picked:
+      check x in xs
+    check picked == picked.deduplicate()
+
+  test "pick returns all elements when n >= len":
+    let xs = @[11, 22, 33]
+    let picked = rng.pick(xs, 10).get()
+    check picked.len == xs.len
+    check picked.sorted() == xs.sorted()
+
+  test "pick returns some for non-empty sequence with n > 0":
+    check rng.pick(@[11, 22, 33], 2).isSome()
+
+  test "pick result contains no duplicates":
+    let xs = @[11, 22, 33, 44, 55, 66, 77, 88]
+    let picked = rng.pick(xs, 5).get()
+    check picked == picked.deduplicate()
+
+  test "pick result is a subset of the input":
+    let xs = @[11, 22, 33, 44, 55]
+    let picked = rng.pick(xs, 4).get()
+    for x in picked:
+      check x in xs
+
+  test "pick n=1 returns a single element":
+    let xs = @[11, 22, 33]
+    let picked = rng.pick(xs, 1).get()
+    check picked.len == 1
+    check picked[0] in xs
+
+  test "pickOne result is always in the sequence":
+    let xs = @[100, 200, 300, 400, 500]
+    for _ in 0 ..< 20:
+      check rng.pickOne(xs).get() in xs

--- a/tests/libp2p/kademlia/mock_kademlia.nim
+++ b/tests/libp2p/kademlia/mock_kademlia.nim
@@ -4,7 +4,7 @@
 import chronos, chronicles
 import
   ../../../libp2p/protocols/kademlia/
-    [types, routingtable, protobuf, get, provider, find]
+    [types, routing_table, protobuf, get, provider, find]
 import ../../../libp2p/[peerid, stream/connection]
 
 type MockKadDHT* = ref object of KadDHT

--- a/tests/libp2p/kademlia/test_routingtable.nim
+++ b/tests/libp2p/kademlia/test_routingtable.nim
@@ -38,7 +38,7 @@ suite "KadDHT Routing Table":
     let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     var rt = RoutingTable.new(selfId, config)
     for _ in 0 ..< config.replication + 5:
-      let kid = randomKeyInBucket(selfId, TargetBucket, rng[])
+      let kid = randomKeyInBucket(selfId, TargetBucket, rng)
       discard rt.insert(kid)
 
     check TargetBucket < rt.buckets.len
@@ -50,7 +50,7 @@ suite "KadDHT Routing Table":
     let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     var rt = RoutingTable.new(selfId, config)
     for _ in 0 ..< config.replication + 10:
-      let kid = randomKeyInBucket(selfId, TargetBucket, rng[])
+      let kid = randomKeyInBucket(selfId, TargetBucket, rng)
       discard rt.insert(kid)
 
     check rt.buckets[TargetBucket].peers.len == config.replication
@@ -58,7 +58,7 @@ suite "KadDHT Routing Table":
     # new entry should evict oldest entry
     let (oldest, _) = rt.buckets[TargetBucket].oldestPeer()
 
-    check rt.insert(randomKeyInBucket(selfId, TargetBucket, rng[]))
+    check rt.insert(randomKeyInBucket(selfId, TargetBucket, rng))
 
     let (oldestAfterInsert, _) = rt.buckets[TargetBucket].oldestPeer()
 
@@ -70,9 +70,9 @@ suite "KadDHT Routing Table":
     let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     var rt = RoutingTable.new(selfId, config)
 
-    let key1 = randomKeyInBucket(selfId, TargetBucket, rng[])
-    let key2 = randomKeyInBucket(selfId, TargetBucket, rng[])
-    let key3 = randomKeyInBucket(selfId, TargetBucket, rng[])
+    let key1 = randomKeyInBucket(selfId, TargetBucket, rng)
+    let key2 = randomKeyInBucket(selfId, TargetBucket, rng)
+    let key3 = randomKeyInBucket(selfId, TargetBucket, rng)
 
     discard rt.insert(key1)
     discard rt.insert(key2)
@@ -132,8 +132,39 @@ suite "KadDHT Routing Table":
 
   test "randomKeyInBucket returns id at correct distance":
     let selfId = testKey(0)
-    var rid = randomKeyInBucket(selfId, TargetBucket, rng[])
+    var rid = randomKeyInBucket(selfId, TargetBucket, rng)
     let idx = bucketIndex(selfId, rid, Opt.some(noOpHasher))
     check:
       idx == TargetBucket
       rid != selfId
+
+  test "randomPeer returns none for empty bucket":
+    var bucket: Bucket
+    check randomPeer(bucket, rng).isNone()
+
+  test "randomPeer returns the only peer in a single-peer bucket":
+    let selfId = testKey(0)
+    let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
+    var rt = RoutingTable.new(selfId, config)
+    let key = randomKeyInBucket(selfId, TargetBucket, rng)
+    discard rt.insert(key)
+
+    let picked = randomPeer(rt.buckets[TargetBucket], rng)
+    check:
+      picked.isSome()
+      picked.get() == key
+
+  test "randomPeer returns a peer from the bucket":
+    let selfId = testKey(0)
+    let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
+    var rt = RoutingTable.new(selfId, config)
+    var keys: seq[Key]
+    for _ in 0 ..< config.replication:
+      let k = randomKeyInBucket(selfId, TargetBucket, rng)
+      keys.add(k)
+      discard rt.insert(k)
+
+    let picked = randomPeer(rt.buckets[TargetBucket], rng)
+    check:
+      picked.isSome()
+      keys.contains(picked.get())


### PR DESCRIPTION
## Summary

Adds `pick` and `pickOne` generic utilities to `libp2p/crypto/crypto.nim`, backed by `HmacDrbgContext` (CSPRNG) with rejection sampling to eliminate modulo bias. These are used to introduce `randomPeer` on the Kademlia routing table, enabling unbiased random peer selection from a bucket.

Also refactors `randomKeyInBucket` to take `ref HmacDrbgContext` instead of `var`, simplifies its bit-randomization logic (boundary byte + bulk slice instead of per-bit iteration), renames `routingtable.nim` → `routing_table.nim` and `randomfind.nim` → `random_find.nim` for snake_case consistency, and removes spurious `var` from `insert` and `peerIndexInBucket` procs (ref semantics made `var` redundant).

## Affected Areas

- [ ] Gossipsub  
- [ ] Transports  
- [x] Peer Management / Discovery  
  `routing_table.nim`: new `randomPeer` proc; `randomKeyInBucket` signature change and logic simplification.  
- [x] Protocol Logic  
  `kademlia.nim`, `find.nim`, `random_find.nim`: updated imports after file renames.  
- [ ] Build / Tooling  
- [x] Other  
  `crypto/crypto.nim`: new `pick`, `pickOne`, and `randBelow` procs.

## Compatibility & Downstream Validation

Internal-only changes. No public API additions visible to downstream consumers beyond the new `pick` / `pickOne` / `randomPeer` procs. File renames affect only internal imports — all call-sites updated in this PR.

- **Nimbus:** N/A — no behavioral changes  
- **Waku:** N/A  
- **Codex:** N/A  

## Impact on Library Users

- New API additions: `pick`, `pickOne`, `randomPeer`
- No removals or breaking changes
- Internal module renames (`routingtable` → `routing_table`, `randomfind` → `random_find`) may affect direct imports, but these are not part of the public API surface

## Risk Assessment

Low.

- `randBelow` uses standard rejection sampling (no modulo bias)
- `randomKeyInBucket` preserves semantics (random key within XOR-distance bucket)
- Covered by existing and new unit tests

## References

Derived from #2238 

## Additional Notes

N/A