### PR TITLE
test(mix): fix flaky test "rate limit exceeded - message rejected at intermediate node"

### DIFF
--- a/tests/libp2p/mix/component/test_spam_protection.nim
+++ b/tests/libp2p/mix/component/test_spam_protection.nim
@@ -65,7 +65,7 @@ suite "Mix Protocol - Spam Protection":
     let testPayload = "test message".toBytes()
 
     # Send 3 messages — all should arrive
-    var receivedMsgFut = newSeqOfCap[Future[ReceivedMessage]](rateLimit)
+    var receivedMsgFut = newSeq[Future[ReceivedMessage]](rateLimit)
     for i in 0 ..< rateLimit:
       let conn = nodes[0]
         .toConnection(destNode.toMixDestination(), nrProto.codec)

--- a/tests/libp2p/mix/component/test_spam_protection.nim
+++ b/tests/libp2p/mix/component/test_spam_protection.nim
@@ -92,9 +92,12 @@ suite "Mix Protocol - Spam Protection":
     await conn.writeLp(testPayload)
 
     expect AsyncTimeoutError:
-      # code needs to wait here more then maximum time that is need for message to 
-      # propagate through mix protocol to ensure that message is not delivered.
-      # max expected time for message ~= number of hops * delay per hop
-      # maxWaitTime = double the max expected time for message
-      let maxWaitTime = (maxDelayPerHop.toDuration * (numNodes - 1)) * 2
+      # wait longer than the maximum time needed for a message to propagate
+      # through the mix protocol, to ensure that the message is not delivered.
+
+      # maxMixDelay = number of hops * delay per hop
+      let maxMixDelay = (maxDelayPerHop.toDuration * (numNodes - 1))
+      # maxWaitTime = maxMixDelay + 2s (to accommodate network transmission overhead)
+      let maxWaitTime = maxMixDelay + 2.seconds
+
       discard await nrProto.receivedMessages.get().wait(maxWaitTime)

--- a/tests/libp2p/mix/component/test_spam_protection.nim
+++ b/tests/libp2p/mix/component/test_spam_protection.nim
@@ -52,7 +52,7 @@ suite "Mix Protocol - Spam Protection":
     const
       numNodes = 4 # sender + 3 path nodes
       rateLimit = 3
-      maxDelayPerHop = 1.Delay # 
+      maxDelayPerHop = 1.Delay # big delay is not really needed here
 
     let nodes = await setupMixNodes(
       numNodes,

--- a/tests/libp2p/mix/component/test_spam_protection.nim
+++ b/tests/libp2p/mix/component/test_spam_protection.nim
@@ -4,8 +4,7 @@
 {.used.}
 
 import chronos, results, stew/byteutils
-import ../../../../libp2p/[protocols/mix, protocols/ping, protocols/protocol]
-
+import ../../../../libp2p/protocols/[protocol, ping, mix, mix/delay_strategy]
 import ../../../tools/[lifecycle, unittest]
 import ../utils
 
@@ -53,9 +52,13 @@ suite "Mix Protocol - Spam Protection":
     const
       numNodes = 4 # sender + 3 path nodes
       rateLimit = 3
+      maxDelayPerHop = 1.Delay # 
 
-    let nodes =
-      await setupMixNodes(numNodes, spamProtectionRateLimit = Opt.some(rateLimit))
+    let nodes = await setupMixNodes(
+      numNodes,
+      spamProtectionRateLimit = Opt.some(rateLimit),
+      delayStrategy = Opt.some(DelayStrategy(FixedDelayStrategy(delay: maxDelayPerHop))),
+    )
     startAndDeferStop(nodes)
 
     let (destNode, nrProto) = await setupDestNode(NoReplyProtocol.new())
@@ -89,4 +92,9 @@ suite "Mix Protocol - Spam Protection":
     await conn.writeLp(testPayload)
 
     expect AsyncTimeoutError:
-      discard await nrProto.receivedMessages.get().wait(2.seconds)
+      # code needs to wait here more then maximum time that is need for message to 
+      # propagate through mix protocol to ensure that message is not delivered.
+      # max expected time for message ~= number of hops * delay per hop
+      # maxWaitTime = double the max expected time for message
+      let maxWaitTime = (maxDelayPerHop.toDuration * (numNodes - 1)) * 2
+      discard await nrProto.receivedMessages.get().wait(maxWaitTime)

--- a/tests/libp2p/mix/component/test_spam_protection.nim
+++ b/tests/libp2p/mix/component/test_spam_protection.nim
@@ -65,6 +65,7 @@ suite "Mix Protocol - Spam Protection":
     let testPayload = "test message".toBytes()
 
     # Send 3 messages — all should arrive
+    var receivedMsgFut = newSeqOfCap[Future[ReceivedMessage]](rateLimit)
     for i in 0 ..< rateLimit:
       let conn = nodes[0]
         .toConnection(destNode.toMixDestination(), nrProto.codec)
@@ -73,8 +74,10 @@ suite "Mix Protocol - Spam Protection":
         await conn.close()
 
       await conn.writeLp(testPayload)
-      let receivedMsg = await nrProto.receivedMessages.get().wait(2.seconds)
-      check testPayload == receivedMsg.data
+      receivedMsgFut[i] = nrProto.receivedMessages.get()
+
+    for fut in receivedMsgFut:
+      check testPayload == (await fut).data
 
     # 4th message — should be dropped at intermediate node
     let conn = nodes[0].toConnection(destNode.toMixDestination(), nrProto.codec).expect(


### PR DESCRIPTION
1) avoid `.wait(2.seconds)` which caused flakiness when sending within the limits
    - this tests does not need to assert message delivery time it should focus on asserting rate limits
   - it's not a problem to assert event that criteria, but avoiding it here for simplicity reasons. because if we do that there should be some clear utility that should return max wait time for give mix setup. that is:
     ```
      .wait(maxMessageDeliveryTime(...mix configuration...))
     ```
     and same principle should be followed through tests. 
     swelling some code here to add max wait time would be out of focus.
     
2) changed from send-receive model. now all 3 messages are sent then awaited on simultaneously. this will save some time when running tests because:
   - as per ai comment here https://github.com/vacp2p/nim-libp2p/pull/2254/changes/1fda8a66bbedc098efe2101d949af5713ced36f9, it takes 1.4sec at max for 1 hop. that's ~4s for one message and 12sec for all messages. now messages will be received withing 4sec.

3) use fixed small delay (big default delay is not really needed for this test

4) improved wait time calculation for message that is dropped 


closes: https://github.com/vacp2p/nim-libp2p/issues/2252
