### PR TITLE
feat: add dial back addr in StatusAndConfidenceHandler

### DIFF
--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -53,7 +53,9 @@ type
     rng: ref HmacDrbgContext
 
   StatusAndConfidenceHandler* = proc(
-    networkReachability: NetworkReachability, confidence: Opt[float]
+    networkReachability: NetworkReachability,
+    confidence: Opt[float],
+    dialBackAddr: Opt[MultiAddress],
   ): Future[void] {.gcsafe, async: (raises: [CancelledError]).}
 
 proc new*(
@@ -89,9 +91,13 @@ proc new*(
     rng: rng,
   )
 
-proc callHandler(self: AutonatV2Service) {.async: (raises: [CancelledError]).} =
+proc callHandler(
+    self: AutonatV2Service, dialBackAddr: Opt[MultiAddress]
+) {.async: (raises: [CancelledError]).} =
   if not isNil(self.statusAndConfidenceHandler):
-    await self.statusAndConfidenceHandler(self.networkReachability, self.confidence)
+    await self.statusAndConfidenceHandler(
+      self.networkReachability, self.confidence, dialBackAddr
+    )
 
 proc hasEnoughIncomingSlots(switch: Switch): bool =
   # we leave some margin instead of comparing to 0 as a peer could connect to us while we are asking for the dial back
@@ -150,11 +156,13 @@ proc askPeer(
     return Unknown
 
   trace "Asking peer for reachability"
+  var dialBackAddr = Opt.none(MultiAddress)
   let ans =
     try:
       let reqAddrs = switch.peerInfo.addrs
       let autonatV2Resp = await self.client.sendDialRequest(peerId, reqAddrs)
       debug "AutonatV2Response", autonatV2Resp = autonatV2Resp
+      dialBackAddr = autonatV2Resp.addrs
       autonatV2Resp.reachability
     except CancelledError as exc:
       raise exc
@@ -169,7 +177,7 @@ proc askPeer(
       Unknown
   let hasReachabilityOrConfidenceChanged = await self.handleAnswer(ans)
   if hasReachabilityOrConfidenceChanged:
-    await self.callHandler()
+    await self.callHandler(dialBackAddr)
   await switch.peerInfo.update()
   return ans
 

--- a/tests/interop/autonatv2.nim
+++ b/tests/interop/autonatv2.nim
@@ -34,7 +34,9 @@ proc autonatInteropTest*(
   let awaiter = newFuture[void]()
 
   proc statusAndConfidenceHandler(
-      networkReachability: NetworkReachability, confidence: Opt[float]
+      networkReachability: NetworkReachability,
+      confidence: Opt[float],
+      dialBackAddr: Opt[MultiAddress],
   ) {.async: (raises: [CancelledError]).} =
     if networkReachability != NetworkReachability.Unknown and confidence.isSome() and
         confidence.get() >= 0.3:

--- a/tests/libp2p/protocols/test_autonat_v2_service.nim
+++ b/tests/libp2p/protocols/test_autonat_v2_service.nim
@@ -133,7 +133,9 @@ suite "AutonatV2 Service":
     let awaiter = newFuture[void]()
 
     proc statusAndConfidenceHandler(
-        networkReachability: NetworkReachability, confidence: Opt[float]
+        networkReachability: NetworkReachability,
+        confidence: Opt[float],
+        dialBackAddr: Opt[MultiAddress],
     ) {.async: (raises: [CancelledError]).} =
       if networkReachability == NetworkReachability.Reachable and confidence.isSome() and
           confidence.get() >= 0.3:
@@ -179,7 +181,9 @@ suite "AutonatV2 Service":
     let reachableObserved = newFuture[void]()
 
     proc statusAndConfidenceHandler(
-        networkReachability: NetworkReachability, confidence: Opt[float]
+        networkReachability: NetworkReachability,
+        confidence: Opt[float],
+        dialBackAddr: Opt[MultiAddress],
     ) {.async: (raises: [CancelledError]).} =
       if networkReachability == NetworkReachability.NotReachable and confidence.isSome() and
           confidence.get() >= 0.3:
@@ -231,7 +235,9 @@ suite "AutonatV2 Service":
     let awaiter = newFuture[void]()
 
     proc statusAndConfidenceHandler(
-        networkReachability: NetworkReachability, confidence: Opt[float]
+        networkReachability: NetworkReachability,
+        confidence: Opt[float],
+        dialBackAddr: Opt[MultiAddress],
     ) {.async: (raises: [CancelledError]).} =
       if networkReachability == NetworkReachability.Reachable and confidence.isSome() and
           confidence.get() == 1:
@@ -261,7 +267,9 @@ suite "AutonatV2 Service":
     let awaiter = newFuture[void]()
 
     proc statusAndConfidenceHandler(
-        networkReachability: NetworkReachability, confidence: Opt[float]
+        networkReachability: NetworkReachability,
+        confidence: Opt[float],
+        dialBackAddr: Opt[MultiAddress],
     ) {.async: (raises: [CancelledError]).} =
       if networkReachability == NetworkReachability.NotReachable and confidence.isSome() and
           confidence.get() >= 0.3:
@@ -320,7 +328,9 @@ suite "AutonatV2 Service":
     let awaiter = newFuture[void]()
 
     proc statusAndConfidenceHandler(
-        networkReachability: NetworkReachability, confidence: Opt[float]
+        networkReachability: NetworkReachability,
+        confidence: Opt[float],
+        dialBackAddr: Opt[MultiAddress],
     ) {.async: (raises: [CancelledError]).} =
       if networkReachability == NetworkReachability.Reachable and confidence.isSome() and
           confidence.get() == 1:
@@ -372,7 +382,9 @@ suite "AutonatV2 Service":
       awaiter2 = newFuture[void]()
 
     proc statusAndConfidenceHandler1(
-        networkReachability: NetworkReachability, confidence: Opt[float]
+        networkReachability: NetworkReachability,
+        confidence: Opt[float],
+        dialBackAddr: Opt[MultiAddress],
     ) {.async: (raises: [CancelledError]).} =
       if networkReachability == NetworkReachability.Reachable and confidence.isSome() and
           confidence.get() == 1:
@@ -380,7 +392,9 @@ suite "AutonatV2 Service":
           awaiter1.complete()
 
     proc statusAndConfidenceHandler2(
-        networkReachability: NetworkReachability, confidence: Opt[float]
+        networkReachability: NetworkReachability,
+        confidence: Opt[float],
+        dialBackAddr: Opt[MultiAddress],
     ) {.async: (raises: [CancelledError]).} =
       if networkReachability == NetworkReachability.Reachable and confidence.isSome() and
           confidence.get() == 1:
@@ -429,7 +443,9 @@ suite "AutonatV2 Service":
     let awaiter1 = newFuture[void]()
 
     proc statusAndConfidenceHandler1(
-        networkReachability: NetworkReachability, confidence: Opt[float]
+        networkReachability: NetworkReachability,
+        confidence: Opt[float],
+        dialBackAddr: Opt[MultiAddress],
     ) {.async: (raises: [CancelledError]).} =
       if networkReachability == NetworkReachability.Reachable and confidence.isSome() and
           confidence.get() == 1:
@@ -476,7 +492,9 @@ suite "AutonatV2 Service":
     var awaiter = newFuture[void]()
 
     proc statusAndConfidenceHandler(
-        networkReachability: NetworkReachability, confidence: Opt[float]
+        networkReachability: NetworkReachability,
+        confidence: Opt[float],
+        dialBackAddr: Opt[MultiAddress],
     ) {.async: (raises: [CancelledError]).} =
       if networkReachability == NetworkReachability.Reachable and confidence.isSome() and
           confidence.get() == 1:
@@ -517,7 +535,9 @@ suite "AutonatV2 Service":
     let switch2 = createSwitch()
 
     proc statusAndConfidenceHandler(
-        networkReachability: NetworkReachability, confidence: Opt[float]
+        networkReachability: NetworkReachability,
+        confidence: Opt[float],
+        dialBackAddr: Opt[MultiAddress],
     ) {.async: (raises: [CancelledError]).} =
       fail()
 
@@ -531,3 +551,66 @@ suite "AutonatV2 Service":
     await sleepAsync(250.milliseconds)
 
     await allFuturesRaising(switch1.stop(), switch2.stop())
+
+  asyncTest "Handler must receive the dial-back address on Reachable":
+    let
+      (service, _) = newService(NetworkReachability.Reachable)
+      switch = createSwitch(Opt.some(service))
+    var switches = createSwitches(3)
+
+    let awaiter = newFuture[void]()
+    var capturedAddr = Opt.none(MultiAddress)
+
+    proc statusAndConfidenceHandler(
+        networkReachability: NetworkReachability,
+        confidence: Opt[float],
+        dialBackAddr: Opt[MultiAddress],
+    ) {.async: (raises: [CancelledError]).} =
+      if networkReachability == NetworkReachability.Reachable and confidence.isSome() and
+          confidence.get() >= 0.3:
+        if not awaiter.finished:
+          capturedAddr = dialBackAddr
+          awaiter.complete()
+
+    service.setStatusAndConfidenceHandler(statusAndConfidenceHandler)
+    await switch.startAndConnect(switches)
+    await awaiter
+
+    check service.networkReachability == NetworkReachability.Reachable
+    check capturedAddr.isSome()
+    check capturedAddr.get() == switch.peerInfo.addrs[0]
+
+    await switch.stop()
+    await switches.stopAll()
+
+  asyncTest "Handler must receive the attempted address on NotReachable":
+    let
+      (service, client) = newService(NetworkReachability.NotReachable)
+      switch = createSwitch(Opt.some(service))
+    var switches = createSwitches(3)
+
+    let awaiter = newFuture[void]()
+    var capturedAddr = Opt.none(MultiAddress)
+
+    proc statusAndConfidenceHandler(
+        networkReachability: NetworkReachability,
+        confidence: Opt[float],
+        dialBackAddr: Opt[MultiAddress],
+    ) {.async: (raises: [CancelledError]).} =
+      if networkReachability == NetworkReachability.NotReachable and confidence.isSome() and
+          confidence.get() >= 0.3:
+        if not awaiter.finished:
+          capturedAddr = dialBackAddr
+          awaiter.complete()
+
+    service.setStatusAndConfidenceHandler(statusAndConfidenceHandler)
+    await switch.startAndConnect(switches)
+    await awaiter
+    await client.finished
+
+    check service.networkReachability == NetworkReachability.NotReachable
+    check capturedAddr.isSome()
+    check capturedAddr.get() == switch.peerInfo.addrs[0]
+
+    await switch.stop()
+    await switches.stopAll()

--- a/tests/libp2p/protocols/test_autonat_v2_service.nim
+++ b/tests/libp2p/protocols/test_autonat_v2_service.nim
@@ -558,8 +558,7 @@ suite "AutonatV2 Service":
       switch = createSwitch(Opt.some(service))
     var switches = createSwitches(3)
 
-    let awaiter = newFuture[void]()
-    var capturedAddr = Opt.none(MultiAddress)
+    let awaiter = newFuture[Opt[MultiAddress]]()
 
     proc statusAndConfidenceHandler(
         networkReachability: NetworkReachability,
@@ -569,12 +568,11 @@ suite "AutonatV2 Service":
       if networkReachability == NetworkReachability.Reachable and confidence.isSome() and
           confidence.get() >= 0.3:
         if not awaiter.finished:
-          capturedAddr = dialBackAddr
-          awaiter.complete()
+          awaiter.complete(dialBackAddr)
 
     service.setStatusAndConfidenceHandler(statusAndConfidenceHandler)
     await switch.startAndConnect(switches)
-    await awaiter
+    let capturedAddr = await awaiter
 
     check service.networkReachability == NetworkReachability.Reachable
     check capturedAddr.isSome()
@@ -589,8 +587,7 @@ suite "AutonatV2 Service":
       switch = createSwitch(Opt.some(service))
     var switches = createSwitches(3)
 
-    let awaiter = newFuture[void]()
-    var capturedAddr = Opt.none(MultiAddress)
+    let awaiter = newFuture[Opt[MultiAddress]]()
 
     proc statusAndConfidenceHandler(
         networkReachability: NetworkReachability,
@@ -600,12 +597,11 @@ suite "AutonatV2 Service":
       if networkReachability == NetworkReachability.NotReachable and confidence.isSome() and
           confidence.get() >= 0.3:
         if not awaiter.finished:
-          capturedAddr = dialBackAddr
-          awaiter.complete()
+          awaiter.complete(dialBackAddr)
 
     service.setStatusAndConfidenceHandler(statusAndConfidenceHandler)
     await switch.startAndConnect(switches)
-    await awaiter
+    let capturedAddr = await awaiter
     await client.finished
 
     check service.networkReachability == NetworkReachability.NotReachable


### PR DESCRIPTION
## Summary

Adds `dialBackAddr: Opt[MultiAddress]` to `StatusAndConfidenceHandler`. `peerInfo.update()` is
called after the handler, so `peerInfo.addrs` is stale inside the callback, `dialBackAddr` is
the only way to know which address was attempted during the dial-back.

## Affected Areas

- [x] Protocol Logic

  <!-- nimble format: exclude nimbledeps/ from nph -->

## Compatibility & Downstream Validation

Breaking change: all `StatusAndConfidenceHandler` implementations must add the new `dialBackAddr` parameter.

- **Nimbus:** N/A
- **Waku:** N/A
- **Codex:** N/A

## Impact on Library Users

API change: `StatusAndConfidenceHandler` has a new required parameter `dialBackAddr: Opt[MultiAddress]`.

## Risk Assessment

Low. Additive change, no behavior is altered, only additional data is surfaced.

## References

go-libp2p exposes the dial-back address [here](https://github.com/libp2p/go-libp2p/blob/2f158627d8599d90c1c8fd33d8b414308ae3c61f/p2p/protocol/autonatv2/client.go#L165)  

## Additional Notes

N / A
