### PR TITLE
feat(cbind): add peerstore

### DIFF
--- a/cbind/examples/cbindings.c
+++ b/cbind/examples/cbindings.c
@@ -49,6 +49,11 @@ static void private_key_handler(int callerRet, const uint8_t *keyData,
                               size_t keyDataLen, const char *msg, size_t len,
                               void *userData);
 
+static void peerstore_entry_handler(int callerRet,
+                                    const Libp2pPeerStoreEntry *entry,
+                                    const char *msg, size_t len,
+                                    void *userData);
+
 static void connection_handler(int callerRet, libp2p_stream_t *conn,
                                const char *msg, size_t len, void *userData);
 static void create_cid_handler(int callerRet, const char *msg, size_t len,
@@ -226,6 +231,41 @@ int main(int argc, char **argv) {
   waitForCallback();
 
   libp2p_kad_get_providers(ctx2, cid, get_providers_handler, NULL);
+  waitForCallback();
+
+  // Peerstore operations
+  // After connect+identify, node2 is in node1's peerstore.
+
+  printf("Known peers in peerstore:\n");
+  libp2p_peerstore_get_peers(ctx1, peers_handler, NULL);
+  waitForCallback();
+
+  printf("Peer info for node2:\n");
+  libp2p_peerstore_get_peer_info(ctx1, pInfo2.peerId, peerstore_entry_handler, NULL);
+  waitForCallback();
+
+  // Merge an extra address for node2
+  const char *extra_addrs[] = {"/ip4/1.2.3.4/tcp/9999"};
+  libp2p_peerstore_add_peer(ctx1, pInfo2.peerId, extra_addrs, 1, NULL, 0,
+                            event_handler, NULL);
+  waitForCallback();
+
+  // Replace node2's protocols
+  const char *test_protos[] = {"/test/1.0.0"};
+  libp2p_peerstore_set_peer_protocols(ctx1, pInfo2.peerId, test_protos, 1,
+                                      event_handler, NULL);
+  waitForCallback();
+
+  printf("Peer info after modifications:\n");
+  libp2p_peerstore_get_peer_info(ctx1, pInfo2.peerId, peerstore_entry_handler, NULL);
+  waitForCallback();
+
+  // Delete node2 from peerstore
+  libp2p_peerstore_delete_peer(ctx1, pInfo2.peerId, event_handler, NULL);
+  waitForCallback();
+
+  printf("Known peers after delete:\n");
+  libp2p_peerstore_get_peers(ctx1, peers_handler, NULL);
   waitForCallback();
 
   sleep(5);
@@ -470,6 +510,33 @@ static void connection_handler(int callerRet, libp2p_stream_t *conn,
   }
 
   ping_stream = conn;
+
+  signal_callback_executed();
+}
+
+static void peerstore_entry_handler(int callerRet,
+                                    const Libp2pPeerStoreEntry *entry,
+                                    const char *msg, size_t len,
+                                    void *userData) {
+  if (callerRet != RET_OK || entry == NULL) {
+    printf("PeerStoreEntry error(%d): %.*s\n", callerRet, (int)len,
+           msg != NULL ? msg : "");
+    exit(1);
+  }
+
+  printf("  peerId: %s\n", entry->peerId != NULL ? entry->peerId : "(null)");
+  printf("  addresses (%zu):\n", entry->addrsLen);
+  for (size_t i = 0; i < entry->addrsLen; i++)
+    printf("    %s\n", entry->addrs[i] != NULL ? entry->addrs[i] : "(null)");
+  printf("  protocols (%zu):\n", entry->protocolsLen);
+  for (size_t i = 0; i < entry->protocolsLen; i++)
+    printf("    %s\n",
+           entry->protocols[i] != NULL ? entry->protocols[i] : "(null)");
+  printf("  publicKey: %zu bytes\n", entry->publicKeyLen);
+  printf("  agentVersion: %s\n",
+         entry->agentVersion != NULL ? entry->agentVersion : "");
+  printf("  protoVersion: %s\n",
+         entry->protoVersion != NULL ? entry->protoVersion : "");
 
   signal_callback_executed();
 }

--- a/cbind/examples/cbindings.c
+++ b/cbind/examples/cbindings.c
@@ -519,8 +519,10 @@ static void peerstore_entry_handler(int callerRet,
                                     const char *msg, size_t len,
                                     void *userData) {
   if (callerRet != RET_OK || entry == NULL) {
-    printf("PeerStoreEntry error(%d): %.*s\n", callerRet, (int)len,
-           msg != NULL ? msg : "");
+    printf("PeerStoreEntry error(%d)", callerRet);
+    if (msg != NULL && len > 0) {
+        printf(": %.*s\n", (int)len, msg);
+    }
     exit(1);
   }
 

--- a/cbind/ffi_types.nim
+++ b/cbind/ffi_types.nim
@@ -186,6 +186,25 @@ type MixCurve25519Key* {.bycopy.} = object
 type MixSecp256k1PubKey* {.bycopy.} = object
   bytes*: array[33, byte]
 
+type Libp2pPeerStoreEntry* {.bycopy.} = object
+  peerId*: cstring
+  addrs*: ptr cstring
+  addrsLen*: csize_t
+  protocols*: ptr cstring
+  protocolsLen*: csize_t
+  publicKey*: ptr byte
+  publicKeyLen*: csize_t
+  agentVersion*: cstring
+  protoVersion*: cstring
+
+type PeerStoreEntryCallback* = proc(
+  callerRet: cint,
+  entry: ptr Libp2pPeerStoreEntry,
+  msg: ptr cchar,
+  len: csize_t,
+  userData: pointer,
+) {.cdecl, gcsafe, raises: [].}
+
 ### End of exported types
 ################################################################################
 

--- a/cbind/libp2p.h
+++ b/cbind/libp2p.h
@@ -206,6 +206,27 @@ typedef struct {
   size_t addrsLen;
 } Libp2pPeerInfo;
 
+// Peerstore entry containing all known metadata for a peer.
+// All fields are only valid for the duration of the callback; copy if needed.
+// publicKey is NULL and publicKeyLen is 0 when the key is not known.
+// agentVersion and protoVersion are empty strings when not known.
+typedef struct {
+  const char    *peerId;
+  const char   **addrs;
+  size_t         addrsLen;
+  const char   **protocols;
+  size_t         protocolsLen;
+  const uint8_t *publicKey;
+  size_t         publicKeyLen;
+  const char    *agentVersion;
+  const char    *protoVersion;
+} Libp2pPeerStoreEntry;
+
+typedef void (*PeerStoreEntryCallback)(int callerRet,
+                                       const Libp2pPeerStoreEntry *entry,
+                                       const char *msg, size_t len,
+                                       void *userData);
+
 // Service descriptor returned by Service discovery.
 // Fields are only valid for the duration of the callback; copy if needed.
 typedef struct {
@@ -552,6 +573,41 @@ int libp2p_dial_circuit_relay(libp2p_ctx_t *ctx, const char *dstPeerId,
 int libp2p_circuit_relay_reserve(libp2p_ctx_t *ctx, const char *relayPeerId,
                                  const char **relayAddrs, size_t relayAddrsLen,
                                  ReservationCallback callback, void *userData);
+
+// === Peerstore APIs ===
+
+// Returns peer IDs of all peers known to the address book.
+int libp2p_peerstore_get_peers(libp2p_ctx_t *ctx, PeersCallback callback,
+                               void *userData);
+
+// Returns all known metadata for peerId.
+// Addresses and protocols are populated from the peerstore books.
+// publicKey is set when the key has been received via identify.
+int libp2p_peerstore_get_peer_info(libp2p_ctx_t *ctx, const char *peerId,
+                                   PeerStoreEntryCallback callback,
+                                   void *userData);
+
+// Merges addrs into the address book for peerId (extends without duplicates).
+// Optionally merges protos into the protocol book when protosLen > 0.
+// addrsLen must be > 0.
+int libp2p_peerstore_add_peer(libp2p_ctx_t *ctx, const char *peerId,
+                              const char **addrs, size_t addrsLen,
+                              const char **protos, size_t protosLen,
+                              Libp2pCallback callback, void *userData);
+
+// Replaces all addresses stored for peerId.
+int libp2p_peerstore_set_peer_addresses(libp2p_ctx_t *ctx, const char *peerId,
+                                        const char **addrs, size_t addrsLen,
+                                        Libp2pCallback callback, void *userData);
+
+// Replaces all protocols stored for peerId.
+int libp2p_peerstore_set_peer_protocols(libp2p_ctx_t *ctx, const char *peerId,
+                                        const char **protos, size_t protosLen,
+                                        Libp2pCallback callback, void *userData);
+
+// Removes peerId from all peerstore books.
+int libp2p_peerstore_delete_peer(libp2p_ctx_t *ctx, const char *peerId,
+                                 Libp2pCallback callback, void *userData);
 
 #ifdef __cplusplus
 }

--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -17,6 +17,7 @@ import
     libp2p_lifecycle_requests, libp2p_peer_manager_requests, libp2p_pubsub_requests,
     libp2p_kademlia_requests, libp2p_stream_requests, libp2p_relay_requests,
     libp2p_protocol_requests, libp2p_service_discovery_requests,
+    libp2p_peerstore_requests,
   ],
   ../libp2p,
   ../libp2p/crypto/crypto,
@@ -1465,6 +1466,160 @@ proc libp2p_circuit_relay_reserve(
     return RET_ERR.cint
 
   RET_OK.cint
+
+### Peerstore APIs
+
+proc libp2p_peerstore_get_peers(
+    ctx: ptr LibP2PContext, callback: PeersCallback, userData: pointer
+): cint {.dynlib, exportc.} =
+  initializeLibrary()
+  checkLibParams(ctx, callback, userData)
+
+  libp2p_thread.sendRequestToLibP2PThread(
+    ctx,
+    RequestType.PEERSTORE,
+    PeerStoreRequest.createShared(PS_GET_PEERS),
+    callback,
+    CallbackKind.DEFAULT,
+    userData,
+  ).isOkOr:
+    let msg = "libp2p error: " & $error
+    callback(RET_ERR.cint, nil, 0, msg[0].addr, cast[csize_t](len(msg)), userData)
+    return RET_ERR.cint
+
+  return RET_OK.cint
+
+proc libp2p_peerstore_get_peer_info(
+    ctx: ptr LibP2PContext,
+    peerId: cstring,
+    callback: PeerStoreEntryCallback,
+    userData: pointer,
+): cint {.dynlib, exportc.} =
+  initializeLibrary()
+  checkLibParams(ctx, callback, userData)
+
+  if peerId.isNil():
+    let msg = "peerId is not set"
+    callback(RET_ERR.cint, nil, msg[0].addr, cast[csize_t](len(msg)), userData)
+    return RET_ERR.cint
+
+  libp2p_thread.sendRequestToLibP2PThread(
+    ctx,
+    RequestType.PEERSTORE,
+    PeerStoreRequest.createShared(PS_GET_PEER_INFO, peerId = peerId),
+    callback,
+    userData,
+  ).isOkOr:
+    let msg = "libp2p error: " & $error
+    callback(RET_ERR.cint, nil, msg[0].addr, cast[csize_t](len(msg)), userData)
+    return RET_ERR.cint
+
+  return RET_OK.cint
+
+proc libp2p_peerstore_add_peer(
+    ctx: ptr LibP2PContext,
+    peerId: cstring,
+    addrs: ptr cstring,
+    addrsLen: csize_t,
+    protos: ptr cstring,
+    protosLen: csize_t,
+    callback: Libp2pCallback,
+    userData: pointer,
+): cint {.dynlib, exportc.} =
+  initializeLibrary()
+  checkLibParams(ctx, callback, userData)
+
+  if peerId.isNil():
+    failWithMsg(callback, userData, "peerId is not set")
+
+  if addrsLen == 0:
+    failWithMsg(callback, userData, "at least one address is required")
+
+  failIfDataMissing(cast[ptr byte](addrs), addrsLen, callback, userData)
+
+  handleRequest(
+    ctx,
+    RequestType.PEERSTORE,
+    PeerStoreRequest.createShared(
+      PS_ADD_PEER,
+      peerId = peerId,
+      addrs = addrs,
+      addrsLen = addrsLen,
+      protocols = protos,
+      protocolsLen = protosLen,
+    ),
+    callback,
+    userData,
+  ).cint
+
+proc libp2p_peerstore_set_peer_addresses(
+    ctx: ptr LibP2PContext,
+    peerId: cstring,
+    addrs: ptr cstring,
+    addrsLen: csize_t,
+    callback: Libp2pCallback,
+    userData: pointer,
+): cint {.dynlib, exportc.} =
+  initializeLibrary()
+  checkLibParams(ctx, callback, userData)
+
+  if peerId.isNil():
+    failWithMsg(callback, userData, "peerId is not set")
+
+  failIfDataMissing(cast[ptr byte](addrs), addrsLen, callback, userData)
+
+  handleRequest(
+    ctx,
+    RequestType.PEERSTORE,
+    PeerStoreRequest.createShared(
+      PS_SET_ADDRESSES, peerId = peerId, addrs = addrs, addrsLen = addrsLen
+    ),
+    callback,
+    userData,
+  ).cint
+
+proc libp2p_peerstore_set_peer_protocols(
+    ctx: ptr LibP2PContext,
+    peerId: cstring,
+    protos: ptr cstring,
+    protosLen: csize_t,
+    callback: Libp2pCallback,
+    userData: pointer,
+): cint {.dynlib, exportc.} =
+  initializeLibrary()
+  checkLibParams(ctx, callback, userData)
+
+  if peerId.isNil():
+    failWithMsg(callback, userData, "peerId is not set")
+
+  failIfDataMissing(cast[ptr byte](protos), protosLen, callback, userData)
+
+  handleRequest(
+    ctx,
+    RequestType.PEERSTORE,
+    PeerStoreRequest.createShared(
+      PS_SET_PROTOCOLS, peerId = peerId, protocols = protos, protocolsLen = protosLen
+    ),
+    callback,
+    userData,
+  ).cint
+
+proc libp2p_peerstore_delete_peer(
+    ctx: ptr LibP2PContext, peerId: cstring, callback: Libp2pCallback, userData: pointer
+): cint {.dynlib, exportc.} =
+  initializeLibrary()
+  checkLibParams(ctx, callback, userData)
+
+  if peerId.isNil():
+    failWithMsg(callback, userData, "peerId is not set")
+
+  handleRequest(
+    ctx,
+    RequestType.PEERSTORE,
+    PeerStoreRequest.createShared(PS_DELETE_PEER, peerId = peerId),
+    callback,
+    userData,
+  ).cint
 
 ### End of exported procs
 ################################################################################

--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -1536,7 +1536,7 @@ proc libp2p_peerstore_add_peer(
     failWithMsg(callback, userData, "at least one address is required")
 
   failIfDataMissing(cast[ptr byte](addrs), addrsLen, callback, userData)
-
+  failIfDataMissing(cast[ptr byte](protos), protosLen, callback, userData)
   handleRequest(
     ctx,
     RequestType.PEERSTORE,

--- a/cbind/libp2p_thread/inter_thread_communication/libp2p_thread_request.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/libp2p_thread_request.nim
@@ -14,7 +14,7 @@ import
   ./requests/[
     libp2p_lifecycle_requests, libp2p_peer_manager_requests, libp2p_pubsub_requests,
     libp2p_kademlia_requests, libp2p_service_discovery_requests, libp2p_stream_requests,
-    libp2p_relay_requests, libp2p_protocol_requests,
+    libp2p_relay_requests, libp2p_protocol_requests, libp2p_peerstore_requests,
   ],
   ../../../libp2p
 
@@ -27,6 +27,7 @@ type RequestType* {.pure.} = enum
   STREAM
   RELAY
   PROTOCOL
+  PEERSTORE
 
 type CallbackKind* {.pure.} = enum
   DEFAULT
@@ -91,6 +92,8 @@ proc destroyUnprocessedRequest*(request: ptr LibP2PThreadRequest) =
       destroyShared(cast[ptr RelayRequest](request[].reqContent))
     of RequestType.PROTOCOL:
       destroyShared(cast[ptr ProtocolRequest](request[].reqContent))
+    of RequestType.PEERSTORE:
+      destroyShared(cast[ptr PeerStoreRequest](request[].reqContent))
 
   deallocShared(request)
 
@@ -292,6 +295,37 @@ proc handleReservationRes(
 
   deallocReservationResult(rsvp)
 
+proc handlePeerStoreEntryRes(
+    res: Result[ptr Libp2pPeerStoreEntry, string], request: ptr LibP2PThreadRequest
+) =
+  defer:
+    deallocShared(request)
+
+  let cb = cast[PeerStoreEntryCallback](request[].callback)
+
+  let entry = res.valueOr:
+    foreignThreadGc:
+      let msg = $error
+      cb(RET_ERR.cint, nil, msg[0].addr, cast[csize_t](len(msg)), request[].userData)
+    return
+
+  foreignThreadGc:
+    cb(RET_OK.cint, entry, nil, 0, request[].userData)
+
+  deallocPeerStoreEntry(entry)
+
+proc processPeerStore(
+    request: ptr LibP2PThreadRequest, libp2p: ptr LibP2P
+) {.async: (raises: [CancelledError]).} =
+  let req = cast[ptr PeerStoreRequest](request[].reqContent)
+  case req[].operation
+  of PS_GET_PEERS:
+    handleConnectedPeersRes(await req.processGetPeers(libp2p), request)
+  of PS_GET_PEER_INFO:
+    handlePeerStoreEntryRes(await req.processGetPeerInfo(libp2p), request)
+  else:
+    handleRes(await req.process(libp2p), request)
+
 proc processRelay(
     request: ptr LibP2PThreadRequest, libp2p: ptr LibP2P
 ) {.async: (raises: [CancelledError]).} =
@@ -442,6 +476,8 @@ proc process*(
     await processRelay(request, libp2p)
   of RequestType.PROTOCOL:
     await processProtocol(request, libp2p)
+  of RequestType.PEERSTORE:
+    await processPeerStore(request, libp2p)
 
 # String representation of the request type
 proc `$`*(self: LibP2PThreadRequest): string =

--- a/cbind/libp2p_thread/inter_thread_communication/libp2p_thread_request.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/libp2p_thread_request.nim
@@ -306,7 +306,10 @@ proc handlePeerStoreEntryRes(
   let entry = res.valueOr:
     foreignThreadGc:
       let msg = $error
-      cb(RET_ERR.cint, nil, msg[0].addr, cast[csize_t](len(msg)), request[].userData)
+      if msg.len() > 0:
+        cb(RET_ERR.cint, nil, msg[0].addr, cast[csize_t](msg.len()), request[].userData)
+      else:
+        cb(RET_ERR.cint, nil, nil, cast[csize_t](msg.len()), request[].userData)
     return
 
   foreignThreadGc:

--- a/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_peerstore_requests.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_peerstore_requests.nim
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+import std/[sequtils, tables]
+import chronos, results
+import ../../../[alloc, ffi_types, types]
+import ../../../../libp2p
+import ../../../../libp2p/crypto/crypto
+import ./libp2p_peer_manager_requests
+
+type PeerStoreMsgType* = enum
+  PS_GET_PEERS
+  PS_GET_PEER_INFO
+  PS_ADD_PEER
+  PS_SET_ADDRESSES
+  PS_SET_PROTOCOLS
+  PS_DELETE_PEER
+
+type PeerStoreRequest* = object
+  operation*: PeerStoreMsgType
+  peerId: cstring
+  addrs: SharedSeq[cstring]
+  protocols: SharedSeq[cstring]
+
+proc createShared*(
+    T: type PeerStoreRequest,
+    op: PeerStoreMsgType,
+    peerId: cstring = "",
+    addrs: ptr cstring = nil,
+    addrsLen: csize_t = 0,
+    protocols: ptr cstring = nil,
+    protocolsLen: csize_t = 0,
+): ptr type T =
+  var ret = createShared(T)
+  ret[].operation = op
+  ret[].peerId = peerId.alloc()
+  ret[].addrs = allocSharedSeqFromCArray(addrs, addrsLen.int)
+  ret[].protocols = allocSharedSeqFromCArray(protocols, protocolsLen.int)
+  return ret
+
+proc destroyShared*(self: ptr PeerStoreRequest) =
+  deallocShared(self[].peerId)
+  deallocSharedSeq(self[].addrs)
+  deallocSharedSeq(self[].protocols)
+  deallocShared(self)
+
+proc deallocPeerStoreEntry*(e: ptr Libp2pPeerStoreEntry) =
+  if e.isNil():
+    return
+  if not e[].peerId.isNil():
+    deallocShared(e[].peerId)
+  deallocCStringArray(e[].addrs, e[].addrsLen)
+  deallocCStringArray(e[].protocols, e[].protocolsLen)
+  if not e[].publicKey.isNil():
+    deallocShared(e[].publicKey)
+  if not e[].agentVersion.isNil():
+    deallocShared(e[].agentVersion)
+  if not e[].protoVersion.isNil():
+    deallocShared(e[].protoVersion)
+  deallocShared(e)
+
+proc process*(
+    self: ptr PeerStoreRequest, libp2p: ptr LibP2P
+): Future[Result[void, string]] {.async: (raises: []).} =
+  defer:
+    destroyShared(self)
+
+  let peerId = PeerId.init($self[].peerId).valueOr:
+    return err($error)
+
+  let peerStore = libp2p.switch.peerStore
+
+  case self.operation
+  of PS_ADD_PEER:
+    let addrs =
+      try:
+        self[].addrs.toSeq().mapIt(MultiAddress.init($it).tryGet())
+      except LPError:
+        return err("invalid multiaddress")
+    peerStore[AddressBook].extend(peerId, addrs)
+    if self[].protocols.len > 0:
+      peerStore[ProtoBook].extend(peerId, self[].protocols.toSeq().mapIt($it))
+  of PS_SET_ADDRESSES:
+    let addrs =
+      try:
+        self[].addrs.toSeq().mapIt(MultiAddress.init($it).tryGet())
+      except LPError:
+        return err("invalid multiaddress")
+    peerStore[AddressBook][peerId] = addrs
+  of PS_SET_PROTOCOLS:
+    peerStore[ProtoBook][peerId] = self[].protocols.toSeq().mapIt($it)
+  of PS_DELETE_PEER:
+    peerStore.del(peerId)
+  else:
+    raiseAssert "unsupported operation"
+
+  return ok()
+
+proc processGetPeers*(
+    self: ptr PeerStoreRequest, libp2p: ptr LibP2P
+): Future[Result[ptr ConnectedPeersList, string]] {.async: (raises: []).} =
+  defer:
+    destroyShared(self)
+
+  let peersPtr = cast[ptr ConnectedPeersList](createShared(ConnectedPeersList, 1))
+
+  var peerIds: seq[string]
+  try:
+    for peerId in keys(libp2p.switch.peerStore[AddressBook].book):
+      peerIds.add($peerId)
+  except LPError as exc:
+    deallocConnectedPeers(peersPtr)
+    return err(exc.msg)
+
+  peersPtr[].peerIdsLen = peerIds.len.csize_t
+  if peerIds.len == 0:
+    peersPtr[].peerIds = nil
+    return ok(peersPtr)
+
+  peersPtr[].peerIds = allocCStringArrayFromSeq(peerIds)
+  return ok(peersPtr)
+
+proc processGetPeerInfo*(
+    self: ptr PeerStoreRequest, libp2p: ptr LibP2P
+): Future[Result[ptr Libp2pPeerStoreEntry, string]] {.async: (raises: []).} =
+  defer:
+    destroyShared(self)
+
+  let peerId = PeerId.init($self[].peerId).valueOr:
+    return err($error)
+
+  let peerStore = libp2p.switch.peerStore
+  let entryPtr = cast[ptr Libp2pPeerStoreEntry](createShared(Libp2pPeerStoreEntry, 1))
+
+  try:
+    entryPtr[].peerId = ($peerId).alloc()
+
+    let addrs = peerStore[AddressBook][peerId].mapIt($it)
+    entryPtr[].addrsLen = addrs.len.csize_t
+    entryPtr[].addrs = allocCStringArrayFromSeq(addrs)
+
+    let protos = peerStore[ProtoBook][peerId]
+    entryPtr[].protocolsLen = protos.len.csize_t
+    entryPtr[].protocols = allocCStringArrayFromSeq(protos)
+
+    if peerStore[KeyBook].contains(peerId):
+      let keyBytes = peerStore[KeyBook][peerId].getBytes().valueOr:
+        seq[byte].default
+      if keyBytes.len > 0:
+        entryPtr[].publicKeyLen = keyBytes.len.csize_t
+        entryPtr[].publicKey = cast[ptr byte](allocShared(keyBytes.len))
+        copyMem(entryPtr[].publicKey, unsafeAddr keyBytes[0], keyBytes.len)
+
+    entryPtr[].agentVersion = peerStore[AgentBook][peerId].alloc()
+    entryPtr[].protoVersion = peerStore[ProtoVersionBook][peerId].alloc()
+  except LPError as exc:
+    deallocPeerStoreEntry(entryPtr)
+    return err(exc.msg)
+
+  return ok(entryPtr)

--- a/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_peerstore_requests.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_peerstore_requests.nim
@@ -72,20 +72,20 @@ proc process*(
 
   case self.operation
   of PS_ADD_PEER:
-    let addrs =
-      try:
-        self[].addrs.toSeq().mapIt(MultiAddress.init($it).tryGet())
-      except LPError:
-        return err("invalid multiaddress")
+    var addrs = newSeqOfCap[MultiAddress](self[].addrs.len)
+    for addr in self[].addrs.toSeq():
+      let parsedAddr = MultiAddress.init($addr).valueOr:
+        return err($error)
+      addrs.add(parsedAddr)
     peerStore[AddressBook].extend(peerId, addrs)
     if self[].protocols.len > 0:
       peerStore[ProtoBook].extend(peerId, self[].protocols.toSeq().mapIt($it))
   of PS_SET_ADDRESSES:
-    let addrs =
-      try:
-        self[].addrs.toSeq().mapIt(MultiAddress.init($it).tryGet())
-      except LPError:
-        return err("invalid multiaddress")
+    var addrs = newSeqOfCap[MultiAddress](self[].addrs.len)
+    for addr in self[].addrs.toSeq():
+      let parsedAddr = MultiAddress.init($addr).valueOr:
+        return err($error)
+      addrs.add(parsedAddr)
     peerStore[AddressBook][peerId] = addrs
   of PS_SET_PROTOCOLS:
     peerStore[ProtoBook][peerId] = self[].protocols.toSeq().mapIt($it)

--- a/cbind/libp2p_thread/libp2p_thread.nim
+++ b/cbind/libp2p_thread/libp2p_thread.nim
@@ -283,3 +283,15 @@ proc sendRequestToLibP2PThread*(
 ): Result[void, string] =
   ## Sends a request to the LibP2P thread for reservation callbacks
   sendRequest(ctx, reqType, reqContent, userData, callbackKind, cast[pointer](callback))
+
+proc sendRequestToLibP2PThread*(
+    ctx: ptr LibP2PContext,
+    reqType: RequestType,
+    reqContent: pointer,
+    callback: PeerStoreEntryCallback,
+    userData: pointer,
+): Result[void, string] =
+  ## Sends a request to the LibP2P thread for peerstore entry callbacks
+  sendRequest(
+    ctx, reqType, reqContent, userData, CallbackKind.DEFAULT, cast[pointer](callback)
+  )


### PR DESCRIPTION
## Summary

This PR exposes nim-libp2p's peerstore through the C bindings layer, giving downstream C consumers the ability to read all known metadata for a peer and to add, update, or remove peers from the store through the same async-callback API used by the rest of the cbind surface.

### Changes

- **cbind/ffi_types.nim**
  - Added `Libp2pPeerStoreEntry` — a by-copy struct carrying all peerstore metadata for one peer:
    - `peerId`
    - `addrs` / `addrsLen`
    - `protocols` / `protocolsLen`
    - `publicKey` / `publicKeyLen`
    - `agentVersion`
    - `protoVersion`
  - Added `PeerStoreEntryCallback` — callback type used by `libp2p_peerstore_get_peer_info`.

- **cbind/libp2p_thread/inter_thread_communication/requests/libp2p_peerstore_requests.nim** (new)
  - Defines `PeerStoreMsgType` enum and `PeerStoreRequest` object (with `operation*` exported for cross-module dispatch).
  - Implements:
    - `createShared`
    - `destroyShared`
    - `deallocPeerStoreEntry`
    - (following the shared-memory ownership pattern used by all other request types)
  - Functions:
    - `process`
      - Handles:
        - `PS_ADD_PEER` (extend via `peerBook.extend()`)
        - `PS_SET_ADDRESSES`
        - `PS_SET_PROTOCOLS`
        - `PS_DELETE_PEER`
    - `processGetPeers`
      - Iterates `AddressBook.book` keys
      - Returns a `ConnectedPeersList` (reused from `libp2p_peer_manager_requests`)
    - `processGetPeerInfo`
      - Assembles a full `Libp2pPeerStoreEntry` from:
        - `AddressBook`
        - `ProtoBook`
        - `KeyBook` (`getBytes()` serialization)
        - `AgentBook`
        - `ProtoVersionBook`

- **cbind/libp2p_thread/libp2p_thread.nim**
  - Added `sendRequestToLibP2PThread` overload for `PeerStoreEntryCallback`, using `CallbackKind.DEFAULT`
  - Operation dispatch occurs inside `processPeerStore` via `req[].operation`

- **cbind/libp2p_thread/inter_thread_communication/libp2p_thread_request.nim**
  - Added `PEERSTORE` to `RequestType` enum
  - Imported `libp2p_peerstore_requests`
  - Wired `destroyShared` into `destroyUnprocessedRequest`
  - Added:
    - `handlePeerStoreEntryRes` (mirrors `handlePeerInfoRes`)
    - `processPeerStore`, dispatching:
      - `PS_GET_PEERS` → `handleConnectedPeersRes`
      - `PS_GET_PEER_INFO` → `handlePeerStoreEntryRes`
      - others → `handleRes`
  - Wired `PEERSTORE` into the main dispatcher

- **cbind/libp2p.nim**
  - Imported `libp2p_peerstore_requests`
  - Added exported functions:
    - `libp2p_peerstore_get_peers`
    - `libp2p_peerstore_get_peer_info`
    - `libp2p_peerstore_add_peer`
    - `libp2p_peerstore_set_peer_addresses`
    - `libp2p_peerstore_set_peer_protocols`
    - `libp2p_peerstore_delete_peer`

- **cbind/libp2p.h**
  - Added:
    - `Libp2pPeerStoreEntry` struct
    - `PeerStoreEntryCallback` typedef
  - Included field-level documentation on lifetime and NULL semantics
  - Added declarations under `=== Peerstore APIs ===`

- **cbind/examples/cbindings.c**
  - Added `peerstore_entry_handler` (forward declaration + implementation)
    - Prints all entry fields
  - Added test flow in `main`:
    1. List peers
    2. Get full info
    3. Merge an extra address
    4. Replace protocols
    5. Re-read info to verify changes
    6. Delete peer
    7. List peers to confirm removal

---

## Affected Areas

- Gossipsub  
- Transports  
- Peer Management / Discovery  
  - Two new read paths: `get_peers`, `get_peer_info`  
  - Four write paths provide direct access to peerstore books used by identify and connection management  
- Protocol Logic  
- Build / Tooling  
- Other  

---

## Compatibility & Downstream Validation

- All changes are **purely additive**
- No existing:
  - functions
  - types
  - enums
  - callback signatures  
  have been modified
- `RequestType` gains one trailing member: `PEERSTORE`
- `CallbackKind` unchanged
- Existing bindings compile and behave identically

Downstream consumers (Nimbus, Waku, Codex, or any project linking `libp2p.so` / `libp2p.a`) are unaffected unless they depend on raw integer values of `RequestType` (not part of the public ABI).

No validation required for existing usage. Validation only needed if adopting the new peerstore API.

---

## Impact on Library Users

- **Additive**
  - `Libp2pPeerStoreEntry` struct (read-only during callback)
  - `PeerStoreEntryCallback` typedef
  - Six new `libp2p_peerstore_*` functions

- **Behavior Notes**
  - `libp2p_peerstore_add_peer`
    - Merges addresses (no duplicates)
    - Does **not** replace
    - Use `libp2p_peerstore_set_peer_addresses` to replace
  - `publicKey`
    - `NULL` with `publicKeyLen = 0` if not yet identified
    - Must be null-checked
  - `agentVersion`, `protoVersion`
    - Always non-NULL (empty string if unknown)

---

## Risk Assessment

- **Threading model**
  - All peerstore operations run on the libp2p worker thread (async loop)
  - Matches existing bindings
  - Risk: low

- **Adding unknown peers**
  - `add_peer` with unknown peer creates partial entry
  - `get_peer_info` returns:
    - empty protocols
    - no public key
    - empty agent/protoVersion
  - Expected behavior
  - Risk: low

- **Deleting connected peers**
  - Removes metadata but does **not** disconnect
  - Connection remains active
  - Reconnect may fail until re-advertised
  - Recommended:
    - call `libp2p_disconnect` before deletion
  - Risk: low/medium

- **KeyBook access**
  - Missing key returns `default(PublicKey)`
  - Guarded with `.contains(peerId)` before serialization
  - Risk: low

---

## References

N/A