### PR TITLE
chore: update actions

### DIFF
--- a/.github/actions/install_nim/action.yml
+++ b/.github/actions/install_nim/action.yml
@@ -61,7 +61,7 @@ runs:
     - name: Restore Nim DLLs dependencies (Windows) from cache
       if: inputs.os == 'Windows'
       id: windows-dlls-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: external/dlls
         key: 'dlls'
@@ -116,7 +116,7 @@ runs:
 
     - name: Restore Nim from cache
       id: nim-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: '${{ github.workspace }}/nim'
         key: ${{ inputs.os }}-${{ inputs.cpu }}-nim-${{ inputs.nim_ref }}-cache-${{ env.cache_nonce }}-${{ env.NIMBLE_COMMIT }}

--- a/.github/actions/publish_history/action.yml
+++ b/.github/actions/publish_history/action.yml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
     - name: Clone the branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ github.repository }}
         ref: ${{ env.PUBLISH_BRANCH_NAME }}

--- a/.github/workflows/cbindings.yml
+++ b/.github/workflows/cbindings.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -42,7 +42,7 @@ jobs:
 
       - name: Restore deps from cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: nimbledeps
           key: nimbledeps-${{ hashFiles('.pinned') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -90,7 +90,7 @@ jobs:
 
       - name: Restore deps from cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: nimbledeps
           # Using nim.ref as a simple way to differentiate between nimble using the "pkgs" or "pkgs2" directories.
@@ -100,7 +100,7 @@ jobs:
       - name: Restore llvm-mingw (Windows) from cache
         if: runner.os == 'Windows' && matrix.platform.cc == 'clang'
         id: windows-mingw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: external/mingw-${{ matrix.platform.cpu }}
           key: 'mingw-llvm-17-${{ matrix.platform.cpu }}'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
       NIMBLE_COMMIT: 9207e8b2bbdf66b5a4d1020214cff44d2d30df92 # v0.20.1
       CICOV: YES
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
 
       - name: Restore deps from cache
         id: deps-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: nimbledeps
           key: nimbledeps-${{ hashFiles('.pinned') }}-${{ env.NIMBLE_COMMIT }}

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Checkout
         if: ${{ inputs.pinned_deps == false }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Resolve dependencies
         id: resolve
@@ -77,7 +77,7 @@ jobs:
     runs-on: ${{ matrix.config.builder }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -92,7 +92,7 @@ jobs:
       - name: Restore llvm-mingw (Windows) from cache
         if: runner.os == 'Windows' && matrix.config.cc == 'clang'
         id: windows-mingw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: external/mingw-${{ matrix.config.cpu }}
           key: 'mingw-llvm-17-${{ matrix.config.cpu }}'

--- a/.github/workflows/daily_nimbus.yml
+++ b/.github/workflows/daily_nimbus.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Compile nimbus using nim-libp2p
         run: |
@@ -22,4 +22,3 @@ jobs:
 
           make -j"$(nproc)"
           make -j"$(nproc)" nimbus_beacon_node
-

--- a/.github/workflows/daily_tests_no_flags.yml
+++ b/.github/workflows/daily_tests_no_flags.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -33,7 +33,7 @@ jobs:
 
       - name: Restore deps from cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: nimbledeps
           key: nimbledeps-${{ hashFiles('.pinned') }}
@@ -46,5 +46,3 @@ jobs:
       - name: Build and run tests without feature flags
         run: |
           nim c -r tests/test_all.nim
-  
-

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -33,7 +33,7 @@ jobs:
             secret: ACTIONS_GITHUB_TOKEN_NIM_CODEX
     steps:
       - name: Clone target repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ matrix.target.repository }}
           ref: ${{ matrix.target.ref}}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -15,11 +15,11 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
-      - uses: jiro4989/setup-nim-action@v1
+      - uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: '2.2.x'
 
@@ -35,7 +35,7 @@ jobs:
           ls ${GITHUB_REF##*/}
 
       - name: Clone the gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: vacp2p/nim-libp2p
           ref: gh-pages
@@ -66,13 +66,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
 
-      - uses: jiro4989/setup-nim-action@v1
+      - uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: 'stable'
 
@@ -80,7 +80,7 @@ jobs:
         run: pip install mkdocs-material && cd examples && nimble -y website
 
       - name: Clone the gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: vacp2p/nim-libp2p
           ref: gh-pages

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -42,7 +42,7 @@ jobs:
 
       - name: Restore deps from cache
         id: deps-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: nimbledeps
           key: nimbledeps-examples-${{ hashFiles('.pinned') }}

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -24,8 +24,8 @@ jobs:
         with:
           tool-cache: true
 
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
       - name: Build image
         run: docker buildx build --load -t nim-libp2p-transport-head -f interop/transport/Dockerfile .
       - name: Run tests
@@ -50,8 +50,8 @@ jobs:
   #       with:
   #         tool-cache: true
 
-  #     - uses: actions/checkout@v4
-  #     - uses: docker/setup-buildx-action@v3
+  #     - uses: actions/checkout@v6
+  #     - uses: docker/setup-buildx-action@v4
   #     - name: Build image
   #       run: docker buildx build --load -t nim-libp2p-hp-head -f interop/hole-punching/Dockerfile .
   #     - name: Run tests
@@ -69,15 +69,15 @@ jobs:
     name: Run AutoNATv2 interoperability tests
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
 
       - name: Set up Nim
-        uses: jiro4989/setup-nim-action@v1
+        uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: "stable"
 
@@ -98,7 +98,7 @@ jobs:
     name: Run Kademlia DHT interoperability tests
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -106,7 +106,7 @@ jobs:
           toolchain: stable
 
       - name: Set up Nim
-        uses: jiro4989/setup-nim-action@v1
+        uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: "stable"
 
@@ -123,15 +123,15 @@ jobs:
     name: Run Partial Message interoperability tests
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
 
       - name: Set up Nim
-        uses: jiro4989/setup-nim-action@v1
+        uses: jiro4989/setup-nim-action@v2
         with:
           nim-version: "stable"
 

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2  # In PR, has extra merge commit: ^1 = PR, ^2 = base
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -45,12 +45,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker Image with cache
         uses: docker/build-push-action@v6

--- a/.github/workflows/update_copilot_instructions.yml
+++ b/.github/workflows/update_copilot_instructions.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 


### PR DESCRIPTION
## Summary

Getting rid of:
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v3, actions/cache@v4, actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24.

And "while in there", update all other outdated actions.