### PR TITLE
fix(bump): waku vendor init failing

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -18,6 +19,10 @@ jobs:
           - repository: status-im/nimbus-eth2
             ref: unstable
             secret: ACTIONS_GITHUB_TOKEN_NIMBUS_ETH2
+          - repository: logos-messaging/logos-delivery
+            ref: master
+            secret: ACTIONS_GITHUB_TOKEN_NWAKU
+            nimble: true
           - repository: codex-storage/nim-codex
             ref: master
             secret: ACTIONS_GITHUB_TOKEN_NIM_CODEX
@@ -34,9 +39,18 @@ jobs:
       - name: Checkout this ref in target repository
         run: |
           cd nbc
-          git submodule update --init vendor/nim-libp2p
-          cd vendor/nim-libp2p
-          git checkout $GITHUB_SHA
+          if [ "${{ matrix.target.nimble }}" = "true" ]; then
+            # nwaku uses nimble — update nim-libp2p's pinned revision in the lock file
+            jq --arg sha "$GITHUB_SHA" \
+              '.packages["nim-libp2p"].vcsRevision = $sha' \
+              nimble.lock > nimble.lock.tmp
+            mv nimble.lock.tmp nimble.lock
+          else
+            git submodule update --init vendor/nim-libp2p
+            cd vendor/nim-libp2p
+            git fetch https://github.com/status-im/nim-libp2p.git $GITHUB_SHA
+            git checkout $GITHUB_SHA
+          fi
 
       - name: Push this ref to target repository
         run: |

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
   # All PR event types are listed so GitHub delivers the event payload (which includes label info).
-  # The job-level `if` then gates execution on the `run-bump-job` label — GitHub's `on:` syntax
+  # The job-level `if` then gates execution on the `run-bump-ci` label — GitHub's `on:` syntax
   # has no native label filter, so this two-part pattern is the standard workaround.
   pull_request:
     types: [labeled, synchronize, opened, reopened]

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -37,7 +37,9 @@ jobs:
       - name: Checkout this ref in target repository
         run: |
           cd nbc
-          git submodule update --init vendor/nim-libp2p
+          if [ "${{ matrix.target.repository }}" != "waku-org/nwaku" ]; then
+            git submodule update --init vendor/nim-libp2p
+          fi
           cd vendor/nim-libp2p
           git checkout $GITHUB_SHA
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -41,6 +41,12 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets[matrix.target.secret] }}
 
+      - name: Setup Nim (only for nimble targets)
+        if: matrix.target.nimble == true
+        uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: '2.2.4'
+
       - name: Checkout this ref in target repository
         run: |
           cd nbc
@@ -49,14 +55,22 @@ jobs:
             # Update waku.nimble: replace commit after 'nim-libp2p.git#' with current commit
             sed -i -E "s|(https://github.com/vacp2p/nim-libp2p\.git#)[a-f0-9]+|\1$GITHUB_SHA|" waku.nimble
 
-            # Re-resolve dependencies and regenerate lock
-            rm nimble.lock
+            # Clean previous state
+            rm -rf nimble.lock nimbledeps nimble.paths
+
+            # Ensure nimble is up-to-date
+            nimble install nimble -y
+
+            # Regenerate lock file
+            nimble setup --localdeps -y
 
           else
+
             git submodule update --init vendor/nim-libp2p
             cd vendor/nim-libp2p
             git fetch https://github.com/status-im/nim-libp2p.git $GITHUB_SHA
             git checkout $GITHUB_SHA
+
           fi
 
       - name: Push this ref to target repository

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -68,7 +68,7 @@ jobs:
 
             git submodule update --init vendor/nim-libp2p
             cd vendor/nim-libp2p
-            git fetch https://github.com/status-im/nim-libp2p.git $GITHUB_SHA
+            git fetch https://github.com/vacp2p/nim-libp2p.git $GITHUB_SHA
             git checkout $GITHUB_SHA
 
           fi

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -43,40 +43,14 @@ jobs:
 
       - name: Checkout this ref in target repository
         run: |
-
           cd nbc
-
+          GITHUB_SHA=${{ github.event.pull_request.head.sha || github.sha }}
           if [ "${{ matrix.target.nimble }}" = "true" ]; then
-            # Clone libp2p at the target SHA
-            tmpdir=$(mktemp -d)
+            # Update waku.nimble: replace commit after 'nim-libp2p.git#' with current commit
+            sed -i -E "s|(https://github.com/vacp2p/nim-libp2p\.git#)[a-f0-9]+|\1$GITHUB_SHA|" waku.nimble
 
-            git init "$tmpdir"
-            cd "$tmpdir"
-
-            git remote add origin https://github.com/vacp2p/nim-libp2p.git
-
-            # Fetch the exact commit with full history for that object
-            git fetch --depth=1 origin $GITHUB_SHA
-
-            git checkout FETCH_HEAD
-
-            # Compute SHA1 of repo contents (same idea Nimble uses)
-            checksum=$(git ls-files -z | sort -z | xargs -0 sha1sum | sha1sum | cut -d ' ' -f1)
-
-            cd - >/dev/null
-            rm -rf "$tmpdir"
-
-            # Update nimble.lock with BOTH revision and checksum
-            jq --arg sha "$GITHUB_SHA" \
-               --arg checksum "$checksum" \
-               '.packages["libp2p"].vcsRevision = $sha |
-                .packages["libp2p"].checksums = (.packages["libp2p"].checksums // {}) |
-                .packages["libp2p"].checksums.sha1 = $checksum' \
-               nimble.lock > nimble.lock.tmp
-
-            mv nimble.lock.tmp nimble.lock
-
-            rm -rf "$tmpdir"
+            # Re-resolve dependencies and regenerate lock
+            rm nimble.lock
 
           else
             git submodule update --init vendor/nim-libp2p

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -5,11 +5,13 @@ on:
     branches:
       - master
   pull_request:
+    types: [labeled, synchronize, opened, reopened]
   workflow_dispatch:
 
 jobs:
   bumper:
     # Pushes new refs to interested external repositories, so they can do early testing against libp2p's newer versions
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-bump-job')
     runs-on: ubuntu-latest
     name: Bump libp2p's version for ${{ matrix.target.repository }}:${{ matrix.target.ref }}
     strategy:


### PR DESCRIPTION
## Summary

The `dependencies.yml` workflow bumps nim-libp2p into downstream repositories on every push to `master`.

Waku (`waku-org/nwaku`) manages its vendored dependencies differently and does not use a `vendor/nim-libp2p` submodule in the same way. This causes the submodule init step to fail or behave unexpectedly for that target.

This PR skips:

```
git submodule update --init vendor/nim-libp2p
```

when the matrix target is `waku-org/nwaku`.

---

## Affected Areas

* Gossipsub
* Transports
* Peer Management / Discovery
* Protocol Logic
* Build / Tooling

  * CI-only change: controls which downstream targets initialize the nim-libp2p vendor submodule during the auto-bump workflow
* Other

---

## Compatibility & Downstream Validation

No library code is changed.

* The bump workflow for `nimbus-eth2` and `nim-codex` is unchanged.
* Waku’s bump step will now skip the submodule init and proceed directly to:

  ```
  git checkout $GITHUB_SHA
  ```

  inside `vendor/nim-libp2p`.

Waku must already have that path available via its own submodule setup for the subsequent `cd` and `checkout` steps to succeed.

Confirm with the Waku team that their repository structure satisfies this requirement.

---

## Impact on Library Users

* No API, ABI, or behavioral changes to the library
* CI workflow only

---

## Risk Assessment

* The step:

  ```
  cd vendor/nim-libp2p && git checkout $GITHUB_SHA
  ```

  still runs unconditionally for all targets, including Waku.

* If Waku does not have `vendor/nim-libp2p` pre-initialized, this step will fail.

**Risk: low–medium**

* The condition change addresses the reported issue
* However, the subsequent step may also need guarding depending on Waku’s actual repository layout

---

## References

* https://github.com/logos-messaging/logos-delivery/actions/runs/24361715999/job/71142938647

## Additional Notes

Depends on https://github.com/logos-messaging/logos-delivery/pull/3812
