### PR TITLE
feat(quic): add getStreams, close session after handle exit

### DIFF
--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -120,12 +120,12 @@ method closeImpl*(stream: QuicStream) {.async: (raises: []).} =
 method closed*(session: QuicSession): bool {.raises: [].} =
   procCall P2PConnection(session).isClosed or session.connection.isClosed
 
-method closeImpl*(session: QuicSession) {.async: (raises: []).} =
+method close*(session: QuicSession) {.async: (raises: []).} =
   let streams = session.streams
   session.streams.clear()
   await noCancel allFutures(streams.mapIt(it.close()))
   session.connection.close()
-  await procCall P2PConnection(session).closeImpl()
+  await procCall P2PConnection(session).close()
 
 proc getStream(
     session: QuicSession, direction = Direction.In

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -190,7 +190,10 @@ method newStream*(
     raise newException(MuxerError, "error in newStream: " & e.msg, e)
 
 method getStreams*(m: QuicMuxer): seq[connection.Connection] {.gcsafe.} =
-  toSeq(m.session.streams)
+  var streams: seq[connection.Connection]
+  for s in m.session.streams:
+    streams.add(s)
+  return streams
 
 method handle*(m: QuicMuxer): Future[void] {.async: (raises: []).} =
   proc handleStream(stream: QuicStream) {.async: (raises: []).} =

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -120,12 +120,12 @@ method closeImpl*(stream: QuicStream) {.async: (raises: []).} =
 method closed*(session: QuicSession): bool {.raises: [].} =
   procCall P2PConnection(session).isClosed or session.connection.isClosed
 
-method close*(session: QuicSession) {.async: (raises: []).} =
+method closeImpl*(session: QuicSession) {.async: (raises: []).} =
   let streams = session.streams
   session.streams.clear()
   await noCancel allFutures(streams.mapIt(it.close()))
   session.connection.close()
-  await procCall P2PConnection(session).close()
+  await procCall P2PConnection(session).closeImpl()
 
 proc getStream(
     session: QuicSession, direction = Direction.In

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -190,8 +190,7 @@ method newStream*(
     raise newException(MuxerError, "error in newStream: " & e.msg, e)
 
 method getStreams*(m: QuicMuxer): seq[connection.Connection] {.gcsafe.} =
-  for s in m.session.streams:
-    result.add(s)
+  toSeq(m.session.streams)
 
 method handle*(m: QuicMuxer): Future[void] {.async: (raises: []).} =
   proc handleStream(stream: QuicStream) {.async: (raises: []).} =

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -190,7 +190,7 @@ method newStream*(
     raise newException(MuxerError, "error in newStream: " & e.msg, e)
 
 method getStreams*(m: QuicMuxer): seq[connection.Connection] {.gcsafe.} =
-  var streams: seq[connection.Connection]
+  var streams = newSeqOfCap[connection.Connection](m.session.streams.len)
   for s in m.session.streams:
     streams.add(s)
   return streams

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -189,6 +189,10 @@ method newStream*(
   except ConnectionError as e:
     raise newException(MuxerError, "error in newStream: " & e.msg, e)
 
+method getStreams*(m: QuicMuxer): seq[connection.Connection] {.gcsafe.} =
+  for s in m.session.streams:
+    result.add(s)
+
 method handle*(m: QuicMuxer): Future[void] {.async: (raises: []).} =
   proc handleStream(stream: QuicStream) {.async: (raises: []).} =
     ## call the muxer stream handler for this channel
@@ -209,6 +213,9 @@ method handle*(m: QuicMuxer): Future[void] {.async: (raises: []).} =
       # keep handling, until connection is closed. 
       # this stream failed but we need to keep handling for other streams.
       trace "QuicMuxer.handler got error while opening stream", msg = e.msg
+
+  if not m.session.isClosed:
+    await m.session.close()
 
 method close*(m: QuicMuxer) {.async: (raises: []).} =
   try:


### PR DESCRIPTION
## Summary

Two small additions to libp2p/transports/quictransport.nim to fit QuicMuxer to the logos-delivery QUIC implementation.

* Add QuicMuxer.getStreams()
* Close the session after the QuicMuxer.handle() loop exits

The session close change was needed to get our QUIC PoC tests to pass. With this fix, tests that assumed a TCP transport before now do not hang/crash/fail when configured to use QUIC instead.

## Affected Areas

- [ ] Gossipsub
- [x] Transports
- [ ] Peer Management / Discovery
- [ ] Protocol Logic
- [ ] Build / Tooling
- [ ] Other

## Compatibility & Downstream Validation

Tested in logos-delivery during development of a QUIC PoC. These are the only two changes needed that we identified.

## Impact on Library Users

A closing QUIC connection now closes itself and QuicMuxer.getStreams() doesn't crash with the "not implemented" base class defect.

## Risk Assessment

No risk identified.

## References

logos-delivery QUIC PoC PR: https://github.com/logos-messaging/logos-delivery/pull/3793 -- the PoC PR is a bit messy (it's still with the old build system and outdated nim-libp2p and lsquic vendored/pinned versions; it applies a custom patch before compilation), but all tests pass, and I made it work in Waku Simulator (it's a rickety simulation setup for now, but with that PoC PR, which includes the two changes in this libp2p PR, QUIC worked end-to-end).