### PR TITLE
chore(deps): use lsquic nimble package

### DIFF
--- a/.pinned
+++ b/.pinned
@@ -7,7 +7,7 @@ httputils;https://github.com/status-im/nim-http-utils@#79cbab1460f4c0cdde2084589
 json_serialization;https://github.com/status-im/nim-json-serialization@#2b1c5eb11df3647a2cee107cd4cce3593cbb8bcf
 metrics;https://github.com/status-im/nim-metrics@#6142e433fc8ea9b73379770a788017ac528d46ff
 nimcrypto;https://github.com/cheatfate/nimcrypto@#19c41d6be4c00b4a2c8000583bd30cf8ceb5f4b1
-lsquic;https://github.com/vacp2p/nim-lsquic@#86b8efc703d06a493fa984b76e4ffb6ddde99c41
+lsquic;https://github.com/vacp2p/nim-lsquic@#a776eced48d1f3c630d8f3a8a3e976171dd1f9c1
 results;https://github.com/arnetheduck/nim-results@#df8113dda4c2d74d460a8fa98252b0b771bf1f27
 secp256k1;https://github.com/status-im/nim-secp256k1@#f808ed5e7a7bfc42204ec7830f14b7a42b63c284
 serialization;https://github.com/status-im/nim-serialization@#548d0adc9797a10b2db7f788b804330306293088

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -10,9 +10,8 @@ skipDirs = @["cbind", "examples", "interop", "performance", "tests", "tools"]
 requires "nim >= 2.0.0",
   "nimcrypto >= 0.6.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.7",
   "chronicles >= 0.11.0", "chronos >= 4.2.2", "metrics", "secp256k1", "stew >= 0.4.2",
-  "unittest2", "results", "serialization",
+  "unittest2", "results", "serialization", "lsquic",
   "https://github.com/status-im/nim-websock#42c37b4172519566db016810eccfce8a02cc1cdf",
-  "https://github.com/vacp2p/nim-lsquic#86b8efc703d06a493fa984b76e4ffb6ddde99c41",
   "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
 
 import hashes, os, sequtils, strutils


### PR DESCRIPTION
## Summary
Instead of using a commit, use the `lsquic` package published recently in https://github.com/nim-lang/packages/pull/3326 

## Affected Areas

- [ ] Gossipsub  
- [ ] Transports  
- [ ] Peer Management / Discovery
- [ ] Protocol Logic
- [x] Build / Tooling
- [ ] Other  
