### PR TITLE
test(interop): perf

### DIFF
--- a/interop/perf/Dockerfile
+++ b/interop/perf/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1.5-labs
+FROM nimlang/nim:2.2.6-ubuntu-regular as builder
+
+WORKDIR /app
+
+COPY .pinned libp2p.nimble nim-libp2p/
+
+RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y --no-install-recommends ca-certificates binutils \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN cd nim-libp2p && nimble install_pinned && nimble install redis -y
+
+COPY . nim-libp2p/
+
+RUN \
+  cd nim-libp2p && \
+  nim c -d:release --skipProjCfg --skipParentCfg --NimblePath:./nimbledeps/pkgs2 -p:nim-libp2p --mm:refc -d:chronicles_log_level=INFO -d:chronicles_default_output_device=stderr -d:chronicles_colors=None --threads:on -o:/app/perf-interop ./interop/perf/main.nim
+
+FROM debian:trixie-slim AS runtime
+
+COPY --from=builder /app/perf-interop /app/perf-interop
+
+ENTRYPOINT ["/app/perf-interop"]

--- a/interop/perf/README.md
+++ b/interop/perf/README.md
@@ -1,0 +1,3 @@
+# Perf Interop Test App
+
+Test app for [libp2p/unified-testing](https://github.com/libp2p/unified-testing) perf tests.

--- a/interop/perf/main.nim
+++ b/interop/perf/main.nim
@@ -3,6 +3,7 @@
 
 import chronos, chronicles, os
 import ../../libp2p/builders
+import ../../tests/tools/crypto
 import ../unified_testing
 import ./measurements
 
@@ -53,7 +54,7 @@ proc readConfig(): Config =
   config
 
 proc createSwitch(config: Config, mountPerfProto: bool): Switch =
-  var builder = SwitchBuilder.new().withRng(newRng())
+  var builder = SwitchBuilder.new().withRng(rng())
   builder.addTransport(
     config.transport, config.bindIp, tcpFlags = {ServerFlags.TcpNoDelay}
   )
@@ -122,14 +123,10 @@ proc runDialer(config: Config) {.async.} =
   echo ""
   printMeasurement("latency", config.latencyIterations, latencyStats, 3, "ms")
 
-let testTimeout = parseIntEnv("TEST_TIMEOUT_SECS", DefaultTestTimeoutSecs).seconds
+let config = readConfig()
 
-proc main() {.async.} =
-  let config = readConfig()
+runMain(config.testTimeoutSecs.seconds):
   if config.isDialer:
     await runDialer(config)
   else:
     await runListener(config)
-
-runMain(testTimeout):
-  await main()

--- a/interop/perf/main.nim
+++ b/interop/perf/main.nim
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+import chronos, chronicles, os
+import ../../libp2p/builders
+import ../unified_testing
+import ./measurements
+
+logScope:
+  topics = "perf interop"
+
+const
+  DefaultUploadBytes = 1_073_741_824'u64
+  DefaultDownloadBytes = 1_073_741_824'u64
+  DefaultUploadIterations = 10
+  DefaultDownloadIterations = 10
+  DefaultLatencyIterations = 100
+  DefaultTestTimeoutSecs = 600
+  DialTimeout = 30.seconds
+
+type Config = object
+  isDialer: bool
+  bindIp: string
+  redisAddr: string
+  testKey: string
+  transport: string
+  secureChannel: string
+  muxer: string
+  uploadBytes: uint64
+  downloadBytes: uint64
+  uploadIterations: int
+  downloadIterations: int
+  latencyIterations: int
+  testTimeoutSecs: int
+
+proc readConfig(): Config =
+  let config = Config(
+    isDialer: parseBoolEnv("IS_DIALER", false),
+    bindIp: resolveBindIp(getEnv("LISTENER_IP", "0.0.0.0")),
+    redisAddr: getEnv("REDIS_ADDR", "redis:6379"),
+    testKey: getEnv("TEST_KEY"),
+    transport: getEnv("TRANSPORT", "tcp"),
+    secureChannel: getEnv("SECURE_CHANNEL", ""),
+    muxer: getEnv("MUXER", ""),
+    uploadBytes: parseUint64Env("UPLOAD_BYTES", DefaultUploadBytes),
+    downloadBytes: parseUint64Env("DOWNLOAD_BYTES", DefaultDownloadBytes),
+    uploadIterations: parseIntEnv("UPLOAD_ITERATIONS", DefaultUploadIterations),
+    downloadIterations: parseIntEnv("DOWNLOAD_ITERATIONS", DefaultDownloadIterations),
+    latencyIterations: parseIntEnv("LATENCY_ITERATIONS", DefaultLatencyIterations),
+    testTimeoutSecs: parseIntEnv("TEST_TIMEOUT_SECS", DefaultTestTimeoutSecs),
+  )
+  info "Loaded perf interop configuration", config
+  config
+
+proc createSwitch(config: Config, mountPerfProto: bool): Switch =
+  var builder = SwitchBuilder.new().withRng(newRng())
+  builder.addTransport(config.transport, config.bindIp)
+  builder.addSecureChannel(config.secureChannel)
+  builder.addMuxer(config.muxer)
+
+  let sw = builder.build()
+  if mountPerfProto:
+    sw.mountPerf()
+  sw
+
+proc runListener(config: Config) {.async.} =
+  let
+    redisClient = setupRedis(config.redisAddr)
+    sw = createSwitch(config, mountPerfProto = true)
+
+  await sw.start()
+  defer:
+    await sw.stop()
+
+  let listenerAddrs = sw.peerInfo.fullAddrs.tryGet()
+  if listenerAddrs.len == 0:
+    raise newException(CatchableError, "Listener did not expose any listen addresses")
+
+  let listenerAddr = $listenerAddrs[0]
+  redisClient.setk(config.testKey & "_listener_multiaddr", listenerAddr)
+  info "Published listener multiaddr", listenerAddr
+
+  await sleepAsync(100.hours)
+
+proc runDialer(config: Config) {.async.} =
+  let
+    redisClient = setupRedis(config.redisAddr)
+    listenerAddr = await redisClient.pollGet(config.testKey & "_listener_multiaddr")
+    sw = createSwitch(config, mountPerfProto = false)
+
+  await sw.start()
+  defer:
+    await sw.stop()
+
+  let remoteMA = MultiAddress.init(listenerAddr).tryGet()
+  let remotePeerId =
+    try:
+      await sw.connect(remoteMA).wait(DialTimeout)
+    except AsyncTimeoutError as e:
+      raise newException(
+        CatchableError,
+        "Timeout connecting to listener at " & listenerAddr & ": " & e.msg,
+        e,
+      )
+  info "Connected to listener", remotePeerId, listenerAddr
+
+  let
+    uploadStats = await runMeasurement(
+      sw, remotePeerId, config.uploadBytes, 0'u64, config.uploadIterations
+    )
+    downloadStats = await runMeasurement(
+      sw, remotePeerId, 0'u64, config.downloadBytes, config.downloadIterations
+    )
+    latencyStats =
+      await runMeasurement(sw, remotePeerId, 1'u64, 1'u64, config.latencyIterations)
+
+  printMeasurement("upload", config.uploadIterations, uploadStats, 2, "Gbps")
+  echo ""
+  printMeasurement("download", config.downloadIterations, downloadStats, 2, "Gbps")
+  echo ""
+  printMeasurement("latency", config.latencyIterations, latencyStats, 3, "ms")
+
+let testTimeout = parseIntEnv("TEST_TIMEOUT_SECS", DefaultTestTimeoutSecs).seconds
+
+proc main() {.async.} =
+  let config = readConfig()
+  if config.isDialer:
+    await runDialer(config)
+  else:
+    await runListener(config)
+
+runMain(testTimeout):
+  await main()

--- a/interop/perf/main.nim
+++ b/interop/perf/main.nim
@@ -16,7 +16,7 @@ const
   DefaultUploadIterations = 10
   DefaultDownloadIterations = 10
   DefaultLatencyIterations = 100
-  DefaultTestTimeoutSecs = 600
+  DefaultTestTimeout = 600.seconds
   DialTimeout = 30.seconds
 
 type Config = object
@@ -32,7 +32,7 @@ type Config = object
   uploadIterations: int
   downloadIterations: int
   latencyIterations: int
-  testTimeoutSecs: int
+  testTimeout: Duration
 
 proc readConfig(): Config =
   let config = Config(
@@ -48,7 +48,7 @@ proc readConfig(): Config =
     uploadIterations: parseIntEnv("UPLOAD_ITERATIONS", DefaultUploadIterations),
     downloadIterations: parseIntEnv("DOWNLOAD_ITERATIONS", DefaultDownloadIterations),
     latencyIterations: parseIntEnv("LATENCY_ITERATIONS", DefaultLatencyIterations),
-    testTimeoutSecs: parseIntEnv("TEST_TIMEOUT_SECS", DefaultTestTimeoutSecs),
+    testTimeout: parseDurationEnv("TEST_TIMEOUT_SECS", 1.seconds, DefaultTestTimeout),
   )
   info "Loaded perf interop configuration", config
   config
@@ -83,6 +83,7 @@ proc runListener(config: Config) {.async.} =
   redisClient.setk(config.testKey & "_listener_multiaddr", listenerAddr)
   info "Published listener multiaddr", listenerAddr
 
+  # Listener stays alive until terminated by the test harness.
   await sleepAsync(100.hours)
 
 proc runDialer(config: Config) {.async.} =
@@ -118,15 +119,16 @@ proc runDialer(config: Config) {.async.} =
       await runMeasurement(sw, remotePeerId, 1'u64, 1'u64, config.latencyIterations)
 
   printMeasurement("upload", config.uploadIterations, uploadStats, 2, "Gbps")
-  echo ""
   printMeasurement("download", config.downloadIterations, downloadStats, 2, "Gbps")
-  echo ""
   printMeasurement("latency", config.latencyIterations, latencyStats, 3, "ms")
 
-let config = readConfig()
+proc main() =
+  let config = readConfig()
 
-runMain(config.testTimeoutSecs.seconds):
-  if config.isDialer:
-    await runDialer(config)
-  else:
-    await runListener(config)
+  runMain(config.testTimeout):
+    if config.isDialer:
+      await runDialer(config)
+    else:
+      await runListener(config)
+
+main()

--- a/interop/perf/main.nim
+++ b/interop/perf/main.nim
@@ -54,7 +54,9 @@ proc readConfig(): Config =
 
 proc createSwitch(config: Config, mountPerfProto: bool): Switch =
   var builder = SwitchBuilder.new().withRng(newRng())
-  builder.addTransport(config.transport, config.bindIp)
+  builder.addTransport(
+    config.transport, config.bindIp, tcpFlags = {ServerFlags.TcpNoDelay}
+  )
   builder.addSecureChannel(config.secureChannel)
   builder.addMuxer(config.muxer)
 

--- a/interop/perf/measurements.nim
+++ b/interop/perf/measurements.nim
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+import algorithm, chronos, math, sequtils, strformat, strutils
+import
+  ../../libp2p/
+    [builders, protocols/perf/client, protocols/perf/core, protocols/perf/server]
+
+type MeasurementStats* = object
+  min*: float
+  q1*: float
+  median*: float
+  q3*: float
+  max*: float
+  outliers*: seq[float]
+  samples*: seq[float]
+
+proc percentile(sortedValues: seq[float], p: float): float =
+  if sortedValues.len == 0:
+    return 0.0
+
+  let index = (p / 100.0) * float(sortedValues.len - 1)
+  let lower = int(floor(index))
+  let upper = int(ceil(index))
+
+  if lower == upper:
+    return sortedValues[lower]
+
+  let weight = index - float(lower)
+  sortedValues[lower] * (1.0 - weight) + sortedValues[upper] * weight
+
+proc calculateStats*(values: seq[float]): MeasurementStats =
+  if values.len == 0:
+    return MeasurementStats()
+
+  var samples = values
+  samples.sort()
+
+  let
+    q1 = percentile(samples, 25.0)
+    median = percentile(samples, 50.0)
+    q3 = percentile(samples, 75.0)
+    iqr = q3 - q1
+    lowerFence = q1 - 1.5 * iqr
+    upperFence = q3 + 1.5 * iqr
+
+  var
+    outliers: seq[float]
+    nonOutliers: seq[float]
+
+  for value in samples:
+    if value < lowerFence or value > upperFence:
+      outliers.add(value)
+    else:
+      nonOutliers.add(value)
+
+  let filtered = if nonOutliers.len > 0: nonOutliers else: samples
+
+  MeasurementStats(
+    min: filtered[0],
+    q1: q1,
+    median: median,
+    q3: q3,
+    max: filtered[^1],
+    outliers: outliers,
+    samples: samples,
+  )
+
+proc formatList(values: seq[float], decimals: int): string =
+  if values.len == 0:
+    return "[]"
+
+  "[" & values.mapIt(formatFloat(it, ffDecimal, decimals)).join(", ") & "]"
+
+proc printMeasurement*(
+    name: string, iterations: int, stats: MeasurementStats, decimals: int, unit: string
+) =
+  echo name & ":"
+  echo &"  iterations: {iterations}"
+  echo &"  min: {formatFloat(stats.min, ffDecimal, decimals)}"
+  echo &"  q1: {formatFloat(stats.q1, ffDecimal, decimals)}"
+  echo &"  median: {formatFloat(stats.median, ffDecimal, decimals)}"
+  echo &"  q3: {formatFloat(stats.q3, ffDecimal, decimals)}"
+  echo &"  max: {formatFloat(stats.max, ffDecimal, decimals)}"
+  echo "  outliers: " & formatList(stats.outliers, decimals)
+  echo "  samples: " & formatList(stats.samples, decimals)
+  echo "  unit: " & unit
+
+proc measurementValue*(
+    uploadBytes: uint64, downloadBytes: uint64, duration: Duration
+): float =
+  # Transfers above 100 bytes are throughput measurements (report Gbps);
+  # <= 100 bytes are latency measurements (report milliseconds).
+  # Same convention as the go-libp2p reference perf impl.
+  if uploadBytes > 100'u64 or downloadBytes > 100'u64:
+    let
+      transferredBytes = max(uploadBytes, downloadBytes)
+      seconds = max(float(duration.microseconds()) / 1_000_000.0, 1e-9)
+    return (float(transferredBytes) * 8.0) / seconds / 1_000_000_000.0
+
+  float(duration.microseconds()) / 1_000.0
+
+proc runMeasurement*(
+    sw: Switch,
+    remotePeerId: PeerId,
+    uploadBytes: uint64,
+    downloadBytes: uint64,
+    iterations: int,
+): Future[MeasurementStats] {.async.} =
+  var values: seq[float]
+  let perfClient = PerfClient.new()
+
+  for iteration in 0 ..< iterations:
+    let
+      startedAt = Moment.now()
+      conn = await sw.dial(remotePeerId, PerfCodec)
+
+    try:
+      discard await perfClient.perf(conn, uploadBytes, downloadBytes)
+      values.add(measurementValue(uploadBytes, downloadBytes, Moment.now() - startedAt))
+    finally:
+      await conn.close()
+
+  calculateStats(values)
+
+proc mountPerf*(sw: Switch) =
+  sw.mount(Perf.new())

--- a/interop/perf/measurements.nim
+++ b/interop/perf/measurements.nim
@@ -111,13 +111,11 @@ proc runMeasurement*(
   let perfClient = PerfClient.new()
 
   for iteration in 0 ..< iterations:
-    let
-      startedAt = Moment.now()
-      conn = await sw.dial(remotePeerId, PerfCodec)
+    let conn = await sw.dial(remotePeerId, PerfCodec)
 
     try:
-      discard await perfClient.perf(conn, uploadBytes, downloadBytes)
-      values.add(measurementValue(uploadBytes, downloadBytes, Moment.now() - startedAt))
+      let duration = await perfClient.perf(conn, uploadBytes, downloadBytes)
+      values.add(measurementValue(uploadBytes, downloadBytes, duration))
     finally:
       await conn.close()
 

--- a/interop/perf/measurements.nim
+++ b/interop/perf/measurements.nim
@@ -85,6 +85,7 @@ proc printMeasurement*(
   echo "  outliers: " & formatList(stats.outliers, decimals)
   echo "  samples: " & formatList(stats.samples, decimals)
   echo "  unit: " & unit
+  echo ""
 
 proc measurementValue*(
     uploadBytes: uint64, downloadBytes: uint64, duration: Duration
@@ -110,7 +111,7 @@ proc runMeasurement*(
   var values: seq[float]
   let perfClient = PerfClient.new()
 
-  for iteration in 0 ..< iterations:
+  for _ in 0 ..< iterations:
     let conn = await sw.dial(remotePeerId, PerfCodec)
 
     try:

--- a/interop/unified_testing.nim
+++ b/interop/unified_testing.nim
@@ -26,6 +26,15 @@ proc parseUint64Env*(name: string, defaultValue: uint64): uint64 =
   except ValueError:
     defaultValue
 
+proc parseDurationEnv*(name: string, unit: Duration, defaultValue: Duration): Duration =
+  let raw = getEnv(name)
+  if raw.len == 0:
+    return defaultValue
+  try:
+    parseInt(raw) * unit
+  except ValueError:
+    defaultValue
+
 proc resolveBindIp*(ip: string): string =
   ## If `ip` is the wildcard 0.0.0.0, pick the first eth0 address
   ## (the docker-compose network the interop harness wires up). Otherwise

--- a/interop/unified_testing.nim
+++ b/interop/unified_testing.nim
@@ -111,7 +111,7 @@ proc addTransport*(
         MultiAddress.init("/ip4/" & bindIp & "/tcp/0").tryGet()
       )
   of "ws":
-    discard builder.withWsTransport().withAddress(
+    discard builder.withWsTransport(flags = tcpFlags).withAddress(
         MultiAddress.init("/ip4/" & bindIp & "/tcp/0/ws").tryGet()
       )
   of "quic-v1":


### PR DESCRIPTION
## Summary

Adds a perf interop test app under so nim-libp2p can run in [libp2p/unified-testing](https://github.com/libp2p/unified-testing) perf benchmarks. The app implements the standard perf protocol dialer/listener pattern (upload/download throughput + latency) and plugs into the harness via env vars + Redis coordination.

## Affected Areas
- [x] Tests
  New interop test app under `interop/perf/`. No library code paths touched.

## Impact on Library Users

None.

## Risk Assessment

Low.

## References

- [libp2p/unified-testing](https://github.com/libp2p/unified-testing)
- https://github.com/libp2p/unified-testing/pull/93
