### PR TITLE
feat: reset stream

### DIFF
--- a/.pinned
+++ b/.pinned
@@ -7,7 +7,7 @@ httputils;https://github.com/status-im/nim-http-utils@#f142cb2e8bd812dd002a6493b
 json_serialization;https://github.com/status-im/nim-json-serialization@#a6dcf03e04e179127a5fcb7e495d19a821d56c17
 metrics;https://github.com/status-im/nim-metrics@#a1296caf3ebb5f30f51a5feae7749a30df2824c2
 nimcrypto;https://github.com/cheatfate/nimcrypto@#721fb99ee099b632eb86dfad1f0d96ee87583774
-lsquic;https://github.com/vacp2p/nim-lsquic@#6d2bc489d05a0a33636a144d48bd99c707285a42
+lsquic;https://github.com/vacp2p/nim-lsquic@#504c8c1574f1fc47d994ed7fc94f17a28d95d579
 results;https://github.com/arnetheduck/nim-results@#df8113dda4c2d74d460a8fa98252b0b771bf1f27
 secp256k1;https://github.com/status-im/nim-secp256k1@#d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15
 serialization;https://github.com/status-im/nim-serialization@#f80cfd8657f272a2abd063d070b77f2a74f704cd

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -11,7 +11,7 @@ skipDirs =
 requires "nim >= 2.0.0",
   "nimcrypto >= 0.6.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.7",
   "chronicles >= 0.11.0", "chronos >= 4.2.2", "metrics", "secp256k1", "stew >= 0.4.2",
-  "unittest2", "results", "serialization", "lsquic >= 0.2.0",
+  "unittest2", "results", "serialization", "lsquic >= 0.3.0",
   "https://github.com/status-im/nim-websock#42c37b4172519566db016810eccfce8a02cc1cdf",
   "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
 

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -91,18 +91,19 @@ proc closeUnderlying(s: LPChannel): Future[void] {.async: (raises: []).} =
   if s.closedLocal and s.atEof():
     await procCall BufferStream(s).close()
 
-proc reset*(s: LPChannel) {.async: (raises: []).} =
-  if s.isClosed:
-    trace "Already closed", s
+proc resetChannel*(s: LPChannel, isLocal: bool) {.async: (raises: []).} =
+  if s.localReset or s.remoteReset:
+    trace "Already reset", s
     return
 
   s.isClosed = true
   s.closedLocal = true
-  s.localReset = not s.remoteReset
+  s.localReset = isLocal
+  s.remoteReset = not isLocal
 
   trace "Resetting channel", s, len = s.len
 
-  if s.isOpen and not s.conn.isClosed:
+  if isLocal and s.isOpen and not s.conn.isClosed:
     # If the connection is still active, notify the other end
     proc resetMessage() {.async: (raises: []).} =
       try:
@@ -117,6 +118,9 @@ proc reset*(s: LPChannel) {.async: (raises: []).} =
   await s.closeImpl()
 
   trace "Channel reset", s
+
+method resetImpl*(s: LPChannel) {.async: (raises: []).} =
+  await s.resetChannel(isLocal = true)
 
 method close*(s: LPChannel) {.async: (raises: []).} =
   ## Close channel for writing - a message will be sent to the other peer

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -175,8 +175,7 @@ method handle*(m: Mplex) {.async: (raises: []).} =
       of MessageType.CloseIn, MessageType.CloseOut:
         await channel.pushEof()
       of MessageType.ResetIn, MessageType.ResetOut:
-        channel.remoteReset = true
-        await channel.reset()
+        await channel.resetChannel(isLocal = false)
   except CancelledError:
     debug "Unexpected cancellation in mplex handler", m
   except LPStreamEOFError as exc:

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -233,6 +233,7 @@ proc reset(channel: YamuxChannel, isLocal: bool = false) {.async: (raises: []).}
   trace "Reset channel"
   channel.isReset = true
   channel.remoteReset = not isLocal
+  channel.isClosed = true
   channel.clearQueues(newLPStreamEOFError())
 
   channel.sendWindow = 0
@@ -242,13 +243,16 @@ proc reset(channel: YamuxChannel, isLocal: bool = false) {.async: (raises: []).}
         await channel.conn.write(YamuxHeader.data(channel.id, 0, {Rst}))
       except CancelledError, LPStreamError:
         discard
-    await channel.close()
+    await channel.closeImpl()
   if not channel.closedRemotely.isSet():
     await channel.remoteClosed()
   channel.receivedData.fire()
   if not isLocal:
     # If the reset is remote, there's no reason to flush anything.
     channel.recvWindow = 0
+
+method resetImpl*(channel: YamuxChannel) {.async: (raises: []).} =
+  await channel.reset(isLocal = true)
 
 proc updateRecvWindow(
     channel: YamuxChannel

--- a/libp2p/protocols/connectivity/relay/rconn.nim
+++ b/libp2p/protocols/connectivity/relay/rconn.nim
@@ -33,6 +33,10 @@ method closeImpl*(self: RelayConnection): Future[void] {.async: (raises: []).} =
   await self.conn.close()
   await procCall Connection(self).closeImpl()
 
+method resetImpl*(self: RelayConnection): Future[void] {.async: (raises: []).} =
+  await self.conn.reset()
+  await procCall Connection(self).closeImpl()
+
 method getWrapped*(self: RelayConnection): Connection =
   self.conn
 

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -72,6 +72,13 @@ method closeImpl*(s: SecureConn) {.async: (raises: []).} =
 
   await procCall Connection(s).closeImpl()
 
+method resetImpl*(s: SecureConn) {.async: (raises: []).} =
+  trace "Resetting secure conn", s, dir = s.dir
+  if s.stream != nil:
+    await s.stream.reset()
+
+  await procCall Connection(s).closeImpl()
+
 method readMessage*(
     c: SecureConn
 ): Future[seq[byte]] {.

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -38,6 +38,7 @@ type
     oid*: Oid
     dir*: Direction
     closedWithEOF: bool # prevent concurrent calls
+    isResetLocally: bool
     isClosedRemotely*: bool
 
   LPStreamError* = object of LPError
@@ -119,6 +120,9 @@ method closed*(s: LPStream): bool {.base.} =
 
 method atEof*(s: LPStream): bool {.base.} =
   s.isEof
+
+func wasResetLocally*(s: LPStream): bool {.inline.} =
+  s.isResetLocally
 
 method readOnce*(
     s: LPStream, pbytes: pointer, nbytes: int
@@ -264,6 +268,10 @@ method closeImpl*(s: LPStream): Future[void] {.async: (raises: [], raw: true), b
   trace "Closed stream", s, objName = s.objName, dir = $s.dir
   newFutureCompleted[void]()
 
+method resetImpl*(s: LPStream): Future[void] {.async: (raises: [], raw: true), base.} =
+  ## Default reset fallback for transports without an abort primitive.
+  closeImpl(s)
+
 method close*(s: LPStream): Future[void] {.async: (raises: [], raw: true), base.} =
   ## close the stream - this may block, but will not raise exceptions
   ##
@@ -277,6 +285,19 @@ method close*(s: LPStream): Future[void] {.async: (raises: [], raw: true), base.
   # override `closeImpl`, it is called only once - anyone overriding `close`
   # itself must implement this - once-only check as well, with their own field
   closeImpl(s)
+
+proc resetStream(s: LPStream): Future[void] {.async: (raises: [], raw: true).} =
+  ## Abort the stream and best-effort notify the remote peer, if supported.
+  if s.isClosed:
+    trace "Already closed", s
+    return newFutureCompleted[void]()
+
+  s.isClosed = true
+  s.isResetLocally = true
+  resetImpl(s)
+
+template reset*[T: LPStream](s: T): untyped =
+  resetStream(s)
 
 proc closeWithEOF*(s: LPStream): Future[void] {.async: (raises: []).} =
   ## Close the stream and wait for EOF - use this with half-closed streams where
@@ -300,7 +321,7 @@ proc closeWithEOF*(s: LPStream): Future[void] {.async: (raises: []).} =
   s.closedWithEOF = true
   await s.close()
 
-  if s.atEof():
+  if s.isResetLocally or s.atEof():
     return
 
   try:

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -88,14 +88,20 @@ when defined(libp2p_agents_metrics):
 method readOnce*(
     stream: QuicStream, pbytes: pointer, nbytes: int
 ): Future[int] {.async: (raises: [CancelledError, LPStreamError]).} =
+  if stream.wasResetLocally:
+    raise newLPStreamClosedError()
+
   if stream.atEof:
     raise newLPStreamRemoteClosedError()
 
-  let readLen =
-    try:
-      await stream.stream.readOnce(cast[ptr byte](pbytes), nbytes)
-    except StreamError as e:
-      raise (ref LPStreamError)(msg: "error in readOnce: " & e.msg, parent: e)
+  var readLen: int
+  try:
+    readLen = await stream.stream.readOnce(cast[ptr byte](pbytes), nbytes)
+  except StreamError as e:
+    if e of ref StreamResetError:
+      raise newLPStreamResetError()
+
+    raise (ref LPStreamError)(msg: "error in readOnce: " & e.msg, parent: e)
 
   if readLen == 0:
     stream.isEof = true
@@ -112,6 +118,9 @@ method readOnce*(
 method write*(
     stream: QuicStream, bytes: seq[byte]
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
+  if stream.wasResetLocally:
+    raise newLPStreamClosedError()
+
   try:
     await stream.stream.write(bytes)
     libp2p_network_bytes.inc(bytes.len.int64, labelValues = ["out"])
@@ -121,7 +130,10 @@ method write*(
         libp2p_peers_traffic_write.inc(
           bytes.len.int64, labelValues = [stream.shortAgent]
         )
-  except StreamError:
+  except StreamError as e:
+    if e of ref StreamResetError:
+      raise newLPStreamResetError()
+
     raise newLPStreamEOFError()
 
 method closeWrite*(stream: QuicStream) {.async: (raises: []).} =
@@ -130,6 +142,12 @@ method closeWrite*(stream: QuicStream) {.async: (raises: []).} =
     await stream.stream.close()
   except CancelledError, StreamError:
     discard
+
+method resetImpl*(stream: QuicStream) {.async: (raises: []).} =
+  stream.stream.abort()
+  stream.isEof = true
+  stream.session.streams.excl(stream)
+  await procCall P2PConnection(stream).closeImpl()
 
 method closeImpl*(stream: QuicStream) {.async: (raises: []).} =
   try:

--- a/tests/libp2p/muxers/test_mplex.nim
+++ b/tests/libp2p/muxers/test_mplex.nim
@@ -740,6 +740,43 @@ suite "Mplex":
       await allFuturesRaising(transport1.stop(), transport2.stop())
       await acceptFut
 
+    asyncTest "Connection.reset aborts the dialer stream":
+      let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
+      let transport1 = TcpTransport.new(upgrade = Upgrade())
+
+      proc acceptHandler() {.async.} =
+        let conn = await transport1.accept()
+        let mplexListen = Mplex.new(conn)
+        mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+          await stream.reset()
+
+        await mplexListen.handle()
+        await mplexListen.close()
+
+      await transport1.start(ma)
+      let acceptFut = acceptHandler()
+
+      let transport2: TcpTransport = TcpTransport.new(upgrade = Upgrade())
+      let conn = await transport2.dial(transport1.addrs[0])
+
+      let mplexDial = Mplex.new(conn)
+      let mplexDialFut = mplexDial.handle()
+      let stream = await mplexDial.newStream()
+
+      expect LPStreamResetError:
+        discard await stream.readLp(1024)
+      expect LPStreamResetError:
+        await stream.writeLp("HELLO")
+
+      await stream.close()
+
+      checkTracker(LPChannelTrackerName)
+
+      await conn.close()
+      await mplexDialFut
+      await allFuturesRaising(transport1.stop(), transport2.stop())
+      await acceptFut
+
     asyncTest "dialing mplex closes both ends":
       let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
       let transport1 = TcpTransport.new(upgrade = Upgrade())

--- a/tests/libp2p/muxers/test_yamux.nim
+++ b/tests/libp2p/muxers/test_yamux.nim
@@ -399,6 +399,22 @@ suite "Yamux":
       blocker.complete()
       await streamA.close()
 
+    asyncTest "Connection.reset aborts the initiator stream":
+      mSetup()
+
+      yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
+        await conn.reset()
+
+      let streamA = await yamuxa.newStream()
+      check streamA == yamuxa.getStreams()[0]
+
+      expect LPStreamResetError:
+        discard await streamA.readLp(100)
+      expect LPStreamResetError:
+        await streamA.writeLp(fromHex("1234"))
+
+      await streamA.close()
+
     asyncTest "Peer must be able to read from stream after closing it for writing":
       mSetup()
 

--- a/tests/libp2p/stream/test_bufferstream.nim
+++ b/tests/libp2p/stream/test_bufferstream.nim
@@ -239,3 +239,16 @@ suite "BufferStream":
 
     await stream.closeWithEOF()
     await push
+
+  asyncTest "reset is terminal and closeWithEOF returns immediately after reset":
+    let stream = BufferStream.new()
+
+    var data: array[1, byte]
+    let readFut = stream.readOnce(addr data[0], data.len)
+
+    await stream.reset()
+
+    check await readFut.withTimeout(100.milliseconds)
+    check (await readFut) == 0
+    check stream.closed
+    check await stream.closeWithEOF().withTimeout(100.milliseconds)

--- a/tests/libp2p/transports/test_quic.nim
+++ b/tests/libp2p/transports/test_quic.nim
@@ -50,6 +50,35 @@ suite "Quic transport":
     streamProvider,
   )
 
+  asyncTest "Connection.reset aborts the initiator stream":
+    var serverResetDone = newFuture[void]()
+
+    proc serverStreamHandler(stream: Connection) {.async: (raises: []).} =
+      noExceptionWithStreamClose(stream):
+        let msg = await stream.readLp(100)
+        check msg == fromHex("1234")
+        await stream.reset()
+        serverResetDone.complete()
+
+    proc clientStreamHandler(stream: Connection) {.async: (raises: []).} =
+      noExceptionWithStreamClose(stream):
+        await stream.writeLp(fromHex("1234"))
+        await serverResetDone
+
+        var buffer: array[1, byte]
+        check (await stream.readOnce(addr buffer[0], 1)) == 0
+
+        expect LPStreamResetError:
+          await stream.writeLp(fromHex("1234"))
+
+    await runSingleStreamScenario(
+      @[MultiAddress.init(addressIP4).get()],
+      quicTransProvider,
+      streamProvider,
+      serverStreamHandler,
+      clientStreamHandler,
+    )
+
   asyncTest "transport e2e - invalid cert - server":
     let server = await createQuicTransport(isServer = true, withInvalidCert = true)
     asyncSpawn createServerAcceptConn(server)()


### PR DESCRIPTION
## Summary

This PR adds stream reset support across nim-libp2p streams.
It introduces/reset-wires `Connection.reset()` behavior through the shared stream layer and existing muxer/connection wrappers, including mplex, yamux, secure connections, relay connections, and QUIC streams. This is needed so callers using the existing stream reset API get consistent reset semantics across transports and muxers instead of close/EOF-style behaviors (specially useful for when there are protocol violations).

## Affected Areas

- [ ] Gossipsub
- [x] Transports  
- [ ] Peer Management / Discovery
- [ ] Protocol Logic
- [ ] Build / Tooling  
- [ ] Other

## Compatibility & Downstream Validation

Reference PRs / branches / commits demonstrating successful integration:

- **Nimbus:**  
  Not validated in this PR.

- **Waku:**  
  Not validated in this PR.

- **Codex:**  
  Not validated in this PR.

## Impact on Library Users

The existing `Connection.reset()` API now has broader and more consistent behavior across supported stream implementations. Downstream users may observe `LPStreamResetError` where a peer resets a stream, including on QUIC connections.

## Risk Assessment

Risk is moderate because this changes stream lifecycle behavior.

Potential risks:
- Reset/close timing differences compared with previous EOF-style behavior.
- Incorrect propagation of reset state through muxers or wrapper connections.
- MPlex is modified

