### PR TITLE
feat(builder): `withPrivateAddressFilter`

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -619,4 +619,4 @@ proc newStandardSwitch*(
     sendSignedPeerRecord = sendSignedPeerRecord,
     peerStoreCapacity = peerStoreCapacity,
   )
-    .build()
+  .build()

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -14,6 +14,7 @@ import
   switch,
   peerid,
   peerinfo,
+  peeraddrpolicy,
   stream/connection,
   multiaddress,
   crypto/crypto,
@@ -42,8 +43,8 @@ import
 import services/wildcardresolverservice
 
 export
-  switch, peerid, peerinfo, connection, multiaddress, crypto, errors, TLSPrivateKey,
-  TLSCertificate, TLSFlags, ServerFlags
+  switch, peerid, peerinfo, peeraddrpolicy, connection, multiaddress, crypto, errors,
+  TLSPrivateKey, TLSCertificate, TLSFlags, ServerFlags
 
 const MemoryAutoAddress* = memorytransport.MemoryAutoAddress
 
@@ -96,6 +97,7 @@ type
     services: seq[Service]
     observedAddrManager: ObservedAddrManager
     enableWildcardResolver: bool
+    addressPolicy: PeerAddressPolicy
 
 proc new*(T: type[SwitchBuilder]): T {.public.} =
   ## Creates a SwitchBuilder
@@ -369,6 +371,22 @@ proc withObservedAddrManager*(
   b.observedAddrManager = observedAddrManager
   b
 
+proc withAddressPolicy*(
+    b: SwitchBuilder, addressPolicy: PeerAddressPolicy
+): SwitchBuilder {.public.} =
+  ## Applies a single address visibility policy across local address
+  ## announcements and all discovery/storage paths configured by the builder.
+  b.addressPolicy = addressPolicy
+  b
+
+proc withPrivateAddressFilter*(b: SwitchBuilder): SwitchBuilder {.public.} =
+  ## Filter private (RFC1918/link-local) addresses from all peer address
+  ## announcements and incoming peer address records. When enabled:
+  ## - Our node will not announce private addresses to the network
+  ## - Private addresses received from other peers are discarded
+  ## Circuit relay and DNS addresses are never filtered.
+  b.withAddressPolicy(publicRoutableAddressPolicy())
+
 proc build*(b: SwitchBuilder): Switch {.raises: [LPError], public.} =
   if b.rng == nil: # newRng could fail
     raise newException(Defect, "Cannot initialize RNG")
@@ -385,7 +403,11 @@ proc build*(b: SwitchBuilder): Switch {.raises: [LPError], public.} =
     secureManagerInstances.add(Noise.new(b.rng, seckey).Secure)
 
   let peerInfo = PeerInfo.new(
-    seckey, b.addresses, protoVersion = b.protoVersion, agentVersion = b.agentVersion
+    seckey,
+    b.addresses,
+    protoVersion = b.protoVersion,
+    agentVersion = b.agentVersion,
+    addressPolicy = b.addressPolicy,
   )
 
   let identify =
@@ -442,6 +464,8 @@ proc build*(b: SwitchBuilder): Switch {.raises: [LPError], public.} =
   b.hpService.withValue(hpservice):
     b.services.add(hpservice)
 
+  peerStore.addressPolicy = b.addressPolicy
+
   let switch = newSwitch(
     peerInfo = peerInfo,
     transports = transports,
@@ -477,6 +501,7 @@ proc build*(b: SwitchBuilder): Switch {.raises: [LPError], public.} =
     switch.mount(rdvService)
 
   b.kad.withValue(kadInfo):
+    kadInfo.config.addressPolicy = b.addressPolicy
     let kad = KadDHT.new(
       switch, bootstrapNodes = kadInfo.bootstrapNodes, config = kadInfo.config
     )
@@ -594,4 +619,4 @@ proc newStandardSwitch*(
     sendSignedPeerRecord = sendSignedPeerRecord,
     peerStoreCapacity = peerStoreCapacity,
   )
-  .build()
+    .build()

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -120,7 +120,7 @@ proc new*(T: type[SwitchBuilder]): T {.public.} =
     rdv: Opt.none(RendezVous),
     kad: Opt.none(KadInfo),
     enableWildcardResolver: true,
-    addressPolicy: defaultAddressPolicy(),
+    addressPolicy: defaultAddressPolicy,
   )
 
 proc withPrivateKey*(
@@ -386,7 +386,7 @@ proc withPrivateAddressFilter*(b: SwitchBuilder): SwitchBuilder {.public.} =
   ## - Our node will not announce private addresses to the network
   ## - Private addresses received from other peers are discarded
   ## Circuit relay and DNS addresses are never filtered.
-  b.withAddressPolicy(publicRoutableAddressPolicy())
+  b.withAddressPolicy(publicRoutableAddressPolicy)
 
 proc build*(b: SwitchBuilder): Switch {.raises: [LPError], public.} =
   if b.rng == nil: # newRng could fail

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -120,6 +120,7 @@ proc new*(T: type[SwitchBuilder]): T {.public.} =
     rdv: Opt.none(RendezVous),
     kad: Opt.none(KadInfo),
     enableWildcardResolver: true,
+    addressPolicy: defaultAddressPolicy(),
   )
 
 proc withPrivateKey*(

--- a/libp2p/peeraddrpolicy.nim
+++ b/libp2p/peeraddrpolicy.nim
@@ -7,42 +7,38 @@ import std/sequtils
 import results
 import multiaddress, routing_record, wire
 
-type PeerAddressPolicy* = ref object
+type PeerAddressPolicy* = object
   accept*: proc(ma: MultiAddress): bool {.gcsafe, raises: [].}
 
+proc defaultAddressPolicy*(): PeerAddressPolicy =
+  ## The default policy that accepts all addresses. Used so that consumers can
+  ## always rely on a policy with a non-nil `accept` proc.
+  PeerAddressPolicy(
+    accept: proc(ma: MultiAddress): bool {.gcsafe, raises: [].} =
+      true
+  )
+
 proc accepts*(policy: PeerAddressPolicy, ma: MultiAddress): bool =
-  policy.isNil or policy.accept.isNil or policy.accept(ma)
+  doAssert not policy.accept.isNil, "invalid peerAddr policy"
+  policy.accept(ma)
 
 proc filterAddrs*(
     policy: PeerAddressPolicy, addrs: openArray[MultiAddress]
 ): seq[MultiAddress] =
-  if policy.isNil or policy.accept.isNil:
-    return @addrs
+  doAssert not policy.accept.isNil, "invalid peerAddr policy"
   addrs.filterIt(policy.accept(it))
 
 proc preservesAddrs*(policy: PeerAddressPolicy, addrs: openArray[MultiAddress]): bool =
   policy.filterAddrs(addrs).len == addrs.len
 
 proc filterPeerRecord*(policy: PeerAddressPolicy, record: PeerRecord): Opt[PeerRecord] =
-  if policy.isNil or policy.accept.isNil:
-    return Opt.some(record)
+  doAssert not policy.accept.isNil, "invalid peerAddr policy"
 
   var filtered = record
   filtered.addresses.keepItIf(policy.accepts(it.address))
   if filtered.addresses.len == 0:
     return Opt.none(PeerRecord)
   Opt.some(filtered)
-
-proc allowsSignedPeerRecord*(
-    policy: PeerAddressPolicy, signedPeerRecord: seq[byte]
-): bool =
-  if policy.isNil or policy.accept.isNil:
-    return true
-
-  let spr = SignedPeerRecord.decode(signedPeerRecord).valueOr:
-    return false
-
-  policy.preservesAddrs(spr.data.addresses.mapIt(it.address))
 
 proc publicRoutableAddressPolicy*(): PeerAddressPolicy =
   PeerAddressPolicy(

--- a/libp2p/peeraddrpolicy.nim
+++ b/libp2p/peeraddrpolicy.nim
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.push raises: [].}
+
+import std/sequtils
+import results
+import multiaddress, routing_record, wire
+
+type PeerAddressPolicy* = ref object
+  accept*: proc(ma: MultiAddress): bool {.gcsafe, raises: [].}
+
+proc accepts*(policy: PeerAddressPolicy, ma: MultiAddress): bool =
+  policy.isNil or policy.accept.isNil or policy.accept(ma)
+
+proc filterAddrs*(
+    policy: PeerAddressPolicy, addrs: openArray[MultiAddress]
+): seq[MultiAddress] =
+  if policy.isNil or policy.accept.isNil:
+    return @addrs
+  addrs.filterIt(policy.accept(it))
+
+proc preservesAddrs*(
+    policy: PeerAddressPolicy, addrs: openArray[MultiAddress]
+): bool =
+  policy.filterAddrs(addrs).len == addrs.len
+
+proc filterPeerRecord*(
+    policy: PeerAddressPolicy, record: PeerRecord
+): Opt[PeerRecord] =
+  if policy.isNil or policy.accept.isNil:
+    return Opt.some(record)
+
+  var filtered = record
+  filtered.addresses.keepItIf(policy.accepts(it.address))
+  if filtered.addresses.len == 0:
+    return Opt.none(PeerRecord)
+  Opt.some(filtered)
+
+proc allowsSignedPeerRecord*(
+    policy: PeerAddressPolicy, signedPeerRecord: seq[byte]
+): bool =
+  if policy.isNil or policy.accept.isNil:
+    return true
+
+  let spr = SignedPeerRecord.decode(signedPeerRecord).valueOr:
+    return false
+  
+  policy.preservesAddrs(spr.data.addresses.mapIt(it.address))
+
+proc publicRoutableAddressPolicy*(): PeerAddressPolicy =
+  PeerAddressPolicy(
+    accept: proc(ma: MultiAddress): bool {.gcsafe, raises: [].} =
+      not isFilterablePrivateMA(ma)
+  )

--- a/libp2p/peeraddrpolicy.nim
+++ b/libp2p/peeraddrpolicy.nim
@@ -4,44 +4,22 @@
 {.push raises: [].}
 
 import std/sequtils
-import results
 import multiaddress, routing_record, wire
 
-type PeerAddressPolicy* = object
-  accept*: proc(ma: MultiAddress): bool {.gcsafe, raises: [].}
+type PeerAddressPolicy* = proc(ma: MultiAddress): bool {.gcsafe, raises: [].}
 
-proc defaultAddressPolicy*(): PeerAddressPolicy =
-  ## The default policy that accepts all addresses. Used so that consumers can
-  ## always rely on a policy with a non-nil `accept` proc.
-  PeerAddressPolicy(
-    accept: proc(ma: MultiAddress): bool {.gcsafe, raises: [].} =
-      true
-  )
+const defaultAddressPolicy* = proc(ma: MultiAddress): bool {.gcsafe, raises: [].} =
+  true
 
 proc accepts*(policy: PeerAddressPolicy, ma: MultiAddress): bool =
-  doAssert not policy.accept.isNil, "invalid peerAddr policy"
-  policy.accept(ma)
+  policy(ma)
 
 proc filterAddrs*(
     policy: PeerAddressPolicy, addrs: openArray[MultiAddress]
 ): seq[MultiAddress] =
-  doAssert not policy.accept.isNil, "invalid peerAddr policy"
-  addrs.filterIt(policy.accept(it))
+  addrs.filterIt(policy(it))
 
-proc preservesAddrs*(policy: PeerAddressPolicy, addrs: openArray[MultiAddress]): bool =
-  policy.filterAddrs(addrs).len == addrs.len
-
-proc filterPeerRecord*(policy: PeerAddressPolicy, record: PeerRecord): Opt[PeerRecord] =
-  doAssert not policy.accept.isNil, "invalid peerAddr policy"
-
-  var filtered = record
-  filtered.addresses.keepItIf(policy.accepts(it.address))
-  if filtered.addresses.len == 0:
-    return Opt.none(PeerRecord)
-  Opt.some(filtered)
-
-proc publicRoutableAddressPolicy*(): PeerAddressPolicy =
-  PeerAddressPolicy(
-    accept: proc(ma: MultiAddress): bool {.gcsafe, raises: [].} =
-      not isFilterablePrivateMA(ma)
-  )
+const publicRoutableAddressPolicy* = proc(
+    ma: MultiAddress
+): bool {.gcsafe, raises: [].} =
+  not isFilterablePrivateMA(ma)

--- a/libp2p/peeraddrpolicy.nim
+++ b/libp2p/peeraddrpolicy.nim
@@ -20,14 +20,10 @@ proc filterAddrs*(
     return @addrs
   addrs.filterIt(policy.accept(it))
 
-proc preservesAddrs*(
-    policy: PeerAddressPolicy, addrs: openArray[MultiAddress]
-): bool =
+proc preservesAddrs*(policy: PeerAddressPolicy, addrs: openArray[MultiAddress]): bool =
   policy.filterAddrs(addrs).len == addrs.len
 
-proc filterPeerRecord*(
-    policy: PeerAddressPolicy, record: PeerRecord
-): Opt[PeerRecord] =
+proc filterPeerRecord*(policy: PeerAddressPolicy, record: PeerRecord): Opt[PeerRecord] =
   if policy.isNil or policy.accept.isNil:
     return Opt.some(record)
 
@@ -45,7 +41,7 @@ proc allowsSignedPeerRecord*(
 
   let spr = SignedPeerRecord.decode(signedPeerRecord).valueOr:
     return false
-  
+
   policy.preservesAddrs(spr.data.addresses.mapIt(it.address))
 
 proc publicRoutableAddressPolicy*(): PeerAddressPolicy =

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -110,7 +110,7 @@ proc new*(
     protoVersion: string = "",
     agentVersion: string = "",
     addressMappers = newSeq[AddressMapper](),
-    addressPolicy: PeerAddressPolicy = defaultAddressPolicy(),
+    addressPolicy: PeerAddressPolicy = defaultAddressPolicy,
 ): PeerInfo {.raises: [LPError].} =
   let pubkey =
     try:

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -110,7 +110,7 @@ proc new*(
     protoVersion: string = "",
     agentVersion: string = "",
     addressMappers = newSeq[AddressMapper](),
-    addressPolicy: PeerAddressPolicy = nil,
+    addressPolicy: PeerAddressPolicy = defaultAddressPolicy(),
 ): PeerInfo {.raises: [LPError].} =
   let pubkey =
     try:

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -6,9 +6,17 @@
 
 import std/sequtils
 import pkg/[chronos, chronicles, results]
-import peerid, multiaddress, multicodec, crypto/crypto, routing_record, errors, utility
+import
+  peerid,
+  multiaddress,
+  multicodec,
+  crypto/crypto,
+  routing_record,
+  peeraddrpolicy,
+  errors,
+  utility
 
-export peerid, multiaddress, crypto, routing_record, errors, results
+export peerid, multiaddress, crypto, routing_record, peeraddrpolicy, errors, results
 
 ## Our local peer info
 
@@ -27,6 +35,8 @@ type
     ## contains resolved addresses that other peers can use to connect, including public-facing NAT and port-forwarded addresses.
     addressMappers*: seq[AddressMapper]
     ## contains a list of procs that can be used to resolve the listen addresses into dialable addresses.
+    addressPolicy*: PeerAddressPolicy
+    ## applied after address mappers
     protocols*: seq[string]
     protoVersion*: string
     agentVersion*: string
@@ -52,12 +62,13 @@ proc expandAddrs*(
   var addrs = p.listenAddrs
   for mapper in p.addressMappers:
     addrs = await mapper(addrs)
-  addrs
+  p.addressPolicy.filterAddrs(addrs)
 
 proc update*(p: PeerInfo) {.async: (raises: [CancelledError]).} =
   p.addrs = p.listenAddrs
   for mapper in p.addressMappers:
     p.addrs = await mapper(p.addrs)
+  p.addrs = p.addressPolicy.filterAddrs(p.addrs)
 
   p.signedPeerRecord = SignedPeerRecord.init(
     p.privateKey, PeerRecord.init(p.peerId, p.addrs)
@@ -99,6 +110,7 @@ proc new*(
     protoVersion: string = "",
     agentVersion: string = "",
     addressMappers = newSeq[AddressMapper](),
+    addressPolicy: PeerAddressPolicy = nil,
 ): PeerInfo {.raises: [LPError].} =
   let pubkey =
     try:
@@ -119,6 +131,7 @@ proc new*(
     listenAddrs: @listenAddrs,
     protocols: @protocols,
     addressMappers: addressMappers,
+    addressPolicy: addressPolicy,
   )
 
   return peerInfo

--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -82,7 +82,7 @@ type
 proc new*(
     T: type PeerStore, identify: Identify, capacity = 1000
 ): PeerStore {.public.} =
-  T(identify: identify, capacity: capacity)
+  T(identify: identify, capacity: capacity, addressPolicy: defaultAddressPolicy())
 
 #########################
 # Generic Peer Book API #

--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -18,13 +18,14 @@ runnableExamples:
 {.push raises: [].}
 
 import
-  std/[tables, sets, macros],
+  std/[tables, sets, macros, sequtils],
   chronos,
   ./crypto/crypto,
   ./crypto/curve25519,
   ./protocols/identify,
   ./protocols/protocol,
   ./peerid,
+  ./peeraddrpolicy,
   ./peerinfo,
   ./routing_record,
   ./multiaddress,
@@ -74,6 +75,9 @@ type
     identify: Identify
     capacity*: int
     toClean*: seq[PeerId]
+    addressPolicy*: PeerAddressPolicy
+      ## When set, inbound peer addresses are filtered through the shared
+      ## policy before they are stored or redistributed.
 
 proc new*(
     T: type PeerStore, identify: Identify, capacity = 1000
@@ -152,7 +156,11 @@ proc updatePeerInfo*(
     direction: Opt[Direction] = Opt.none(Direction),
 ) =
   if len(info.addrs) > 0:
-    peerStore[AddressBook][info.peerId] = info.addrs
+    let addrs = peerStore.addressPolicy.filterAddrs(info.addrs)
+    if addrs.len > 0:
+      peerStore[AddressBook][info.peerId] = addrs
+    else:
+      discard peerStore[AddressBook].del(info.peerId)
 
   peerStore[LastSeenBook][info.peerId] = observedAddr
 

--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -82,7 +82,7 @@ type
 proc new*(
     T: type PeerStore, identify: Identify, capacity = 1000
 ): PeerStore {.public.} =
-  T(identify: identify, capacity: capacity, addressPolicy: defaultAddressPolicy())
+  T(identify: identify, capacity: capacity, addressPolicy: defaultAddressPolicy)
 
 #########################
 # Generic Peer Book API #

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -167,8 +167,8 @@ proc updatePeers*(
     let addrs = addressPolicy.filterAddrs(p.addrs)
     if addrs.len == 0:
       continue
-    if rtable.insert(p.peerId) and addrs.len > 0:
-      switch.peerStore[AddressBook].extend(p.peerId, p.addrs)
+    if rtable.insert(p.peerId):
+      switch.peerStore[AddressBook].extend(p.peerId, addrs)
 
 proc updatePeers*(kad: KadDHT, peerInfos: seq[PeerInfo]) {.raises: [].} =
   updatePeers(kad.switch, kad.config.addressPolicy, kad.rtable, peerInfos)

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -3,7 +3,7 @@
 
 import std/[tables, sequtils, sets, algorithm]
 import chronos, chronicles, results
-import ../../[peerid, peerinfo, switch, multihash]
+import ../../[peerid, peerinfo, switch, multihash, peeraddrpolicy]
 import ../protocol
 import ./[routing_table, protobuf, types, kademlia_metrics]
 
@@ -158,14 +158,20 @@ proc dispatchFindNode*(
   return Opt.some(reply)
 
 proc updatePeers*(
-    switch: Switch, rtable: RoutingTable, peerInfos: seq[PeerInfo]
+    switch: Switch,
+    addressPolicy: PeerAddressPolicy,
+    rtable: RoutingTable,
+    peerInfos: seq[PeerInfo],
 ) {.raises: [].} =
   for p in peerInfos:
-    if rtable.insert(p.peerId):
+    let addrs = addressPolicy.filterAddrs(p.addrs)
+    if addrs.len == 0:
+      continue
+    if rtable.insert(p.peerId) and addrs.len > 0:
       switch.peerStore[AddressBook].extend(p.peerId, p.addrs)
 
 proc updatePeers*(kad: KadDHT, peerInfos: seq[PeerInfo]) {.raises: [].} =
-  updatePeers(kad.switch, kad.rtable, peerInfos)
+  updatePeers(kad.switch, kad.config.addressPolicy, kad.rtable, peerInfos)
 
 proc updatePeers*(kad: KadDHT, peers: seq[(PeerId, seq[MultiAddress])]) {.raises: [].} =
   let peerInfos = peers.mapIt(PeerInfo(peerId: it[0], addrs: it[1]))
@@ -215,7 +221,7 @@ proc iterativeLookup*(
     for (peerId, msg) in completedRPCBatch:
       msg.withValue(reply):
         let newPeerInfos = state.updateShortlist(reply)
-        kad.switch.updatePeers(rtable, newPeerInfos)
+        kad.switch.updatePeers(kad.config.addressPolicy, rtable, newPeerInfos)
       await onReply(peerId, msg, state)
 
   return state

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -313,7 +313,7 @@ proc new*(
     republishProvidedKeysInterval: chronos.Duration = DefaultRepublishInterval,
     cleanupProvidersInterval: chronos.Duration = DefaultCleanupProvidersInterval,
     providerExpirationInterval: chronos.Duration = DefaultProviderExpirationInterval,
-    addressPolicy: PeerAddressPolicy = defaultAddressPolicy(),
+    addressPolicy: PeerAddressPolicy = defaultAddressPolicy,
 ): T {.raises: [].} =
   KadDHTConfig(
     validator: validator,

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -4,7 +4,7 @@
 import std/[tables, sequtils, sets, heapqueue]
 from times import now
 import chronos, chronicles, results, sugar, stew/arrayOps, nimcrypto/sha2
-import ../../[peerid, switch, multihash, cid, multicodec]
+import ../../[peerid, switch, multihash, cid, multicodec, peeraddrpolicy]
 import ../protocol
 import ./protobuf
 
@@ -296,6 +296,7 @@ type KadDHTConfig* = ref object
   republishProvidedKeysInterval*: chronos.Duration
   cleanupProvidersInterval*: chronos.Duration
   providerExpirationInterval*: chronos.Duration
+  addressPolicy*: PeerAddressPolicy
 
 proc new*(
     T: typedesc[KadDHTConfig],
@@ -312,6 +313,7 @@ proc new*(
     republishProvidedKeysInterval: chronos.Duration = DefaultRepublishInterval,
     cleanupProvidersInterval: chronos.Duration = DefaultCleanupProvidersInterval,
     providerExpirationInterval: chronos.Duration = DefaultProviderExpirationInterval,
+    addressPolicy: PeerAddressPolicy = nil,
 ): T {.raises: [].} =
   KadDHTConfig(
     validator: validator,
@@ -327,6 +329,7 @@ proc new*(
     republishProvidedKeysInterval: republishProvidedKeysInterval,
     cleanupProvidersInterval: cleanupProvidersInterval,
     providerExpirationInterval: providerExpirationInterval,
+    addressPolicy: addressPolicy,
   )
 
 type KadDHT* = ref object of LPProtocol

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -313,7 +313,7 @@ proc new*(
     republishProvidedKeysInterval: chronos.Duration = DefaultRepublishInterval,
     cleanupProvidersInterval: chronos.Duration = DefaultCleanupProvidersInterval,
     providerExpirationInterval: chronos.Duration = DefaultProviderExpirationInterval,
-    addressPolicy: PeerAddressPolicy = nil,
+    addressPolicy: PeerAddressPolicy = defaultAddressPolicy(),
 ): T {.raises: [].} =
   KadDHTConfig(
     validator: validator,

--- a/libp2p/wire.nim
+++ b/libp2p/wire.nim
@@ -161,3 +161,12 @@ proc isPublicMA*(ma: MultiAddress): bool =
   let hostIP = initTAddress(ma).valueOr:
     return false
   return hostIP.isGlobal()
+
+proc isFilterablePrivateMA*(ma: MultiAddress): bool =
+  ## Returns true if this address should be filtered out because it is private
+  ## or not globally routable. Circuit relay addresses are never filtered even
+  ## if the relay itself has a private IP, since the relay address may still
+  ## provide connectivity.
+  if ma.contains(multiCodec("p2p-circuit")).get(false):
+    return false
+  return not isPublicMA(ma)

--- a/tests/libp2p/services/test_private_addr_filter.nim
+++ b/tests/libp2p/services/test_private_addr_filter.nim
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import std/sets
+import chronos
+import
+  ../../../libp2p/[
+    builders,
+    peeraddrpolicy,
+    routing_record,
+    switch,
+    wire,
+    multiaddress,
+    peerid,
+    peerstore,
+    protocols/identify,
+    protocols/kademlia,
+    protocols/rendezvous,
+  ]
+import ../../tools/[unittest, crypto]
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+proc ma(s: string): MultiAddress =
+  MultiAddress.init(s).tryGet()
+
+# ---------------------------------------------------------------------------
+# Unit tests: isFilterablePrivateMA
+# ---------------------------------------------------------------------------
+
+suite "isFilterablePrivateMA":
+  test "RFC1918 addresses are filterable":
+    check isFilterablePrivateMA(ma("/ip4/10.0.0.1/tcp/4001"))
+    check isFilterablePrivateMA(ma("/ip4/172.16.0.1/tcp/4001"))
+    check isFilterablePrivateMA(ma("/ip4/172.31.255.255/tcp/4001"))
+    check isFilterablePrivateMA(ma("/ip4/192.168.1.5/tcp/4001"))
+
+  test "loopback addresses are filterable":
+    check isFilterablePrivateMA(ma("/ip4/127.0.0.1/tcp/4001"))
+    check isFilterablePrivateMA(ma("/ip6/::1/tcp/4001"))
+
+  test "link-local addresses are filterable":
+    check isFilterablePrivateMA(ma("/ip4/169.254.1.1/tcp/4001"))
+    check isFilterablePrivateMA(ma("/ip6/fe80::1/tcp/4001"))
+
+  test "public IPv4 addresses are not filterable":
+    check not isFilterablePrivateMA(ma("/ip4/1.1.1.1/tcp/4001"))
+    check not isFilterablePrivateMA(ma("/ip4/8.8.8.8/tcp/53"))
+
+  test "DNS addresses are not filterable":
+    check not isFilterablePrivateMA(ma("/dns4/example.com/tcp/4001"))
+    check not isFilterablePrivateMA(ma("/dns/example.com/tcp/4001"))
+
+  test "circuit relay addresses are not filterable even with private relay IP":
+    check not isFilterablePrivateMA(
+      ma("/ip4/192.168.1.5/tcp/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit")
+    )
+    check not isFilterablePrivateMA(
+      ma("/ip4/127.0.0.1/tcp/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit")
+    )
+
+# ---------------------------------------------------------------------------
+# Unit tests: PeerStore.addressPolicy via updatePeerInfo
+# ---------------------------------------------------------------------------
+
+suite "PeerStore addressPolicy":
+  test "updatePeerInfo stores all addresses when filter is nil":
+    let peerId = PeerId.random(rng()).tryGet()
+    let peerStore = PeerStore.new(nil)
+
+    peerStore.updatePeerInfo(
+      IdentifyInfo(
+        peerId: peerId,
+        addrs: @[ma("/ip4/192.168.1.5/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")],
+      )
+    )
+
+    # updatePeerInfo does a direct assignment (not extend), so order is preserved
+    check peerStore[AddressBook][peerId] ==
+      @[ma("/ip4/192.168.1.5/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")]
+
+  test "updatePeerInfo filters private addresses when addressPolicy is set":
+    let peerId = PeerId.random(rng()).tryGet()
+    let peerStore = PeerStore.new(nil)
+    peerStore.addressPolicy = publicRoutableAddressPolicy()
+
+    peerStore.updatePeerInfo(
+      IdentifyInfo(
+        peerId: peerId,
+        addrs:
+          @[
+            ma("/ip4/192.168.1.5/tcp/4001"),
+            ma("/ip4/1.1.1.1/tcp/4001"),
+            ma("/ip4/10.0.0.1/tcp/4001"),
+          ],
+      )
+    )
+
+    check peerStore[AddressBook][peerId] == @[ma("/ip4/1.1.1.1/tcp/4001")]
+
+  test "updatePeerInfo skips storage when all addresses are filtered":
+    let peerId = PeerId.random(rng()).tryGet()
+    let peerStore = PeerStore.new(nil)
+    peerStore.addressPolicy = publicRoutableAddressPolicy()
+
+    peerStore.updatePeerInfo(
+      IdentifyInfo(
+        peerId: peerId, addrs: @[ma("/ip4/192.168.1.5/tcp/4001"), ma("/ip4/127.0.0.1/tcp/4001")]
+      )
+    )
+
+    # Peer should not have any addresses stored
+    check peerStore[AddressBook][peerId].len == 0
+
+  test "updatePeerInfo clears stale addresses when a later update filters everything":
+    let peerId = PeerId.random(rng()).tryGet()
+    let peerStore = PeerStore.new(nil)
+    peerStore.addressPolicy = publicRoutableAddressPolicy()
+
+    peerStore.updatePeerInfo(
+      IdentifyInfo(peerId: peerId, addrs: @[ma("/ip4/1.1.1.1/tcp/4001")])
+    )
+    check peerStore[AddressBook][peerId] == @[ma("/ip4/1.1.1.1/tcp/4001")]
+
+    peerStore.updatePeerInfo(
+      IdentifyInfo(peerId: peerId, addrs: @[ma("/ip4/192.168.1.5/tcp/4001")])
+    )
+    check peerStore[AddressBook][peerId].len == 0
+
+  test "updatePeerInfo drops stored SPRs when address filtering would change them":
+    let
+      privKey = PrivateKey.random(rng[]).tryGet()
+      peerId = PeerId.init(privKey).tryGet()
+      peerStore = PeerStore.new(nil)
+    peerStore.addressPolicy = publicRoutableAddressPolicy()
+
+    let signedPeerRecord = SignedPeerRecord.init(
+      privKey,
+      PeerRecord.init(
+        peerId, @[ma("/ip4/127.0.0.1/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")]
+      ),
+    ).tryGet()
+
+    peerStore.updatePeerInfo(
+      IdentifyInfo(
+        peerId: peerId,
+        addrs: @[ma("/ip4/127.0.0.1/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")],
+        signedPeerRecord: Opt.some(signedPeerRecord.envelope),
+      )
+    )
+
+    check peerStore[SPRBook][peerId] == default(Envelope)
+
+  test "updatePeerInfo drops stored SPRs even when identify addrs are omitted":
+    let
+      privKey = PrivateKey.random(rng[]).tryGet()
+      peerId = PeerId.init(privKey).tryGet()
+      peerStore = PeerStore.new(nil)
+    peerStore.addressPolicy = publicRoutableAddressPolicy()
+
+    let signedPeerRecord = SignedPeerRecord.init(
+      privKey,
+      PeerRecord.init(
+        peerId, @[ma("/ip4/127.0.0.1/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")]
+      ),
+    ).tryGet()
+
+    peerStore.updatePeerInfo(
+      IdentifyInfo(
+        peerId: peerId,
+        addrs: @[],
+        signedPeerRecord: Opt.some(signedPeerRecord.envelope),
+      )
+    )
+
+    check peerStore[SPRBook][peerId] == default(Envelope)
+
+  test "circuit relay addresses pass through the filter":
+    let peerId = PeerId.random(rng()).tryGet()
+    let peerStore = PeerStore.new(nil)
+    peerStore.addressPolicy = publicRoutableAddressPolicy()
+
+    let relayAddr =
+      ma("/ip4/192.168.1.5/tcp/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit")
+    peerStore.updatePeerInfo(IdentifyInfo(peerId: peerId, addrs: @[relayAddr]))
+
+    check peerStore[AddressBook][peerId] == @[relayAddr]
+
+# ---------------------------------------------------------------------------
+# Unit tests: KadDHT.updatePeers with addressPolicy
+# ---------------------------------------------------------------------------
+
+suite "KadDHT updatePeers address policy":
+  test "updatePeers stores all addresses when addressPolicy is nil":
+    let switch = SwitchBuilder
+      .new()
+      .withRng(rng)
+      .withAddresses(@[ma("/ip4/127.0.0.1/tcp/0")])
+      .withTcpTransport()
+      .withMplex()
+      .withNoise()
+      .build()
+
+    let config = KadDHTConfig.new()
+    let kad = KadDHT.new(switch, @[], config)
+    switch.mount(kad)
+
+    let remotePeer = PeerId.random(rng()).tryGet()
+    kad.updatePeers(@[PeerInfo(peerId: remotePeer, addrs: @[ma("/ip4/192.168.1.5/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")])])
+
+    # Use set comparison: extend() uses HashSet internally so order is not guaranteed
+    check switch.peerStore[AddressBook][remotePeer].toHashSet() ==
+      @[ma("/ip4/192.168.1.5/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")].toHashSet()
+
+  test "updatePeers filters private addresses when addressPolicy is set":
+    let switch = SwitchBuilder
+      .new()
+      .withRng(rng)
+      .withAddresses(@[ma("/ip4/127.0.0.1/tcp/0")])
+      .withTcpTransport()
+      .withMplex()
+      .withNoise()
+      .build()
+
+    let config = KadDHTConfig.new(addressPolicy = publicRoutableAddressPolicy())
+    let kad = KadDHT.new(switch, @[], config)
+    switch.mount(kad)
+
+    let remotePeer = PeerId.random(rng()).tryGet()
+    kad.updatePeers(@[PeerInfo(peerId: remotePeer, addrs: @[ma("/ip4/192.168.1.5/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")])])
+
+    check switch.peerStore[AddressBook][remotePeer] == @[ma("/ip4/1.1.1.1/tcp/4001")]
+
+  test "updatePeers does not add peer to AddressBook when all addresses filtered":
+    let switch = SwitchBuilder
+      .new()
+      .withRng(rng)
+      .withAddresses(@[ma("/ip4/127.0.0.1/tcp/0")])
+      .withTcpTransport()
+      .withMplex()
+      .withNoise()
+      .build()
+
+    let config = KadDHTConfig.new(addressPolicy = publicRoutableAddressPolicy())
+    let kad = KadDHT.new(switch, @[], config)
+    switch.mount(kad)
+
+    let remotePeer = PeerId.random(rng()).tryGet()
+    kad.updatePeers(@[PeerInfo(peerId: remotePeer, addrs: @[ma("/ip4/192.168.1.5/tcp/4001")])])
+
+    check switch.peerStore[AddressBook][remotePeer].len == 0
+    check kad.rtable.findClosestPeerIds(remotePeer.toKey(), 1).len == 0
+
+# ---------------------------------------------------------------------------
+# Integration tests: RendezVous filtering
+# ---------------------------------------------------------------------------
+
+proc createRendezVousSwitch(rdv: RendezVous): Switch =
+  SwitchBuilder
+    .new()
+    .withRng(rng)
+    .withAddresses(@[ma(MemoryAutoAddress)])
+    .withMemoryTransport()
+    .withMplex()
+    .withNoise()
+    .withRendezVous(rdv)
+    .build()
+
+suite "RendezVous private address filtering":
+  teardown:
+    checkTrackers()
+
+  asyncTest "server-side filtering omits signed peer records with private addresses":
+    let
+      rendezvousNode = RendezVous.new()
+      requester = RendezVous.new()
+      advertisingPeer = RendezVous.new()
+      rendezvousSwitch = createRendezVousSwitch(rendezvousNode)
+      requesterSwitch = createRendezVousSwitch(requester)
+      advertisingSwitch = createRendezVousSwitch(advertisingPeer)
+
+    discard rendezvousNode.withAddressPolicy(publicRoutableAddressPolicy())
+
+    defer:
+      await advertisingSwitch.stop()
+      await requesterSwitch.stop()
+      await rendezvousSwitch.stop()
+
+    await rendezvousSwitch.start()
+    await requesterSwitch.start()
+    await advertisingSwitch.start()
+
+    await advertisingSwitch.connect(
+      rendezvousSwitch.peerInfo.peerId, rendezvousSwitch.peerInfo.addrs
+    )
+    await requesterSwitch.connect(
+      rendezvousSwitch.peerInfo.peerId, rendezvousSwitch.peerInfo.addrs
+    )
+
+    advertisingSwitch.peerInfo.signedPeerRecord = SignedPeerRecord.init(
+      advertisingSwitch.peerInfo.privateKey,
+      PeerRecord.init(
+        advertisingSwitch.peerInfo.peerId,
+        @[ma("/ip4/127.0.0.1/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")],
+      ),
+    ).tryGet()
+
+    const namespace = "filtered-rdv"
+    await advertisingPeer.advertise(namespace)
+
+    let discovered = await rendezvous.request(
+      requester,
+      Opt.some(namespace),
+      Opt.none(int),
+      Opt.some(@[rendezvousSwitch.peerInfo.peerId]),
+    )
+
+    check discovered.len == 0
+
+# ---------------------------------------------------------------------------
+# Integration tests: SwitchBuilder.withPrivateAddressFilter (outbound)
+# ---------------------------------------------------------------------------
+
+suite "SwitchBuilder withPrivateAddressFilter outbound":
+  teardown:
+    checkTrackers()
+
+  asyncTest "private addresses are removed from peerInfo.addrs when filter is enabled":
+    # Listen on loopback — a non-public address that is always available.
+    # The filter should remove it, leaving no announced addresses.
+    let switch = SwitchBuilder
+      .new()
+      .withRng(rng)
+      .withAddresses(@[ma("/ip4/127.0.0.1/tcp/0")], false) # disable wildcard resolver
+      .withTcpTransport()
+      .withMplex()
+      .withNoise()
+      .withPrivateAddressFilter()
+      .build()
+
+    await switch.start()
+    check switch.peerInfo.addrs.len == 0
+    await switch.stop()
+
+  asyncTest "public addresses are kept when filter is enabled":
+    # This test uses 127.0.0.1 (private) as listen addr but checks the mapper
+    # logic by directly verifying addresses without relying on a real public IP.
+    # We verify that a switch without the filter retains loopback addresses.
+    let switchNoFilter = SwitchBuilder
+      .new()
+      .withRng(rng)
+      .withAddresses(@[ma("/ip4/127.0.0.1/tcp/0")], false)
+      .withTcpTransport()
+      .withMplex()
+      .withNoise()
+      .build()
+
+    await switchNoFilter.start()
+    # Without filter, loopback address should be present
+    check switchNoFilter.peerInfo.addrs.len > 0
+    await switchNoFilter.stop()
+
+  asyncTest "withPrivateAddressFilter default is off":
+    # Without calling withPrivateAddressFilter, private addresses pass through
+    let switch = SwitchBuilder
+      .new()
+      .withRng(rng)
+      .withAddresses(@[ma("/ip4/127.0.0.1/tcp/0")], false)
+      .withTcpTransport()
+      .withMplex()
+      .withNoise()
+      .build()
+
+    await switch.start()
+    check switch.peerInfo.addrs.len > 0
+    await switch.stop()

--- a/tests/libp2p/services/test_private_addr_filter.nim
+++ b/tests/libp2p/services/test_private_addr_filter.nim
@@ -17,20 +17,11 @@ import
     peerstore,
     protocols/identify,
     protocols/kademlia,
-    protocols/rendezvous,
   ]
 import ../../tools/[unittest, crypto]
 
-# ---------------------------------------------------------------------------
-# Helper
-# ---------------------------------------------------------------------------
-
 proc ma(s: string): MultiAddress =
   MultiAddress.init(s).tryGet()
-
-# ---------------------------------------------------------------------------
-# Unit tests: isFilterablePrivateMA
-# ---------------------------------------------------------------------------
 
 suite "isFilterablePrivateMA":
   test "RFC1918 addresses are filterable":
@@ -57,15 +48,15 @@ suite "isFilterablePrivateMA":
 
   test "circuit relay addresses are not filterable even with private relay IP":
     check not isFilterablePrivateMA(
-      ma("/ip4/192.168.1.5/tcp/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit")
+      ma(
+        "/ip4/192.168.1.5/tcp/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit"
+      )
     )
     check not isFilterablePrivateMA(
-      ma("/ip4/127.0.0.1/tcp/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit")
+      ma(
+        "/ip4/127.0.0.1/tcp/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit"
+      )
     )
-
-# ---------------------------------------------------------------------------
-# Unit tests: PeerStore.addressPolicy via updatePeerInfo
-# ---------------------------------------------------------------------------
 
 suite "PeerStore addressPolicy":
   test "updatePeerInfo stores all addresses when filter is nil":
@@ -91,12 +82,11 @@ suite "PeerStore addressPolicy":
     peerStore.updatePeerInfo(
       IdentifyInfo(
         peerId: peerId,
-        addrs:
-          @[
-            ma("/ip4/192.168.1.5/tcp/4001"),
-            ma("/ip4/1.1.1.1/tcp/4001"),
-            ma("/ip4/10.0.0.1/tcp/4001"),
-          ],
+        addrs: @[
+          ma("/ip4/192.168.1.5/tcp/4001"),
+          ma("/ip4/1.1.1.1/tcp/4001"),
+          ma("/ip4/10.0.0.1/tcp/4001"),
+        ],
       )
     )
 
@@ -109,7 +99,8 @@ suite "PeerStore addressPolicy":
 
     peerStore.updatePeerInfo(
       IdentifyInfo(
-        peerId: peerId, addrs: @[ma("/ip4/192.168.1.5/tcp/4001"), ma("/ip4/127.0.0.1/tcp/4001")]
+        peerId: peerId,
+        addrs: @[ma("/ip4/192.168.1.5/tcp/4001"), ma("/ip4/127.0.0.1/tcp/4001")],
       )
     )
 
@@ -138,12 +129,14 @@ suite "PeerStore addressPolicy":
       peerStore = PeerStore.new(nil)
     peerStore.addressPolicy = publicRoutableAddressPolicy()
 
-    let signedPeerRecord = SignedPeerRecord.init(
-      privKey,
-      PeerRecord.init(
-        peerId, @[ma("/ip4/127.0.0.1/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")]
-      ),
-    ).tryGet()
+    let signedPeerRecord = SignedPeerRecord
+      .init(
+        privKey,
+        PeerRecord.init(
+          peerId, @[ma("/ip4/127.0.0.1/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")]
+        ),
+      )
+      .tryGet()
 
     peerStore.updatePeerInfo(
       IdentifyInfo(
@@ -162,12 +155,14 @@ suite "PeerStore addressPolicy":
       peerStore = PeerStore.new(nil)
     peerStore.addressPolicy = publicRoutableAddressPolicy()
 
-    let signedPeerRecord = SignedPeerRecord.init(
-      privKey,
-      PeerRecord.init(
-        peerId, @[ma("/ip4/127.0.0.1/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")]
-      ),
-    ).tryGet()
+    let signedPeerRecord = SignedPeerRecord
+      .init(
+        privKey,
+        PeerRecord.init(
+          peerId, @[ma("/ip4/127.0.0.1/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")]
+        ),
+      )
+      .tryGet()
 
     peerStore.updatePeerInfo(
       IdentifyInfo(
@@ -184,8 +179,9 @@ suite "PeerStore addressPolicy":
     let peerStore = PeerStore.new(nil)
     peerStore.addressPolicy = publicRoutableAddressPolicy()
 
-    let relayAddr =
-      ma("/ip4/192.168.1.5/tcp/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit")
+    let relayAddr = ma(
+      "/ip4/192.168.1.5/tcp/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit"
+    )
     peerStore.updatePeerInfo(IdentifyInfo(peerId: peerId, addrs: @[relayAddr]))
 
     check peerStore[AddressBook][peerId] == @[relayAddr]
@@ -210,7 +206,14 @@ suite "KadDHT updatePeers address policy":
     switch.mount(kad)
 
     let remotePeer = PeerId.random(rng()).tryGet()
-    kad.updatePeers(@[PeerInfo(peerId: remotePeer, addrs: @[ma("/ip4/192.168.1.5/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")])])
+    kad.updatePeers(
+      @[
+        PeerInfo(
+          peerId: remotePeer,
+          addrs: @[ma("/ip4/192.168.1.5/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")],
+        )
+      ]
+    )
 
     # Use set comparison: extend() uses HashSet internally so order is not guaranteed
     check switch.peerStore[AddressBook][remotePeer].toHashSet() ==
@@ -231,7 +234,14 @@ suite "KadDHT updatePeers address policy":
     switch.mount(kad)
 
     let remotePeer = PeerId.random(rng()).tryGet()
-    kad.updatePeers(@[PeerInfo(peerId: remotePeer, addrs: @[ma("/ip4/192.168.1.5/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")])])
+    kad.updatePeers(
+      @[
+        PeerInfo(
+          peerId: remotePeer,
+          addrs: @[ma("/ip4/192.168.1.5/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")],
+        )
+      ]
+    )
 
     check switch.peerStore[AddressBook][remotePeer] == @[ma("/ip4/1.1.1.1/tcp/4001")]
 
@@ -250,80 +260,12 @@ suite "KadDHT updatePeers address policy":
     switch.mount(kad)
 
     let remotePeer = PeerId.random(rng()).tryGet()
-    kad.updatePeers(@[PeerInfo(peerId: remotePeer, addrs: @[ma("/ip4/192.168.1.5/tcp/4001")])])
+    kad.updatePeers(
+      @[PeerInfo(peerId: remotePeer, addrs: @[ma("/ip4/192.168.1.5/tcp/4001")])]
+    )
 
     check switch.peerStore[AddressBook][remotePeer].len == 0
     check kad.rtable.findClosestPeerIds(remotePeer.toKey(), 1).len == 0
-
-# ---------------------------------------------------------------------------
-# Integration tests: RendezVous filtering
-# ---------------------------------------------------------------------------
-
-proc createRendezVousSwitch(rdv: RendezVous): Switch =
-  SwitchBuilder
-    .new()
-    .withRng(rng)
-    .withAddresses(@[ma(MemoryAutoAddress)])
-    .withMemoryTransport()
-    .withMplex()
-    .withNoise()
-    .withRendezVous(rdv)
-    .build()
-
-suite "RendezVous private address filtering":
-  teardown:
-    checkTrackers()
-
-  asyncTest "server-side filtering omits signed peer records with private addresses":
-    let
-      rendezvousNode = RendezVous.new()
-      requester = RendezVous.new()
-      advertisingPeer = RendezVous.new()
-      rendezvousSwitch = createRendezVousSwitch(rendezvousNode)
-      requesterSwitch = createRendezVousSwitch(requester)
-      advertisingSwitch = createRendezVousSwitch(advertisingPeer)
-
-    discard rendezvousNode.withAddressPolicy(publicRoutableAddressPolicy())
-
-    defer:
-      await advertisingSwitch.stop()
-      await requesterSwitch.stop()
-      await rendezvousSwitch.stop()
-
-    await rendezvousSwitch.start()
-    await requesterSwitch.start()
-    await advertisingSwitch.start()
-
-    await advertisingSwitch.connect(
-      rendezvousSwitch.peerInfo.peerId, rendezvousSwitch.peerInfo.addrs
-    )
-    await requesterSwitch.connect(
-      rendezvousSwitch.peerInfo.peerId, rendezvousSwitch.peerInfo.addrs
-    )
-
-    advertisingSwitch.peerInfo.signedPeerRecord = SignedPeerRecord.init(
-      advertisingSwitch.peerInfo.privateKey,
-      PeerRecord.init(
-        advertisingSwitch.peerInfo.peerId,
-        @[ma("/ip4/127.0.0.1/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")],
-      ),
-    ).tryGet()
-
-    const namespace = "filtered-rdv"
-    await advertisingPeer.advertise(namespace)
-
-    let discovered = await rendezvous.request(
-      requester,
-      Opt.some(namespace),
-      Opt.none(int),
-      Opt.some(@[rendezvousSwitch.peerInfo.peerId]),
-    )
-
-    check discovered.len == 0
-
-# ---------------------------------------------------------------------------
-# Integration tests: SwitchBuilder.withPrivateAddressFilter (outbound)
-# ---------------------------------------------------------------------------
 
 suite "SwitchBuilder withPrivateAddressFilter outbound":
   teardown:
@@ -335,7 +277,8 @@ suite "SwitchBuilder withPrivateAddressFilter outbound":
     let switch = SwitchBuilder
       .new()
       .withRng(rng)
-      .withAddresses(@[ma("/ip4/127.0.0.1/tcp/0")], false) # disable wildcard resolver
+      .withAddresses(@[ma("/ip4/127.0.0.1/tcp/0")], false)
+      # disable wildcard resolver
       .withTcpTransport()
       .withMplex()
       .withNoise()

--- a/tests/libp2p/services/test_private_addr_filter.nim
+++ b/tests/libp2p/services/test_private_addr_filter.nim
@@ -58,7 +58,7 @@ suite "isFilterablePrivateMA":
     )
 
 suite "PeerStore addressPolicy":
-  test "updatePeerInfo stores all addresses when filter is nil":
+  test "updatePeerInfo stores all addresses with default policy":
     let peerId = PeerId.random(rng()).tryGet()
     let peerStore = PeerStore.new(nil)
 
@@ -81,11 +81,12 @@ suite "PeerStore addressPolicy":
     peerStore.updatePeerInfo(
       IdentifyInfo(
         peerId: peerId,
-        addrs: @[
-          ma("/ip4/192.168.1.5/tcp/4001"),
-          ma("/ip4/1.1.1.1/tcp/4001"),
-          ma("/ip4/10.0.0.1/tcp/4001"),
-        ],
+        addrs:
+          @[
+            ma("/ip4/192.168.1.5/tcp/4001"),
+            ma("/ip4/1.1.1.1/tcp/4001"),
+            ma("/ip4/10.0.0.1/tcp/4001"),
+          ],
       )
     )
 
@@ -134,7 +135,7 @@ suite "PeerStore addressPolicy":
     check peerStore[AddressBook][peerId] == @[relayAddr]
 
 suite "KadDHT updatePeers address policy":
-  test "updatePeers stores all addresses when addressPolicy is nil":
+  test "updatePeers stores all addresses with default policy":
     let switch = SwitchBuilder
       .new()
       .withRng(rng)

--- a/tests/libp2p/services/test_private_addr_filter.nim
+++ b/tests/libp2p/services/test_private_addr_filter.nim
@@ -122,58 +122,6 @@ suite "PeerStore addressPolicy":
     )
     check peerStore[AddressBook][peerId].len == 0
 
-  test "updatePeerInfo drops stored SPRs when address filtering would change them":
-    let
-      privKey = PrivateKey.random(rng[]).tryGet()
-      peerId = PeerId.init(privKey).tryGet()
-      peerStore = PeerStore.new(nil)
-    peerStore.addressPolicy = publicRoutableAddressPolicy()
-
-    let signedPeerRecord = SignedPeerRecord
-      .init(
-        privKey,
-        PeerRecord.init(
-          peerId, @[ma("/ip4/127.0.0.1/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")]
-        ),
-      )
-      .tryGet()
-
-    peerStore.updatePeerInfo(
-      IdentifyInfo(
-        peerId: peerId,
-        addrs: @[ma("/ip4/127.0.0.1/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")],
-        signedPeerRecord: Opt.some(signedPeerRecord.envelope),
-      )
-    )
-
-    check peerStore[SPRBook][peerId] == default(Envelope)
-
-  test "updatePeerInfo drops stored SPRs even when identify addrs are omitted":
-    let
-      privKey = PrivateKey.random(rng[]).tryGet()
-      peerId = PeerId.init(privKey).tryGet()
-      peerStore = PeerStore.new(nil)
-    peerStore.addressPolicy = publicRoutableAddressPolicy()
-
-    let signedPeerRecord = SignedPeerRecord
-      .init(
-        privKey,
-        PeerRecord.init(
-          peerId, @[ma("/ip4/127.0.0.1/tcp/4001"), ma("/ip4/1.1.1.1/tcp/4001")]
-        ),
-      )
-      .tryGet()
-
-    peerStore.updatePeerInfo(
-      IdentifyInfo(
-        peerId: peerId,
-        addrs: @[],
-        signedPeerRecord: Opt.some(signedPeerRecord.envelope),
-      )
-    )
-
-    check peerStore[SPRBook][peerId] == default(Envelope)
-
   test "circuit relay addresses pass through the filter":
     let peerId = PeerId.random(rng()).tryGet()
     let peerStore = PeerStore.new(nil)
@@ -185,10 +133,6 @@ suite "PeerStore addressPolicy":
     peerStore.updatePeerInfo(IdentifyInfo(peerId: peerId, addrs: @[relayAddr]))
 
     check peerStore[AddressBook][peerId] == @[relayAddr]
-
-# ---------------------------------------------------------------------------
-# Unit tests: KadDHT.updatePeers with addressPolicy
-# ---------------------------------------------------------------------------
 
 suite "KadDHT updatePeers address policy":
   test "updatePeers stores all addresses when addressPolicy is nil":

--- a/tests/libp2p/services/test_private_addr_filter.nim
+++ b/tests/libp2p/services/test_private_addr_filter.nim
@@ -9,7 +9,6 @@ import
   ../../../libp2p/[
     builders,
     peeraddrpolicy,
-    routing_record,
     switch,
     wire,
     multiaddress,

--- a/tests/libp2p/services/test_private_addr_filter.nim
+++ b/tests/libp2p/services/test_private_addr_filter.nim
@@ -10,7 +10,6 @@ import
     builders,
     peeraddrpolicy,
     switch,
-    wire,
     multiaddress,
     peerid,
     peerstore,
@@ -21,41 +20,6 @@ import ../../tools/[unittest, crypto]
 
 proc ma(s: string): MultiAddress =
   MultiAddress.init(s).tryGet()
-
-suite "isFilterablePrivateMA":
-  test "RFC1918 addresses are filterable":
-    check isFilterablePrivateMA(ma("/ip4/10.0.0.1/tcp/4001"))
-    check isFilterablePrivateMA(ma("/ip4/172.16.0.1/tcp/4001"))
-    check isFilterablePrivateMA(ma("/ip4/172.31.255.255/tcp/4001"))
-    check isFilterablePrivateMA(ma("/ip4/192.168.1.5/tcp/4001"))
-
-  test "loopback addresses are filterable":
-    check isFilterablePrivateMA(ma("/ip4/127.0.0.1/tcp/4001"))
-    check isFilterablePrivateMA(ma("/ip6/::1/tcp/4001"))
-
-  test "link-local addresses are filterable":
-    check isFilterablePrivateMA(ma("/ip4/169.254.1.1/tcp/4001"))
-    check isFilterablePrivateMA(ma("/ip6/fe80::1/tcp/4001"))
-
-  test "public IPv4 addresses are not filterable":
-    check not isFilterablePrivateMA(ma("/ip4/1.1.1.1/tcp/4001"))
-    check not isFilterablePrivateMA(ma("/ip4/8.8.8.8/tcp/53"))
-
-  test "DNS addresses are not filterable":
-    check not isFilterablePrivateMA(ma("/dns4/example.com/tcp/4001"))
-    check not isFilterablePrivateMA(ma("/dns/example.com/tcp/4001"))
-
-  test "circuit relay addresses are not filterable even with private relay IP":
-    check not isFilterablePrivateMA(
-      ma(
-        "/ip4/192.168.1.5/tcp/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit"
-      )
-    )
-    check not isFilterablePrivateMA(
-      ma(
-        "/ip4/127.0.0.1/tcp/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit"
-      )
-    )
 
 suite "PeerStore addressPolicy":
   test "updatePeerInfo stores all addresses with default policy":
@@ -76,7 +40,7 @@ suite "PeerStore addressPolicy":
   test "updatePeerInfo filters private addresses when addressPolicy is set":
     let peerId = PeerId.random(rng()).tryGet()
     let peerStore = PeerStore.new(nil)
-    peerStore.addressPolicy = publicRoutableAddressPolicy()
+    peerStore.addressPolicy = publicRoutableAddressPolicy
 
     peerStore.updatePeerInfo(
       IdentifyInfo(
@@ -95,7 +59,7 @@ suite "PeerStore addressPolicy":
   test "updatePeerInfo skips storage when all addresses are filtered":
     let peerId = PeerId.random(rng()).tryGet()
     let peerStore = PeerStore.new(nil)
-    peerStore.addressPolicy = publicRoutableAddressPolicy()
+    peerStore.addressPolicy = publicRoutableAddressPolicy
 
     peerStore.updatePeerInfo(
       IdentifyInfo(
@@ -110,7 +74,7 @@ suite "PeerStore addressPolicy":
   test "updatePeerInfo clears stale addresses when a later update filters everything":
     let peerId = PeerId.random(rng()).tryGet()
     let peerStore = PeerStore.new(nil)
-    peerStore.addressPolicy = publicRoutableAddressPolicy()
+    peerStore.addressPolicy = publicRoutableAddressPolicy
 
     peerStore.updatePeerInfo(
       IdentifyInfo(peerId: peerId, addrs: @[ma("/ip4/1.1.1.1/tcp/4001")])
@@ -125,7 +89,7 @@ suite "PeerStore addressPolicy":
   test "circuit relay addresses pass through the filter":
     let peerId = PeerId.random(rng()).tryGet()
     let peerStore = PeerStore.new(nil)
-    peerStore.addressPolicy = publicRoutableAddressPolicy()
+    peerStore.addressPolicy = publicRoutableAddressPolicy
 
     let relayAddr = ma(
       "/ip4/192.168.1.5/tcp/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit"
@@ -173,7 +137,7 @@ suite "KadDHT updatePeers address policy":
       .withNoise()
       .build()
 
-    let config = KadDHTConfig.new(addressPolicy = publicRoutableAddressPolicy())
+    let config = KadDHTConfig.new(addressPolicy = publicRoutableAddressPolicy)
     let kad = KadDHT.new(switch, @[], config)
     switch.mount(kad)
 
@@ -199,7 +163,7 @@ suite "KadDHT updatePeers address policy":
       .withNoise()
       .build()
 
-    let config = KadDHTConfig.new(addressPolicy = publicRoutableAddressPolicy())
+    let config = KadDHTConfig.new(addressPolicy = publicRoutableAddressPolicy)
     let kad = KadDHT.new(switch, @[], config)
     switch.mount(kad)
 
@@ -234,22 +198,31 @@ suite "SwitchBuilder withPrivateAddressFilter outbound":
     await switch.stop()
 
   asyncTest "public addresses are kept when filter is enabled":
-    # This test uses 127.0.0.1 (private) as listen addr but checks the mapper
-    # logic by directly verifying addresses without relying on a real public IP.
-    # We verify that a switch without the filter retains loopback addresses.
-    let switchNoFilter = SwitchBuilder
+    # Listen on loopback (always available) but use a stubbed address mapper
+    # to surface a routable address to the announcement pipeline. The filter
+    # must keep the public address while dropping the private listen address.
+    let publicAddr = ma("/ip4/1.2.3.4/tcp/4001")
+    let switch = SwitchBuilder
       .new()
       .withRng(rng)
       .withAddresses(@[ma("/ip4/127.0.0.1/tcp/0")], false)
       .withTcpTransport()
       .withMplex()
       .withNoise()
+      .withPrivateAddressFilter()
       .build()
 
-    await switchNoFilter.start()
-    # Without filter, loopback address should be present
-    check switchNoFilter.peerInfo.addrs.len > 0
-    await switchNoFilter.stop()
+    proc stubMapper(
+        input: seq[MultiAddress]
+    ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
+      return input & @[publicAddr]
+
+    switch.peerInfo.addressMappers.add(stubMapper)
+
+    await switch.start()
+    # Filter removes loopback but keeps the mapper-injected public address.
+    check switch.peerInfo.addrs == @[publicAddr]
+    await switch.stop()
 
   asyncTest "withPrivateAddressFilter default is off":
     # Without calling withPrivateAddressFilter, private addresses pass through

--- a/tests/libp2p/test_wire.nim
+++ b/tests/libp2p/test_wire.nim
@@ -145,3 +145,41 @@ suite "Wire":
   test "initTAddress returns error for a p2p-circuit address":
     let ma = MultiAddress.init("/ip4/127.0.0.1/tcp/1234/p2p-circuit").get()
     check initTAddress(ma).isErr
+
+suite "isFilterablePrivateMA":
+  proc ma(s: string): MultiAddress =
+    MultiAddress.init(s).tryGet()
+
+  test "RFC1918 addresses are filterable":
+    check isFilterablePrivateMA(ma("/ip4/10.0.0.1/tcp/4001"))
+    check isFilterablePrivateMA(ma("/ip4/172.16.0.1/tcp/4001"))
+    check isFilterablePrivateMA(ma("/ip4/172.31.255.255/tcp/4001"))
+    check isFilterablePrivateMA(ma("/ip4/192.168.1.5/tcp/4001"))
+
+  test "loopback addresses are filterable":
+    check isFilterablePrivateMA(ma("/ip4/127.0.0.1/tcp/4001"))
+    check isFilterablePrivateMA(ma("/ip6/::1/tcp/4001"))
+
+  test "link-local addresses are filterable":
+    check isFilterablePrivateMA(ma("/ip4/169.254.1.1/tcp/4001"))
+    check isFilterablePrivateMA(ma("/ip6/fe80::1/tcp/4001"))
+
+  test "public IPv4 addresses are not filterable":
+    check not isFilterablePrivateMA(ma("/ip4/1.1.1.1/tcp/4001"))
+    check not isFilterablePrivateMA(ma("/ip4/8.8.8.8/tcp/53"))
+
+  test "DNS addresses are not filterable":
+    check not isFilterablePrivateMA(ma("/dns4/example.com/tcp/4001"))
+    check not isFilterablePrivateMA(ma("/dns/example.com/tcp/4001"))
+
+  test "circuit relay addresses are not filterable even with private relay IP":
+    check not isFilterablePrivateMA(
+      ma(
+        "/ip4/192.168.1.5/tcp/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit"
+      )
+    )
+    check not isFilterablePrivateMA(
+      ma(
+        "/ip4/127.0.0.1/tcp/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit"
+      )
+    )


### PR DESCRIPTION
## Summary

Adds the ability to filter private/non-routable IP addresses from a node's announced addresses and from peer address records received from the network. This is done by adding two new `SwitchBuilder` methods:
- `withAddressPolicy(policy)`: accepts any custom policy
- `withPrivateAddressFilter()`: convenience wrapper that applies publicRoutableAddressPolicy()

Enabling one of those options propagates the policy to `PeerInfo`, `PeerStore` and `Kademlia`

Only addresses in `peerStore[AddressBook]` are affected by this change. SignedPeerRecords will still contain local addresses, because changing the record invalidates it. We could add a getter function that returns the filtered addresses should the need arise, though

Fixes: https://github.com/vacp2p/nim-libp2p/issues/2248

cc: @SionoiS 

## Affected Areas
- [ ] Gossipsub  
- [ ] Transports
- [x] Peer Management / Discovery
- [ ] Protocol Logic
- [ ] Build / Tooling
- [ ] Other  : Switch Builder options

## Impact on Library Users
New options were added that are Opt-in.

## Risk Assessment
- Nodes behind NAT will lose all addresses. Those nodes should not enable this option
- Mix protocol might bypass this policy if adding entries manually to the MixNodePool