### PR TITLE
ci: add timeout for `coverage` workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,6 +17,7 @@ jobs:
   codecov:
     name: Run coverage and upload to codecov
     runs-on: ubuntu-22.04
+    timeout-minutes: 55
     env:
       NIMBLE_COMMIT: 9207e8b2bbdf66b5a4d1020214cff44d2d30df92 # v0.20.1
       CICOV: YES


### PR DESCRIPTION
<img width="572" height="102" alt="image" src="https://github.com/user-attachments/assets/a91afe86-34fb-4afa-bdf6-857787a7f44d" />

https://github.com/vacp2p/nim-libp2p/actions/runs/25007835050/job/73235535427