### PR TITLE
chore(service-disco): add peer table and store update side effect

### DIFF
--- a/libp2p/protocols/service_discovery/advertiser.nim
+++ b/libp2p/protocols/service_discovery/advertiser.nim
@@ -16,7 +16,7 @@ logScope:
 type RegistrationResponse* = object
   status*: kademlia_protobuf.RegistrationStatus
   ticket*: Opt[Ticket]
-  closerPeers*: seq[PeerId]
+  closerPeers*: seq[PeerInfo]
 
 proc clear*(a: Advertiser) =
   for task in a.running:
@@ -77,14 +77,15 @@ proc sendRegister*(
   let reply = Message.decode(replyBuf).valueOr:
     return err("failed to decode register message response: " & $error)
 
-  let closerPeers = reply.closerPeers.toPeerIds()
-
   let registerMsg = reply.register.valueOr:
     return err("register reply not found")
   let status = registerMsg.status.valueOr:
     return err("register reply status not found")
 
   cd_register_responses.inc(labelValues = [$status])
+
+  let closerPeers = reply.closerPeers.toPeerInfos()
+
   return ok(
     RegistrationResponse(
       status: status, ticket: registerMsg.ticket, closerPeers: closerPeers
@@ -124,8 +125,10 @@ proc startAdvertising*(
       error "failed to register ad", error
       return
 
-    for pid in response.closerPeers:
-      disco.rtManager.insertPeer(serviceId, pid.toKey())
+    disco.updatePeers(response.closerPeers)
+
+    for p in response.closerPeers:
+      disco.rtManager.insertPeer(serviceId, p.peerId.toKey())
 
     case response.status
     of kademlia_protobuf.RegistrationStatus.Confirmed:

--- a/libp2p/protocols/service_discovery/discoverer.nim
+++ b/libp2p/protocols/service_discovery/discoverer.nim
@@ -13,7 +13,7 @@ logScope:
 
 type GetAdsResult = object
   ads: seq[Advertisement]
-  closerPeers: seq[PeerId]
+  closerPeers: seq[PeerInfo]
 
 proc validAds(ads: seq[seq[byte]], serviceId: ServiceId): seq[Advertisement] =
   var validAds: seq[Advertisement] = @[]
@@ -83,7 +83,7 @@ proc dispatchGetAds(
   return Opt.some(
     GetAdsResult(
       ads: getAdsMsg.advertisements.validAds(serviceId),
-      closerPeers: reply.closerPeers.toPeerIds(),
+      closerPeers: reply.closerPeers.toPeerInfos(),
     )
   )
 
@@ -107,7 +107,9 @@ proc processResponse(
     found: var seq[Advertisement],
     limit: int,
 ) =
-  disco.insertCloserPeers(serviceId, response.closerPeers)
+  disco.updatePeers(response.closerPeers)
+
+  disco.insertCloserPeers(serviceId, response.closerPeers.mapIt(it.peerId))
   let remaining = limit - found.len
   if remaining > 0:
     found.add(response.ads[0 ..< min(remaining, response.ads.len)])
@@ -119,7 +121,7 @@ proc drainCompletedPeers(
 ) =
   for fut in pending.filterIt(it.completed()):
     fut.value().withValue(response):
-      disco.insertCloserPeers(serviceId, response.closerPeers)
+      disco.insertCloserPeers(serviceId, response.closerPeers.mapIt(it.peerId))
 
 proc collectBucketAds(
     disco: ServiceDiscovery, serviceId: ServiceId, peers: seq[PeerId], limit: int

--- a/libp2p/protocols/service_discovery/types.nim
+++ b/libp2p/protocols/service_discovery/types.nim
@@ -10,7 +10,7 @@ import
   ]
 import ../../protobuf/minprotobuf
 import ../../utils/iptree
-import ../kademlia/types
+import ../kademlia/[types, protobuf]
 
 const
   DefaultSelfSPRRereshTime* = 10.minutes
@@ -223,3 +223,16 @@ proc record*(disco: ServiceDiscovery): Result[SignedExtendedPeerRecord, string] 
     return err("Failed to create signed peer record: " & $error)
 
   return ok(extPeerRecord)
+
+proc toPeerInfos*(peers: seq[Peer]): seq[PeerInfo] =
+  var peerInfos: seq[PeerInfo]
+
+  for p in peers:
+    let pid = PeerId.init(p.id).valueOr:
+      continue
+
+    let peerInfo = PeerInfo(peerId: pid, addrs: p.addrs)
+
+    peerInfos.add(peerInfo)
+
+  return peerInfos


### PR DESCRIPTION
For service discovery when a reply contains closer peers, update both the peer store and the main table.