### PR TITLE
test(gossipsub): partial messages with fanout bug + fix

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import tables, chronicles, results
+import tables, sets, chronicles, results
 import ../../../utils/tablekey
 import ../../../[peerid]
 import ../rpc/messages
@@ -331,10 +331,13 @@ proc publishPartial*(
       # with peers that already exchanged metadata for this group.
       # This preserves replies to a remote peer acting as an unsubscribed
       # fanout publisher.
+      var seen = publishTargets.toHashSet()
       for p in groupState.peerState.keys:
-        if p notin publishTargets:
+        if not seen.containsOrIncl(p):
           publishTargets.add(p)
       publishTargets
+
+  let nodeRequestsPartial = ext.config.nodeTopicOpts(topic).requestsPartial
 
   var publishedToCount: int = 0
   for p in publishToPeers:
@@ -354,7 +357,6 @@ proc publishPartial*(
     # advertised partial support for the topic or already have per-group
     # state. peerHasState covers peers that already sent metadata for this
     # group without ever sending a subscription RPC.
-    let nodeRequestsPartial = ext.config.nodeTopicOpts(topic).requestsPartial
     let peerHasState = groupState.peerState.hasKey(p)
     if nodeRequestsPartial and (peerSubOpt.supportsSendingPartial or peerHasState):
       if ext.publishPartialToPeer(topic, pm, groupState, p, false):

--- a/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
@@ -322,7 +322,7 @@ proc publishPartial*(
   groupState.heartbeatsTillEviction = ext.config.heartbeatsTillEviction
   groupState.lastPublishedMetadata = pm.partsMetadata()
 
-  var peersToTry =
+  var publishToPeers =
     if peers.len > 0:
       peers
     else:
@@ -337,7 +337,7 @@ proc publishPartial*(
       publishTargets
 
   var publishedToCount: int = 0
-  for p in peersToTry:
+  for p in publishToPeers:
     if not ext.config.isSupported(p):
       continue
 

--- a/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import tables, sets, chronicles, results
+import tables, sets, sequtils, chronicles, results
 import ../../../utils/tablekey
 import ../../../[peerid]
 import ../rpc/messages
@@ -135,6 +135,9 @@ template getGroupState(
 
 template getPeerState(gs: GroupState, peerId: PeerId): PeerGroupState =
   gs.peerState.mgetOrPut(peerId, PeerGroupState())
+
+template hasPeer(gs: GroupState, peerId: PeerId): bool =
+  gs.peerState.hasKey(peerId)
 
 proc unionWithSentPartsMetadata(
     ext: PartialMessageExtension,
@@ -322,20 +325,18 @@ proc publishPartial*(
   groupState.heartbeatsTillEviction = ext.config.heartbeatsTillEviction
   groupState.lastPublishedMetadata = pm.partsMetadata()
 
-  var publishToPeers =
+  let publishToPeers =
     if peers.len > 0:
       peers
     else:
-      var publishTargets = ext.config.publishToPeers(topic)
       # Extend this node's current publish targets
       # with peers that already exchanged metadata for this group.
       # This preserves replies to a remote peer acting as an unsubscribed
       # fanout publisher.
-      var seen = publishTargets.toHashSet()
+      var targets = ext.config.publishToPeers(topic).toHashSet()
       for p in groupState.peerState.keys:
-        if not seen.containsOrIncl(p):
-          publishTargets.add(p)
-      publishTargets
+        targets.incl(p)
+      targets.toSeq()
 
   let nodeRequestsPartial = ext.config.nodeTopicOpts(topic).requestsPartial
 
@@ -355,10 +356,10 @@ proc publishPartial*(
 
     # If this node requests partials, send metadata to peers that either
     # advertised partial support for the topic or already have per-group
-    # state. peerHasState covers peers that already sent metadata for this
-    # group without ever sending a subscription RPC.
-    let peerHasState = groupState.peerState.hasKey(p)
-    if nodeRequestsPartial and (peerSubOpt.supportsSendingPartial or peerHasState):
+    # state. The hasPeer check covers peers that already sent metadata for
+    # this group without ever sending a subscription RPC.
+    if nodeRequestsPartial and
+        (peerSubOpt.supportsSendingPartial or groupState.hasPeer(p)):
       if ext.publishPartialToPeer(topic, pm, groupState, p, false):
         publishedToCount.inc
 

--- a/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
@@ -322,29 +322,41 @@ proc publishPartial*(
   groupState.heartbeatsTillEviction = ext.config.heartbeatsTillEviction
   groupState.lastPublishedMetadata = pm.partsMetadata()
 
-  var publishedToCount: int = 0
-  let publishToPeers =
+  var peersToTry =
     if peers.len > 0:
       peers
     else:
-      ext.config.publishToPeers(topic)
-  for _, p in publishToPeers:
+      var publishTargets = ext.config.publishToPeers(topic)
+      # Extend this node's current publish targets
+      # with peers that already exchanged metadata for this group.
+      # This preserves replies to a remote peer acting as an unsubscribed
+      # fanout publisher.
+      for p in groupState.peerState.keys:
+        if p notin publishTargets:
+          publishTargets.add(p)
+      publishTargets
+
+  var publishedToCount: int = 0
+  for p in peersToTry:
     if not ext.config.isSupported(p):
-      # peer needs to support this extension
       continue
 
     let peerSubOpt = ext.peerTopicOpts.getOrDefault(PeerTopicKey.new(p, topic))
-    let nodeSubOpt = ext.config.nodeTopicOpts(topic)
-
-    # publish partial message to peer if ...
-    if peerSubOpt.requestsPartial and
-        (nodeSubOpt.supportsSendingPartial or nodeSubOpt.requestsPartial):
-      # 1) peer has requested partial messages for this topic
+    if peerSubOpt.requestsPartial:
+      # If the peer requests partials, publish to it without checking this
+      # node's own topic opts. A node may publish partials as a fanout
+      # publisher without being subscribed to the topic.
       if ext.publishPartialToPeer(topic, pm, groupState, p, true):
         publishedToCount.inc
-    elif nodeSubOpt.requestsPartial and
-        (peerSubOpt.supportsSendingPartial or peerSubOpt.requestsPartial):
-      # 2) this node has requested partial messages and peer (other node) supports sending it
+      continue
+
+    # If this node requests partials, send metadata to peers that either
+    # advertised partial support for the topic or already have per-group
+    # state. peerHasState covers peers that already sent metadata for this
+    # group without ever sending a subscription RPC.
+    let nodeRequestsPartial = ext.config.nodeTopicOpts(topic).requestsPartial
+    let peerHasState = groupState.peerState.hasKey(p)
+    if nodeRequestsPartial and (peerSubOpt.supportsSendingPartial or peerHasState):
       if ext.publishPartialToPeer(topic, pm, groupState, p, false):
         publishedToCount.inc
 

--- a/tests/interop/gossipsub/test_runner.nim
+++ b/tests/interop/gossipsub/test_runner.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import chronos, streams, sequtils, strutils
+import chronos, streams, sequtils, strutils, tables
 import ../../../libp2p/[multiaddress, protocols/pubsub/gossipsub, switch]
 import
   ../../../interop/gossipsub/src/[node, instructions, runner, interop_partial_message]
@@ -37,21 +37,24 @@ suite "GossipSub Interop - Script runner - Component":
     )
 
     # Build a script for node 0
-    let script = @[
-      ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
-      ScriptInstruction(kind: Connect, connectTo: @[1]),
-      ScriptInstruction(kind: SubscribeToTopic, topicID: topic, partial: false),
-      ScriptInstruction(kind: WaitUntil, elapsed: 2.seconds),
-      ScriptInstruction(
-        kind: Publish,
-        publishMessageID: 99,
-        messageSizeBytes: 512,
-        publishTopicID: topic,
-      ),
-      ScriptInstruction(
-        kind: SetTopicValidationDelay, validationTopicID: topic, delay: 300.milliseconds
-      ),
-    ]
+    let script =
+      @[
+        ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
+        ScriptInstruction(kind: Connect, connectTo: @[1]),
+        ScriptInstruction(kind: SubscribeToTopic, topicID: topic, partial: false),
+        ScriptInstruction(kind: WaitUntil, elapsed: 2.seconds),
+        ScriptInstruction(
+          kind: Publish,
+          publishMessageID: 99,
+          messageSizeBytes: 512,
+          publishTopicID: topic,
+        ),
+        ScriptInstruction(
+          kind: SetTopicValidationDelay,
+          validationTopicID: topic,
+          delay: 300.milliseconds,
+        ),
+      ]
 
     var stream = newStringStream()
     let runner = newScriptRunner(
@@ -81,11 +84,12 @@ suite "GossipSub Interop - Script runner - Component":
     let inner = new ScriptInstruction
     inner[] = ScriptInstruction(kind: Connect, connectTo: @[1])
 
-    let script = @[
-      ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
-      # This should be skipped (node 5 != node 0)
-      ScriptInstruction(kind: IfNodeIDEquals, nodeID: 5, inner: inner),
-    ]
+    let script =
+      @[
+        ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
+        # This should be skipped (node 5 != node 0)
+        ScriptInstruction(kind: IfNodeIDEquals, nodeID: 5, inner: inner),
+      ]
 
     var stream = newStringStream()
     let runner = newScriptRunner(
@@ -166,30 +170,100 @@ suite "GossipSub Interop - Script runner - Component":
     runner0.messages[key] = pm0
 
     # Build a script for node 1
-    let script = @[
-      ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
-      ScriptInstruction(kind: Connect, connectTo: @[0]),
-      ScriptInstruction(kind: WaitUntil, elapsed: 1.seconds),
-      ScriptInstruction(kind: SubscribeToTopic, topicID: topic, partial: true),
-      ScriptInstruction(kind: WaitUntil, elapsed: 5.seconds),
-      ScriptInstruction(
-        kind: AddPartialMessage,
-        addTopicID: topic,
-        groupID: groupId,
-        partsBitmap: 0b11110000,
-      ),
-      ScriptInstruction(
-        kind: PublishPartial,
-        publishPartialTopicID: topic,
-        publishPartialGroupID: groupId,
-        publishToNodeIDs: @[0],
-      ),
-    ]
+    let script =
+      @[
+        ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
+        ScriptInstruction(kind: Connect, connectTo: @[0]),
+        ScriptInstruction(kind: WaitUntil, elapsed: 1.seconds),
+        ScriptInstruction(kind: SubscribeToTopic, topicID: topic, partial: true),
+        ScriptInstruction(kind: WaitUntil, elapsed: 5.seconds),
+        ScriptInstruction(
+          kind: AddPartialMessage,
+          addTopicID: topic,
+          groupID: groupId,
+          partsBitmap: 0b11110000,
+        ),
+        ScriptInstruction(
+          kind: PublishPartial,
+          publishPartialTopicID: topic,
+          publishPartialGroupID: groupId,
+          publishToNodeIDs: @[0],
+        ),
+      ]
 
     await runner1.runScript(script)
 
     # Assert both nodes receive full messages
     checkUntilTimeout:
+      runner0.messages[key].isComplete()
+      runner1.messages[key].isComplete()
+      logStream0.data.contains("All parts received")
+      logStream1.data.contains("All parts received")
+
+  asyncTest "fanout scenario":
+    let logStream0 = newStringStream()
+    let logStream1 = newStringStream()
+
+    let runner0 = newScriptRunner(
+      nodeId = 0,
+      logStream = logStream0,
+      listenAddr = localhost,
+      enablePartialMessages = true,
+    )
+    let runner1 = newScriptRunner(
+      nodeId = 1,
+      logStream = logStream1,
+      listenAddr = localhost,
+      enablePartialMessages = true,
+    )
+
+    await allFutures(@[runner0, runner1].mapIt(it.start()))
+    defer:
+      await allFutures(@[runner0, runner1].mapIt(it.stop()))
+
+    runner0.setResolveAddr(
+      proc(id: int): MultiAddress {.gcsafe.} =
+        runner1.node.getAddr()
+    )
+
+    const topic = "foobar"
+    const groupId = 77'u64
+    let key = makeKey(topic, groupId)
+
+    # Node 0 has the message and is not subscribed, publishes to 1 explicitely
+    let node0Script =
+      @[
+        ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
+        ScriptInstruction(kind: Connect, connectTo: @[1]),
+        ScriptInstruction(kind: WaitUntil, elapsed: 3.seconds),
+        ScriptInstruction(
+          kind: AddPartialMessage,
+          addTopicID: topic,
+          groupID: groupId,
+          partsBitmap: 0b11111111,
+        ),
+        ScriptInstruction(
+          kind: PublishPartial,
+          publishPartialTopicID: topic,
+          publishPartialGroupID: groupId,
+          publishToNodeIDs: @[1],
+        ),
+        ScriptInstruction(kind: WaitUntil, elapsed: 6.seconds),
+      ]
+
+    # Node 1 supports partials and is subscribed
+    let node1Script =
+      @[
+        ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
+        ScriptInstruction(kind: SubscribeToTopic, topicID: topic, partial: true),
+        ScriptInstruction(kind: WaitUntil, elapsed: 6.seconds),
+      ]
+
+    await allFutures(@[runner0.runScript(node0Script), runner1.runScript(node1Script)])
+
+    checkUntilTimeout:
+      key in runner0.messages
+      key in runner1.messages
       runner0.messages[key].isComplete()
       runner1.messages[key].isComplete()
       logStream0.data.contains("All parts received")

--- a/tests/interop/gossipsub/test_runner.nim
+++ b/tests/interop/gossipsub/test_runner.nim
@@ -37,24 +37,21 @@ suite "GossipSub Interop - Script runner - Component":
     )
 
     # Build a script for node 0
-    let script =
-      @[
-        ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
-        ScriptInstruction(kind: Connect, connectTo: @[1]),
-        ScriptInstruction(kind: SubscribeToTopic, topicID: topic, partial: false),
-        ScriptInstruction(kind: WaitUntil, elapsed: 2.seconds),
-        ScriptInstruction(
-          kind: Publish,
-          publishMessageID: 99,
-          messageSizeBytes: 512,
-          publishTopicID: topic,
-        ),
-        ScriptInstruction(
-          kind: SetTopicValidationDelay,
-          validationTopicID: topic,
-          delay: 300.milliseconds,
-        ),
-      ]
+    let script = @[
+      ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
+      ScriptInstruction(kind: Connect, connectTo: @[1]),
+      ScriptInstruction(kind: SubscribeToTopic, topicID: topic, partial: false),
+      ScriptInstruction(kind: WaitUntil, elapsed: 2.seconds),
+      ScriptInstruction(
+        kind: Publish,
+        publishMessageID: 99,
+        messageSizeBytes: 512,
+        publishTopicID: topic,
+      ),
+      ScriptInstruction(
+        kind: SetTopicValidationDelay, validationTopicID: topic, delay: 300.milliseconds
+      ),
+    ]
 
     var stream = newStringStream()
     let runner = newScriptRunner(
@@ -84,12 +81,11 @@ suite "GossipSub Interop - Script runner - Component":
     let inner = new ScriptInstruction
     inner[] = ScriptInstruction(kind: Connect, connectTo: @[1])
 
-    let script =
-      @[
-        ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
-        # This should be skipped (node 5 != node 0)
-        ScriptInstruction(kind: IfNodeIDEquals, nodeID: 5, inner: inner),
-      ]
+    let script = @[
+      ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
+      # This should be skipped (node 5 != node 0)
+      ScriptInstruction(kind: IfNodeIDEquals, nodeID: 5, inner: inner),
+    ]
 
     var stream = newStringStream()
     let runner = newScriptRunner(
@@ -170,26 +166,25 @@ suite "GossipSub Interop - Script runner - Component":
     runner0.messages[key] = pm0
 
     # Build a script for node 1
-    let script =
-      @[
-        ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
-        ScriptInstruction(kind: Connect, connectTo: @[0]),
-        ScriptInstruction(kind: WaitUntil, elapsed: 1.seconds),
-        ScriptInstruction(kind: SubscribeToTopic, topicID: topic, partial: true),
-        ScriptInstruction(kind: WaitUntil, elapsed: 5.seconds),
-        ScriptInstruction(
-          kind: AddPartialMessage,
-          addTopicID: topic,
-          groupID: groupId,
-          partsBitmap: 0b11110000,
-        ),
-        ScriptInstruction(
-          kind: PublishPartial,
-          publishPartialTopicID: topic,
-          publishPartialGroupID: groupId,
-          publishToNodeIDs: @[0],
-        ),
-      ]
+    let script = @[
+      ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
+      ScriptInstruction(kind: Connect, connectTo: @[0]),
+      ScriptInstruction(kind: WaitUntil, elapsed: 1.seconds),
+      ScriptInstruction(kind: SubscribeToTopic, topicID: topic, partial: true),
+      ScriptInstruction(kind: WaitUntil, elapsed: 5.seconds),
+      ScriptInstruction(
+        kind: AddPartialMessage,
+        addTopicID: topic,
+        groupID: groupId,
+        partsBitmap: 0b11110000,
+      ),
+      ScriptInstruction(
+        kind: PublishPartial,
+        publishPartialTopicID: topic,
+        publishPartialGroupID: groupId,
+        publishToNodeIDs: @[0],
+      ),
+    ]
 
     await runner1.runScript(script)
 
@@ -231,33 +226,31 @@ suite "GossipSub Interop - Script runner - Component":
     let key = makeKey(topic, groupId)
 
     # Node 0 has the message and is not subscribed, publishes to 1 explicitely
-    let node0Script =
-      @[
-        ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
-        ScriptInstruction(kind: Connect, connectTo: @[1]),
-        ScriptInstruction(kind: WaitUntil, elapsed: 3.seconds),
-        ScriptInstruction(
-          kind: AddPartialMessage,
-          addTopicID: topic,
-          groupID: groupId,
-          partsBitmap: 0b11111111,
-        ),
-        ScriptInstruction(
-          kind: PublishPartial,
-          publishPartialTopicID: topic,
-          publishPartialGroupID: groupId,
-          publishToNodeIDs: @[1],
-        ),
-        ScriptInstruction(kind: WaitUntil, elapsed: 6.seconds),
-      ]
+    let node0Script = @[
+      ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
+      ScriptInstruction(kind: Connect, connectTo: @[1]),
+      ScriptInstruction(kind: WaitUntil, elapsed: 3.seconds),
+      ScriptInstruction(
+        kind: AddPartialMessage,
+        addTopicID: topic,
+        groupID: groupId,
+        partsBitmap: 0b11111111,
+      ),
+      ScriptInstruction(
+        kind: PublishPartial,
+        publishPartialTopicID: topic,
+        publishPartialGroupID: groupId,
+        publishToNodeIDs: @[1],
+      ),
+      ScriptInstruction(kind: WaitUntil, elapsed: 6.seconds),
+    ]
 
     # Node 1 supports partials and is subscribed
-    let node1Script =
-      @[
-        ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
-        ScriptInstruction(kind: SubscribeToTopic, topicID: topic, partial: true),
-        ScriptInstruction(kind: WaitUntil, elapsed: 6.seconds),
-      ]
+    let node1Script = @[
+      ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
+      ScriptInstruction(kind: SubscribeToTopic, topicID: topic, partial: true),
+      ScriptInstruction(kind: WaitUntil, elapsed: 6.seconds),
+    ]
 
     await allFutures(@[runner0.runScript(node0Script), runner1.runScript(node1Script)])
 

--- a/tests/interop/gossipsub/test_runner.nim
+++ b/tests/interop/gossipsub/test_runner.nim
@@ -225,7 +225,7 @@ suite "GossipSub Interop - Script runner - Component":
     const groupId = 77'u64
     let key = makeKey(topic, groupId)
 
-    # Node 0 has the message and is not subscribed, publishes to 1 explicitely
+    # Node 0 has the message and is not subscribed, publishes to 1 explicitly
     let node0Script = @[
       ScriptInstruction(kind: InitGossipSub, gossipSubParams: GossipSubParams.init()),
       ScriptInstruction(kind: Connect, connectTo: @[1]),

--- a/tests/libp2p/pubsub/component/test_gossipsub_extensions.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_extensions.nim
@@ -362,6 +362,72 @@ suite "GossipSub Component - Extensions":
           partsMetadata: MyPartsMetadata.have(toSeq(pmData.data.keys)),
         )
 
+  asyncTest "Partial Message Extension - fanout publisher":
+    # Fanout pattern: publisher node is not subscribed to the topic but
+    # pushes partial messages to peers via an explicit peer list.
+    const topic = "logos-partial"
+    const groupId = "group-id-1".toBytes
+
+    proc validateRPC(
+        rpc: PartialMessageExtensionRPC
+    ): Result[void, string] {.gcsafe, raises: [].} =
+      checkLen(rpc.partsMetadata)
+      return ok()
+
+    var incomingRPC: Table[PeerId, seq[PartialMessageExtensionRPC]]
+    proc onIncomingRPC(
+        peer: PeerId, rpc: PartialMessageExtensionRPC
+    ) {.gcsafe, raises: [].} =
+      incomingRPC.mgetOrPut(peer, newSeq[PartialMessageExtensionRPC]()).add(rpc)
+
+    let
+      numberOfNodes = 2
+      nodes = generateNodes(
+          numberOfNodes,
+          gossip = true,
+          partialMessageExtensionConfig = Opt.some(
+            PartialMessageExtensionConfig(
+              unionPartsMetadata: my_partial_message.unionPartsMetadata,
+              validateRPC: validateRPC,
+              onIncomingRPC: onIncomingRPC,
+              heartbeatsTillEviction: 100,
+            )
+          ),
+        )
+        .toGossipSub()
+
+    startAndDeferStop(nodes)
+
+    await connect(nodes[0], nodes[1])
+
+    # Only node 1 subscribes (requesting partials). Node 0 does not subscribe.
+    nodes[1].subscribe(topic, voidTopicHandler, requestsPartial = true)
+
+    # Wait for node 0 to learn node 1 is subscribed to the topic with partial.
+    checkUntilTimeout:
+      nodes[0].gossipsub.getOrDefault(topic).len == 1
+
+    # Node 0 publishes parts via the explicit peer list.
+    let pmData = MyPartialMessage(
+      groupID: groupId,
+      data: {1: "one".toBytes, 2: "two".toBytes, 3: "three".toBytes}.toTable,
+    )
+    await nodes[0].publishPartial(topic, pmData)
+
+    # Node 1 should receive the announcement even though node 0 never subscribed.
+    # Peer has not yet expressed what it wants, so only parts metadata is sent
+    # on this first publish.
+    checkUntilTimeout:
+      incomingRPC.getOrDefault(nodes[0].peerInfo.peerId, @[]).len == 1
+
+    check:
+      incomingRPC[nodes[0].peerInfo.peerId][0] ==
+        PartialMessageExtensionRPC(
+          topicID: topic,
+          groupID: groupId,
+          partsMetadata: MyPartsMetadata.have(toSeq(pmData.data.keys)),
+        )
+
   asyncTest "PingPong Extension":
     let
       numberOfNodes = 2

--- a/tests/libp2p/pubsub/component/test_gossipsub_extensions.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_extensions.nim
@@ -364,7 +364,7 @@ suite "GossipSub Component - Extensions":
 
   asyncTest "Partial Message Extension - fanout publisher":
     # Fanout pattern: publisher node is not subscribed to the topic but
-    # pushes partial messages to peers via an explicit peer list.
+    # pushes partial messages to peers via broadcast publish.
     const topic = "logos-partial"
     const groupId = "group-id-1".toBytes
 
@@ -407,7 +407,7 @@ suite "GossipSub Component - Extensions":
     checkUntilTimeout:
       nodes[0].gossipsub.getOrDefault(topic).len == 1
 
-    # Node 0 publishes parts via the explicit peer list.
+    # Node 0 publishes parts via broadcast publish.
     let pmData = MyPartialMessage(
       groupID: groupId,
       data: {1: "one".toBytes, 2: "two".toBytes, 3: "three".toBytes}.toTable,

--- a/tests/libp2p/pubsub/component/test_gossipsub_extensions.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_extensions.nim
@@ -374,11 +374,11 @@ suite "GossipSub Component - Extensions":
       checkLen(rpc.partsMetadata)
       return ok()
 
-    var incomingRPC: Table[PeerId, seq[PartialMessageExtensionRPC]]
+    let incomingRPC = newAsyncQueue[(PeerId, PartialMessageExtensionRPC)]()
     proc onIncomingRPC(
         peer: PeerId, rpc: PartialMessageExtensionRPC
     ) {.gcsafe, raises: [].} =
-      incomingRPC.mgetOrPut(peer, newSeq[PartialMessageExtensionRPC]()).add(rpc)
+      discard incomingRPC.put((peer, rpc))
 
     let
       numberOfNodes = 2
@@ -417,11 +417,10 @@ suite "GossipSub Component - Extensions":
     # Node 1 should receive the announcement even though node 0 never subscribed.
     # Peer has not yet expressed what it wants, so only parts metadata is sent
     # on this first publish.
-    checkUntilTimeout:
-      incomingRPC.getOrDefault(nodes[0].peerInfo.peerId, @[]).len == 1
-
+    let (fromPeer, rpc) = await incomingRPC.get.wait(3.seconds)
     check:
-      incomingRPC[nodes[0].peerInfo.peerId][0] ==
+      fromPeer == nodes[0].peerInfo.peerId
+      rpc ==
         PartialMessageExtensionRPC(
           topicID: topic,
           groupID: groupId,

--- a/tests/libp2p/pubsub/extensions/test_extension_partial_message.nim
+++ b/tests/libp2p/pubsub/extensions/test_extension_partial_message.nim
@@ -73,13 +73,14 @@ proc subscribe(
   ext.onHandleRPC(
     peerId,
     RPCMsg(
-      subscriptions: @[
-        SubOpts(
-          topic: topic,
-          subscribe: subscribe,
-          requestsPartial: Opt.some(isPartialTopic(topic)),
-        )
-      ]
+      subscriptions:
+        @[
+          SubOpts(
+            topic: topic,
+            subscribe: subscribe,
+            requestsPartial: Opt.some(isPartialTopic(topic)),
+          )
+        ]
     ),
   )
 
@@ -273,9 +274,10 @@ suite "GossipSub Extensions :: Partial Message Extension":
     # - node A: fulfills request sending message only to node B (this is where second test, this test, ends)
     const topic = "logos-partial"
     var cr = CallbackRecorder(
-      publishToPeers: @[peerId]
-        # note: this is list of peers that we publish to by default, 
-        # but in this test this list is ignored because test is publishing to selected peers.
+      publishToPeers:
+        @[peerId]
+          # note: this is list of peers that we publish to by default, 
+          # but in this test this list is ignored because test is publishing to selected peers.
     )
     var ext = PartialMessageExtension.new(cr.config())
     let selectedPeerId = PeerId.random(rng).get()
@@ -322,6 +324,113 @@ suite "GossipSub Extensions :: Partial Message Extension":
     # because peer's request is already fulfilled
     check ext.publishPartial(topic, pm, peers = @[selectedPeerId]) == 0
     check cr.sentRPC.len == 1
+
+  test "publish partial message: selected peer without subscription can receive explicit metadata reply":
+    const topic = "logos-partial"
+    var cr = CallbackRecorder()
+    var ext = PartialMessageExtension.new(cr.config())
+    let publisherPeerId = PeerId.random(rng).get()
+
+    # publisher sent metadata for this group but is not subscribed to the topic
+    ext.handlePartialMessage(
+      publisherPeerId,
+      PartialMessageExtensionRPC(
+        topicID: topic,
+        groupID: groupId,
+        partsMetadata: MyPartsMetadata.have(@[1, 2, 3]),
+      ),
+    )
+
+    # local node can still send an explicit metadata reply to that peer
+    let pm = MyPartialMessage(
+      groupId: groupId, data: initTable[Chunk, seq[byte]](), want: @[1, 2]
+    )
+
+    check ext.publishPartial(topic, pm, peers = @[publisherPeerId]) == 1
+    check:
+      cr.sentRPC.len == 1
+      cr.sentRPC[0] ==
+        PeerRPC(
+          peerId: publisherPeerId,
+          rpc: PartialMessageExtensionRPC(
+            groupID: groupId,
+            topicID: topic,
+            partsMetadata: MyPartsMetadata.want(@[1, 2]),
+            partialMessage: @[],
+          ),
+        )
+
+  test "publish partial message: fanout publisher":
+    # fanout usecase when application publishes parts on a topic it has not
+    # subscribed to.
+    const topic = "logos-partial"
+    var cr = CallbackRecorder(publishToPeers: @[peerId])
+    var config = cr.config()
+    # override nodeTopicOpts to mimic a non-subscribed publisher: both flags false
+    config.nodeTopicOpts = proc(topic: string): TopicOpts {.gcsafe, raises: [].} =
+      TopicOpts()
+    var ext = PartialMessageExtension.new(config)
+
+    # peer subscribes with partial capability
+    ext.subscribe(peerId, topic, true)
+
+    # application/user is publishing message with parts [1, 2, 3]
+    let pm = MyPartialMessage(
+      groupId: groupId,
+      data: {1: "one".toBytes, 2: "two".toBytes, 3: "three".toBytes}.toTable,
+    )
+    check ext.publishPartial(topic, pm, peers = @[peerId]) == 1
+      # should publish to peer even though node is not subscribed
+
+    # peer should receive parts metadata announcing what publisher has
+    check:
+      cr.sentRPC.len == 1
+      cr.sentRPC[0] ==
+        PeerRPC(
+          peerId: peerId,
+          rpc: PartialMessageExtensionRPC(
+            groupID: groupId,
+            topicID: topic,
+            partsMetadata: MyPartsMetadata.have(@[1, 2, 3]),
+            partialMessage: @[],
+          ),
+        )
+
+  test "publish partial message: broadcast reaches publish targets and peers with group state":
+    # broadcast publish (no explicit peers) should reach the union of:
+    #   - default publish targets returned by publishToPeers, and
+    #   - peers that already have per-group state for this topic.
+    # the stateOnlyPeer is intentionally not subscribed, it is reached
+    # only through groupState.peerState.keys and receives metadata-only.
+    const topic = "logos-partial"
+    let publishTargetPeerId = PeerId.random(rng).get()
+    let stateOnlyPeerId = PeerId.random(rng).get()
+    var cr = CallbackRecorder(publishToPeers: @[publishTargetPeerId])
+    var ext = PartialMessageExtension.new(cr.config())
+
+    ext.subscribe(publishTargetPeerId, topic, true)
+    ext.handlePartialMessage(
+      stateOnlyPeerId,
+      PartialMessageExtensionRPC(
+        topicID: topic, groupID: groupId, partsMetadata: MyPartsMetadata.want(@[1])
+      ),
+    )
+
+    let pm = MyPartialMessage(groupId: groupId, data: {1: "one".toBytes}.toTable)
+    check ext.publishPartial(topic, pm) == 2 # both peers reached
+    check cr.sentRPC.len == 2
+
+    let publishTargetRPC = cr.sentRPC.filterIt(it.peerId == publishTargetPeerId)
+    let stateOnlyRPC = cr.sentRPC.filterIt(it.peerId == stateOnlyPeerId)
+    check:
+      publishTargetRPC.len == 1
+      publishTargetRPC[0].rpc.partialMessage.len == 0
+        # default publish target has sent no group metadata, gets announcement only
+      publishTargetRPC[0].rpc.partsMetadata == MyPartsMetadata.have(@[1])
+      stateOnlyRPC.len == 1
+      stateOnlyRPC[0].rpc.partialMessage.len == 0
+        # reached via peerState.keys fallback, not subscribed, so metadata-only
+      stateOnlyRPC[0].rpc.partsMetadata == MyPartsMetadata.have(@[1])
 
   test "publish parts metadata":
     const topic = "logos-partial"

--- a/tests/libp2p/pubsub/extensions/test_extension_partial_message.nim
+++ b/tests/libp2p/pubsub/extensions/test_extension_partial_message.nim
@@ -73,14 +73,13 @@ proc subscribe(
   ext.onHandleRPC(
     peerId,
     RPCMsg(
-      subscriptions:
-        @[
-          SubOpts(
-            topic: topic,
-            subscribe: subscribe,
-            requestsPartial: Opt.some(isPartialTopic(topic)),
-          )
-        ]
+      subscriptions: @[
+        SubOpts(
+          topic: topic,
+          subscribe: subscribe,
+          requestsPartial: Opt.some(isPartialTopic(topic)),
+        )
+      ]
     ),
   )
 
@@ -274,10 +273,9 @@ suite "GossipSub Extensions :: Partial Message Extension":
     # - node A: fulfills request sending message only to node B (this is where second test, this test, ends)
     const topic = "logos-partial"
     var cr = CallbackRecorder(
-      publishToPeers:
-        @[peerId]
-          # note: this is list of peers that we publish to by default, 
-          # but in this test this list is ignored because test is publishing to selected peers.
+      publishToPeers: @[peerId]
+        # note: this is list of peers that we publish to by default, 
+        # but in this test this list is ignored because test is publishing to selected peers.
     )
     var ext = PartialMessageExtension.new(cr.config())
     let selectedPeerId = PeerId.random(rng).get()


### PR DESCRIPTION
## Summary

The partial message extension had a bug in `publishPartial` that prevented fanout publishers from working correctly. A fanout publisher is a node that publishes partial messages to a topic it is not subscribed to. Two things were broken:

1. When picking publish targets (no explicit peer list), the function only used the default `publishToPeers` result. It missed peers that already exchanged metadata for the group but never sent a subscription RPC. This broke the reply path when a remote peer is itself a fanout publisher.

2. When deciding whether to send to a given peer, the function required `nodeSubOpt.supportsSendingPartial OR nodeSubOpt.requestsPartial`. That condition always failed for an unsubscribed node (fanout publisher), so no messages went out.

**Fixes:**
- Broadcast publish now extends the default peer list with any peer that has per-group state in `groupState.peerState`.
- When a peer requests partials, the node sends to it regardless of its own subscription opts.
- When this node requests partials, the check now accepts `peerHasState` (peer already sent group metadata) as a valid signal alongside `peerSubOpt.supportsSendingPartial`.


## Affected Areas

- [x] Gossipsub
  - `extension_partial_message.nim`: publish routing in `publishPartial`


## Compatibility & Downstream Validation

Reference PRs / branches / commits demonstrating successful integration:

- **Nimbus:** N/A
- **Waku:** N/A
- **Codex:** N/A


## Impact on Library Users

Behavior change in the partial message extension. Nodes calling `publishPartial` on a topic they are not subscribed to now work correctly. There is no API change.


## Risk Assessment

Low. The change relaxes publish conditions so it is strictly more permissive. The fanout path was previously broken, so there is no regression risk against working behavior. Three levels of tests cover the new scenarios: unit (extension logic), component (full gossipsub node), and interop (two-node script runner).