### PR TITLE
fix(service-disco): add missing tables import

### DIFF
--- a/tests/libp2p/service_discovery/test_routing_table_manager.nim
+++ b/tests/libp2p/service_discovery/test_routing_table_manager.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import chronos, results, sets
+import chronos, results, sets, tables
 import
   ../../../libp2p/protocols/kademlia,
   ../../../libp2p/protocols/service_discovery/[types, routing_table_manager]


### PR DESCRIPTION
## Summary

This PR fixes a missing import in the routing table manager test suite. The `tables` module was required by test logic that uses Nim's standard `Table` type but was absent from the import list, causing compilation failures.

- `tests/libp2p/service_discovery/test_routing_table_manager.nim`:
  - Added `tables` to the import list alongside the existing `chronos`, `results`, and `sets` imports to satisfy the dependency on Nim's `Table` type used in the tests.

## Affected Areas

- Gossipsub
- Transports
- Peer Management / Discovery
- Protocol Logic
- Build / Tooling
- Other

Two-line fix in the routing table manager test file — no production code changed.

## Compatibility & Downstream Validation

No production code was modified. This change only affects test compilation. Existing encode/decode and API paths are completely unaffected. Downstream consumers (Nimbus, Waku, Codex) do not need validation for this change.

## Impact on Library Users

- No API, ABI, or behavioral changes — this is a test-only fix.

## Risk Assessment

- Risk: None. A missing `tables` import was added to a test file. The old behavior was a compilation error; the new behavior is that the test file compiles and runs correctly. Risk is effectively zero.

## References

#2261