### PR TITLE
fix(service-disco): registrar wait formula ceiling

### DIFF
--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -146,7 +146,7 @@ proc waitingTime*(
     advertCacheCap: uint64,
     serviceId: ServiceId,
     now: uint64,
-): float64 =
+): chronos.Duration =
   doAssert advertCacheCap > 0, "advertCacheCap must be > 0"
   let c = registrar.cacheTimestamps.len.uint64
   let c_s = registrar.cache.getOrDefault(serviceId, @[]).len
@@ -192,7 +192,7 @@ proc waitingTime*(
   w = min(w, float64(uint32.high))
   w = ceil(w)
 
-  return w
+  return w.secsAsDuration()
 
 proc updateLowerBounds*(
     registrar: Registrar,
@@ -427,9 +427,10 @@ proc handleRegister*(
     return
 
   let now = getTime().toUnix().uint64
-  var tWait = disco.registrar.waitingTime(
-    disco.discoConfig, ad, disco.discoConfig.advertCacheCap, serviceId, now
-  )
+  var tWait =
+    disco.registrar.waitingTime(
+      disco.discoConfig, ad, disco.discoConfig.advertCacheCap, serviceId, now
+    ).nanoseconds.float64 / 1_000_000_000.0
   tWait = disco.processRetryTicket(regMsg, ad, tWait, now)
 
   if tWait <= 0:

--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -146,7 +146,7 @@ proc waitingTime*(
     advertCacheCap: uint64,
     serviceId: ServiceId,
     now: uint64,
-): chronos.Duration =
+): float64 =
   doAssert advertCacheCap > 0, "advertCacheCap must be > 0"
   let c = registrar.cacheTimestamps.len.uint64
   let c_s = registrar.cache.getOrDefault(serviceId, @[]).len
@@ -187,7 +187,7 @@ proc waitingTime*(
       if ipLowerBound > w:
         w = ipLowerBound
 
-  return secsAsDuration(max(0.0, w))
+  return ceil(max(0.0, w))
 
 proc updateLowerBounds*(
     registrar: Registrar,
@@ -422,10 +422,9 @@ proc handleRegister*(
     return
 
   let now = getTime().toUnix().uint64
-  var tWait =
-    disco.registrar.waitingTime(
-      disco.discoConfig, ad, disco.discoConfig.advertCacheCap, serviceId, now
-    ).nanoseconds.float64 / 1_000_000_000.0
+  var tWait = disco.registrar.waitingTime(
+    disco.discoConfig, ad, disco.discoConfig.advertCacheCap, serviceId, now
+  )
   tWait = disco.processRetryTicket(regMsg, ad, tWait, now)
 
   if tWait <= 0:
@@ -443,7 +442,7 @@ proc handleRegister*(
       advertisement: regMsg.advertisement,
       tInit: regMsg.ticket.tInitOrDefault(now),
       tMod: now,
-      tWaitFor: uint32(min(tWait, float64(uint32.high))),
+      tWaitFor: uint32(tWait),
     )
     if ticket.sign(disco.switch.peerInfo.privateKey).isErr:
       error "failed to sign ticket"

--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -187,7 +187,12 @@ proc waitingTime*(
       if ipLowerBound > w:
         w = ipLowerBound
 
-  return ceil(max(0.0, w))
+  # Bound & Quantize W
+  w = max(0.0, w)
+  w = min(w, float64(uint32.high))
+  w = ceil(w)
+
+  return w
 
 proc updateLowerBounds*(
     registrar: Registrar,

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -2,7 +2,7 @@
 # Copyright (c) Status Research & Development GmbH
 {.used.}
 
-import std/[times]
+import std/[times, math]
 import chronos, chronicles, results
 import
   ../../../libp2p/[
@@ -35,8 +35,10 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
 
     # With empty cache: c = 0, occupancy = 1.0, c_s = 0, ipSim = 0
     # w = advertExpiry * 1.0 * (0 + 0 + safetyParam)
-    let expected = discoConfig.advertExpiry.seconds.float64 * discoConfig.safetyParam
-    check abs(w.inFloatSecs - expected) < 0.001
+    let expected =
+      ceil(discoConfig.advertExpiry.seconds.float64 * discoConfig.safetyParam)
+
+    check abs(w - expected) < 0.001
 
   test "waitingTime increases with cache occupancy":
     let registrar = Registrar.new()
@@ -54,7 +56,7 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
     let w2 = registrar.waitingTime(discoConfig, ad2, 1000, serviceId2, now)
 
     # With non-zero cache, occupancy > 1.0
-    check w1 > ZeroDuration or w2 > ZeroDuration
+    check w1 > 0.0 or w2 > 0.0
 
   test "waitingTime increases with service similarity":
     let registrar = Registrar.new()
@@ -73,7 +75,7 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
     let w = registrar.waitingTime(discoConfig, ad1, 1000, serviceId, now)
 
     # c_s = 3, serviceSim = 3/1000 contributes to wait time
-    check w > ZeroDuration
+    check w > 0.0
 
   test "waitingTime returns 0.0 IP similarity for IPs not in tree":
     let registrar = Registrar.new()
@@ -89,7 +91,7 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w > ZeroDuration
+    check w > 0.0
 
   test "waitingTime uses maximum IP score across multiple addresses":
     let registrar = Registrar.new()
@@ -107,15 +109,16 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
     )
 
     let ad = makeAdvertisement(
-      addrs = @[
-        makeMultiAddress("10.0.0.1"), # Different subnet – low score
-        makeMultiAddress("192.168.1.50"), # Same subnet – high score
-      ]
+      addrs =
+        @[
+          makeMultiAddress("10.0.0.1"), # Different subnet – low score
+          makeMultiAddress("192.168.1.50"), # Same subnet – high score
+        ]
     )
     let now = getTime().toUnix().uint64
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w > ZeroDuration
+    check w > 0.0
 
   test "waitingTime at cache capacity returns high occupancy":
     let registrar = Registrar.new()
@@ -134,7 +137,7 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
     # Allow 1 ns tolerance: float->ns truncation can lose a sub-nanosecond fraction
     let expectedSecs =
       discoConfig.advertExpiry.inFloatSecs * 100.0 * discoConfig.safetyParam
-    check w.inFloatSecs >= expectedSecs - 1e-9
+    check w >= expectedSecs - 1e-9
 
   test "waitingTime formula includes safety parameter":
     let registrar = Registrar.new()
@@ -147,7 +150,7 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
 
     # Empty cache, no IP sim: w = advertExpiry * 1.0 * safetyParam
     let expected = discoConfig.advertExpiry.seconds.float64 * discoConfig.safetyParam
-    check abs(w.inFloatSecs - expected) < 1.0
+    check abs(w - expected) < 1.0
 
 suite "Service Discovery Registrar - Lower Bound Enforcement":
   test "waitingTime enforces service lower bound when exists":
@@ -163,7 +166,7 @@ suite "Service Discovery Registrar - Lower Bound Enforcement":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= chronos.seconds(500)
+    check w >= 500.0
 
   test "waitingTime service lower bound decreases with elapsed time":
     let registrar = Registrar.new()
@@ -178,8 +181,8 @@ suite "Service Discovery Registrar - Lower Bound Enforcement":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= chronos.seconds(500)
-    check w < chronos.seconds(1000)
+    check w >= 500.0
+    check w < 1000.0
 
   test "waitingTime enforces IP lower bound when exists":
     let registrar = Registrar.new()
@@ -194,7 +197,7 @@ suite "Service Discovery Registrar - Lower Bound Enforcement":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= chronos.seconds(500)
+    check w >= 500.0
 
   test "waitingTime IP lower bound is per IP address":
     let registrar = Registrar.new()
@@ -238,7 +241,7 @@ suite "Service Discovery Registrar - Lower Bound Enforcement":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= chronos.seconds(2000)
+    check w >= 2000.0
 
 suite "Service Discovery Registrar - Lower Bound Updates":
   test "updateLowerBounds stores service bound as w + now":
@@ -495,7 +498,7 @@ suite "Service Discovery Registrar - Edge Cases":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= ZeroDuration
+    check w >= 0.0
 
   test "waitingTime with IPv6 addresses only (ignored in IP tree)":
     let registrar = Registrar.new()
@@ -507,7 +510,7 @@ suite "Service Discovery Registrar - Edge Cases":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= ZeroDuration
+    check w >= 0.0
 
   test "waitingTime with mixed IPv4 and IPv6 addresses":
     let registrar = Registrar.new()
@@ -525,7 +528,7 @@ suite "Service Discovery Registrar - Edge Cases":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w > ZeroDuration
+    check w > 0.0
 
   test "waitingTime with service ID not in boundService":
     let registrar = Registrar.new()
@@ -536,7 +539,7 @@ suite "Service Discovery Registrar - Edge Cases":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= ZeroDuration
+    check w >= 0.0
 
   test "waitingTime with IP not in boundIp":
     let registrar = Registrar.new()
@@ -547,7 +550,7 @@ suite "Service Discovery Registrar - Edge Cases":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= ZeroDuration
+    check w >= 0.0
 
   test "updateLowerBounds with zero w":
     let registrar = Registrar.new()
@@ -614,10 +617,13 @@ suite "Service Discovery Registrar - Configuration Variations":
     let now = getTime().toUnix().uint64
     let serviceId = makeServiceId()
 
-    let discoConfig1 = ServiceDiscoveryConfig.new(advertExpiry = chronos.seconds(100))
+    let discoConfig1 =
+      ServiceDiscoveryConfig.new(safetyParam = 1.0, advertExpiry = chronos.seconds(100))
     let w1 = registrar.waitingTime(discoConfig1, ad, 1000, serviceId, now)
 
-    let discoConfig2 = ServiceDiscoveryConfig.new(advertExpiry = chronos.seconds(2000))
+    let discoConfig2 = ServiceDiscoveryConfig.new(
+      safetyParam = 1.0, advertExpiry = chronos.seconds(10000)
+    )
     let w2 = registrar.waitingTime(discoConfig2, ad, 1000, serviceId, now)
 
     check w2 > w1
@@ -650,7 +656,7 @@ suite "Service Discovery Registrar - Configuration Variations":
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
     # pow(x, 0) = 1.0 regardless of x, so occupancy = 1.0 / 1.0 = 1.0
-    check w >= ZeroDuration
+    check w >= 0.0
 
   test "occupancyExp of 1 gives linear occupancy":
     let registrar = Registrar.new()
@@ -666,7 +672,7 @@ suite "Service Discovery Registrar - Configuration Variations":
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
     # occupancyExp=1: occupancy = 1/(1-0.5) = 2.0
-    check w >= ZeroDuration
+    check w >= 0.0
 
 suite "Service Discovery Registrar - Register Message Validation":
   test "validateRegisterMessage rejects empty advertisement":
@@ -1028,7 +1034,7 @@ suite "Service Discovery Registrar - waitingTime never negative":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= ZeroDuration
+    check w >= 0.0
 
   test "waitingTime returns non-negative with stale high IP lower bound":
     let registrar = Registrar.new()
@@ -1044,7 +1050,7 @@ suite "Service Discovery Registrar - waitingTime never negative":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= ZeroDuration
+    check w >= 0.0
 
 suite "Service Discovery Registrar - concurrent same-peer registration":
   test "repeated acceptAdvertisement calls for same ad are idempotent":

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -38,7 +38,7 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
     let expected =
       ceil(discoConfig.advertExpiry.seconds.float64 * discoConfig.safetyParam)
 
-    check abs(w - expected) < 0.001
+    check abs(w.inFloatSecs - expected) < 0.001
 
   test "waitingTime increases with cache occupancy":
     let registrar = Registrar.new()
@@ -56,7 +56,7 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
     let w2 = registrar.waitingTime(discoConfig, ad2, 1000, serviceId2, now)
 
     # With non-zero cache, occupancy > 1.0
-    check w1 > 0.0 or w2 > 0.0
+    check w1 > ZeroDuration or w2 > ZeroDuration
 
   test "waitingTime increases with service similarity":
     let registrar = Registrar.new()
@@ -75,7 +75,7 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
     let w = registrar.waitingTime(discoConfig, ad1, 1000, serviceId, now)
 
     # c_s = 3, serviceSim = 3/1000 contributes to wait time
-    check w > 0.0
+    check w > ZeroDuration
 
   test "waitingTime returns 0.0 IP similarity for IPs not in tree":
     let registrar = Registrar.new()
@@ -91,7 +91,7 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w > 0.0
+    check w > ZeroDuration
 
   test "waitingTime uses maximum IP score across multiple addresses":
     let registrar = Registrar.new()
@@ -117,7 +117,7 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
     let now = getTime().toUnix().uint64
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w > 0.0
+    check w > ZeroDuration
 
   test "waitingTime at cache capacity returns high occupancy":
     let registrar = Registrar.new()
@@ -136,7 +136,7 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
     # Allow 1 ns tolerance: float->ns truncation can lose a sub-nanosecond fraction
     let expectedSecs =
       discoConfig.advertExpiry.inFloatSecs * 100.0 * discoConfig.safetyParam
-    check w >= expectedSecs - 1e-9
+    check w.inFloatSecs >= expectedSecs - 1e-9
 
   test "waitingTime formula includes safety parameter":
     let registrar = Registrar.new()
@@ -149,7 +149,7 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
 
     # Empty cache, no IP sim: w = advertExpiry * 1.0 * safetyParam
     let expected = discoConfig.advertExpiry.seconds.float64 * discoConfig.safetyParam
-    check abs(w - expected) < 1.0
+    check abs(w.inFloatSecs - expected) < 1.0
 
 suite "Service Discovery Registrar - Lower Bound Enforcement":
   test "waitingTime enforces service lower bound when exists":
@@ -165,7 +165,7 @@ suite "Service Discovery Registrar - Lower Bound Enforcement":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= 500.0
+    check w >= chronos.seconds(500)
 
   test "waitingTime service lower bound decreases with elapsed time":
     let registrar = Registrar.new()
@@ -180,8 +180,8 @@ suite "Service Discovery Registrar - Lower Bound Enforcement":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= 500.0
-    check w < 1000.0
+    check w >= chronos.seconds(500)
+    check w < chronos.seconds(1000)
 
   test "waitingTime enforces IP lower bound when exists":
     let registrar = Registrar.new()
@@ -196,7 +196,7 @@ suite "Service Discovery Registrar - Lower Bound Enforcement":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= 500.0
+    check w >= chronos.seconds(500)
 
   test "waitingTime IP lower bound is per IP address":
     let registrar = Registrar.new()
@@ -240,7 +240,7 @@ suite "Service Discovery Registrar - Lower Bound Enforcement":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= 2000.0
+    check w >= chronos.seconds(2000)
 
 suite "Service Discovery Registrar - Lower Bound Updates":
   test "updateLowerBounds stores service bound as w + now":
@@ -497,7 +497,7 @@ suite "Service Discovery Registrar - Edge Cases":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= 0.0
+    check w >= ZeroDuration
 
   test "waitingTime with IPv6 addresses only (ignored in IP tree)":
     let registrar = Registrar.new()
@@ -509,7 +509,7 @@ suite "Service Discovery Registrar - Edge Cases":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= 0.0
+    check w >= ZeroDuration
 
   test "waitingTime with mixed IPv4 and IPv6 addresses":
     let registrar = Registrar.new()
@@ -527,7 +527,7 @@ suite "Service Discovery Registrar - Edge Cases":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w > 0.0
+    check w > ZeroDuration
 
   test "waitingTime with service ID not in boundService":
     let registrar = Registrar.new()
@@ -538,7 +538,7 @@ suite "Service Discovery Registrar - Edge Cases":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= 0.0
+    check w >= ZeroDuration
 
   test "waitingTime with IP not in boundIp":
     let registrar = Registrar.new()
@@ -549,7 +549,7 @@ suite "Service Discovery Registrar - Edge Cases":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= 0.0
+    check w >= ZeroDuration
 
   test "updateLowerBounds with zero w":
     let registrar = Registrar.new()
@@ -655,7 +655,7 @@ suite "Service Discovery Registrar - Configuration Variations":
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
     # pow(x, 0) = 1.0 regardless of x, so occupancy = 1.0 / 1.0 = 1.0
-    check w >= 0.0
+    check w >= ZeroDuration
 
   test "occupancyExp of 1 gives linear occupancy":
     let registrar = Registrar.new()
@@ -671,7 +671,7 @@ suite "Service Discovery Registrar - Configuration Variations":
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
     # occupancyExp=1: occupancy = 1/(1-0.5) = 2.0
-    check w >= 0.0
+    check w >= ZeroDuration
 
 suite "Service Discovery Registrar - Register Message Validation":
   test "validateRegisterMessage rejects empty advertisement":
@@ -1033,7 +1033,7 @@ suite "Service Discovery Registrar - waitingTime never negative":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= 0.0
+    check w >= ZeroDuration
 
   test "waitingTime returns non-negative with stale high IP lower bound":
     let registrar = Registrar.new()
@@ -1049,7 +1049,7 @@ suite "Service Discovery Registrar - waitingTime never negative":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w >= 0.0
+    check w >= ZeroDuration
 
 suite "Service Discovery Registrar - concurrent same-peer registration":
   test "repeated acceptAdvertisement calls for same ad are idempotent":

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -109,11 +109,10 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
     )
 
     let ad = makeAdvertisement(
-      addrs =
-        @[
-          makeMultiAddress("10.0.0.1"), # Different subnet – low score
-          makeMultiAddress("192.168.1.50"), # Same subnet – high score
-        ]
+      addrs = @[
+        makeMultiAddress("10.0.0.1"), # Different subnet – low score
+        makeMultiAddress("192.168.1.50"), # Same subnet – high score
+      ]
     )
     let now = getTime().toUnix().uint64
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)


### PR DESCRIPTION
For service discovery, I added a `ceil()` to the registrar waiting time. The effect is that now the value is quantized.