### PR TITLE
chore(ci): test with 2.2.4 (nimbus) and 2.2.10 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         nim:
           - ref: v2.2.10
             memory_management: refc
-          - ref: v2.2.6
+          - ref: v2.2.4
             memory_management: refc
         include:
           - platform:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
             cpu: amd64
             cc: gcc
         nim:
-          - ref: v2.0.16
+          - ref: v2.2.10
             memory_management: refc
           - ref: v2.2.6
             memory_management: refc

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Jump into the [contributing](docs/contributing.md) page to get started, `nim-lib
 
 ## Install
 
-The currently supported Nim versions are v2.0.16 and v2.2.6.
+The currently supported Nim versions are v2.2.4 and v2.2.10.
 
 ```
 nimble install libp2p


### PR DESCRIPTION
## Summary

Drop support for Nim 2.0.16 and 2.2.6 in CI, replacing them with 2.2.10 and 2.2.4 respectively. This keeps the test matrix on actively maintained 2.2.x releases and removes the legacy 2.0.x line.

- `.github/workflows/ci.yml`:
  - Replaced v2.0.16 with v2.2.10 in the Nim version matrix
  - Replaced v2.2.6 with v2.2.4 in the Nim version matrix
- `README.md`:
  - Updated the supported Nim versions line from v2.0.16 and v2.2.6 to v2.2.4 and v2.2.10
  - Added missing newline at end of file

## Affected Areas

- Gossipsub  
- Transports  
- Peer Management / Discovery  
- Protocol Logic  
- Build / Tooling  

Two Nim versions in the CI matrix updated; no source changes.

- Other

## Compatibility & Downstream Validation

No library code changed. All existing encode/decode and API paths are unaffected. Downstream consumers (Nimbus, Waku, Codex) should validate that their own builds are compatible with Nim 2.2.4 and 2.2.10 if they pin to the versions advertised here.

## Impact on Library Users

- None — purely a CI and documentation change. No types, procs, or ABIs were modified.

## Risk Assessment

- **Nim 2.0.x dropped**: Code that relied on 2.0.x-specific behaviour will no longer be caught by CI. Risk is low because 2.0.x is end-of-life and the codebase already targets 2.2.x.
- **2.2.6 → 2.2.4**: Minor regression in tested patch version (older patch). Risk is low; 2.2.4 is a stable release and any regressions introduced between 2.2.4 and 2.2.6 would need to be re-verified manually.

## References

#2339 