### PR TITLE
fix(gossipsub): flaky scoring test

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
-# Copyright (c) Status Research & Development GmbH 
+# Copyright (c) Status Research & Development GmbH
 
 {.push raises: [].}
 

--- a/tests/libp2p/mix/utils.nim
+++ b/tests/libp2p/mix/utils.nim
@@ -153,9 +153,6 @@ proc new*(T: typedesc[NoReplyProtocol]): NoReplyProtocol =
       await nrProto.receivedMessages.put(
         ReceivedMessage(connPeerId: conn.peerId, data: buffer)
       )
-      # Drain remaining data (important)
-      while true:
-        discard await conn.readLp(1024)
     except LPStreamError:
       raiseAssert "should not happen"
     finally:

--- a/tests/libp2p/mix/utils.nim
+++ b/tests/libp2p/mix/utils.nim
@@ -153,6 +153,9 @@ proc new*(T: typedesc[NoReplyProtocol]): NoReplyProtocol =
       await nrProto.receivedMessages.put(
         ReceivedMessage(connPeerId: conn.peerId, data: buffer)
       )
+      # Drain remaining data (important)
+      while true:
+        discard await conn.readLp(1024)
     except LPStreamError:
       raiseAssert "should not happen"
     finally:

--- a/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
@@ -146,7 +146,8 @@ suite "GossipSub Component - Scoring":
     waitSubscribeStar(nodes, topic)
 
     checkUntilTimeout:
-      nodes[0].peers[nodes[1].switch.peerInfo.peerId] in nodes[0].mesh.getOrDefault(topic)
+      nodes[0].peers[nodes[1].switch.peerInfo.peerId] in
+        nodes[0].mesh.getOrDefault(topic)
 
     let msg = RPCMsg.withControl(
       ControlMessage.withPrune(

--- a/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
@@ -145,6 +145,9 @@ suite "GossipSub Component - Scoring":
     subscribeAllNodes(nodes, topic, voidTopicHandler)
     waitSubscribeStar(nodes, topic)
 
+    checkUntilTimeout:
+      nodes[0].peers[nodes[1].switch.peerInfo.peerId] in nodes[0].mesh.getOrDefault(topic)
+
     let msg = RPCMsg.withControl(
       ControlMessage.withPrune(
         topic, 123'u64, @[PeerInfoMsg(peerId: PeerId(data: newSeq[byte](33)))]


### PR DESCRIPTION
## Summary

Fixes a flaky test in the GossipSub scoring suite where the  
**"Should rate limit decodable messages above the size allowed"** test would intermittently fail on slow CI architectures.

The test was broadcasting to `nodes[0].mesh[topic]` immediately after `waitSubscribeStar`, which only guarantees that peers are present in the GossipSub routing table—not in the mesh.

Mesh population happens later, after the GossipSub heartbeat runs and GRAFT exchanges complete. On slower machines, the mesh could still be empty at broadcast time, resulting in no message delivery and the rate-limit counter not incrementing.

---

## Changes

### `tests/libp2p/pubsub/component/test_gossipsub_scoring.nim`

- Added a `checkUntilTimeout` guard after `waitSubscribeStar`
  - Waits until `nodes[0].mesh[topic]` contains exactly one peer
  - Ensures:
    - Heartbeat has executed
    - Mesh is established before broadcasting

---

## Affected Areas

- Gossipsub
  - Fixes flaky scoring test by synchronizing on mesh population before broadcast
- Transports
- Peer Management / Discovery
- Protocol Logic
- Build / Tooling
- Other

---

## Compatibility & Downstream Validation

- Test-only change
- No production code paths modified
- No changes to:
  - Encoding/decoding logic
  - Public APIs

No validation required for downstream consumers (Nimbus, Waku, Codex).

---

## Impact on Library Users

- None
  - No API, ABI, or behavioral changes

---

## Risk Assessment

- **Low**
  - Adds a synchronization point in a test only
  - Tightens timing assumptions instead of relaxing them
  - The condition (`mesh.len == 1`) is already implicitly required for the test to be valid

No risk of masking real bugs:
- `waitSubscribeStar` already ensures routing table population
- GossipSub heartbeat is expected to run shortly after

---

## References

- #2261 
- #2287 