### PR TITLE
feat(gossip): reduce score of slow peers

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -90,6 +90,9 @@ proc init*(
     appSpecificWeight = 0.0,
     ipColocationFactorWeight = 0.0,
     ipColocationFactorThreshold = 1.0,
+    slowPeerPenaltyWeight = -0.05,
+    slowPeerPenaltyThreshold = 2.0,
+    slowPeerPenaltyDecay = 0.2,
     behaviourPenaltyWeight = -1.0,
     behaviourPenaltyDecay = 0.999,
     directPeers = initTable[PeerId, seq[MultiAddress]](),
@@ -155,6 +158,9 @@ proc init*(
     appSpecificWeight: appSpecificWeight,
     ipColocationFactorWeight: ipColocationFactorWeight,
     ipColocationFactorThreshold: ipColocationFactorThreshold,
+    slowPeerPenaltyWeight: slowPeerPenaltyWeight,
+    slowPeerPenaltyThreshold: slowPeerPenaltyThreshold,
+    slowPeerPenaltyDecay: slowPeerPenaltyDecay,
     behaviourPenaltyWeight: behaviourPenaltyWeight,
     behaviourPenaltyDecay: behaviourPenaltyDecay,
     directPeers: directPeers,
@@ -198,6 +204,14 @@ proc validateParameters*(parameters: GossipSubParams): Result[void, cstring] =
     err("gossipsub: ipColocationFactorWeight parameter error, Must be negative or 0")
   elif parameters.ipColocationFactorThreshold < 1.0:
     err("gossipsub: ipColocationFactorThreshold parameter error, Must be at least 1")
+  elif parameters.slowPeerPenaltyWeight > 0:
+    err("gossipsub: slowPeerPenaltyWeight parameter error, Must be negative or 0")
+  elif parameters.slowPeerPenaltyThreshold < 0:
+    err("gossipsub: slowPeerPenaltyThreshold parameter error, Must be positive or 0")
+  elif parameters.slowPeerPenaltyDecay <= 0 or parameters.slowPeerPenaltyDecay >= 1:
+    err(
+      "gossipsub: slowPeerPenaltyDecay parameter error, Must be between 0 and 1 (exclusive)"
+    )
   elif parameters.behaviourPenaltyWeight >= 0:
     err("gossipsub: behaviourPenaltyWeight parameter error, Must be negative")
   elif parameters.behaviourPenaltyDecay < 0 or parameters.behaviourPenaltyDecay >= 1:
@@ -301,6 +315,7 @@ method onNewPeer*(g: GossipSub, peer: PubSubPeer) =
     # from a previous connection
     peer.score = stats.score
     peer.appScore = stats.appScore
+    peer.slowPeerPenalty = stats.slowPeerPenalty
     peer.behaviourPenalty = stats.behaviourPenalty
 
     # Check if the score is below the threshold and disconnect the peer if necessary

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -51,6 +51,11 @@ declareGauge(
   labels = ["agent"],
 )
 declareGauge(
+  libp2p_gossipsub_peers_score_slowPeerPenalty,
+  "Detailed gossipsub scoring metric",
+  labels = ["agent"],
+)
+declareGauge(
   libp2p_gossipsub_peers_score_behaviourPenalty,
   "Detailed gossipsub scoring metric",
   labels = ["agent"],
@@ -257,6 +262,16 @@ proc updateScores*(g: GossipSub) = # avoid async
       appScore = peer.appScore,
       appSpecificWeight = g.parameters.appSpecificWeight
 
+    if peer.slowPeerPenalty > g.parameters.slowPeerPenaltyThreshold:
+      let excess = peer.slowPeerPenalty - g.parameters.slowPeerPenaltyThreshold
+      scoreAcc += excess * g.parameters.slowPeerPenaltyWeight
+      trace "slowPeerPenalty",
+        peer,
+        scoreAcc,
+        slowPeerPenalty = peer.slowPeerPenalty,
+        slowPeerPenaltyThreshold = g.parameters.slowPeerPenaltyThreshold,
+        slowPeerPenaltyWeight = g.parameters.slowPeerPenaltyWeight
+
     # The value of the parameter is the square of the counter and is mixed with a negative weight.
     scoreAcc +=
       peer.behaviourPenalty * peer.behaviourPenalty * g.parameters.behaviourPenaltyWeight
@@ -276,12 +291,20 @@ proc updateScores*(g: GossipSub) = # avoid async
     # Score metrics
     let agent = peer.getAgent()
     libp2p_gossipsub_peers_score_appScore.inc(peer.appScore, labelValues = [agent])
+    libp2p_gossipsub_peers_score_slowPeerPenalty.inc(
+      peer.slowPeerPenalty, labelValues = [agent]
+    )
     libp2p_gossipsub_peers_score_behaviourPenalty.inc(
       peer.behaviourPenalty, labelValues = [agent]
     )
     libp2p_gossipsub_peers_score_colocationFactor.inc(
       colocationFactor, labelValues = [agent]
     )
+
+    # decay slowPeerPenalty
+    peer.slowPeerPenalty *= g.parameters.slowPeerPenaltyDecay
+    if peer.slowPeerPenalty < g.parameters.decayToZero:
+      peer.slowPeerPenalty = 0
 
     # decay behaviourPenalty
     peer.behaviourPenalty *= g.parameters.behaviourPenaltyDecay
@@ -293,6 +316,7 @@ proc updateScores*(g: GossipSub) = # avoid async
     # copy into stats the score to keep until expired
     stats.score = peer.score
     stats.appScore = peer.appScore
+    stats.slowPeerPenalty = peer.slowPeerPenalty
     stats.behaviourPenalty = peer.behaviourPenalty
     stats.expire = now + g.parameters.retainScore # refresh expiration
 

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -97,6 +97,7 @@ type
     # the following are copies from PubSubPeer, in order to restore them on re-connection
     score*: float64 # a copy of the score to keep in case the peer is disconnected
     appScore*: float64 # application specific score
+    slowPeerPenalty*: float64 # penalty from repeated medium/low queue overflow drops
     behaviourPenalty*: float64 # the eventual penalty score
 
   GossipSubParams* {.public.} = object
@@ -137,6 +138,9 @@ type
     appSpecificWeight*: float64
     ipColocationFactorWeight*: float64
     ipColocationFactorThreshold*: float64
+    slowPeerPenaltyWeight*: float64
+    slowPeerPenaltyThreshold*: float64
+    slowPeerPenaltyDecay*: float64
     behaviourPenaltyWeight*: float64
     behaviourPenaltyDecay*: float64
 

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -95,16 +95,10 @@ type
       ## Relayed messages and IWANT replies
       ## They are dropped if exceeded max. Peer is not disconnected.
 
-  QueueActionType* {.pure.} = enum
-    SendHigh
-    SendMedium
-    DropMedium
-    SendLow
-    DropLow
-    Disconnect
-
   QueueAction* = object
-    action*: QueueActionType
+    priority*: MessagePriority
+    send*: bool
+      # if true msg should be sent respecting priority, if false it means drop/disconnect
     slowPeerPenaltyDelta*: float64
 
   PubSubPeerEventKind* {.pure.} = enum
@@ -244,21 +238,29 @@ func determineQueueAction*(
     sendPriorityQueueLen == 0 and mediumPriorityQueueLen == 0 and
     lowPriorityQueueLen == 0
 
+  var send = true
+  var slowPeerPenaltyDelta = 0.0
+  var priority = priority
+
   if priority == MessagePriority.High or emptyQueues:
+    # If queues are empty, we can send medium/low messages immediatly
+    # thus setting the priority of the message to high
+    priority = MessagePriority.High
+
     if sendPriorityQueueLen >= maxHighPriorityQueueLen:
-      QueueAction(action: QueueActionType.Disconnect, slowPeerPenaltyDelta: 0.0)
-    else:
-      QueueAction(action: QueueActionType.SendHigh, slowPeerPenaltyDelta: 0.0)
+      send = false
   elif priority == MessagePriority.Medium:
     if mediumPriorityQueueLen >= maxMediumPriorityQueueLen:
-      QueueAction(action: QueueActionType.DropMedium, slowPeerPenaltyDelta: 1.0)
-    else:
-      QueueAction(action: QueueActionType.SendMedium, slowPeerPenaltyDelta: 0.0)
+      send = false
+      slowPeerPenaltyDelta = 1.0
   else:
     if lowPriorityQueueLen >= maxLowPriorityQueueLen:
-      QueueAction(action: QueueActionType.DropLow, slowPeerPenaltyDelta: 1.0)
-    else:
-      QueueAction(action: QueueActionType.SendLow, slowPeerPenaltyDelta: 0.0)
+      slowPeerPenaltyDelta = 1.0
+      send = false
+
+  QueueAction(
+    priority: priority, send: send, slowPeerPenaltyDelta: slowPeerPenaltyDelta
+  )
 
 func determineQueueAction*(
     priority: MessagePriority,
@@ -525,7 +527,7 @@ proc enqueueNonHighPriorityMessage(
     when defined(pubsubpeer_queue_metrics):
       libp2p_gossipsub_low_priority_queue_size.inc(labelValues = [$p.peerId])
   of MessagePriority.High:
-    doAssert false, "high-priority messages are not enqueued"
+    raiseAssert "high-priority messages are not enqueued"
   p.rpcmessagequeue.dataAvailableEvent.fire()
 
   return newFutureCompleted[void]()
@@ -544,7 +546,7 @@ proc dropNonHighPriorityMessage(
       libp2p_pubsub_low_priority_queue_drops.inc()
     trace "low priority queue full, dropping message", p
   of MessagePriority.High:
-    doAssert false, "high-priority messages are not dropped via queue overflow scoring"
+    raiseAssert "high-priority messages are not dropped via queue overflow scoring"
   return newFutureCompleted[void]()
 
 proc sendEncoded*(
@@ -578,28 +580,22 @@ proc sendEncoded*(
       maxSize = p.maxMessageSize, msgSize = msg.len
     newFutureCompleted[void]()
   else:
-    let queueAction = determineQueueAction(
+    let action = determineQueueAction(
       priority, p.rpcmessagequeue, p.maxHighPriorityQueueLen,
       p.maxMediumPriorityQueueLen, p.maxLowPriorityQueueLen,
     )
 
-    case queueAction.action
-    of QueueActionType.SendHigh:
-      p.sendHighPriorityMessage(msg, useCustomConn)
-    of QueueActionType.SendMedium:
-      p.enqueueNonHighPriorityMessage(msg, useCustomConn, MessagePriority.Medium)
-    of QueueActionType.DropMedium:
-      p.dropNonHighPriorityMessage(
-        queueAction.slowPeerPenaltyDelta, MessagePriority.Medium
-      )
-    of QueueActionType.SendLow:
-      p.enqueueNonHighPriorityMessage(msg, useCustomConn, MessagePriority.Low)
-    of QueueActionType.DropLow:
-      p.dropNonHighPriorityMessage(
-        queueAction.slowPeerPenaltyDelta, MessagePriority.Low
-      )
-    of QueueActionType.Disconnect:
-      p.disconnectPeer()
+    case action.priority
+    of High:
+      if action.send:
+        p.sendHighPriorityMessage(msg, useCustomConn)
+      else:
+        p.disconnectPeer()
+    of Medium, Low:
+      if action.send:
+        p.enqueueNonHighPriorityMessage(msg, useCustomConn, action.priority)
+      else:
+        p.dropNonHighPriorityMessage(action.slowPeerPenaltyDelta, action.priority)
 
 iterator splitRPCMsg(
     peer: PubSubPeer, rpcMsg: RPCMsg, maxSize: int, anonymize: bool

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -95,6 +95,18 @@ type
       ## Relayed messages and IWANT replies
       ## They are dropped if exceeded max. Peer is not disconnected.
 
+  QueueActionType* {.pure.} = enum
+    SendHigh
+    SendMedium
+    DropMedium
+    SendLow
+    DropLow
+    Disconnect
+
+  QueueAction* = object
+    action*: QueueActionType
+    slowPeerPenaltyDelta*: float64
+
   PubSubPeerEventKind* {.pure.} = enum
     StreamOpened
     StreamClosed
@@ -163,6 +175,7 @@ type
     iHaveBudget*: int
     maxMessageSize: int
     appScore*: float64 # application specific score
+    slowPeerPenalty*: float64 # penalty from repeated medium/low queue overflow drops
     behaviourPenalty*: float64 # the eventual penalty score
     overheadRateLimitOpt*: Opt[TokenBucket]
     rpcmessagequeue: RpcMessageQueue
@@ -221,6 +234,42 @@ func outbound*(p: PubSubPeer): bool =
   # https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#outbound-mesh-quotas
   # This behaviour is presrcibed to counter sybil attacks and ensures that a coordinated inbound attack can never fully take over the mesh
   if not p.sendConn.isNil and p.sendConn.transportDir == Direction.Out: true else: false
+
+func determineQueueAction*(
+    priority: MessagePriority,
+    sendPriorityQueueLen, mediumPriorityQueueLen, lowPriorityQueueLen: int,
+    maxHighPriorityQueueLen, maxMediumPriorityQueueLen, maxLowPriorityQueueLen: int,
+): QueueAction =
+  let emptyQueues =
+    sendPriorityQueueLen == 0 and mediumPriorityQueueLen == 0 and
+    lowPriorityQueueLen == 0
+
+  if priority == MessagePriority.High or emptyQueues:
+    if sendPriorityQueueLen >= maxHighPriorityQueueLen:
+      QueueAction(action: QueueActionType.Disconnect, slowPeerPenaltyDelta: 0.0)
+    else:
+      QueueAction(action: QueueActionType.SendHigh, slowPeerPenaltyDelta: 0.0)
+  elif priority == MessagePriority.Medium:
+    if mediumPriorityQueueLen >= maxMediumPriorityQueueLen:
+      QueueAction(action: QueueActionType.DropMedium, slowPeerPenaltyDelta: 1.0)
+    else:
+      QueueAction(action: QueueActionType.SendMedium, slowPeerPenaltyDelta: 0.0)
+  else:
+    if lowPriorityQueueLen >= maxLowPriorityQueueLen:
+      QueueAction(action: QueueActionType.DropLow, slowPeerPenaltyDelta: 1.0)
+    else:
+      QueueAction(action: QueueActionType.SendLow, slowPeerPenaltyDelta: 0.0)
+
+func determineQueueAction*(
+    priority: MessagePriority,
+    rpcmessagequeue: RpcMessageQueue,
+    maxHighPriorityQueueLen, maxMediumPriorityQueueLen, maxLowPriorityQueueLen: int,
+): QueueAction =
+  determineQueueAction(
+    priority, rpcmessagequeue.sendPriorityQueue.len,
+    rpcmessagequeue.mediumPriorityQueue.len, rpcmessagequeue.lowPriorityQueue.len,
+    maxHighPriorityQueueLen, maxMediumPriorityQueueLen, maxLowPriorityQueueLen,
+  )
 
 proc recvObservers*(p: PubSubPeer, msg: var RPCMsg) =
   # trigger hooks
@@ -443,20 +492,18 @@ proc sendMsg(
     trace "sending encoded msg to peer via slow path"
     sendMsgSlow(p, msg)
 
+proc disconnectPeer(p: PubSubPeer): Future[void] =
+  if not p.disconnected:
+    p.disconnected = true
+    when defined(pubsubpeer_queue_metrics):
+      libp2p_pubsub_disconnects_over_high_priority_queue_limit.inc()
+    return p.closeSendConn(PubSubPeerEventKind.DisconnectionRequested)
+
+  return newFutureCompleted[void]()
+
 proc sendHighPriorityMessage(
     p: PubSubPeer, msg: seq[byte], useCustomConn: bool
 ): Future[void] =
-  # Check high-priority queue bound - if exceeded, the peer is too slow
-  # to keep up with protocol-critical messages and must be disconnected.
-  if p.rpcmessagequeue.sendPriorityQueue.len >= p.maxHighPriorityQueueLen:
-    if not p.disconnected:
-      p.disconnected = true
-      when defined(pubsubpeer_queue_metrics):
-        libp2p_pubsub_disconnects_over_high_priority_queue_limit.inc()
-      return p.closeSendConn(PubSubPeerEventKind.DisconnectionRequested)
-
-    return newFutureCompleted[void]()
-
   let f = p.sendMsg(msg, useCustomConn)
   if not f.finished:
     p.rpcmessagequeue.sendPriorityQueue.addLast(f)
@@ -464,36 +511,40 @@ proc sendHighPriorityMessage(
       libp2p_gossipsub_high_priority_queue_size.inc(labelValues = [$p.peerId])
   return f
 
-proc sendMediumPriorityMessage(
-    p: PubSubPeer, msg: seq[byte], useCustomConn: bool
+proc enqueueNonHighPriorityMessage(
+    p: PubSubPeer, msg: seq[byte], useCustomConn: bool, priority: MessagePriority
 ): Future[void] =
   let queuedMsg = QueuedMessage(data: msg, useCustomConn: useCustomConn)
-  if p.rpcmessagequeue.mediumPriorityQueue.len >= p.maxMediumPriorityQueueLen:
-    when defined(pubsubpeer_queue_metrics):
-      libp2p_pubsub_medium_priority_queue_drops.inc()
-    trace "medium priority queue full, dropping message", p
-  else:
+  case priority
+  of MessagePriority.Medium:
     p.rpcmessagequeue.mediumPriorityQueue.addLast(queuedMsg)
     when defined(pubsubpeer_queue_metrics):
       libp2p_gossipsub_medium_priority_queue_size.inc(labelValues = [$p.peerId])
-    p.rpcmessagequeue.dataAvailableEvent.fire()
-
-  return newFutureCompleted[void]()
-
-proc sendLowPriorityMessage(
-    p: PubSubPeer, msg: seq[byte], useCustomConn: bool
-): Future[void] =
-  let queuedMsg = QueuedMessage(data: msg, useCustomConn: useCustomConn)
-  if p.rpcmessagequeue.lowPriorityQueue.len >= p.maxLowPriorityQueueLen:
-    when defined(pubsubpeer_queue_metrics):
-      libp2p_pubsub_low_priority_queue_drops.inc()
-    trace "low priority queue full, dropping message", p
-  else:
+  of MessagePriority.Low:
     p.rpcmessagequeue.lowPriorityQueue.addLast(queuedMsg)
     when defined(pubsubpeer_queue_metrics):
       libp2p_gossipsub_low_priority_queue_size.inc(labelValues = [$p.peerId])
-    p.rpcmessagequeue.dataAvailableEvent.fire()
+  of MessagePriority.High:
+    doAssert false, "high-priority messages are not enqueued"
+  p.rpcmessagequeue.dataAvailableEvent.fire()
 
+  return newFutureCompleted[void]()
+
+proc dropNonHighPriorityMessage(
+    p: PubSubPeer, slowPeerPenaltyDelta: float64, priority: MessagePriority
+): Future[void] =
+  p.slowPeerPenalty += slowPeerPenaltyDelta
+  case priority
+  of MessagePriority.Medium:
+    when defined(pubsubpeer_queue_metrics):
+      libp2p_pubsub_medium_priority_queue_drops.inc()
+    trace "medium priority queue full, dropping message", p
+  of MessagePriority.Low:
+    when defined(pubsubpeer_queue_metrics):
+      libp2p_pubsub_low_priority_queue_drops.inc()
+    trace "low priority queue full, dropping message", p
+  of MessagePriority.High:
+    doAssert false, "high-priority messages are not dropped via queue overflow scoring"
   return newFutureCompleted[void]()
 
 proc sendEncoded*(
@@ -519,13 +570,6 @@ proc sendEncoded*(
 
   p.clearSendPriorityQueue()
 
-  # When all queues are empty, any priority message is sent immediately
-  # to reduce latency (no need to go through the background task).
-  let emptyQueues =
-    p.rpcmessagequeue.sendPriorityQueue.len == 0 and
-    p.rpcmessagequeue.mediumPriorityQueue.len == 0 and
-    p.rpcmessagequeue.lowPriorityQueue.len == 0
-
   if msg.len <= 0:
     debug "empty message, skipping", p, payload = shortLog(msg)
     newFutureCompleted[void]()
@@ -533,12 +577,27 @@ proc sendEncoded*(
     info "trying to send a msg too big for pubsub",
       maxSize = p.maxMessageSize, msgSize = msg.len
     newFutureCompleted[void]()
-  elif priority == MessagePriority.High or emptyQueues:
-    p.sendHighPriorityMessage(msg, useCustomConn)
-  elif priority == MessagePriority.Medium:
-    p.sendMediumPriorityMessage(msg, useCustomConn)
-  else: # Low
-    p.sendLowPriorityMessage(msg, useCustomConn)
+  else:
+    let queueAction = determineQueueAction(
+      priority, p.rpcmessagequeue, p.maxHighPriorityQueueLen,
+      p.maxMediumPriorityQueueLen, p.maxLowPriorityQueueLen,
+    )
+
+    case queueAction.action
+    of QueueActionType.SendHigh:
+      p.sendHighPriorityMessage(msg, useCustomConn)
+    of QueueActionType.SendMedium:
+      p.enqueueNonHighPriorityMessage(msg, useCustomConn, MessagePriority.Medium)
+    of QueueActionType.DropMedium:
+      p.dropNonHighPriorityMessage(
+        queueAction.slowPeerPenaltyDelta, MessagePriority.Medium
+      )
+    of QueueActionType.SendLow:
+      p.enqueueNonHighPriorityMessage(msg, useCustomConn, MessagePriority.Low)
+    of QueueActionType.DropLow:
+      p.dropNonHighPriorityMessage(queueAction.slowPeerPenaltyDelta, MessagePriority.Low)
+    of QueueActionType.Disconnect:
+      p.disconnectPeer()
 
 iterator splitRPCMsg(
     peer: PubSubPeer, rpcMsg: RPCMsg, maxSize: int, anonymize: bool
@@ -633,12 +692,13 @@ proc sendNonHighPriorityTask(p: PubSubPeer) {.async: (raises: [CancelledError]).
       await p.rpcmessagequeue.dataAvailableEvent.wait()
       p.rpcmessagequeue.dataAvailableEvent.clear()
 
-    # Dequeue messages by priority
-    let (msg, priority) =
+    var priority = MessagePriority.Low
+    let msg =
       if p.rpcmessagequeue.mediumPriorityQueue.len != 0:
-        (p.rpcmessagequeue.mediumPriorityQueue.popFirst(), MessagePriority.Medium)
+        priority = MessagePriority.Medium
+        p.rpcmessagequeue.mediumPriorityQueue.popFirst()
       elif p.rpcmessagequeue.lowPriorityQueue.len != 0:
-        (p.rpcmessagequeue.lowPriorityQueue.popFirst(), MessagePriority.Low)
+        p.rpcmessagequeue.lowPriorityQueue.popFirst()
       else:
         continue
 

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -595,7 +595,9 @@ proc sendEncoded*(
     of QueueActionType.SendLow:
       p.enqueueNonHighPriorityMessage(msg, useCustomConn, MessagePriority.Low)
     of QueueActionType.DropLow:
-      p.dropNonHighPriorityMessage(queueAction.slowPeerPenaltyDelta, MessagePriority.Low)
+      p.dropNonHighPriorityMessage(
+        queueAction.slowPeerPenaltyDelta, MessagePriority.Low
+      )
     of QueueActionType.Disconnect:
       p.disconnectPeer()
 

--- a/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
@@ -243,13 +243,13 @@ suite "GossipSub Component - Scoring":
       handlerFut.finished() == true
 
   asyncTest "Slow peer penalty can prune a peer on heartbeat":
-    let nodes =
-      generateNodes(
+    let nodes = generateNodes(
         2,
         gossip = true,
         decayInterval = 20.milliseconds,
         heartbeatInterval = TEST_GOSSIPSUB_HEARTBEAT_INTERVAL,
-      ).toGossipSub()
+      )
+      .toGossipSub()
 
     startAndDeferStop(nodes)
     await connectStar(nodes)

--- a/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
@@ -242,6 +242,33 @@ suite "GossipSub Component - Scoring":
     checkUntilTimeout:
       handlerFut.finished() == true
 
+  asyncTest "Slow peer penalty can prune a peer on heartbeat":
+    let nodes =
+      generateNodes(
+        2,
+        gossip = true,
+        decayInterval = 20.milliseconds,
+        heartbeatInterval = TEST_GOSSIPSUB_HEARTBEAT_INTERVAL,
+      ).toGossipSub()
+
+    startAndDeferStop(nodes)
+    await connectStar(nodes)
+
+    nodes[0].subscribe(topic, voidTopicHandler)
+    nodes[1].subscribe(topic, voidTopicHandler)
+    waitSubscribeStar(nodes, topic)
+
+    nodes[0].parameters.slowPeerPenaltyWeight = -10.0
+    nodes[0].parameters.slowPeerPenaltyThreshold = 0.0
+    nodes[0].parameters.slowPeerPenaltyDecay = 0.9
+
+    let peer = nodes[0].getPeerByPeerId(topic, nodes[1].peerInfo.peerId)
+    peer.slowPeerPenalty = 2.0
+
+    checkUntilTimeout:
+      nodes[0].getPeerScore(peer.peerId) < 0.0
+      not nodes[0].mesh.hasPeerId(topic, peer.peerId)
+
   asyncTest "Peers disconnections mechanics":
     const numberOfNodes = 10
     let nodes =

--- a/tests/libp2p/pubsub/test_gossipsub.nim
+++ b/tests/libp2p/pubsub/test_gossipsub.nim
@@ -27,6 +27,7 @@ suite "GossipSub":
       peerStats = PeerStats(
         score: gossipSub.parameters.graylistThreshold - 1.0,
         appScore: 10.0,
+        slowPeerPenalty: 3.0,
         behaviourPenalty: 5.0,
       )
     defer:
@@ -48,6 +49,7 @@ suite "GossipSub":
     check:
       peer.score == peerStats.score
       peer.appScore == peerStats.appScore
+      peer.slowPeerPenalty == peerStats.slowPeerPenalty
       peer.behaviourPenalty == peerStats.behaviourPenalty
 
     # And peer budgets are set to default values

--- a/tests/libp2p/pubsub/test_gossipsub_params.nim
+++ b/tests/libp2p/pubsub/test_gossipsub_params.nim
@@ -245,6 +245,76 @@ suite "GossipSubParams validation":
     params.behaviourPenaltyDecay = 0.5
     check params.validateParameters().isOk()
 
+  test "slowPeerPenaltyWeight fails when positive":
+    const errorMessage =
+      "gossipsub: slowPeerPenaltyWeight parameter error, Must be negative or 0"
+    var params = newDefaultValidParams()
+    params.slowPeerPenaltyWeight = 0.1
+    let res = params.validateParameters()
+    check res.isErr()
+    check res.error == errorMessage
+
+  test "slowPeerPenaltyWeight succeeds when zero":
+    var params = newDefaultValidParams()
+    params.slowPeerPenaltyWeight = 0.0
+    check params.validateParameters().isOk()
+
+  test "slowPeerPenaltyWeight succeeds when negative":
+    var params = newDefaultValidParams()
+    params.slowPeerPenaltyWeight = -0.0001
+    check params.validateParameters().isOk()
+
+  test "slowPeerPenaltyThreshold fails when negative":
+    const errorMessage =
+      "gossipsub: slowPeerPenaltyThreshold parameter error, Must be positive or 0"
+    var params = newDefaultValidParams()
+    params.slowPeerPenaltyThreshold = -0.1
+    let res = params.validateParameters()
+    check res.isErr()
+    check res.error == errorMessage
+
+  test "slowPeerPenaltyThreshold succeeds when zero":
+    var params = newDefaultValidParams()
+    params.slowPeerPenaltyThreshold = 0.0
+    check params.validateParameters().isOk()
+
+  test "slowPeerPenaltyThreshold succeeds when positive":
+    var params = newDefaultValidParams()
+    params.slowPeerPenaltyThreshold = 1.0
+    check params.validateParameters().isOk()
+
+  test "slowPeerPenaltyDecay fails when negative":
+    const errorMessage =
+      "gossipsub: slowPeerPenaltyDecay parameter error, Must be between 0 and 1 (exclusive)"
+    var params = newDefaultValidParams()
+    params.slowPeerPenaltyDecay = -0.1
+    let res = params.validateParameters()
+    check res.isErr()
+    check res.error == errorMessage
+
+  test "slowPeerPenaltyDecay fails when zero":
+    const errorMessage =
+      "gossipsub: slowPeerPenaltyDecay parameter error, Must be between 0 and 1 (exclusive)"
+    var params = newDefaultValidParams()
+    params.slowPeerPenaltyDecay = 0.0
+    let res = params.validateParameters()
+    check res.isErr()
+    check res.error == errorMessage
+
+  test "slowPeerPenaltyDecay fails when equal to 1":
+    const errorMessage =
+      "gossipsub: slowPeerPenaltyDecay parameter error, Must be between 0 and 1 (exclusive)"
+    var params = newDefaultValidParams()
+    params.slowPeerPenaltyDecay = 1.0
+    let res = params.validateParameters()
+    check res.isErr()
+    check res.error == errorMessage
+
+  test "slowPeerPenaltyDecay succeeds when between 0 and 1":
+    var params = newDefaultValidParams()
+    params.slowPeerPenaltyDecay = 0.5
+    check params.validateParameters().isOk()
+
   test "maxHighPriorityQueueLen fails when zero":
     const errorMessage =
       "gossipsub: maxHighPriorityQueueLen parameter error, Must be > 0"

--- a/tests/libp2p/pubsub/test_priority_queues.nim
+++ b/tests/libp2p/pubsub/test_priority_queues.nim
@@ -269,3 +269,48 @@ suite "Priority queue behavior":
     checkUntilTimeout:
       mediumDrain.finished
       lowDrain.finished
+
+  test "Queue admission drops medium when backlog exists and medium queue is full":
+    let queueAction = determineQueueAction(
+      priority = MessagePriority.Medium,
+      sendPriorityQueueLen = 1,
+      mediumPriorityQueueLen = 1,
+      lowPriorityQueueLen = 0,
+      maxHighPriorityQueueLen = 2,
+      maxMediumPriorityQueueLen = 1,
+      maxLowPriorityQueueLen = 2,
+    )
+
+    check:
+      queueAction.action == QueueActionType.DropMedium
+      queueAction.slowPeerPenaltyDelta == 1.0
+
+  test "Queue admission drops low when backlog exists and low queue is full":
+    let queueAction = determineQueueAction(
+      priority = MessagePriority.Low,
+      sendPriorityQueueLen = 1,
+      mediumPriorityQueueLen = 0,
+      lowPriorityQueueLen = 1,
+      maxHighPriorityQueueLen = 2,
+      maxMediumPriorityQueueLen = 2,
+      maxLowPriorityQueueLen = 1,
+    )
+
+    check:
+      queueAction.action == QueueActionType.DropLow
+      queueAction.slowPeerPenaltyDelta == 1.0
+
+  test "Queue admission disconnects when high priority queue is full":
+    let queueAction = determineQueueAction(
+      priority = MessagePriority.High,
+      sendPriorityQueueLen = 1,
+      mediumPriorityQueueLen = 0,
+      lowPriorityQueueLen = 0,
+      maxHighPriorityQueueLen = 1,
+      maxMediumPriorityQueueLen = 2,
+      maxLowPriorityQueueLen = 2,
+    )
+
+    check:
+      queueAction.action == QueueActionType.Disconnect
+      queueAction.slowPeerPenaltyDelta == 0.0

--- a/tests/libp2p/pubsub/test_priority_queues.nim
+++ b/tests/libp2p/pubsub/test_priority_queues.nim
@@ -282,7 +282,8 @@ suite "Priority queue behavior":
     )
 
     check:
-      queueAction.action == QueueActionType.DropMedium
+      queueAction.priority == MessagePriority.Medium
+      queueAction.send == false
       queueAction.slowPeerPenaltyDelta == 1.0
 
   test "Queue admission drops low when backlog exists and low queue is full":
@@ -297,7 +298,8 @@ suite "Priority queue behavior":
     )
 
     check:
-      queueAction.action == QueueActionType.DropLow
+      queueAction.priority == MessagePriority.Low
+      queueAction.send == false
       queueAction.slowPeerPenaltyDelta == 1.0
 
   test "Queue admission disconnects when high priority queue is full":
@@ -312,5 +314,6 @@ suite "Priority queue behavior":
     )
 
     check:
-      queueAction.action == QueueActionType.Disconnect
+      queueAction.priority == MessagePriority.High
+      queueAction.send == false
       queueAction.slowPeerPenaltyDelta == 0.0

--- a/tests/libp2p/pubsub/test_scoring.nim
+++ b/tests/libp2p/pubsub/test_scoring.nim
@@ -346,6 +346,7 @@ suite "GossipSub Scoring":
       slowPeerPenaltyDecay = 0.5
       initialPenalty = 4.0
       expectedScore = (initialPenalty - defaultThreshold) * defaultWeight
+      expectedDecayedPenalty = initialPenalty * slowPeerPenaltyDecay
 
     check:
       defaultWeight == -0.05
@@ -358,8 +359,8 @@ suite "GossipSub Scoring":
     gossipSub.updateScores()
 
     check:
-      abs(peers[0].score - expectedScore) < 1e-9
-      abs(peers[0].slowPeerPenalty - (initialPenalty * slowPeerPenaltyDecay)) < 1e-9
+      peers[0].score == expectedScore
+      peers[0].slowPeerPenalty == expectedDecayedPenalty
 
   asyncTest "Slow peer penalty can still be disabled with zero weight":
     let (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)

--- a/tests/libp2p/pubsub/test_scoring.nim
+++ b/tests/libp2p/pubsub/test_scoring.nim
@@ -278,62 +278,98 @@ suite "GossipSub Scoring":
     defer:
       await teardownGossipSub(gossipSub, conns)
 
-    gossipSub.parameters.slowPeerPenaltyWeight = -1.0
-    gossipSub.parameters.slowPeerPenaltyThreshold = 1.0
-    gossipSub.parameters.slowPeerPenaltyDecay = 0.5
+    let
+      slowPeerPenaltyWeight = -1.0
+      slowPeerPenaltyThreshold = 1.0
+      slowPeerPenaltyDecay = 0.5
+      initialPenalties = [4.0, 2.0, 1.0]
+      expectedScores = [
+        (initialPenalties[0] - slowPeerPenaltyThreshold) * slowPeerPenaltyWeight,
+        (initialPenalties[1] - slowPeerPenaltyThreshold) * slowPeerPenaltyWeight,
+        0.0,
+      ]
+      expectedDecayedPenalties = [
+        initialPenalties[0] * slowPeerPenaltyDecay,
+        initialPenalties[1] * slowPeerPenaltyDecay,
+        initialPenalties[2] * slowPeerPenaltyDecay,
+      ]
 
-    peers[0].slowPeerPenalty = 4.0
-    peers[1].slowPeerPenalty = 2.0
-    peers[2].slowPeerPenalty = 1.0
+    gossipSub.parameters.slowPeerPenaltyWeight = slowPeerPenaltyWeight
+    gossipSub.parameters.slowPeerPenaltyThreshold = slowPeerPenaltyThreshold
+    gossipSub.parameters.slowPeerPenaltyDecay = slowPeerPenaltyDecay
+
+    peers[0].slowPeerPenalty = initialPenalties[0]
+    peers[1].slowPeerPenalty = initialPenalties[1]
+    peers[2].slowPeerPenalty = initialPenalties[2]
 
     gossipSub.updateScores()
 
     check:
-      round(peers[0].score, 1) == -3.0 # (4.0 - 1.0) * -1.0
-      round(peers[1].score, 1) == -1.0 # (2.0 - 1.0) * -1.0
-      round(peers[2].score, 1) == 0.0 # threshold is not penalized
+      peers[0].score == expectedScores[0]
+      peers[1].score == expectedScores[1]
+      peers[2].score == expectedScores[2]
 
     check:
-      round(peers[0].slowPeerPenalty, 1) == 2.0
-      round(peers[1].slowPeerPenalty, 1) == 1.0
-      round(peers[2].slowPeerPenalty, 1) == 0.5
+      peers[0].slowPeerPenalty == expectedDecayedPenalties[0]
+      peers[1].slowPeerPenalty == expectedDecayedPenalties[1]
+      peers[2].slowPeerPenalty == expectedDecayedPenalties[2]
 
   asyncTest "Slow peer penalty decay is independent from behaviourPenalty":
     let (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
     defer:
       await teardownGossipSub(gossipSub, conns)
 
-    gossipSub.parameters.slowPeerPenaltyWeight = -0.5
-    gossipSub.parameters.slowPeerPenaltyThreshold = 1.0
-    gossipSub.parameters.slowPeerPenaltyDecay = 0.5
-    gossipSub.parameters.behaviourPenaltyWeight = -1.0
-    gossipSub.parameters.behaviourPenaltyDecay = 0.25
+    let
+      slowPeerPenaltyWeight = -0.5
+      slowPeerPenaltyThreshold = 1.0
+      slowPeerPenaltyDecay = 0.5
+      behaviourPenaltyWeight = -1.0
+      behaviourPenaltyDecay = 0.25
+      initialSlowPeerPenalty = 5.0
+      initialBehaviourPenalty = 2.0
+      expectedScore =
+        ((initialSlowPeerPenalty - slowPeerPenaltyThreshold) * slowPeerPenaltyWeight) +
+        (initialBehaviourPenalty * initialBehaviourPenalty * behaviourPenaltyWeight)
+      expectedSlowPeerPenalty = initialSlowPeerPenalty * slowPeerPenaltyDecay
+      expectedBehaviourPenalty = initialBehaviourPenalty * behaviourPenaltyDecay
 
-    peers[0].slowPeerPenalty = 5.0
-    peers[0].behaviourPenalty = 2.0
+    gossipSub.parameters.slowPeerPenaltyWeight = slowPeerPenaltyWeight
+    gossipSub.parameters.slowPeerPenaltyThreshold = slowPeerPenaltyThreshold
+    gossipSub.parameters.slowPeerPenaltyDecay = slowPeerPenaltyDecay
+    gossipSub.parameters.behaviourPenaltyWeight = behaviourPenaltyWeight
+    gossipSub.parameters.behaviourPenaltyDecay = behaviourPenaltyDecay
+
+    peers[0].slowPeerPenalty = initialSlowPeerPenalty
+    peers[0].behaviourPenalty = initialBehaviourPenalty
 
     gossipSub.updateScores()
 
     check:
-      round(peers[0].score, 1) == -6.0 # ((5 - 1) * -0.5) + (2^2 * -1.0)
-      round(peers[0].slowPeerPenalty, 1) == 2.5
-      round(peers[0].behaviourPenalty, 1) == 0.5
+      peers[0].score == expectedScore
+      peers[0].slowPeerPenalty == expectedSlowPeerPenalty
+      peers[0].behaviourPenalty == expectedBehaviourPenalty
 
   asyncTest "Slow peer penalty is retained in peer stats":
     let (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
     defer:
       await teardownGossipSub(gossipSub, conns)
 
-    gossipSub.parameters.slowPeerPenaltyWeight = -1.0
-    gossipSub.parameters.slowPeerPenaltyDecay = 0.5
+    let
+      slowPeerPenaltyWeight = -1.0
+      slowPeerPenaltyDecay = 0.5
+      initialPenalty = 4.0
+      expectedRetainedPenalty = initialPenalty * slowPeerPenaltyDecay
 
-    peers[0].slowPeerPenalty = 4.0
+    gossipSub.parameters.slowPeerPenaltyWeight = slowPeerPenaltyWeight
+    gossipSub.parameters.slowPeerPenaltyDecay = slowPeerPenaltyDecay
+
+    peers[0].slowPeerPenalty = initialPenalty
 
     gossipSub.updateScores()
 
     gossipSub.withPeerStats(peers[0].peerId) do(stats: var PeerStats):
       check:
-        round(stats.slowPeerPenalty, 1) == 2.0
+        stats.slowPeerPenalty == expectedRetainedPenalty
 
   asyncTest "Default slow peer penalty settings apply a mild penalty above threshold":
     let (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
@@ -367,17 +403,26 @@ suite "GossipSub Scoring":
     defer:
       await teardownGossipSub(gossipSub, conns)
 
-    gossipSub.parameters.slowPeerPenaltyWeight = 0.0
-    gossipSub.parameters.slowPeerPenaltyThreshold = 0.0
-    gossipSub.parameters.slowPeerPenaltyDecay = 0.5
+    let
+      slowPeerPenaltyWeight = 0.0
+      slowPeerPenaltyThreshold = 0.0
+      slowPeerPenaltyDecay = 0.5
+      initialPenalty = 4.0
+      expectedScore =
+        (initialPenalty - slowPeerPenaltyThreshold) * slowPeerPenaltyWeight
+      expectedDecayedPenalty = initialPenalty * slowPeerPenaltyDecay
 
-    peers[0].slowPeerPenalty = 4.0
+    gossipSub.parameters.slowPeerPenaltyWeight = slowPeerPenaltyWeight
+    gossipSub.parameters.slowPeerPenaltyThreshold = slowPeerPenaltyThreshold
+    gossipSub.parameters.slowPeerPenaltyDecay = slowPeerPenaltyDecay
+
+    peers[0].slowPeerPenalty = initialPenalty
 
     gossipSub.updateScores()
 
     check:
-      round(peers[0].score, 1) == 0.0
-      round(peers[0].slowPeerPenalty, 1) == 2.0
+      peers[0].score == expectedScore
+      peers[0].slowPeerPenalty == expectedDecayedPenalty
 
   asyncTest "Colocation factor scoring":
     let (gossipSub, conns, peers) = setupGossipSubWithPeers(5, topic)

--- a/tests/libp2p/pubsub/test_scoring.nim
+++ b/tests/libp2p/pubsub/test_scoring.nim
@@ -340,15 +340,26 @@ suite "GossipSub Scoring":
     defer:
       await teardownGossipSub(gossipSub, conns)
 
-    gossipSub.parameters.slowPeerPenaltyDecay = 0.5
+    let
+      defaultWeight = gossipSub.parameters.slowPeerPenaltyWeight
+      defaultThreshold = gossipSub.parameters.slowPeerPenaltyThreshold
+      slowPeerPenaltyDecay = 0.5
+      initialPenalty = 4.0
+      expectedScore = (initialPenalty - defaultThreshold) * defaultWeight
 
-    peers[0].slowPeerPenalty = 4.0
+    check:
+      defaultWeight == -0.05
+      defaultThreshold == 2.0
+
+    gossipSub.parameters.slowPeerPenaltyDecay = slowPeerPenaltyDecay
+
+    peers[0].slowPeerPenalty = initialPenalty
 
     gossipSub.updateScores()
 
     check:
-      round(peers[0].score, 1) == -0.1
-      round(peers[0].slowPeerPenalty, 1) == 2.0
+      abs(peers[0].score - expectedScore) < 1e-9
+      abs(peers[0].slowPeerPenalty - (initialPenalty * slowPeerPenaltyDecay)) < 1e-9
 
   asyncTest "Slow peer penalty can still be disabled with zero weight":
     let (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)

--- a/tests/libp2p/pubsub/test_scoring.nim
+++ b/tests/libp2p/pubsub/test_scoring.nim
@@ -273,6 +273,100 @@ suite "GossipSub Scoring":
       round(peers[1].behaviourPenalty, 1) == 1.0 # 2.0 * 0.5
       round(peers[2].behaviourPenalty, 1) == 0.0
 
+  asyncTest "Slow peer penalty scoring":
+    let (gossipSub, conns, peers) = setupGossipSubWithPeers(3, topic)
+    defer:
+      await teardownGossipSub(gossipSub, conns)
+
+    gossipSub.parameters.slowPeerPenaltyWeight = -1.0
+    gossipSub.parameters.slowPeerPenaltyThreshold = 1.0
+    gossipSub.parameters.slowPeerPenaltyDecay = 0.5
+
+    peers[0].slowPeerPenalty = 4.0
+    peers[1].slowPeerPenalty = 2.0
+    peers[2].slowPeerPenalty = 1.0
+
+    gossipSub.updateScores()
+
+    check:
+      round(peers[0].score, 1) == -3.0 # (4.0 - 1.0) * -1.0
+      round(peers[1].score, 1) == -1.0 # (2.0 - 1.0) * -1.0
+      round(peers[2].score, 1) == 0.0 # threshold is not penalized
+
+    check:
+      round(peers[0].slowPeerPenalty, 1) == 2.0
+      round(peers[1].slowPeerPenalty, 1) == 1.0
+      round(peers[2].slowPeerPenalty, 1) == 0.5
+
+  asyncTest "Slow peer penalty decay is independent from behaviourPenalty":
+    let (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
+    defer:
+      await teardownGossipSub(gossipSub, conns)
+
+    gossipSub.parameters.slowPeerPenaltyWeight = -0.5
+    gossipSub.parameters.slowPeerPenaltyThreshold = 1.0
+    gossipSub.parameters.slowPeerPenaltyDecay = 0.5
+    gossipSub.parameters.behaviourPenaltyWeight = -1.0
+    gossipSub.parameters.behaviourPenaltyDecay = 0.25
+
+    peers[0].slowPeerPenalty = 5.0
+    peers[0].behaviourPenalty = 2.0
+
+    gossipSub.updateScores()
+
+    check:
+      round(peers[0].score, 1) == -6.0 # ((5 - 1) * -0.5) + (2^2 * -1.0)
+      round(peers[0].slowPeerPenalty, 1) == 2.5
+      round(peers[0].behaviourPenalty, 1) == 0.5
+
+  asyncTest "Slow peer penalty is retained in peer stats":
+    let (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
+    defer:
+      await teardownGossipSub(gossipSub, conns)
+
+    gossipSub.parameters.slowPeerPenaltyWeight = -1.0
+    gossipSub.parameters.slowPeerPenaltyDecay = 0.5
+
+    peers[0].slowPeerPenalty = 4.0
+
+    gossipSub.updateScores()
+
+    gossipSub.withPeerStats(peers[0].peerId) do(stats: var PeerStats):
+      check:
+        round(stats.slowPeerPenalty, 1) == 2.0
+
+  asyncTest "Default slow peer penalty settings apply a mild penalty above threshold":
+    let (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
+    defer:
+      await teardownGossipSub(gossipSub, conns)
+
+    gossipSub.parameters.slowPeerPenaltyDecay = 0.5
+
+    peers[0].slowPeerPenalty = 4.0
+
+    gossipSub.updateScores()
+
+    check:
+      round(peers[0].score, 1) == -0.1
+      round(peers[0].slowPeerPenalty, 1) == 2.0
+
+  asyncTest "Slow peer penalty can still be disabled with zero weight":
+    let (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
+    defer:
+      await teardownGossipSub(gossipSub, conns)
+
+    gossipSub.parameters.slowPeerPenaltyWeight = 0.0
+    gossipSub.parameters.slowPeerPenaltyThreshold = 0.0
+    gossipSub.parameters.slowPeerPenaltyDecay = 0.5
+
+    peers[0].slowPeerPenalty = 4.0
+
+    gossipSub.updateScores()
+
+    check:
+      round(peers[0].score, 1) == 0.0
+      round(peers[0].slowPeerPenalty, 1) == 2.0
+
   asyncTest "Colocation factor scoring":
     let (gossipSub, conns, peers) = setupGossipSubWithPeers(5, topic)
     defer:


### PR DESCRIPTION
## Summary

This PR adds a separate slow-peer scoring signal for gossipsub peers that repeatedly overflow their medium- or low-priority outbound queues.

It is needed because high-priority queue overflow already disconnects a peer immediately, but repeated medium/low queue drops previously had no direct effect on peer score or pruning. The change introduces a mild secondary penalty that can help deprioritize persistently slow peers without changing existing gossip parameters

Concretely, this PR:
- adds `slowPeerPenaltyWeight`, `slowPeerPenaltyThreshold`, and `slowPeerPenaltyDecay` to `GossipSubParams`
- tracks `slowPeerPenalty` in both live peer state and retained peer stats
- increments that penalty only when medium/low queue overflow causes message drops
- applies and decays the penalty during score updates
- keeps high-priority overflow behavior unchanged: it still disconnects and does not affect score
- refactors queue-action selection into a dedicated helper to make the behavior explicit and directly testable


## Affected Areas

- [x] Gossipsub  
  - Adds a new slow-peer scoring component, parameter validation, retained-state restore logic, and queue-overflow integration.  Changes how medium/low queue overflow contributes to pruning pressure, while preserving high-priority disconnect behavior.
  - Adds test coverage for params, score calculation/decay, queue-action decisions, retained score state, and heartbeat pruning.  
- [ ] Transports
- [ ] Peer Management / Discovery
- [ ] Protocol Logic  
- [ ] Build / Tooling
- [ ] Other  

## Compatibility & Downstream Validation

Reference PRs / branches / commits demonstrating successful integration:

- **Nimbus:**  
  Not yet validated in a downstream integration branch.

- **Waku:**  
  Not yet validated in a downstream integration branch.

- **Codex:**  
  Not yet validated in a downstream integration branch.


## Impact on Library Users

Downstream users get three new gossipsub tuning parameters:
- `slowPeerPenaltyWeight`
- `slowPeerPenaltyThreshold`
- `slowPeerPenaltyDecay`

Behaviorally, peers that repeatedly overflow medium/low outbound queues can now accumulate a mild score penalty and eventually be pruned. The default settings on this branch are conservative but enabled by default: `weight = -0.05`, `threshold = 2.0`, `decay = 0.2`.

There is also a new public queue-action helper in `pubsubpeer` used to make queue behavior deterministic and testable, but it does not require migration for normal library consumers.


## Risk Assessment

Main risk is network-behavior drift: peers that are locally slow to drain medium/low queues may now see lower scores and be pruned more often than before.

Additional risks:
- the signal is based on local backpressure, so its impact is workload- and deployment-dependent
- defaults are conservative but active by default
- queue-action logic was refactored, so regressions in send/queue routing are possible even though focused tests pass

The change does not expand the disconnect surface for high-priority overflow, and it does not modify mesh delivery penalties or protocol-misbehavior scoring.


## References

- Prior related work: `vacp2p/nim-libp2p#1083`
- Upstream comparison considered during design: `go-libp2p-pubsub` and `rust-libp2p` slow-peer behavior

