### PR TITLE
chore: remove runAfter

### DIFF
--- a/libp2p/utils/heartbeat.nim
+++ b/libp2p/utils/heartbeat.nim
@@ -7,18 +7,6 @@ import chronos, chronicles
 
 export chronicles
 
-template runAfter*(waitTime: Duration, body: untyped): untyped =
-  asyncSpawn (
-    proc() {.async: (raises: [CancelledError]).} =
-      try:
-        await sleepAsync(waitTime)
-        body
-      except CancelledError as e:
-        raise e
-      except CatchableError as e:
-        error "runAfter task failed", msg = e.msg
-  )()
-
 template heartbeat*(
     name: string, interval: Duration, sleepFirst: bool, body: untyped
 ): untyped =

--- a/tests/libp2p/utils/test_heartbeat.nim
+++ b/tests/libp2p/utils/test_heartbeat.nim
@@ -11,17 +11,6 @@ when not defined(macosx):
   import ../../tools/[unittest]
 
   suite "Heartbeat":
-    asyncTest "simple runAfter":
-      var i = 0
-      proc t() {.async.} =
-        runAfter 500.milliseconds:
-          i.inc()
-
-      discard t()
-      check i == 0
-      await sleepAsync(700.milliseconds)
-      check i == 1
-
     asyncTest "simple heartbeat":
       var i = 0
       proc t() {.async.} =


### PR DESCRIPTION
this utility was never used, and since it brakes guides it shouldn't really exist.

- code should minimize usage of `asyncSpawn`  with untracked futures
-  `sleepAsync` should not be hidden inside other utilities. because if we are going to use it we should document why `sleepAsync` was needed. 