### PR TITLE
feat(connmanager): composable modes

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -312,6 +312,8 @@ proc withWatermark*(
   ## down to `lowWater`, skipping peers within `gracePeriod` and protected peers.
   ## Can be combined with `withMaxConnections`/`withMaxInOut` to apply both
   ## a hard semaphore cap and active trimming simultaneously.
+  doAssert lowWater > 0, "lowWater must be > 0"
+  doAssert highWater > lowWater, "highWater must be > lowWater"
   b.watermarkCfg = Opt.some(
     WatermarkConfig(
       lowWater: lowWater,
@@ -326,6 +328,7 @@ proc withScoring*(
     b: SwitchBuilder, scoringConfig: ScoringConfig = ScoringConfig()
 ): SwitchBuilder {.public.} =
   ## Configure connection scoring parameters.
+  doAssert scoringConfig.decayResolution > 0.seconds, "decayResolution must be > 0"
   b.scoringConfig = scoringConfig
   b
 

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -111,7 +111,7 @@ proc new*(T: type[SwitchBuilder]): T {.public.} =
     privKey: Opt.none(PrivateKey),
     addresses: @[address],
     secureManagers: @[],
-    maxConnections: MaxConnections,
+    maxConnections: -1,
     maxIn: -1,
     maxOut: -1,
     maxConnsPerPeer: MaxConnectionsPerPeer,
@@ -310,7 +310,8 @@ proc withWatermark*(
   ## Enable hi/lo watermark connection management.
   ## When connected peers exceed `highWater`, the connection manager trims
   ## down to `lowWater`, skipping peers within `gracePeriod` and protected peers.
-  ## Takes priority over `withMaxConnections`/`withMaxIn`/`withMaxOut`.
+  ## Can be combined with `withMaxConnections`/`withMaxInOut` to apply both
+  ## a hard semaphore cap and active trimming simultaneously.
   b.watermarkCfg = Opt.some(
     WatermarkConfig(
       lowWater: lowWater,
@@ -464,19 +465,23 @@ proc build*(b: SwitchBuilder): Switch {.raises: [LPError], public.} =
     else:
       Identify.new(peerInfo, b.sendSignedPeerRecord)
 
-  var connManager: ConnManager
-  if b.watermarkCfg.isSome:
-    connManager =
-      ConnManager.newWatermark(b.watermarkCfg.get(), b.maxConnsPerPeer, b.scoringConfig)
+  var maxConnections, maxIn, maxOut = 0
+  if b.maxIn > 0 and b.maxOut > 0:
+    maxIn = b.maxIn
+    maxOut = b.maxOut
   elif b.maxIn > 0 or b.maxOut > 0:
-    if b.maxIn > 0 and b.maxOut > 0:
-      connManager = ConnManager.newMaxInOut(b.maxIn, b.maxOut, b.maxConnsPerPeer)
-    else:
-      raiseAssert "withMaxIn() should be paired with withMaxOut()"
+    raiseAssert "withMaxIn() should be paired with withMaxOut()"
   elif b.maxConnections > 0:
-    connManager = ConnManager.newMaxTotal(b.maxConnections, b.maxConnsPerPeer)
-  else:
-    connManager = ConnManager.newMaxTotal()
+    maxConnections = b.maxConnections
+
+  let connManager = ConnManager.new(
+    maxConnections = maxConnections,
+    maxIn = maxIn,
+    maxOut = maxOut,
+    maxConnsPerPeer = b.maxConnsPerPeer,
+    watermark = b.watermarkCfg,
+    scoringConfig = b.scoringConfig,
+  )
 
   let ms = MultistreamSelect.new()
   let muxedUpgrade = MuxedUpgrade.new(b.muxers, secureManagerInstances, ms, connManager)

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -136,69 +136,62 @@ proc decayNone*(): DecayFn =
 proc newTooManyConnectionsError(): ref TooManyConnectionsError {.inline.} =
   result = newException(TooManyConnectionsError, "Too many connections")
 
-proc newMaxTotal*(
-    C: type ConnManager,
-    maxConnections = MaxConnections,
-    maxConnsPerPeer = MaxConnectionsPerPeer,
+proc new*(
+    T: type ConnManager,
+    maxConnections: int = 0,
+    maxIn: int = 0,
+    maxOut: int = 0,
+    maxConnsPerPeer: int = MaxConnectionsPerPeer,
+    watermark: Opt[WatermarkConfig] = Opt.none(WatermarkConfig),
+    scoringConfig: ScoringConfig = ScoringConfig(),
 ): ConnManager =
-  ## Creates a `ConnManager` where incoming and outgoing connections share a
-  ## single pool capped at `maxConnections`. Acquiring a slot for either
-  ## direction draws from the same semaphore, so the combined total never
-  ## exceeds `maxConnections`.
-  doAssert maxConnections > 0, "`maxConnections` must be greater than 0"
+  ## Creates a `ConnManager`.
+  ##
+  ## By default (no arguments), a shared semaphore caps connections at
+  ## `MaxConnections`. Pass `maxConnections` for a custom shared cap, or
+  ## `maxIn`/`maxOut` for independent per-direction caps.
+  ##
+  ## When `watermark` is provided without explicit connection limits the
+  ## semaphore is omitted and hi/lo trimming is the only guard.  When both
+  ## are provided the semaphore blocks new connections hard while trimming
+  ## also prunes existing ones.
+  let hasWatermark = watermark.isSome
+  let hasInOut = maxIn > 0 and maxOut > 0
+  let hasTotal = maxConnections > 0
 
-  let sema = newAsyncSemaphore(maxConnections)
-  C(
+  if hasWatermark:
+    watermark.withValue(wm):
+      doAssert wm.lowWater > 0, "lowWater must be > 0"
+      doAssert wm.highWater > wm.lowWater, "highWater must be > lowWater"
+    doAssert scoringConfig.decayResolution > 0.seconds, "decayResolution must be > 0"
+
+  var inSema, outSema: AsyncSemaphore
+  var maxInArg, maxOutArg: int
+
+  if hasInOut:
+    inSema = newAsyncSemaphore(maxIn)
+    outSema = newAsyncSemaphore(maxOut)
+    maxInArg = maxIn
+    maxOutArg = maxOut
+  elif hasTotal or not hasWatermark:
+    let cap = if hasTotal: maxConnections else: MaxConnections
+    let sema = newAsyncSemaphore(cap)
+    inSema = sema
+    outSema = sema
+    maxInArg = cap
+    maxOutArg = cap
+  else:
+    maxInArg = connectionsUnlimited
+    maxOutArg = connectionsUnlimited
+
+  T(
     muxerStore: MuxerStore.new(),
     maxConnsPerPeer: maxConnsPerPeer,
-    maxConnectionsIn: maxConnections,
-    maxConnectionsOut: maxConnections,
-    inSema: sema,
-    outSema: sema,
-  )
-
-proc newMaxInOut*(
-    C: type ConnManager,
-    maxIn: int,
-    maxOut: int,
-    maxConnsPerPeer = MaxConnectionsPerPeer,
-): ConnManager =
-  ## Creates a `ConnManager` where incoming and outgoing connections are limited
-  ## independently: at most `maxIn` inbound and `maxOut` outbound connections
-  ## may be open concurrently, each tracked by its own semaphore.
-  doAssert maxIn > 0 and maxOut > 0,
-    "ConnManager.newMaxInOut requires maxIn > 0 and maxOut > 0"
-
-  C(
-    muxerStore: MuxerStore.new(),
-    maxConnsPerPeer: maxConnsPerPeer,
-    maxConnectionsIn: maxIn,
-    maxConnectionsOut: maxOut,
-    inSema: newAsyncSemaphore(maxIn),
-    outSema: newAsyncSemaphore(maxOut),
-  )
-
-proc newWatermark*(
-    C: type ConnManager,
-    watermark: WatermarkConfig,
-    maxConnsPerPeer = MaxConnectionsPerPeer,
-    scoringConfig = ScoringConfig(),
-): ConnManager =
-  ## Creates a `ConnManager` in hi/lo watermark mode.
-  ## When the number of connected peers exceeds `highWater`, a trim cycle
-  ## closes the oldest peers first until the count drops to `lowWater`.
-  ## Peers connected within `gracePeriod` and peers marked with `protect`
-  ## are exempt from trimming.
-  ## Use `silencePeriod` to throttle back-to-back trim cycles.
-  doAssert watermark.lowWater > 0, "lowWater must be > 0"
-  doAssert watermark.highWater > watermark.lowWater, "highWater must be > lowWater"
-  doAssert scoringConfig.decayResolution > 0.seconds, "decayResolution must be > 0"
-  C(
-    muxerStore: MuxerStore.new(),
-    watermark: Opt.some(watermark),
-    maxConnectionsIn: connectionsUnlimited,
-    maxConnectionsOut: connectionsUnlimited,
-    maxConnsPerPeer: maxConnsPerPeer,
+    maxConnectionsIn: maxInArg,
+    maxConnectionsOut: maxOutArg,
+    inSema: inSema,
+    outSema: outSema,
+    watermark: watermark,
     scoringConfig: scoringConfig,
   )
 
@@ -482,14 +475,14 @@ proc storeMuxer*(
 proc getIncomingSlot*(
     c: ConnManager
 ): Future[ConnectionSlot] {.async: (raises: [CancelledError]).} =
-  if c.watermark.isNone:
+  if c.inSema != nil:
     await c.inSema.acquire()
   return ConnectionSlot(connManager: c, direction: In)
 
 proc getOutgoingSlot*(
     c: ConnManager, forceDial = false
 ): ConnectionSlot {.raises: [TooManyConnectionsError].} =
-  if c.watermark.isNone:
+  if c.outSema != nil:
     if forceDial:
       # force dial by not blocking/waiting on acquire and
       # still calling acquire to track this connection.
@@ -503,15 +496,17 @@ func semaphore(c: ConnManager, dir: Direction): AsyncSemaphore {.inline.} =
   return if dir == In: c.inSema else: c.outSema
 
 proc availableSlots*(c: ConnManager, dir: Direction): int =
-  if c.watermark.isSome:
-    return connectionsUnlimited # unlimited slots in watermark mode
-  return semaphore(c, dir).availableSlots
+  let sema = semaphore(c, dir)
+  if sema == nil:
+    return connectionsUnlimited
+  return sema.availableSlots
 
 proc release*(cs: ConnectionSlot) =
-  if cs.connManager.watermark.isSome:
-    return # no semaphore in watermark mode
+  let sema = semaphore(cs.connManager, cs.direction)
+  if sema == nil:
+    return
   try:
-    semaphore(cs.connManager, cs.direction).release()
+    sema.release()
   except AsyncSemaphoreError:
     raiseAssert "semaphore released without acquire"
 

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -159,12 +159,6 @@ proc new*(
   let hasInOut = maxIn > 0 and maxOut > 0
   let hasTotal = maxConnections > 0
 
-  if hasWatermark:
-    watermark.withValue(wm):
-      doAssert wm.lowWater > 0, "lowWater must be > 0"
-      doAssert wm.highWater > wm.lowWater, "highWater must be > lowWater"
-    doAssert scoringConfig.decayResolution > 0.seconds, "decayResolution must be > 0"
-
   var inSema, outSema: AsyncSemaphore
   var maxInArg, maxOutArg: int
 

--- a/tests/libp2p/protocols/test_noise.nim
+++ b/tests/libp2p/protocols/test_noise.nim
@@ -70,7 +70,7 @@ proc createSwitch(
         [Secure(PlainText.new())]
       else:
         [Secure(Noise.new(rng, privateKey, outgoing = outgoing))]
-    connManager = ConnManager.newMaxTotal()
+    connManager = ConnManager.new()
     ms = MultistreamSelect.new()
     muxedUpgrade = MuxedUpgrade.new(muxers, secureManagers, ms)
     transports = @[Transport(TcpTransport.new(upgrade = muxedUpgrade))]

--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -20,15 +20,12 @@ method newStream*(
   Connection.new(m.peerId, Direction.Out)
 
 proc newMaxTotal(
-    maxConnections = MaxConnections,
-    maxConnsPerPeer = MaxConnectionsPerPeer,
+    maxConnections = MaxConnections, maxConnsPerPeer = MaxConnectionsPerPeer
 ): ConnManager =
   ConnManager.new(maxConnections = maxConnections, maxConnsPerPeer = maxConnsPerPeer)
 
 proc newMaxInOut(
-    maxIn: int,
-    maxOut: int,
-    maxConnsPerPeer = MaxConnectionsPerPeer,
+    maxIn: int, maxOut: int, maxConnsPerPeer = MaxConnectionsPerPeer
 ): ConnManager =
   ConnManager.new(maxIn = maxIn, maxOut = maxOut, maxConnsPerPeer = maxConnsPerPeer)
 
@@ -46,10 +43,8 @@ proc newWatermark*(
     gracePeriod: gracePeriod,
     silencePeriod: silencePeriod,
   )
-  let scCfg = ScoringConfig(
-    outboundBonus: outboundBonus, 
-    decayResolution: decayResolution,
-  )
+  let scCfg =
+    ScoringConfig(outboundBonus: outboundBonus, decayResolution: decayResolution)
   ConnManager.new(watermark = Opt.some(wtCfg), scoringConfig = scCfg)
 
 proc connectPeers(connMngr: ConnManager, count: int): Future[seq[PeerId]] {.async.} =
@@ -677,10 +672,7 @@ suite "Connection Manager: watermark with connection limiting":
       maxConnections = maxConns,
       watermark = Opt.some(
         WatermarkConfig(
-          lowWater: 1,
-          highWater: 2,
-          gracePeriod: 0.seconds,
-          silencePeriod: 0.seconds,
+          lowWater: 1, highWater: 2, gracePeriod: 0.seconds, silencePeriod: 0.seconds
         )
       ),
     )

--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -19,12 +19,54 @@ method newStream*(
 ): Future[Connection] {.async: (raises: [CancelledError, LPStreamError, MuxerError]).} =
   Connection.new(m.peerId, Direction.Out)
 
+proc newMaxTotal(
+    maxConnections = MaxConnections,
+    maxConnsPerPeer = MaxConnectionsPerPeer,
+): ConnManager =
+  ConnManager.new(maxConnections = maxConnections, maxConnsPerPeer = maxConnsPerPeer)
+
+proc newMaxInOut(
+    maxIn: int,
+    maxOut: int,
+    maxConnsPerPeer = MaxConnectionsPerPeer,
+): ConnManager =
+  ConnManager.new(maxIn = maxIn, maxOut = maxOut, maxConnsPerPeer = maxConnsPerPeer)
+
+proc newWatermark*(
+    lowWater: int,
+    highWater: int,
+    gracePeriod: Duration = 0.seconds,
+    silencePeriod: Duration = 0.seconds,
+    outboundBonus: int = 0,
+    decayResolution = 1.minutes,
+): ConnManager =
+  let wtCfg = WatermarkConfig(
+    lowWater: lowWater,
+    highWater: highWater,
+    gracePeriod: gracePeriod,
+    silencePeriod: silencePeriod,
+  )
+  let scCfg = ScoringConfig(
+    outboundBonus: outboundBonus, 
+    decayResolution: decayResolution,
+  )
+  ConnManager.new(watermark = Opt.some(wtCfg), scoringConfig = scCfg)
+
+proc connectPeers(connMngr: ConnManager, count: int): Future[seq[PeerId]] {.async.} =
+  var peers: seq[PeerId]
+  for i in 0 ..< count:
+    let peerId = PeerId.random.tryGet()
+    peers.add(peerId)
+    await connMngr.storeMuxer(getMuxer(peerId))
+
+  return peers
+
 suite "Connection Manager":
   teardown:
     checkTrackers()
 
   asyncTest "add and retrieve a muxer":
-    let connMngr = ConnManager.newMaxTotal()
+    let connMngr = newMaxTotal()
     let peerId = PeerId.init(PrivateKey.random(ECDSA, rng[]).tryGet()).tryGet()
     let mux = getMuxer(peerId)
 
@@ -38,7 +80,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "get all connections":
-    let connMngr = ConnManager.newMaxTotal()
+    let connMngr = newMaxTotal()
 
     let peers = @[PeerId.random.tryGet(), PeerId.random.tryGet()]
     let muxs = peers.mapIt(getMuxer(it))
@@ -52,7 +94,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "shouldn't allow a closed connection":
-    let connMngr = ConnManager.newMaxTotal()
+    let connMngr = newMaxTotal()
     let peerId = PeerId.init(PrivateKey.random(ECDSA, rng[]).tryGet()).tryGet()
     let mux = getMuxer(peerId)
     await mux.connection.close()
@@ -63,7 +105,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "shouldn't allow an EOFed connection":
-    let connMngr = ConnManager.newMaxTotal()
+    let connMngr = newMaxTotal()
     let peerId = PeerId.init(PrivateKey.random(ECDSA, rng[]).tryGet()).tryGet()
     let mux = getMuxer(peerId)
     mux.connection.isEof = true
@@ -75,7 +117,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "shouldn't allow a muxer with no connection":
-    let connMngr = ConnManager.newMaxTotal()
+    let connMngr = newMaxTotal()
     let peerId = PeerId.init(PrivateKey.random(ECDSA, rng[]).tryGet()).tryGet()
     let muxer = getMuxer(peerId)
     let conn = muxer.connection
@@ -90,7 +132,7 @@ suite "Connection Manager":
 
   asyncTest "get conn with direction":
     # This would work with 1 as well cause of a bug in connmanager that will get fixed soon
-    let connMngr = ConnManager.newMaxTotal(maxConnsPerPeer = 2)
+    let connMngr = newMaxTotal(maxConnsPerPeer = 2)
     let peerId = PeerId.init(PrivateKey.random(ECDSA, rng[]).tryGet()).tryGet()
     let mux1 = getMuxer(peerId, Direction.Out)
     let mux2 = getMuxer(peerId)
@@ -112,7 +154,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "get muxed stream for peer":
-    let connMngr = ConnManager.newMaxTotal()
+    let connMngr = newMaxTotal()
     let peerId = PeerId.init(PrivateKey.random(ECDSA, rng[]).tryGet()).tryGet()
 
     let muxer = new TestMuxer
@@ -132,7 +174,7 @@ suite "Connection Manager":
     await stream.close()
 
   asyncTest "get stream from directed connection":
-    let connMngr = ConnManager.newMaxTotal()
+    let connMngr = newMaxTotal()
     let peerId = PeerId.init(PrivateKey.random(ECDSA, rng[]).tryGet()).tryGet()
 
     let muxer = new TestMuxer
@@ -153,7 +195,7 @@ suite "Connection Manager":
     await connection.close()
 
   asyncTest "should raise on too many connections":
-    let connMngr = ConnManager.newMaxTotal(maxConnsPerPeer = 0)
+    let connMngr = newMaxTotal(maxConnsPerPeer = 0)
     let peerId = PeerId.init(PrivateKey.random(ECDSA, rng[]).tryGet()).tryGet()
 
     await connMngr.storeMuxer(getMuxer(peerId))
@@ -169,7 +211,7 @@ suite "Connection Manager":
 
   asyncTest "expect connection from peer":
     # FIXME This should be 1 instead of 0, it will get fixed soon
-    let connMngr = ConnManager.newMaxTotal(maxConnsPerPeer = 0)
+    let connMngr = newMaxTotal(maxConnsPerPeer = 0)
     let peerId = PeerId.init(PrivateKey.random(ECDSA, rng[]).tryGet()).tryGet()
 
     await connMngr.storeMuxer(getMuxer(peerId))
@@ -205,7 +247,7 @@ suite "Connection Manager":
     await allFuturesRaising(muxs.mapIt(it.close()))
 
   asyncTest "cleanup on connection close":
-    let connMngr = ConnManager.newMaxTotal()
+    let connMngr = newMaxTotal()
     let peerId = PeerId.init(PrivateKey.random(ECDSA, rng[]).tryGet()).tryGet()
     let muxer = getMuxer(peerId)
 
@@ -221,7 +263,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "waitForPeerReady unblocks when muxer is stored":
-    let connMngr = ConnManager.newMaxTotal()
+    let connMngr = newMaxTotal()
     let peerId = PeerId.init(PrivateKey.random(ECDSA, rng[]).tryGet()).tryGet()
 
     let readyWaiter = connMngr.waitForPeerReady(peerId, 1.seconds)
@@ -231,7 +273,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "waitForPeerReady timeout does not break concurrent waiters":
-    let connMngr = ConnManager.newMaxTotal()
+    let connMngr = newMaxTotal()
     let peerId = PeerId.random(rng).expect("peer should have been created")
 
     let shortWaiter = connMngr.waitForPeerReady(peerId, 10.millis)
@@ -244,7 +286,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "waitForPeerReady cleanup after disconnect":
-    let connMngr = ConnManager.newMaxTotal()
+    let connMngr = newMaxTotal()
     let peerId = PeerId.random(rng).expect("peer should have been created")
     let muxer = getMuxer(peerId)
 
@@ -258,7 +300,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "drop connections for peer":
-    let connMngr = ConnManager.newMaxTotal()
+    let connMngr = newMaxTotal()
     let peerId = PeerId.init(PrivateKey.random(ECDSA, rng[]).tryGet()).tryGet()
 
     for i in 0 ..< 2:
@@ -282,7 +324,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "track total incoming connection limits":
-    let connMngr = ConnManager.newMaxTotal(maxConnections = 3)
+    let connMngr = newMaxTotal(maxConnections = 3)
 
     for i in 0 ..< 3:
       check await connMngr.getIncomingSlot().withTimeout(10.millis)
@@ -293,7 +335,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "track total outgoing connection limits":
-    let connMngr = ConnManager.newMaxTotal(maxConnections = 3)
+    let connMngr = newMaxTotal(maxConnections = 3)
 
     for i in 0 ..< 3:
       discard connMngr.getOutgoingSlot()
@@ -305,7 +347,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "track both incoming and outgoing total connections limits - fail on incoming":
-    let connMngr = ConnManager.newMaxTotal(maxConnections = 3)
+    let connMngr = newMaxTotal(maxConnections = 3)
 
     for i in 0 ..< 3:
       discard connMngr.getOutgoingSlot()
@@ -316,7 +358,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "track both incoming and outgoing total connections limits - fail on outgoing":
-    let connMngr = ConnManager.newMaxTotal(maxConnections = 3)
+    let connMngr = newMaxTotal(maxConnections = 3)
 
     for i in 0 ..< 3:
       check await connMngr.getIncomingSlot().withTimeout(10.millis)
@@ -328,7 +370,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "track max incoming connection limits":
-    let connMngr = ConnManager.newMaxInOut(3, 1)
+    let connMngr = newMaxInOut(3, 1)
 
     for i in 0 ..< 3:
       check await connMngr.getIncomingSlot().withTimeout(10.millis)
@@ -338,7 +380,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "track max outgoing connection limits":
-    let connMngr = ConnManager.newMaxInOut(1, 3)
+    let connMngr = newMaxInOut(1, 3)
 
     for i in 0 ..< 3:
       discard connMngr.getOutgoingSlot()
@@ -350,7 +392,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "track incoming max connections limits - fail on incoming":
-    let connMngr = ConnManager.newMaxInOut(1, 3)
+    let connMngr = newMaxInOut(1, 3)
 
     for i in 0 ..< 3:
       discard connMngr.getOutgoingSlot()
@@ -363,7 +405,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "track incoming max connections limits - fail on outgoing":
-    let connMngr = ConnManager.newMaxInOut(3, 1)
+    let connMngr = newMaxInOut(3, 1)
 
     for i in 0 ..< 3:
       check await connMngr.getIncomingSlot().withTimeout(10.millis)
@@ -377,7 +419,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "allow force dial":
-    let connMngr = ConnManager.newMaxTotal(maxConnections = 2)
+    let connMngr = newMaxTotal(maxConnections = 2)
 
     for i in 0 ..< 3:
       discard connMngr.getOutgoingSlot(true)
@@ -389,7 +431,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "release slot on connection end":
-    let connMngr = ConnManager.newMaxTotal(maxConnections = 3)
+    let connMngr = newMaxTotal(maxConnections = 3)
 
     var muxs: seq[Muxer]
     for i in 0 ..< 3:
@@ -413,35 +455,6 @@ suite "Connection Manager":
 
     await connMngr.close()
 
-proc newWatermark*(
-    C: type ConnManager,
-    lowWater: int,
-    highWater: int,
-    gracePeriod: Duration = 0.seconds,
-    silencePeriod: Duration = 0.seconds,
-    outboundBonus: int = 0,
-    decayResolution = 1.minutes,
-): C =
-  return ConnManager.newWatermark(
-    WatermarkConfig(
-      lowWater: lowWater,
-      highWater: highWater,
-      gracePeriod: gracePeriod,
-      silencePeriod: silencePeriod,
-    ),
-    scoringConfig =
-      ScoringConfig(outboundBonus: outboundBonus, decayResolution: decayResolution),
-  )
-
-proc connectPeers(connMngr: ConnManager, count: int): Future[seq[PeerId]] {.async.} =
-  var peers: seq[PeerId]
-  for i in 0 ..< count:
-    let peerId = PeerId.random.tryGet()
-    peers.add(peerId)
-    await connMngr.storeMuxer(getMuxer(peerId))
-
-  return peers
-
 suite "Connection Manager Watermark":
   teardown:
     checkTrackers()
@@ -450,7 +463,7 @@ suite "Connection Manager Watermark":
     const peersToConnect = 5
     const lowWater = 2
     const highWater = peersToConnect - 1 # connect 1 peer above high water
-    let connMngr = ConnManager.newWatermark(lowWater, highWater)
+    let connMngr = newWatermark(lowWater, highWater)
 
     # connect peers - one over the highWater
     discard await connectPeers(connMngr, peersToConnect)
@@ -464,7 +477,7 @@ suite "Connection Manager Watermark":
     const peersToConnect = 5
     const lowWater = 1
     const highWater = peersToConnect - 3
-    let connMngr = ConnManager.newWatermark(lowWater, highWater, gracePeriod = 1.hours)
+    let connMngr = newWatermark(lowWater, highWater, gracePeriod = 1.hours)
 
     discard await connectPeers(connMngr, peersToConnect)
 
@@ -477,7 +490,7 @@ suite "Connection Manager Watermark":
     const peersToConnect = 3
     const lowWater = 1
     const highWater = peersToConnect
-    let connMngr = ConnManager.newWatermark(lowWater, highWater)
+    let connMngr = newWatermark(lowWater, highWater)
 
     let peers = await connectPeers(connMngr, peersToConnect)
 
@@ -495,7 +508,7 @@ suite "Connection Manager Watermark":
     await connMngr.close()
 
   asyncTest "unprotect removes tag and allows trimming":
-    let connMngr = ConnManager.newWatermark(1, 3)
+    let connMngr = newWatermark(1, 3)
 
     let peerId = PeerId.random.tryGet()
     await connMngr.storeMuxer(getMuxer(peerId))
@@ -513,7 +526,7 @@ suite "Connection Manager Watermark":
   asyncTest "silence period throttles back-to-back trims":
     const peersToConnect = 3
     const highWater = peersToConnect - 1
-    let connMngr = ConnManager.newWatermark(1, highWater, silencePeriod = 1.hours)
+    let connMngr = newWatermark(1, highWater, silencePeriod = 1.hours)
 
     # connect first batch of peers - should cause trim after last peer
     discard await connectPeers(connMngr, peersToConnect)
@@ -531,7 +544,7 @@ suite "Connection Manager Watermark":
     await connMngr.close()
 
   asyncTest "getIncomingSlot does not block in watermark mode":
-    let connMngr = ConnManager.newWatermark(1, 5)
+    let connMngr = newWatermark(1, 5)
 
     # should return immediately without semaphore blocking
     check await connMngr.getIncomingSlot().withTimeout(10.millis)
@@ -539,7 +552,7 @@ suite "Connection Manager Watermark":
     await connMngr.close()
 
   asyncTest "getOutgoingSlot does not raise in watermark mode":
-    let connMngr = ConnManager.newWatermark(1, 5)
+    let connMngr = newWatermark(1, 5)
 
     for i in 0 ..< 10:
       discard connMngr.getOutgoingSlot()
@@ -554,12 +567,12 @@ suite "Connection Manager Scoring":
   let peerId = PeerId.random.tryGet()
 
   asyncTest "peerScore returns 0 for unknown peer":
-    let cm = ConnManager.newWatermark(1, 2)
+    let cm = newWatermark(1, 2)
     check cm.peerScore(peerId) == 0
     await cm.close()
 
   asyncTest "static tag contributes to peer score":
-    let cm = ConnManager.newWatermark(1, 2)
+    let cm = newWatermark(1, 2)
     await cm.storeMuxer(getMuxer(peerId))
     cm.tagPeer(peerId, "🌞", 50)
     check cm.peerScore(peerId) == 50
@@ -568,7 +581,7 @@ suite "Connection Manager Scoring":
     await cm.close()
 
   asyncTest "untagPeer removes score contribution":
-    let cm = ConnManager.newWatermark(1, 2)
+    let cm = newWatermark(1, 2)
     await cm.storeMuxer(getMuxer(peerId))
     cm.tagPeer(peerId, tag, 50)
     cm.untagPeer(peerId, tag)
@@ -577,26 +590,26 @@ suite "Connection Manager Scoring":
 
   asyncTest "outbound connection gets outboundBonus":
     const outboundBonus = 2345432
-    let cm = ConnManager.newWatermark(1, 2, outboundBonus = outboundBonus)
+    let cm = newWatermark(1, 2, outboundBonus = outboundBonus)
     await cm.storeMuxer(getMuxer(peerId, Direction.Out))
     check cm.peerScore(peerId) == outboundBonus
     await cm.close()
 
   asyncTest "inbound connection gets no outboundBonus":
-    let cm = ConnManager.newWatermark(1, 2)
+    let cm = newWatermark(1, 2)
     await cm.storeMuxer(getMuxer(peerId, Direction.In))
     check cm.peerScore(peerId) == 0
     await cm.close()
 
   asyncTest "decaying tag contributes initial value to score":
-    let cm = ConnManager.newWatermark(1, 2)
+    let cm = newWatermark(1, 2)
     await cm.storeMuxer(getMuxer(peerId))
     cm.tagPeerDecaying(peerId, tag, 100, 1.hours, decayLinear(0.5))
     check cm.peerScore(peerId) == 100
     await cm.close()
 
   asyncTest "decaying tag value decreases over interval":
-    let cm = ConnManager.newWatermark(1, 2, decayResolution = 20.millis)
+    let cm = newWatermark(1, 2, decayResolution = 20.millis)
     await cm.storeMuxer(getMuxer(peerId))
     cm.tagPeerDecaying(peerId, tag, 100, 20.millis, decayFixed(30))
     checkUntilTimeout:
@@ -604,7 +617,7 @@ suite "Connection Manager Scoring":
     await cm.close()
 
   asyncTest "decaying tag auto-removed when value hits zero":
-    let cm = ConnManager.newWatermark(1, 2, decayResolution = 20.millis)
+    let cm = newWatermark(1, 2, decayResolution = 20.millis)
     await cm.storeMuxer(getMuxer(peerId))
     cm.tagPeerDecaying(peerId, tag, 10, 20.millis, decayFixed(15))
     checkUntilTimeout:
@@ -612,7 +625,7 @@ suite "Connection Manager Scoring":
     await cm.close()
 
   asyncTest "bumpDecayingTag increases tag value":
-    let cm = ConnManager.newWatermark(1, 2)
+    let cm = newWatermark(1, 2)
     await cm.storeMuxer(getMuxer(peerId))
     cm.tagPeerDecaying(peerId, tag, 50, 1.hours, decayNone())
     cm.bumpDecayingTag(peerId, tag, 25)
@@ -620,7 +633,7 @@ suite "Connection Manager Scoring":
     await cm.close()
 
   asyncTest "removeDecayingTag removes tag immediately":
-    let cm = ConnManager.newWatermark(1, 2)
+    let cm = newWatermark(1, 2)
     await cm.storeMuxer(getMuxer(peerId))
     cm.tagPeerDecaying(peerId, tag, 50, 1.hours, decayNone())
     cm.removeDecayingTag(peerId, tag)
@@ -628,7 +641,7 @@ suite "Connection Manager Scoring":
     await cm.close()
 
   asyncTest "watermark trim prunes lowest-score peer first":
-    let cm = ConnManager.newWatermark(1, 2)
+    let cm = newWatermark(1, 2)
     let highScorePeer = PeerId.random.tryGet()
     let lowScorePeer1 = PeerId.random.tryGet()
     await cm.storeMuxer(getMuxer(highScorePeer))
@@ -641,7 +654,7 @@ suite "Connection Manager Scoring":
     await cm.close()
 
   asyncTest "outbound peer survives watermark trim over inbound peers":
-    let cm = ConnManager.newWatermark(1, 2, outboundBonus = 500)
+    let cm = newWatermark(1, 2, outboundBonus = 500)
     let outboundPeer = PeerId.random.tryGet()
     await cm.storeMuxer(getMuxer(outboundPeer, Direction.Out))
     await cm.storeMuxer(getMuxer(PeerId.random.tryGet(), Direction.In))
@@ -650,3 +663,47 @@ suite "Connection Manager Scoring":
     check cm.contains(outboundPeer)
     check cm.getConnections().len == 1
     await cm.close()
+
+suite "Connection Manager: watermark with connection limiting":
+  teardown:
+    checkTrackers()
+
+  asyncTest "protected peers fill semaphore cap blocking new connections":
+    # both connection limiting (maxConnections=3) and watermark trimming (highWater=2)
+    # are active simultaneously. protected peers survive every trim cycle, so the
+    # semaphore stays exhausted and all further connection attempts are rejected.
+    const maxConns = 3
+    let connMngr = ConnManager.new(
+      maxConnections = maxConns,
+      watermark = Opt.some(
+        WatermarkConfig(
+          lowWater: 1,
+          highWater: 2,
+          gracePeriod: 0.seconds,
+          silencePeriod: 0.seconds,
+        )
+      ),
+    )
+
+    # acquire a semaphore slot for each peer, protect it, then register it.
+    # protecting before storeMuxer ensures the peer is already shielded when
+    # trim fires on the 3rd store (peer count 3 > highWater 2).
+    for _ in 0 ..< maxConns:
+      let peerId = PeerId.random.tryGet()
+      let slot = await connMngr.getIncomingSlot()
+      let muxer = getMuxer(peerId)
+      connMngr.protect(peerId, "keep-forever")
+      slot.trackMuxer(muxer)
+      await connMngr.storeMuxer(muxer)
+
+    # trim fired but found no unprotected candidates, all 3 peers still connected
+    check connMngr.getConnections().len == maxConns
+
+    # all connection slots should be used, getting slot incoming slot must block
+    check not (await connMngr.getIncomingSlot().withTimeout(50.millis))
+
+    # getting outgoing slot must raise (all slots are used)
+    expect TooManyConnectionsError:
+      discard connMngr.getOutgoingSlot()
+
+    await connMngr.close()

--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -319,7 +319,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "track total incoming connection limits":
-    let connMngr = newMaxTotal(maxConnections = 3)
+    let connMngr = newMaxTotal(3)
 
     for i in 0 ..< 3:
       check await connMngr.getIncomingSlot().withTimeout(10.millis)
@@ -330,7 +330,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "track total outgoing connection limits":
-    let connMngr = newMaxTotal(maxConnections = 3)
+    let connMngr = newMaxTotal(3)
 
     for i in 0 ..< 3:
       discard connMngr.getOutgoingSlot()
@@ -342,7 +342,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "track both incoming and outgoing total connections limits - fail on incoming":
-    let connMngr = newMaxTotal(maxConnections = 3)
+    let connMngr = newMaxTotal(3)
 
     for i in 0 ..< 3:
       discard connMngr.getOutgoingSlot()
@@ -353,7 +353,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "track both incoming and outgoing total connections limits - fail on outgoing":
-    let connMngr = newMaxTotal(maxConnections = 3)
+    let connMngr = newMaxTotal(3)
 
     for i in 0 ..< 3:
       check await connMngr.getIncomingSlot().withTimeout(10.millis)
@@ -414,7 +414,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "allow force dial":
-    let connMngr = newMaxTotal(maxConnections = 2)
+    let connMngr = newMaxTotal(2)
 
     for i in 0 ..< 3:
       discard connMngr.getOutgoingSlot(true)
@@ -426,7 +426,7 @@ suite "Connection Manager":
     await connMngr.close()
 
   asyncTest "release slot on connection end":
-    let connMngr = newMaxTotal(maxConnections = 3)
+    let connMngr = newMaxTotal(3)
 
     var muxs: seq[Muxer]
     for i in 0 ..< 3:

--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -691,7 +691,7 @@ suite "Connection Manager: watermark with connection limiting":
     # trim fired but found no unprotected candidates, all 3 peers still connected
     check connMngr.getConnections().len == maxConns
 
-    # all connection slots should be used, getting slot incoming slot must block
+    # all connection slots should be used, getting incoming slot must block
     check not (await connMngr.getIncomingSlot().withTimeout(50.millis))
 
     # getting outgoing slot must raise (all slots are used)


### PR DESCRIPTION
## Summary
<!--
Provide a clear and concise description of the purpose of this PR.

Explain:
- What this PR does
- Why it is needed
- The problem it solves or the improvement it introduces
-->

previously connection manager was implemented with idea of having orthogonal modes: simple connection limiting and watermark trimming.

this pr updates connection manager to support both modes, enabling them to function as composable features. or in other words, this pr add hard connections limit to watermark mode. 

example usage vai builder:

| code | descripiton |
|---|---|
| `.build()`  | shared connections limit @ 50 (default const config) |
|`.withMaxConnections(100)` |   shared connections limit @ 100  |
| `.withMaxInOut(30, 20)` | separate connections limit 30/20 |
| `.withWatermark(10, 20)` | trimming starts in high waters, >19 connections (no  hard connections limit) |
| `.withWatermark(10, 20).withMaxConnections(100)` |   trimming starts in high water and there is hard limit of 100 connections in total |
| `.withWatermark(10, 20).withMaxInOut(30, 20)` | split connection limit, with watermark trimming |

in practice current users will have same functionality as before. but those that want to trim connections, in addition to everything they had, can do so with one more builder config:

```nim
.withMaxConnections(30)
.withWatermark(25, 30)    <--- they will add this
```


## Affected Areas
<!--
Indicate which parts of the codebase are impacted.
Check all that apply and briefly describe the scope of the changes.
-->

- [X] Connection Manager

## Compatibility & Downstream Validation
<!--
For PRs affecting behavior on existing features, provide evidence that
dependent projects build and function correctly with these changes.
-->

Reference PRs / branches / commits demonstrating successful integration:

- **Nimbus:**  
  <!-- Link PR or branch -->

- **Waku:**  
  <!-- Link PR or branch -->

- **Codex:**  
  <!-- Link PR or branch -->


n/a

## Impact on Library Users
<!--
Describe how this affects downstream users of nim-libp2p.

Examples:
- API changes
- Behavior changes
- Performance implications
- Migration requirements
- No impact (internal refactor)
-->

should be fully backwards comparable

## Risk Assessment
<!--
Identify potential risks introduced by this change.

Consider:
- Backward compatibility
- Network behavior changes
- Performance regressions
- Security implications
-->

low.

## References
<!--
Link to related:
- Issues
- Specs
- Design discussions
- Prior PRs
-->


## Additional Notes
<!--
Optional: any extra context reviewers should be aware of.
-->