### PR TITLE
fix(ws): process pending handshakes concurrently

### DIFF
--- a/.pinned
+++ b/.pinned
@@ -14,7 +14,7 @@ serialization;https://github.com/status-im/nim-serialization@#f80cfd8657f272a2ab
 stew;https://github.com/status-im/nim-stew@#b66168735d6f3841c5239c3169d3fe5fe98b1257
 testutils;https://github.com/status-im/nim-testutils@#e85cb6ff9c328a6e12441e81ff632ef8b3af62b3
 unittest2;https://github.com/status-im/nim-unittest2@#26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189
-websock;https://github.com/status-im/nim-websock@#42c37b4172519566db016810eccfce8a02cc1cdf
+websock;https://github.com/status-im/nim-websock@#16cd25dc8661c3979559ff580045947f08e63471
 zlib;https://github.com/status-im/nim-zlib@#e680f269fb01af2c34a2ba879ff281795a5258fe
 bearssl_pkey_decoder;https://github.com/vacp2p/bearssl_pkey_decoder@#d34aa46bf9d0a3ffff810fbd3c4d2fa024eb9368
 jwt;https://github.com/vacp2p/nim-jwt@#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2

--- a/.pinned
+++ b/.pinned
@@ -15,7 +15,7 @@ serialization;https://github.com/status-im/nim-serialization@#f80cfd8657f272a2ab
 stew;https://github.com/status-im/nim-stew@#b66168735d6f3841c5239c3169d3fe5fe98b1257
 testutils;https://github.com/status-im/nim-testutils@#e85cb6ff9c328a6e12441e81ff632ef8b3af62b3
 unittest2;https://github.com/status-im/nim-unittest2@#26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189
-websock;https://github.com/status-im/nim-websock@#42c37b4172519566db016810eccfce8a02cc1cdf
+websock;https://github.com/status-im/nim-websock@#02616eccd5c826b83c580fa092e9675da04491c7
 zlib;https://github.com/status-im/nim-zlib@#e680f269fb01af2c34a2ba879ff281795a5258fe
 bearssl_pkey_decoder;https://github.com/vacp2p/bearssl_pkey_decoder@#d34aa46bf9d0a3ffff810fbd3c4d2fa024eb9368
 jwt;https://github.com/vacp2p/nim-jwt@#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -12,7 +12,7 @@ requires "nim >= 2.0.0",
   "nimcrypto >= 0.6.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.7",
   "chronicles >= 0.11.0", "chronos >= 4.2.2", "metrics", "secp256k1", "stew >= 0.4.2",
   "unittest2", "results", "serialization", "lsquic >= 0.2.0",
-  "https://github.com/status-im/nim-websock#42c37b4172519566db016810eccfce8a02cc1cdf",
+  "https://github.com/status-im/nim-websock#16cd25dc8661c3979559ff580045947f08e63471",
   "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
 
 import hashes, os, sequtils, strutils

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -13,7 +13,7 @@ requires "nim >= 2.2.4",
   "https://github.com/vacp2p/nim-boringssl >= 0.0.4", "chronicles >= 0.11.0",
   "chronos >= 4.2.2", "metrics", "secp256k1", "stew >= 0.4.2", "unittest2", "results",
   "serialization", "lsquic >= 0.4.1",
-  "https://github.com/status-im/nim-websock#42c37b4172519566db016810eccfce8a02cc1cdf",
+  "https://github.com/status-im/nim-websock#02616eccd5c826b83c580fa092e9675da04491c7",
   "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2",
   "https://github.com/status-im/nim-protobuf-serialization#46753f2b90365035bc0f75c6894e160c35880be1"
 

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -27,10 +27,15 @@ export transport, websock, results
 
 const
   DefaultHeadersTimeout = 3.seconds
+  DefaultConcurrentAccepts = 200
   DefaultAutotlsWaitTimeout = 3.seconds
   DefaultAutotlsRetries = 3
 
 type
+  AcceptResult = object
+    conn: Connection
+    closed: bool
+
   WsStream = ref object of Connection
     session: WSSession
     when defined(libp2p_agents_metrics):
@@ -132,19 +137,156 @@ type WsTransport* = ref object of Transport
   httpservers: seq[HttpServer]
   wsserver: WSServer
   connections: array[Direction, seq[WsStream]]
-  acceptFuts: seq[Future[HttpRequest]]
+  acceptLoop: Future[void]
+  handshakeFuts: seq[Future[void]]
+  acceptResults: AsyncQueue[AcceptResult]
+  acceptSem: AsyncSemaphore
 
   tlsPrivateKey*: TLSPrivateKey
   tlsCertificate*: TLSCertificate
   autotls: Opt[AutotlsService]
   tlsFlags: set[TLSFlags]
   flags: set[ServerFlags]
-  handshakeTimeout: Duration
+  headersTimeout: Duration
+  concurrentAccepts: int
   factories: seq[ExtFactory]
   rng: ref HmacDrbgContext
 
 proc secure*(self: WsTransport): bool =
   not (isNil(self.tlsPrivateKey) or isNil(self.tlsCertificate))
+
+proc notifyAcceptClosed(self: WsTransport) {.raises: [].} =
+  if isNil(self.acceptResults):
+    return
+
+  try:
+    self.acceptResults.addLastNoWait(AcceptResult(closed: true))
+  except AsyncQueueFullError:
+    trace "Queue is full"
+
+proc releaseAcceptSlot(self: WsTransport) {.raises: [].} =
+  try:
+    self.acceptSem.release()
+  except AsyncSemaphoreError as exc:
+    trace "Error releasing WS accept semaphore", description = exc.msg
+
+proc closeHttpStream(stream: AsyncStream) {.async: (raises: []).} =
+  try:
+    await noCancel stream.closeWait()
+  except CatchableError as exc:
+    trace "Error closing HTTP stream", description = exc.msg
+
+proc connHandler(
+  self: WsTransport, stream: WSSession, secure: bool, dir: Direction
+): Future[Connection] {.async: (raises: [CatchableError]).}
+
+proc wsHandshakeWorker(
+    self: WsTransport, server: HttpServer, stream: AsyncStream
+) {.async: (raises: [CancelledError]).} =
+  var accepted = false
+  defer:
+    self.releaseAcceptSlot()
+
+  try:
+    let conn = await (
+      proc(): Future[Connection] {.async: (raises: [CatchableError]).} =
+        let req = await readHttpRequest(stream, server.headersTimeout)
+        let wstransp = await self.wsserver.handleRequest(req)
+        return await self.connHandler(wstransp, server.secure, Direction.In)
+    )()
+      .wait(self.headersTimeout)
+
+    await self.acceptResults.addLast(AcceptResult(conn: conn))
+    accepted = true
+  except WebSocketError as exc:
+    debug "Websocket Error", description = exc.msg
+  except HttpError as exc:
+    debug "Http Error", description = exc.msg
+  except AsyncStreamError as exc:
+    debug "AsyncStream Error", description = exc.msg
+  except AsyncTimeoutError as exc:
+    debug "Timed out", description = exc.msg
+  except CancelledError as exc:
+    if not accepted:
+      await noCancel closeHttpStream(stream)
+    raise exc
+  except CatchableError as exc:
+    debug "Unexpected error accepting websocket connection", description = exc.msg
+
+  if not accepted:
+    await closeHttpStream(stream)
+
+proc wsAcceptDispatcher(self: WsTransport) {.async: (raises: []).} =
+  var acceptFuts = self.httpservers.mapIt(it.acceptStream())
+  defer:
+    self.notifyAcceptClosed()
+
+  if acceptFuts.len == 0:
+    return
+
+  try:
+    while self.running:
+      self.handshakeFuts.keepItIf(not it.finished)
+
+      var acquired = false
+      try:
+        await self.acceptSem.acquire()
+        acquired = true
+
+        let finished =
+          try:
+            await one(acceptFuts)
+          except ValueError:
+            raiseAssert("accept futures should not be empty")
+
+        let index = acceptFuts.find(finished)
+        if index < 0:
+          if acquired:
+            self.releaseAcceptSlot()
+          continue
+
+        let server = self.httpservers[index]
+        acceptFuts[index] = server.acceptStream()
+
+        if finished.completed():
+          let stream = finished.read()
+          self.handshakeFuts.add(self.wsHandshakeWorker(server, stream))
+          acquired = false
+        elif finished.failed():
+          let exc = finished.error()
+          if exc of TransportUseClosedError:
+            debug "Server was closed", description = exc.msg
+          elif exc of TransportTooManyError:
+            debug "Too many files opened", description = exc.msg
+          elif exc of TransportAbortedError:
+            debug "Connection aborted", description = exc.msg
+          elif exc of TransportOsError:
+            debug "OS Error", description = exc.msg
+          else:
+            info "Unexpected error accepting websocket stream", description = exc.msg
+
+          if acquired:
+            self.releaseAcceptSlot()
+      except CancelledError:
+        if acquired:
+          self.releaseAcceptSlot()
+        break
+      except CatchableError as exc:
+        if acquired:
+          self.releaseAcceptSlot()
+        if self.running:
+          info "Unexpected error in websocket accept dispatcher", description = exc.msg
+        else:
+          break
+  finally:
+    for fut in acceptFuts:
+      if not fut.finished:
+        await noCancel fut.cancelAndWait()
+      elif fut.completed():
+        try:
+          await closeHttpStream(fut.read())
+        except CatchableError as exc:
+          trace "Error reading completed WS accept stream", description = exc.msg
 
 method start*(
     self: WsTransport, addrs: seq[MultiAddress]
@@ -178,10 +320,9 @@ method start*(
         except TLSStreamProtocolError as exc:
           raise newException(LPError, exc.msg, exc)
 
-  await procCall Transport(self).start(addrs)
-
   self.wsserver = WSServer.new(factories = self.factories, rng = self.rng)
 
+  var resolvedAddrs = addrs
   for i, ma in addrs:
     let isWss =
       if WSS.match(ma):
@@ -197,15 +338,15 @@ method start*(
       try:
         let address = addrsTa[i]
         if isWss:
-          TlsHttpServer.create(
+          HttpServer.create(
             address = address,
             tlsPrivateKey = self.tlsPrivateKey,
             tlsCertificate = self.tlsCertificate,
             flags = self.flags,
-            handshakeTimeout = self.handshakeTimeout,
+            headersTimeout = self.headersTimeout,
           )
         else:
-          HttpServer.create(address, handshakeTimeout = self.handshakeTimeout)
+          HttpServer.create(address, headersTimeout = self.headersTimeout)
       except CatchableError as exc:
         raise (ref WsTransportError)(
           msg: "error in WsTransport start: " & exc.msg, parent: exc
@@ -223,8 +364,15 @@ method start*(
         MultiAddress.init("/ws")
 
     # always get the resolved address in case we're bound to 0.0.0.0:0
-    self.addrs[i] =
+    resolvedAddrs[i] =
       MultiAddress.init(httpserver.localAddress()).tryGet() & codec.tryGet()
+
+  self.acceptSem = newAsyncSemaphore(self.concurrentAccepts)
+  self.acceptResults = newAsyncQueue[AcceptResult](self.concurrentAccepts)
+  self.handshakeFuts = @[]
+
+  await procCall Transport(self).start(resolvedAddrs)
+  self.acceptLoop = self.wsAcceptDispatcher()
 
   trace "Listening on", addresses = self.addrs
 
@@ -233,22 +381,19 @@ method stop*(self: WsTransport) {.async: (raises: []).} =
   ##
 
   self.running = false # mark stopped as soon as possible
+  self.notifyAcceptClosed()
 
   try:
     trace "Stopping WS transport"
     await procCall Transport(self).stop() # call base
 
-    discard await allFinished(
-      self.connections[Direction.In].mapIt(it.close()) &
-        self.connections[Direction.Out].mapIt(it.close())
-    )
-
     var toWait: seq[Future[void]]
-    for fut in self.acceptFuts:
+    if not isNil(self.acceptLoop) and not self.acceptLoop.finished:
+      toWait.add(self.acceptLoop.cancelAndWait())
+
+    for fut in self.handshakeFuts:
       if not fut.finished:
         toWait.add(fut.cancelAndWait())
-      elif fut.completed:
-        toWait.add(fut.read().stream.closeWait())
 
     for server in self.httpservers:
       server.stop()
@@ -256,7 +401,14 @@ method stop*(self: WsTransport) {.async: (raises: []).} =
 
     await allFutures(toWait)
 
+    discard await allFinished(
+      self.connections[Direction.In].mapIt(it.close()) &
+        self.connections[Direction.Out].mapIt(it.close())
+    )
+
     self.httpservers = @[]
+    self.handshakeFuts = @[]
+    self.acceptLoop = nil
     trace "Transport stopped"
   except CatchableError as exc:
     trace "Error shutting down ws transport", description = exc.msg
@@ -304,7 +456,7 @@ method accept*(
   trace "WsTransport accept"
 
   # wstransport can only start accepting connections after autotls is done
-  # if autotls is not present, self.running will be true right after start is called
+  # if autotls is not present, self.running is true after listener setup completes
   var retries = 0
   while not self.running and retries < DefaultAutotlsRetries:
     retries += 1
@@ -313,58 +465,11 @@ method accept*(
   if not self.running:
     raise newTransportClosedError()
 
-  if self.acceptFuts.len <= 0:
-    self.acceptFuts = self.httpservers.mapIt(it.accept())
+  let res = await self.acceptResults.popFirst()
+  if not isNil(res.conn):
+    return res.conn
 
-  if self.acceptFuts.len <= 0:
-    return
-
-  let finished =
-    try:
-      await one(self.acceptFuts)
-    except ValueError:
-      raiseAssert("already checked with if")
-    except CancelledError as e:
-      raise e
-
-  let index = self.acceptFuts.find(finished)
-  self.acceptFuts[index] = self.httpservers[index].accept()
-
-  try:
-    let req = await finished
-
-    try:
-      let wstransp = await self.wsserver.handleRequest(req).wait(self.handshakeTimeout)
-      let isSecure = self.httpservers[index].secure
-
-      return await self.connHandler(wstransp, isSecure, Direction.In)
-    except CatchableError as exc:
-      await noCancel req.stream.closeWait()
-      raise exc
-  except WebSocketError as exc:
-    debug "Websocket Error", description = exc.msg
-  except HttpError as exc:
-    debug "Http Error", description = exc.msg
-  except AsyncStreamError as exc:
-    debug "AsyncStream Error", description = exc.msg
-  except TransportTooManyError as exc:
-    debug "Too many files opened", description = exc.msg
-  except TransportAbortedError as exc:
-    debug "Connection aborted", description = exc.msg
-  except AsyncTimeoutError as exc:
-    debug "Timed out", description = exc.msg
-  except TransportUseClosedError as exc:
-    debug "Server was closed", description = exc.msg
-    raise newTransportClosedError(exc)
-  except CancelledError as exc:
-    raise exc
-  except TransportOsError as exc:
-    debug "OS Error", description = exc.msg
-  except CatchableError as exc:
-    info "Unexpected error accepting connection", description = exc.msg
-    raise newException(
-      transport.TransportError, "Error in WsTransport accept: " & exc.msg, exc
-    )
+  raise newTransportClosedError()
 
 method dial*(
     self: WsTransport,
@@ -411,9 +516,11 @@ proc new*(
     flags: set[ServerFlags] = {},
     factories: openArray[ExtFactory] = [],
     rng: ref HmacDrbgContext = nil,
-    handshakeTimeout = DefaultHeadersTimeout,
+    headersTimeout = DefaultHeadersTimeout,
+    concurrentAccepts = DefaultConcurrentAccepts,
 ): T {.raises: [].} =
   ## Creates a secure WebSocket transport
+  doAssert concurrentAccepts > 0, "concurrentAccepts must be positive"
 
   let self = T(
     upgrader: upgrade,
@@ -424,7 +531,8 @@ proc new*(
     flags: flags,
     factories: @factories,
     rng: rng,
-    handshakeTimeout: handshakeTimeout,
+    headersTimeout: headersTimeout,
+    concurrentAccepts: concurrentAccepts,
   )
   procCall Transport(self).initialize()
   self
@@ -435,7 +543,8 @@ proc new*(
     flags: set[ServerFlags] = {},
     factories: openArray[ExtFactory] = [],
     rng: ref HmacDrbgContext = nil,
-    handshakeTimeout = DefaultHeadersTimeout,
+    headersTimeout = DefaultHeadersTimeout,
+    concurrentAccepts = DefaultConcurrentAccepts,
 ): T {.raises: [].} =
   ## Creates a clear-text WebSocket transport
 
@@ -447,5 +556,6 @@ proc new*(
     flags = flags,
     factories = @factories,
     rng = rng,
-    handshakeTimeout = handshakeTimeout,
+    headersTimeout = headersTimeout,
+    concurrentAccepts = concurrentAccepts,
   )

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -28,10 +28,15 @@ export transport, websock, results
 
 const
   DefaultHeadersTimeout = 3.seconds
+  DefaultConcurrentAccepts = 200
   DefaultAutotlsWaitTimeout = 3.seconds
   DefaultAutotlsRetries = 3
 
 type
+  AcceptResult = object
+    conn: Connection
+    closed: bool
+
   WsStream = ref object of Connection
     session: WSSession
     when defined(libp2p_agents_metrics):
@@ -133,19 +138,156 @@ type WsTransport* = ref object of Transport
   httpservers: seq[HttpServer]
   wsserver: WSServer
   connections: array[Direction, seq[WsStream]]
-  acceptFuts: seq[Future[HttpRequest]]
+  acceptLoop: Future[void]
+  handshakeFuts: seq[Future[void]]
+  acceptResults: AsyncQueue[AcceptResult]
+  acceptSem: AsyncSemaphore
 
   tlsPrivateKey*: TLSPrivateKey
   tlsCertificate*: TLSCertificate
   autotls: Opt[AutotlsService]
   tlsFlags: set[TLSFlags]
   flags: set[ServerFlags]
-  handshakeTimeout: Duration
+  headersTimeout: Duration
+  concurrentAccepts: int
   factories: seq[ExtFactory]
   rng: Rng
 
 proc secure*(self: WsTransport): bool =
   not (isNil(self.tlsPrivateKey) or isNil(self.tlsCertificate))
+
+proc notifyAcceptClosed(self: WsTransport) {.raises: [].} =
+  if isNil(self.acceptResults):
+    return
+
+  try:
+    self.acceptResults.addLastNoWait(AcceptResult(closed: true))
+  except AsyncQueueFullError:
+    trace "Queue is full"
+
+proc releaseAcceptSlot(self: WsTransport) {.raises: [].} =
+  try:
+    self.acceptSem.release()
+  except AsyncSemaphoreError as exc:
+    trace "Error releasing WS accept semaphore", description = exc.msg
+
+proc closeHttpStream(stream: AsyncStream) {.async: (raises: []).} =
+  try:
+    await noCancel stream.closeWait()
+  except CatchableError as exc:
+    trace "Error closing HTTP stream", description = exc.msg
+
+proc connHandler(
+  self: WsTransport, stream: WSSession, secure: bool, dir: Direction
+): Future[Connection] {.async: (raises: [CatchableError]).}
+
+proc wsHandshakeWorker(
+    self: WsTransport, server: HttpServer, stream: AsyncStream
+) {.async: (raises: [CancelledError]).} =
+  var accepted = false
+  defer:
+    self.releaseAcceptSlot()
+
+  try:
+    let conn = await (
+      proc(): Future[Connection] {.async: (raises: [CatchableError]).} =
+        let req = await readHttpRequest(stream, server.headersTimeout)
+        let wstransp = await self.wsserver.handleRequest(req)
+        return await self.connHandler(wstransp, server.secure, Direction.In)
+    )()
+      .wait(self.headersTimeout)
+
+    await self.acceptResults.addLast(AcceptResult(conn: conn))
+    accepted = true
+  except WebSocketError as exc:
+    debug "Websocket Error", description = exc.msg
+  except HttpError as exc:
+    debug "Http Error", description = exc.msg
+  except AsyncStreamError as exc:
+    debug "AsyncStream Error", description = exc.msg
+  except AsyncTimeoutError as exc:
+    debug "Timed out", description = exc.msg
+  except CancelledError as exc:
+    if not accepted:
+      await noCancel closeHttpStream(stream)
+    raise exc
+  except CatchableError as exc:
+    debug "Unexpected error accepting websocket connection", description = exc.msg
+
+  if not accepted:
+    await closeHttpStream(stream)
+
+proc wsAcceptDispatcher(self: WsTransport) {.async: (raises: []).} =
+  var acceptFuts = self.httpservers.mapIt(it.acceptStream())
+  defer:
+    self.notifyAcceptClosed()
+
+  if acceptFuts.len == 0:
+    return
+
+  try:
+    while self.running:
+      self.handshakeFuts.keepItIf(not it.finished)
+
+      var acquired = false
+      try:
+        await self.acceptSem.acquire()
+        acquired = true
+
+        let finished =
+          try:
+            await one(acceptFuts)
+          except ValueError:
+            raiseAssert("accept futures should not be empty")
+
+        let index = acceptFuts.find(finished)
+        if index < 0:
+          if acquired:
+            self.releaseAcceptSlot()
+          continue
+
+        let server = self.httpservers[index]
+        acceptFuts[index] = server.acceptStream()
+
+        if finished.completed():
+          let stream = finished.read()
+          self.handshakeFuts.add(self.wsHandshakeWorker(server, stream))
+          acquired = false
+        elif finished.failed():
+          let exc = finished.error()
+          if exc of TransportUseClosedError:
+            debug "Server was closed", description = exc.msg
+          elif exc of TransportTooManyError:
+            debug "Too many files opened", description = exc.msg
+          elif exc of TransportAbortedError:
+            debug "Connection aborted", description = exc.msg
+          elif exc of TransportOsError:
+            debug "OS Error", description = exc.msg
+          else:
+            info "Unexpected error accepting websocket stream", description = exc.msg
+
+          if acquired:
+            self.releaseAcceptSlot()
+      except CancelledError:
+        if acquired:
+          self.releaseAcceptSlot()
+        break
+      except CatchableError as exc:
+        if acquired:
+          self.releaseAcceptSlot()
+        if self.running:
+          info "Unexpected error in websocket accept dispatcher", description = exc.msg
+        else:
+          break
+  finally:
+    for fut in acceptFuts:
+      if not fut.finished:
+        await noCancel fut.cancelAndWait()
+      elif fut.completed():
+        try:
+          await closeHttpStream(fut.read())
+        except CatchableError as exc:
+          trace "Error reading completed WS accept stream", description = exc.msg
 
 method start*(
     self: WsTransport, addrs: seq[MultiAddress]
@@ -179,11 +321,10 @@ method start*(
         except TLSStreamProtocolError as exc:
           raise newException(LPError, exc.msg, exc)
 
-  await procCall Transport(self).start(addrs)
-
   self.wsserver =
     WSServer.new(factories = self.factories, rng = bearSslDrbgRef(self.rng))
 
+  var resolvedAddrs = addrs
   for i, ma in addrs:
     let isWss =
       if WSS.match(ma):
@@ -199,15 +340,15 @@ method start*(
       try:
         let address = addrsTa[i]
         if isWss:
-          TlsHttpServer.create(
+          HttpServer.create(
             address = address,
             tlsPrivateKey = self.tlsPrivateKey,
             tlsCertificate = self.tlsCertificate,
             flags = self.flags,
-            headersTimeout = self.handshakeTimeout,
+            headersTimeout = self.headersTimeout,
           )
         else:
-          HttpServer.create(address, headersTimeout = self.handshakeTimeout)
+          HttpServer.create(address, headersTimeout = self.headersTimeout)
       except CatchableError as exc:
         raise (ref WsTransportError)(
           msg: "error in WsTransport start: " & exc.msg, parent: exc
@@ -225,8 +366,15 @@ method start*(
         MultiAddress.init("/ws")
 
     # always get the resolved address in case we're bound to 0.0.0.0:0
-    self.addrs[i] =
+    resolvedAddrs[i] =
       MultiAddress.init(httpserver.localAddress()).tryGet() & codec.tryGet()
+
+  self.acceptSem = newAsyncSemaphore(self.concurrentAccepts)
+  self.acceptResults = newAsyncQueue[AcceptResult](self.concurrentAccepts)
+  self.handshakeFuts = @[]
+
+  await procCall Transport(self).start(resolvedAddrs)
+  self.acceptLoop = self.wsAcceptDispatcher()
 
   trace "Listening on", addresses = self.addrs
 
@@ -235,22 +383,19 @@ method stop*(self: WsTransport) {.async: (raises: []).} =
   ##
 
   self.running = false # mark stopped as soon as possible
+  self.notifyAcceptClosed()
 
   try:
     trace "Stopping WS transport"
     await procCall Transport(self).stop() # call base
 
-    discard await allFinished(
-      self.connections[Direction.In].mapIt(it.close()) &
-        self.connections[Direction.Out].mapIt(it.close())
-    )
-
     var toWait: seq[Future[void]]
-    for fut in self.acceptFuts:
+    if not isNil(self.acceptLoop) and not self.acceptLoop.finished:
+      toWait.add(self.acceptLoop.cancelAndWait())
+
+    for fut in self.handshakeFuts:
       if not fut.finished:
         toWait.add(fut.cancelAndWait())
-      elif fut.completed:
-        toWait.add(fut.read().stream.closeWait())
 
     for server in self.httpservers:
       server.stop()
@@ -258,7 +403,14 @@ method stop*(self: WsTransport) {.async: (raises: []).} =
 
     await allFutures(toWait)
 
+    discard await allFinished(
+      self.connections[Direction.In].mapIt(it.close()) &
+        self.connections[Direction.Out].mapIt(it.close())
+    )
+
     self.httpservers = @[]
+    self.handshakeFuts = @[]
+    self.acceptLoop = nil
     trace "Transport stopped"
   except CatchableError as exc:
     trace "Error shutting down ws transport", description = exc.msg
@@ -306,7 +458,7 @@ method accept*(
   trace "WsTransport accept"
 
   # wstransport can only start accepting connections after autotls is done
-  # if autotls is not present, self.running will be true right after start is called
+  # if autotls is not present, self.running is true after listener setup completes
   var retries = 0
   while not self.running and retries < DefaultAutotlsRetries:
     retries += 1
@@ -315,58 +467,11 @@ method accept*(
   if not self.running:
     raise newTransportClosedError()
 
-  if self.acceptFuts.len <= 0:
-    self.acceptFuts = self.httpservers.mapIt(it.accept())
+  let res = await self.acceptResults.popFirst()
+  if not isNil(res.conn):
+    return res.conn
 
-  if self.acceptFuts.len <= 0:
-    return
-
-  let finished =
-    try:
-      await one(self.acceptFuts)
-    except ValueError:
-      raiseAssert("already checked with if")
-    except CancelledError as e:
-      raise e
-
-  let index = self.acceptFuts.find(finished)
-  self.acceptFuts[index] = self.httpservers[index].accept()
-
-  try:
-    let req = await finished
-
-    try:
-      let wstransp = await self.wsserver.handleRequest(req).wait(self.handshakeTimeout)
-      let isSecure = self.httpservers[index].secure
-
-      return await self.connHandler(wstransp, isSecure, Direction.In)
-    except CatchableError as exc:
-      await noCancel req.stream.closeWait()
-      raise exc
-  except WebSocketError as exc:
-    debug "Websocket Error", description = exc.msg
-  except HttpError as exc:
-    debug "Http Error", description = exc.msg
-  except AsyncStreamError as exc:
-    debug "AsyncStream Error", description = exc.msg
-  except TransportTooManyError as exc:
-    debug "Too many files opened", description = exc.msg
-  except TransportAbortedError as exc:
-    debug "Connection aborted", description = exc.msg
-  except AsyncTimeoutError as exc:
-    debug "Timed out", description = exc.msg
-  except TransportUseClosedError as exc:
-    debug "Server was closed", description = exc.msg
-    raise newTransportClosedError(exc)
-  except CancelledError as exc:
-    raise exc
-  except TransportOsError as exc:
-    debug "OS Error", description = exc.msg
-  except CatchableError as exc:
-    info "Unexpected error accepting connection", description = exc.msg
-    raise newException(
-      transport.TransportError, "Error in WsTransport accept: " & exc.msg, exc
-    )
+  raise newTransportClosedError()
 
 method dial*(
     self: WsTransport,
@@ -418,9 +523,11 @@ proc new*(
     tlsFlags: set[TLSFlags] = {},
     flags: set[ServerFlags] = {},
     factories: openArray[ExtFactory] = [],
-    handshakeTimeout = DefaultHeadersTimeout,
+    headersTimeout = DefaultHeadersTimeout,
+    concurrentAccepts = DefaultConcurrentAccepts,
 ): T {.raises: [].} =
   ## Creates a secure WebSocket transport
+  doAssert concurrentAccepts > 0, "concurrentAccepts must be positive"
 
   doAssert not rng.isNil, "Rng is nil"
 
@@ -433,7 +540,8 @@ proc new*(
     flags: flags,
     factories: @factories,
     rng: rng,
-    handshakeTimeout: handshakeTimeout,
+    headersTimeout: headersTimeout,
+    concurrentAccepts: concurrentAccepts,
   )
   procCall Transport(self).initialize()
   self
@@ -444,7 +552,8 @@ proc new*(
     rng: Rng,
     flags: set[ServerFlags] = {},
     factories: openArray[ExtFactory] = [],
-    handshakeTimeout = DefaultHeadersTimeout,
+    headersTimeout = DefaultHeadersTimeout,
+    concurrentAccepts = DefaultConcurrentAccepts,
 ): T {.raises: [].} =
   ## Creates a clear-text WebSocket transport
 
@@ -456,5 +565,6 @@ proc new*(
     flags = flags,
     factories = @factories,
     rng = rng,
-    handshakeTimeout = handshakeTimeout,
+    headersTimeout = headersTimeout,
+    concurrentAccepts = concurrentAccepts,
   )

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -29,14 +29,11 @@ export transport, websock, results
 const
   DefaultHeadersTimeout = 3.seconds
   DefaultConcurrentAccepts = 200
+  DefaultAcceptFailureBackoff = 100.millis
   DefaultAutotlsWaitTimeout = 3.seconds
   DefaultAutotlsRetries = 3
 
 type
-  AcceptResult = object
-    conn: Connection
-    closed: bool
-
   WsStream = ref object of Connection
     session: WSSession
     when defined(libp2p_agents_metrics):
@@ -140,7 +137,7 @@ type WsTransport* = ref object of Transport
   connections: array[Direction, seq[WsStream]]
   acceptLoop: Future[void]
   handshakeFuts: seq[Future[void]]
-  acceptResults: AsyncQueue[AcceptResult]
+  acceptResults: AsyncQueue[Connection]
   acceptSem: AsyncSemaphore
 
   tlsPrivateKey*: TLSPrivateKey
@@ -157,25 +154,25 @@ proc secure*(self: WsTransport): bool =
   not (isNil(self.tlsPrivateKey) or isNil(self.tlsCertificate))
 
 proc notifyAcceptClosed(self: WsTransport) {.raises: [].} =
-  if isNil(self.acceptResults):
+  if self.acceptResults.isNil:
     return
 
   try:
-    self.acceptResults.addLastNoWait(AcceptResult(closed: true))
+    self.acceptResults.addLastNoWait(nil)
   except AsyncQueueFullError:
     trace "Queue is full"
 
 proc releaseAcceptSlot(self: WsTransport) {.raises: [].} =
   try:
     self.acceptSem.release()
-  except AsyncSemaphoreError as exc:
-    trace "Error releasing WS accept semaphore", description = exc.msg
+  except AsyncSemaphoreError as e:
+    trace "Error releasing WS accept semaphore", description = e.msg
 
 proc closeHttpStream(stream: AsyncStream) {.async: (raises: []).} =
   try:
     await noCancel stream.closeWait()
-  except CatchableError as exc:
-    trace "Error closing HTTP stream", description = exc.msg
+  except CatchableError as e:
+    trace "Error closing HTTP stream", description = e.msg
 
 proc connHandler(
   self: WsTransport, stream: WSSession, secure: bool, dir: Direction
@@ -197,32 +194,33 @@ proc wsHandshakeWorker(
     )()
       .wait(self.headersTimeout)
 
-    await self.acceptResults.addLast(AcceptResult(conn: conn))
+    await self.acceptResults.addLast(conn)
     accepted = true
-  except WebSocketError as exc:
-    debug "Websocket Error", description = exc.msg
-  except HttpError as exc:
-    debug "Http Error", description = exc.msg
-  except AsyncStreamError as exc:
-    debug "AsyncStream Error", description = exc.msg
-  except AsyncTimeoutError as exc:
-    debug "Timed out", description = exc.msg
-  except CancelledError as exc:
+  except WebSocketError as e:
+    debug "Websocket Error", description = e.msg
+  except HttpError as e:
+    debug "Http Error", description = e.msg
+  except AsyncStreamError as e:
+    debug "AsyncStream Error", description = e.msg
+  except AsyncTimeoutError as e:
+    debug "Timed out", description = e.msg
+  except CancelledError as e:
     if not accepted:
       await noCancel closeHttpStream(stream)
-    raise exc
-  except CatchableError as exc:
-    debug "Unexpected error accepting websocket connection", description = exc.msg
+    raise e
+  except CatchableError as e:
+    debug "Unexpected error accepting websocket connection", description = e.msg
 
   if not accepted:
     await closeHttpStream(stream)
 
 proc wsAcceptDispatcher(self: WsTransport) {.async: (raises: []).} =
-  var acceptFuts = self.httpservers.mapIt(it.acceptStream())
-  defer:
-    self.notifyAcceptClosed()
+  var acceptServers = self.httpservers
+  var acceptFuts = acceptServers.mapIt(it.acceptStream())
+  var notifyOnClose = false
 
   if acceptFuts.len == 0:
+    self.notifyAcceptClosed()
     return
 
   try:
@@ -241,16 +239,11 @@ proc wsAcceptDispatcher(self: WsTransport) {.async: (raises: []).} =
             raiseAssert("accept futures should not be empty")
 
         let index = acceptFuts.find(finished)
-        if index < 0:
-          if acquired:
-            self.releaseAcceptSlot()
-          continue
-
-        let server = self.httpservers[index]
-        acceptFuts[index] = server.acceptStream()
+        let server = acceptServers[index]
 
         if finished.completed():
           let stream = finished.read()
+          acceptFuts[index] = server.acceptStream()
           self.handshakeFuts.add(self.wsHandshakeWorker(server, stream))
           acquired = false
         elif finished.failed():
@@ -268,15 +261,28 @@ proc wsAcceptDispatcher(self: WsTransport) {.async: (raises: []).} =
 
           if acquired:
             self.releaseAcceptSlot()
+            acquired = false
+
+          if exc of TransportUseClosedError:
+            acceptFuts.delete(index)
+            acceptServers.delete(index)
+            if acceptFuts.len == 0:
+              self.running = false
+              notifyOnClose = true
+              break
+          elif self.running:
+            await sleepAsync(DefaultAcceptFailureBackoff)
+            if self.running:
+              acceptFuts[index] = server.acceptStream()
       except CancelledError:
         if acquired:
           self.releaseAcceptSlot()
         break
-      except CatchableError as exc:
+      except CatchableError as e:
         if acquired:
           self.releaseAcceptSlot()
         if self.running:
-          info "Unexpected error in websocket accept dispatcher", description = exc.msg
+          info "Unexpected error in websocket accept dispatcher", description = e.msg
         else:
           break
   finally:
@@ -286,8 +292,22 @@ proc wsAcceptDispatcher(self: WsTransport) {.async: (raises: []).} =
       elif fut.completed():
         try:
           await closeHttpStream(fut.read())
-        except CatchableError as exc:
-          trace "Error reading completed WS accept stream", description = exc.msg
+        except CatchableError as e:
+          trace "Error reading completed WS accept stream", description = e.msg
+
+    if notifyOnClose:
+      var toWait: seq[Future[void]]
+      for fut in self.handshakeFuts:
+        if not fut.finished:
+          toWait.add(fut.cancelAndWait())
+
+      if toWait.len > 0:
+        try:
+          await noCancel allFutures(toWait)
+        except CatchableError as e:
+          trace "Error stopping WS handshake workers", description = e.msg
+
+      self.notifyAcceptClosed()
 
 method start*(
     self: WsTransport, addrs: seq[MultiAddress]
@@ -316,10 +336,10 @@ method start*(
           let autotlsCert = await autotls.getCertWhenReady()
           self.tlsCertificate = autotlsCert.cert
           self.tlsPrivateKey = autotlsCert.privkey
-        except AutoTLSError as exc:
-          raise newException(LPError, exc.msg, exc)
-        except TLSStreamProtocolError as exc:
-          raise newException(LPError, exc.msg, exc)
+        except AutoTLSError as e:
+          raise newException(LPError, e.msg, e)
+        except TLSStreamProtocolError as e:
+          raise newException(LPError, e.msg, e)
 
   self.wsserver =
     WSServer.new(factories = self.factories, rng = bearSslDrbgRef(self.rng))
@@ -349,10 +369,9 @@ method start*(
           )
         else:
           HttpServer.create(address, headersTimeout = self.headersTimeout)
-      except CatchableError as exc:
-        raise (ref WsTransportError)(
-          msg: "error in WsTransport start: " & exc.msg, parent: exc
-        )
+      except CatchableError as e:
+        raise
+          (ref WsTransportError)(msg: "error in WsTransport start: " & e.msg, parent: e)
 
     self.httpservers &= httpserver
 
@@ -370,7 +389,7 @@ method start*(
       MultiAddress.init(httpserver.localAddress()).tryGet() & codec.tryGet()
 
   self.acceptSem = newAsyncSemaphore(self.concurrentAccepts)
-  self.acceptResults = newAsyncQueue[AcceptResult](self.concurrentAccepts)
+  self.acceptResults = newAsyncQueue[Connection](self.concurrentAccepts)
   self.handshakeFuts = @[]
 
   await procCall Transport(self).start(resolvedAddrs)
@@ -383,7 +402,6 @@ method stop*(self: WsTransport) {.async: (raises: []).} =
   ##
 
   self.running = false # mark stopped as soon as possible
-  self.notifyAcceptClosed()
 
   try:
     trace "Stopping WS transport"
@@ -412,8 +430,10 @@ method stop*(self: WsTransport) {.async: (raises: []).} =
     self.handshakeFuts = @[]
     self.acceptLoop = nil
     trace "Transport stopped"
-  except CatchableError as exc:
-    trace "Error shutting down ws transport", description = exc.msg
+  except CatchableError as e:
+    trace "Error shutting down ws transport", description = e.msg
+  finally:
+    self.notifyAcceptClosed()
 
 proc connHandler(
     self: WsTransport, stream: WSSession, secure: bool, dir: Direction
@@ -435,11 +455,11 @@ proc connHandler(
         MultiAddress.init(remoteAddr).tryGet() & codec.tryGet(),
         MultiAddress.init(localAddr).tryGet() & codec.tryGet(),
       )
-    except CatchableError as exc:
-      trace "Failed to create observedAddr or listenAddr", description = exc.msg
+    except CatchableError as e:
+      trace "Failed to create observedAddr or listenAddr", description = e.msg
       if not (isNil(stream) and stream.stream.reader.closed):
         safeClose(stream)
-      raise exc
+      raise e
 
   let conn = WsStream.new(stream, dir, Opt.some(observedAddr), Opt.some(localAddr))
 
@@ -467,9 +487,9 @@ method accept*(
   if not self.running:
     raise newTransportClosedError()
 
-  let res = await self.acceptResults.popFirst()
-  if not isNil(res.conn):
-    return res.conn
+  let conn = await self.acceptResults.popFirst()
+  if not conn.isNil:
+    return conn
 
   raise newTransportClosedError()
 

--- a/tests/libp2p/transports/stream_tests.nim
+++ b/tests/libp2p/transports/stream_tests.nim
@@ -503,6 +503,7 @@ template streamTransportTest*(
     const chunkCount = 32
     const messageSize = chunkSize * chunkCount
     const numConnections = 5
+    const errorClientId: byte = 0xff
     var serverReadOrder: seq[byte] = @[]
 
     # Track when stream handlers complete
@@ -533,10 +534,18 @@ template streamTransportTest*(
                 # Doing this improves likelihood of parallel data transition on the connections.
                 await sleepAsync(rand(20 .. 100).milliseconds)
 
-              check receivedData == newData(messageSize, byte(handlerIndex))
+              # Concurrent transports may accept clients in a different order.
+              let clientId =
+                if receivedData.len > 0:
+                  receivedData[0]
+                else:
+                  errorClientId
+              check:
+                clientId.int < numConnections
+                receivedData == newData(messageSize, clientId)
 
               # Send back ID
-              await stream.write(@[byte(receivedData[0])])
+              await stream.write(@[clientId])
 
               # Signal that this stream handler is done
               serverStreamHandlerFuts[handlerIndex].complete()

--- a/tests/libp2p/transports/stream_tests.nim
+++ b/tests/libp2p/transports/stream_tests.nim
@@ -505,7 +505,6 @@ template streamTransportTest*(
     const chunkCount = 32
     const messageSize = chunkSize * chunkCount
     const numConnections = 5
-    const errorClientId: byte = 0xff
     var serverReadOrder: seq[byte] = @[]
 
     # Track when stream handlers complete
@@ -537,11 +536,8 @@ template streamTransportTest*(
                 await sleepAsync(rand(20 .. 100).milliseconds)
 
               # Concurrent transports may accept clients in a different order.
-              let clientId =
-                if receivedData.len > 0:
-                  receivedData[0]
-                else:
-                  errorClientId
+              require receivedData.len > 0
+              let clientId = receivedData[0]
               check:
                 clientId.int < numConnections
                 receivedData == newData(messageSize, clientId)

--- a/tests/libp2p/transports/stream_tests.nim
+++ b/tests/libp2p/transports/stream_tests.nim
@@ -505,6 +505,7 @@ template streamTransportTest*(
     const chunkCount = 32
     const messageSize = chunkSize * chunkCount
     const numConnections = 5
+    const errorClientId: byte = 0xff
     var serverReadOrder: seq[byte] = @[]
 
     # Track when stream handlers complete
@@ -535,10 +536,18 @@ template streamTransportTest*(
                 # Doing this improves likelihood of parallel data transition on the connections.
                 await sleepAsync(rand(20 .. 100).milliseconds)
 
-              check receivedData == newData(messageSize, byte(handlerIndex))
+              # Concurrent transports may accept clients in a different order.
+              let clientId =
+                if receivedData.len > 0:
+                  receivedData[0]
+                else:
+                  errorClientId
+              check:
+                clientId.int < numConnections
+                receivedData == newData(messageSize, clientId)
 
               # Send back ID
-              await stream.write(@[byte(receivedData[0])])
+              await stream.write(@[clientId])
 
               # Signal that this stream handler is done
               serverStreamHandlerFuts[handlerIndex].complete()

--- a/tests/libp2p/transports/test_ws.nim
+++ b/tests/libp2p/transports/test_ws.nim
@@ -12,6 +12,7 @@ import
     transports/wstransport,
     upgrademngrs/upgrade,
     multiaddress,
+    wire,
     errors,
     muxers/muxer,
     muxers/mplex/mplex,
@@ -85,6 +86,40 @@ suite "WebSocket transport":
 
   connectionTransportTest(wsTransProvider, wsAddress)
   connectionTransportTest(wsSecureTransProvider, wsSecureAddress)
+
+  asyncTest "slow WebSocket headers do not block valid accepts":
+    let server =
+      WsTransport.new(Upgrade(), headersTimeout = 3.seconds, concurrentAccepts = 2)
+    await server.start(@[MultiAddress.init(wsAddress).get()])
+    defer:
+      await server.stop()
+
+    let rawAddr = server.addrs[0].initTAddress().tryGet()
+    let slow = await connect(rawAddr)
+    var slowClosed = false
+    defer:
+      if not slowClosed:
+        slow.close()
+
+    # Give the server time to wait for this stream in header parsing.
+    discard await slow.write("GET / HTTP/1.1\r\nUpgrade: websocket\r\n")
+    await sleepAsync(500.millis)
+
+    let client = wsTransProvider()
+    defer:
+      await client.stop()
+
+    # The valid WebSocket handshake must not wait for the slow one to time out.
+    let outboundFut = client.dial(server.addrs[0])
+    let inbound = await server.accept().wait(1.seconds)
+    let outbound = await outboundFut.wait(1.seconds)
+
+    slow.close()
+    slowClosed = true
+
+    let outboundClosing = outbound.close()
+    await inbound.close()
+    await outboundClosing
 
   streamTransportTest(
     wsTransProvider,

--- a/tests/libp2p/transports/test_ws.nim
+++ b/tests/libp2p/transports/test_ws.nim
@@ -89,10 +89,9 @@ suite "WebSocket transport":
   connectionTransportTest(wsSecureTransProvider, wsSecureAddress)
 
   asyncTest "slow WebSocket headers do not block valid accepts":
-    let server =
-      WsTransport.new(
-        Upgrade(), rng(), headersTimeout = 3.seconds, concurrentAccepts = 2
-      )
+    let server = WsTransport.new(
+      Upgrade(), rng(), headersTimeout = 3.seconds, concurrentAccepts = 2
+    )
     await server.start(@[MultiAddress.init(wsAddress).get()])
     defer:
       await server.stop()
@@ -100,13 +99,22 @@ suite "WebSocket transport":
     let rawAddr = server.addrs[0].initTAddress().tryGet()
     let slow = await connect(rawAddr)
     var slowClosed = false
-    defer:
-      if not slowClosed:
-        slow.close()
+    proc closeSlow() {.async: (raises: []).} =
+      if slowClosed:
+        return
 
-    # Give the server time to wait for this stream in header parsing.
+      slowClosed = true
+      try:
+        await noCancel slow.closeWait()
+      except CatchableError:
+        discard
+
+    defer:
+      await closeSlow()
+
+    # Keep this raw stream open with incomplete headers while a valid
+    # WebSocket handshake is accepted.
     discard await slow.write("GET / HTTP/1.1\r\nUpgrade: websocket\r\n")
-    await sleepAsync(500.millis)
 
     let client = wsTransProvider()
     defer:
@@ -117,8 +125,7 @@ suite "WebSocket transport":
     let inbound = await server.accept().wait(1.seconds)
     let outbound = await outboundFut.wait(1.seconds)
 
-    slow.close()
-    slowClosed = true
+    await closeSlow()
 
     let outboundClosing = outbound.close()
     await inbound.close()

--- a/tests/libp2p/transports/test_ws.nim
+++ b/tests/libp2p/transports/test_ws.nim
@@ -12,6 +12,7 @@ import
     transports/wstransport,
     upgrademngrs/upgrade,
     multiaddress,
+    wire,
     errors,
     muxers/muxer,
     muxers/mplex/mplex,
@@ -86,6 +87,42 @@ suite "WebSocket transport":
 
   connectionTransportTest(wsTransProvider, wsAddress)
   connectionTransportTest(wsSecureTransProvider, wsSecureAddress)
+
+  asyncTest "slow WebSocket headers do not block valid accepts":
+    let server =
+      WsTransport.new(
+        Upgrade(), rng(), headersTimeout = 3.seconds, concurrentAccepts = 2
+      )
+    await server.start(@[MultiAddress.init(wsAddress).get()])
+    defer:
+      await server.stop()
+
+    let rawAddr = server.addrs[0].initTAddress().tryGet()
+    let slow = await connect(rawAddr)
+    var slowClosed = false
+    defer:
+      if not slowClosed:
+        slow.close()
+
+    # Give the server time to wait for this stream in header parsing.
+    discard await slow.write("GET / HTTP/1.1\r\nUpgrade: websocket\r\n")
+    await sleepAsync(500.millis)
+
+    let client = wsTransProvider()
+    defer:
+      await client.stop()
+
+    # The valid WebSocket handshake must not wait for the slow one to time out.
+    let outboundFut = client.dial(server.addrs[0])
+    let inbound = await server.accept().wait(1.seconds)
+    let outbound = await outboundFut.wait(1.seconds)
+
+    slow.close()
+    slowClosed = true
+
+    let outboundClosing = outbound.close()
+    await inbound.close()
+    await outboundClosing
 
   streamTransportTest(
     wsTransProvider,


### PR DESCRIPTION
## Summary

This PR fixes WebSocket accept head-of-line blocking caused by slow or malformed HTTP upgrade requests.

`WsTransport` now accepts raw HTTP streams separately from WebSocket handshake parsing. A dispatcher owns `HttpServer.acceptStream()`, while bounded handshake workers parse headers with `readHttpRequest()` and pass valid requests to `WSServer.handleRequest()`. Successfully upgraded connections are queued for `WsTransport.accept()`.

This prevents one incomplete WebSocket handshake from blocking later valid WebSocket connections until the header timeout expires.

Requires:
- https://github.com/status-im/nim-websock/pull/193

Should fix:
- https://github.com/logos-messaging/logos-delivery/issues/3634

## Affected Areas

- [ ] Gossipsub
- [x] Transports  
  WebSocket transport accept/handshake path, dependency bump to `nim-websock` PR 193. Do not merge until then
- [ ] Peer Management / Discovery
- [ ] Protocol Logic
- [ ] Build / Tooling  
- [ ] Other

## Compatibility & Downstream Validation

Reference PRs / branches / commits demonstrating successful integration:

- **Nimbus:**  
  N/A

- **Waku:**  
  N/A

- **Codex:**  
  N/A

## Impact on Library Users

This changes the public `WsTransport.new` timeout parameter from `handshakeTimeout` to `headersTimeout`, with the former being deprecated in nim-websocks.

Behaviorally, malformed or slow WebSocket handshakes are now handled inside the transport and should no longer cause the switch accept loop to stop or block valid WebSocket accepts behind header timeouts.

The WebSocket transport also gains a configurable `concurrentAccepts` limit, defaulting to `200`, to bound concurrent handshake work and accepted-connection queueing.

## Risk Assessment

Risk is moderate because this changes the WebSocket accept path and task lifecycle.

Main risks:
- Accept ordering is no longer deterministic when multiple WebSocket handshakes are in flight.
- Downstreams using the old named constructor argument `handshakeTimeout` must rename it to `headersTimeout`.
- Very large malformed-connection floods can still consume bounded accept worker capacity, sockets, TLS resources, or OS backlog, but they should no longer serialize all WebSocket accepts one header timeout at a time.

Mitigations:
- Handshake concurrency is bounded.
- Successful accepts are queued through a bounded internal queue.
- Malformed and slow handshakes are logged and closed inside the transport.
- WebSocket transport tests include a regression for slow incomplete headers not blocking a valid accept.

## References

- https://github.com/logos-messaging/logos-delivery/issues/3634
- https://github.com/status-im/nim-websock/pull/193
- Consumed `nim-websock` commit: `1c12189667ff5586cb81a2e43fd4a19190b7060d`

## Additional Notes

Verified locally with:

```sh
nim c --path:. tests/libp2p/transports/test_ws.nim
./tests/libp2p/transports/test_ws --output-level=VERBOSE
