### PR TITLE
chore: removing `.public.` pragma

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -355,7 +355,7 @@ The test runner (`libp2p.nimble`) always compiles with:
 - Ignore `nim-libp2p/tests/tools/crypto.nim` (that's the definition file)
 
 ### API Stability
-- Procedures marked with `.public.` pragma are backward-compatible within MAJOR versions
+- Always add comment when PR introduces braking change.
 - Do not warn about breaking changes in the following modules as they are still not considered stable and under active development: `kademlia`, `mix`, `service_discovery`
 - Internal procedures may change at MINOR versions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -355,9 +355,10 @@ The test runner (`libp2p.nimble`) always compiles with:
 - Ignore `nim-libp2p/tests/tools/crypto.nim` (that's the definition file)
 
 ### API Stability
-- Always add comment when PR introduces breaking change.
-- Do not warn about breaking changes in the following modules as they are still not considered stable and under active development: `kademlia`, `mix`, `service_discovery`
-- Internal procedures may change at MINOR versions
+- Treat the intended public API surface, especially modules re-exported from `libp2p.nim`, as backward-compatible within a MAJOR version.
+- If a PR introduces a breaking change to that public API surface, add a comment in the PR description that clearly documents the breaking change, the affected modules or APIs, and any required migration notes.
+- Do not warn about breaking changes in the following modules, because they are not yet considered stable and remain under active development: `kademlia`, `mix`, `service_discovery`.
+- Internal procedures and other non-public implementation details may change in MINOR versions.
 
 ### Experimental GossipSub Extensions
 - Must use protobuf field numbers `> 0x200000` to force ≥4-byte tags

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -355,7 +355,7 @@ The test runner (`libp2p.nimble`) always compiles with:
 - Ignore `nim-libp2p/tests/tools/crypto.nim` (that's the definition file)
 
 ### API Stability
-- Always add comment when PR introduces braking change.
+- Always add comment when PR introduces breaking change.
 - Do not warn about breaking changes in the following modules as they are still not considered stable and under active development: `kademlia`, `mix`, `service_discovery`
 - Internal procedures may change at MINOR versions
 

--- a/README.md
+++ b/README.md
@@ -71,10 +71,9 @@ nim-libp2p is used by:
 nim-libp2p has been used in production for many years in high-stake scenarios, so its core is considered stable.
 Some modules are more recent and less stable.
 
-The versioning follows [semver](https://semver.org/), with some additions:
-
-- Some of libp2p procedures are marked as `.public.`, they will remain compatible during each `MAJOR` version
-- The rest of the procedures are considered internal, and can change at any `MINOR` version (but remain compatible for each new `PATCH`)
+The versioning follows [semver](https://semver.org/):
+ - nim-libp2p will remain compatible during each `MAJOR` version. 
+ - non braking changes and new features can happen at any `MINOR` version
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ nim-libp2p is used by:
 nim-libp2p has been used in production for many years in high-stake scenarios, so its core is considered stable.
 Some modules are more recent and less stable.
 
-The versioning follows [semver](https://semver.org/):
- - nim-libp2p will remain compatible during each `MAJOR` version. 
- - non braking changes and new features can happen at any `MINOR` version
+Versioning follows [Semantic Versioning](https://semver.org/):
+ - Releases within the same `MAJOR` version are backwards compatible.
+ - `MINOR` releases may introduce new features and other non-breaking changes.
+ - `PATCH` releases are reserved for backwards-compatible bug fixes.
 
 ## License
 

--- a/libp2p.nim
+++ b/libp2p.nim
@@ -4,13 +4,6 @@
 when defined(nimdoc):
   ## Welcome to the nim-libp2p reference!
   ##
-  ## On the left, you'll find a switch that allows you to see private
-  ## procedures. By default, you'll only see the public one (marked with `{.public.}`)
-  ##
-  ## The difference between public and private procedures is that public procedure
-  ## stay backward compatible during the Major version, whereas private ones can
-  ## change at each new Minor version.
-  ##
   ## If you're new to nim-libp2p, you can find a tutorial `here<https://vacp2p.github.io/nim-libp2p/docs/tutorial_1_connect/>`_
   ## that can help you get started.
 
@@ -30,11 +23,6 @@ when defined(nimdoc):
       peerstore,
       multiaddress,
     ]
-
-  proc dummyPrivateProc*() =
-    ## A private proc example
-    discard
-
 else:
   import
     libp2p/[

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -2,7 +2,6 @@
 # Copyright (c) Status Research & Development GmbH
 
 {.push raises: [].}
-{.push public.}
 
 import chronos, chronicles, net, results
 import chronos/apps/http/httpclient, bearssl/rand

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 {.push raises: [].}
-{.push public.}
 
 import chronicles
 import ../errors

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -420,7 +420,7 @@ proc withPrivateAddressFilter*(b: SwitchBuilder): SwitchBuilder =
   ## Circuit relay and DNS addresses are never filtered.
   b.withAddressPolicy(publicRoutableAddressPolicy)
 
-proc build*(b: SwitchBuilder): Switch {.raises: [LPError], public.} =
+proc build*(b: SwitchBuilder): Switch {.raises: [LPError].} =
   if b.rng == nil: # newRng could fail
     raise newException(Defect, "Cannot initialize RNG")
 
@@ -583,7 +583,7 @@ proc newStandardSwitchBuilder*(
     nameResolver = Opt.none(NameResolver),
     sendSignedPeerRecord = false,
     peerStoreCapacity = 1000,
-): SwitchBuilder {.raises: [LPError], public.} =
+): SwitchBuilder {.raises: [LPError].} =
   ## Helper for common switch configurations.
   var b = SwitchBuilder
     .new()
@@ -653,7 +653,7 @@ proc newStandardSwitch*(
     nameResolver = Opt.none(NameResolver),
     sendSignedPeerRecord = false,
     peerStoreCapacity = 1000,
-): Switch {.raises: [LPError], public.} =
+): Switch {.raises: [LPError].} =
   newStandardSwitchBuilder(
     privKey = privKey,
     addrs = addrs,

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -52,8 +52,7 @@ type
   TransportProvider* {.deprecated: "Use TransportBuilder instead".} =
     proc(upgr: Upgrade, privateKey: PrivateKey): Transport {.gcsafe, raises: [].}
 
-  TransportBuilder* {.public.} =
-    proc(config: TransportConfig): Transport {.gcsafe, raises: [].}
+  TransportBuilder* = proc(config: TransportConfig): Transport {.gcsafe, raises: [].}
 
   TransportConfig* = ref object
     upgr*: Upgrade
@@ -101,7 +100,7 @@ type
     watermarkCfg: Opt[WatermarkConfig]
     scoringConfig: ScoringConfig
 
-proc new*(T: type[SwitchBuilder]): T {.public.} =
+proc new*(T: type[SwitchBuilder]): T =
   ## Creates a SwitchBuilder
 
   let address =
@@ -127,9 +126,7 @@ proc new*(T: type[SwitchBuilder]): T {.public.} =
     scoringConfig: ScoringConfig(),
   )
 
-proc withPrivateKey*(
-    b: SwitchBuilder, privateKey: PrivateKey
-): SwitchBuilder {.public.} =
+proc withPrivateKey*(b: SwitchBuilder, privateKey: PrivateKey): SwitchBuilder =
   ## Set the private key of the switch. Will be used to
   ## generate a PeerId
 
@@ -138,7 +135,7 @@ proc withPrivateKey*(
 
 proc withAddresses*(
     b: SwitchBuilder, addresses: seq[MultiAddress], enableWildcardResolver: bool = true
-): SwitchBuilder {.public.} =
+): SwitchBuilder =
   ## | Set the listening addresses of the switch
   ## | Calling it multiple time will override the value
   b.addresses = addresses
@@ -147,18 +144,18 @@ proc withAddresses*(
 
 proc withAddress*(
     b: SwitchBuilder, address: MultiAddress, enableWildcardResolver: bool = true
-): SwitchBuilder {.public.} =
+): SwitchBuilder =
   ## | Set the listening address of the switch
   ## | Calling it multiple time will override the value
   b.withAddresses(@[address], enableWildcardResolver)
 
-proc withSignedPeerRecord*(b: SwitchBuilder, sendIt = true): SwitchBuilder {.public.} =
+proc withSignedPeerRecord*(b: SwitchBuilder, sendIt = true): SwitchBuilder =
   b.sendSignedPeerRecord = sendIt
   b
 
 proc withMplex*(
     b: SwitchBuilder, inTimeout = 5.minutes, outTimeout = 5.minutes, maxChannCount = 200
-): SwitchBuilder {.public.} =
+): SwitchBuilder =
   ## | Uses `Mplex <https://docs.libp2p.io/concepts/stream-multiplexing/#mplex>`_ as a multiplexer
   ## | `Timeout` is the duration after which a inactive connection will be closed
   proc newMuxer(conn: Connection): Muxer =
@@ -188,13 +185,11 @@ proc withYamux*(
   b.muxers.add(MuxerProvider.new(newMuxer, YamuxCodec))
   b
 
-proc withNoise*(b: SwitchBuilder): SwitchBuilder {.public.} =
+proc withNoise*(b: SwitchBuilder): SwitchBuilder =
   b.secureManagers.add(SecureProtocol.Noise)
   b
 
-proc withTransport*(
-    b: SwitchBuilder, prov: TransportBuilder
-): SwitchBuilder {.public.} =
+proc withTransport*(b: SwitchBuilder, prov: TransportBuilder): SwitchBuilder =
   ## Use a custom transport
   runnableExamples:
     let switch = SwitchBuilder
@@ -223,9 +218,7 @@ proc withTransport*(
     prov(config.upgr, config.privateKey)
   b.withTransport(tBuilder)
 
-proc withTcpTransport*(
-    b: SwitchBuilder, flags: set[ServerFlags] = {}
-): SwitchBuilder {.public.} =
+proc withTcpTransport*(b: SwitchBuilder, flags: set[ServerFlags] = {}): SwitchBuilder =
   b.withTransport(
     proc(config: TransportConfig): Transport =
       TcpTransport.new(flags, config.upgr)
@@ -245,25 +238,23 @@ proc withWsTransport*(
       )
   )
 
-proc withQuicTransport*(b: SwitchBuilder): SwitchBuilder {.public.} =
+proc withQuicTransport*(b: SwitchBuilder): SwitchBuilder =
   b.withTransport(
     proc(config: TransportConfig): Transport =
       QuicTransport.new(config.upgr, config.privateKey, config.connManager)
   )
 
-proc withMemoryTransport*(b: SwitchBuilder): SwitchBuilder {.public.} =
+proc withMemoryTransport*(b: SwitchBuilder): SwitchBuilder =
   b.withTransport(
     proc(config: TransportConfig): Transport =
       MemoryTransport.new(config.upgr)
   )
 
-proc withRng*(b: SwitchBuilder, rng: ref HmacDrbgContext): SwitchBuilder {.public.} =
+proc withRng*(b: SwitchBuilder, rng: ref HmacDrbgContext): SwitchBuilder =
   b.rng = rng
   b
 
-proc withMaxConnections*(
-    b: SwitchBuilder, maxConnections: int
-): SwitchBuilder {.public.} =
+proc withMaxConnections*(b: SwitchBuilder, maxConnections: int): SwitchBuilder =
   ## Maximum concurrent connections of the switch. You should either use this, or
   ## `withMaxIn <#withMaxIn,SwitchBuilder,int>`_ & `withMaxOut<#withMaxOut,SwitchBuilder,int>`_
   doAssert maxConnections > 0, "`maxConnections` must be greater than 0"
@@ -272,21 +263,19 @@ proc withMaxConnections*(
 
 proc withMaxIn*(
     b: SwitchBuilder, maxIn: int
-): SwitchBuilder {.public, deprecated: "Use withMaxInOut() instead".} =
+): SwitchBuilder {.deprecated: "Use withMaxInOut() instead".} =
   ## Maximum concurrent incoming connections. Should be used with `withMaxOut<#withMaxOut,SwitchBuilder,int>`_
   b.maxIn = maxIn
   b
 
 proc withMaxOut*(
     b: SwitchBuilder, maxOut: int
-): SwitchBuilder {.public, deprecated: "Use withMaxInOut() instead".} =
+): SwitchBuilder {.deprecated: "Use withMaxInOut() instead".} =
   ## Maximum concurrent outgoing connections. Should be used with `withMaxIn<#withMaxIn,SwitchBuilder,int>`_
   b.maxOut = maxOut
   b
 
-proc withMaxInOut*(
-    b: SwitchBuilder, maxIn: int, maxOut: int
-): SwitchBuilder {.public.} =
+proc withMaxInOut*(b: SwitchBuilder, maxIn: int, maxOut: int): SwitchBuilder =
   ## Maximum concurrent incoming and outgoing connections.
   doAssert maxIn > 0, "`maxIn` must be greater than 0"
   doAssert maxOut > 0, "`maxOut` must be greater than 0"
@@ -294,9 +283,7 @@ proc withMaxInOut*(
   b.maxOut = maxOut
   b
 
-proc withMaxConnsPerPeer*(
-    b: SwitchBuilder, maxConnsPerPeer: int
-): SwitchBuilder {.public.} =
+proc withMaxConnsPerPeer*(b: SwitchBuilder, maxConnsPerPeer: int): SwitchBuilder =
   b.maxConnsPerPeer = maxConnsPerPeer
   b
 
@@ -306,7 +293,7 @@ proc withWatermark*(
     highWater: int,
     gracePeriod: Duration = 1.minutes,
     silencePeriod: Duration = 10.seconds,
-): SwitchBuilder {.public.} =
+): SwitchBuilder =
   ## Enable hi/lo watermark connection management.
   ## When connected peers exceed `highWater`, the connection manager trims
   ## down to `lowWater`, skipping peers within `gracePeriod` and protected peers.
@@ -326,31 +313,25 @@ proc withWatermark*(
 
 proc withScoring*(
     b: SwitchBuilder, scoringConfig: ScoringConfig = ScoringConfig()
-): SwitchBuilder {.public.} =
+): SwitchBuilder =
   ## Configure connection scoring parameters.
   doAssert scoringConfig.decayResolution > 0.seconds, "decayResolution must be > 0"
   b.scoringConfig = scoringConfig
   b
 
-proc withPeerStore*(b: SwitchBuilder, capacity: int): SwitchBuilder {.public.} =
+proc withPeerStore*(b: SwitchBuilder, capacity: int): SwitchBuilder =
   b.peerStoreCapacity = Opt.some(capacity)
   b
 
-proc withProtoVersion*(
-    b: SwitchBuilder, protoVersion: string
-): SwitchBuilder {.public.} =
+proc withProtoVersion*(b: SwitchBuilder, protoVersion: string): SwitchBuilder =
   b.protoVersion = protoVersion
   b
 
-proc withAgentVersion*(
-    b: SwitchBuilder, agentVersion: string
-): SwitchBuilder {.public.} =
+proc withAgentVersion*(b: SwitchBuilder, agentVersion: string): SwitchBuilder =
   b.agentVersion = agentVersion
   b
 
-proc withNameResolver*(
-    b: SwitchBuilder, nameResolver: NameResolver
-): SwitchBuilder {.public.} =
+proc withNameResolver*(b: SwitchBuilder, nameResolver: NameResolver): SwitchBuilder =
   b.nameResolver = nameResolver
   b
 
@@ -389,7 +370,7 @@ proc withHolePunching*(
 when defined(libp2p_autotls_support):
   proc withAutotls*(
       b: SwitchBuilder, config: AutotlsConfig = AutotlsConfig.new()
-  ): SwitchBuilder {.public.} =
+  ): SwitchBuilder =
     b.autotls = Opt.some(AutotlsService.new(config = config))
     b
 
@@ -425,13 +406,13 @@ proc withObservedAddrManager*(
 
 proc withAddressPolicy*(
     b: SwitchBuilder, addressPolicy: PeerAddressPolicy
-): SwitchBuilder {.public.} =
+): SwitchBuilder =
   ## Applies a single address visibility policy across local address
   ## announcements and all discovery/storage paths configured by the builder.
   b.addressPolicy = addressPolicy
   b
 
-proc withPrivateAddressFilter*(b: SwitchBuilder): SwitchBuilder {.public.} =
+proc withPrivateAddressFilter*(b: SwitchBuilder): SwitchBuilder =
   ## Filter private (RFC1918/link-local) addresses from all peer address
   ## announcements and incoming peer address records. When enabled:
   ## - Our node will not announce private addresses to the network

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -4,7 +4,6 @@
 ## This module implements MultiAddress.
 
 {.push raises: [].}
-{.push public.}
 
 import pkg/[chronos, chronicles, results]
 import std/[nativesockets, net, hashes]

--- a/libp2p/peerid.nim
+++ b/libp2p/peerid.nim
@@ -4,7 +4,7 @@
 ## This module implementes API for libp2p peer.
 
 {.push raises: [].}
-{.push public.}
+
 {.used.}
 
 import

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -27,7 +27,7 @@ type
     gcsafe, async: (raises: [CancelledError])
   .} ## A proc that expected to resolve the listen addresses into dialable addresses
 
-  PeerInfo* {.public.} = ref object
+  PeerInfo* = ref object
     peerId*: PeerId
     listenAddrs*: seq[MultiAddress]
     ## contains addresses the node listens on, which may include wildcard and private addresses (not directly reachable).

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -2,7 +2,6 @@
 # Copyright (c) Status Research & Development GmbH
 
 {.push raises: [].}
-{.push public.}
 
 import std/sequtils
 import pkg/[chronos, chronicles, results]

--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -49,28 +49,28 @@ type
     changeHandlers: seq[PeerBookChangeHandler]
     deletor: PeerBookChangeHandler
 
-  PeerBook*[T] {.public.} = ref object of BasePeerBook
+  PeerBook*[T] = ref object of BasePeerBook
     book*: Table[PeerId, T]
 
   SeqPeerBook*[T] = ref object of PeerBook[seq[T]]
 
-  AddressBook* {.public.} = ref object of SeqPeerBook[MultiAddress]
-  ProtoBook* {.public.} = ref object of SeqPeerBook[string]
-  KeyBook* {.public.} = ref object of PeerBook[PublicKey]
+  AddressBook* = ref object of SeqPeerBook[MultiAddress]
+  ProtoBook* = ref object of SeqPeerBook[string]
+  KeyBook* = ref object of PeerBook[PublicKey]
 
-  AgentBook* {.public.} = ref object of PeerBook[string]
-  LastSeenBook* {.public.} = ref object of PeerBook[Opt[MultiAddress]]
-  LastSeenOutboundBook* {.public.} = ref object of PeerBook[Opt[MultiAddress]]
-  ProtoVersionBook* {.public.} = ref object of PeerBook[string]
-  SPRBook* {.public.} = ref object of PeerBook[Envelope]
+  AgentBook* = ref object of PeerBook[string]
+  LastSeenBook* = ref object of PeerBook[Opt[MultiAddress]]
+  LastSeenOutboundBook* = ref object of PeerBook[Opt[MultiAddress]]
+  ProtoVersionBook* = ref object of PeerBook[string]
+  SPRBook* = ref object of PeerBook[Envelope]
 
-  MixPubKeyBook* {.public.} = ref object of PeerBook[Curve25519Key]
+  MixPubKeyBook* = ref object of PeerBook[Curve25519Key]
     ## Keeps track of Mix protocol public keys of peers
 
   ####################
   # Peer store types #
   ####################
-  PeerStore* {.public.} = ref object
+  PeerStore* = ref object
     books: Table[string, BasePeerBook]
     identify: Identify
     capacity*: int
@@ -79,20 +79,18 @@ type
       ## When set, inbound peer addresses are filtered through the shared
       ## policy before they are stored or redistributed.
 
-proc new*(
-    T: type PeerStore, identify: Identify, capacity = 1000
-): PeerStore {.public.} =
+proc new*(T: type PeerStore, identify: Identify, capacity = 1000): PeerStore =
   T(identify: identify, capacity: capacity, addressPolicy: defaultAddressPolicy)
 
 #########################
 # Generic Peer Book API #
 #########################
 
-proc `[]`*[T](peerBook: PeerBook[T], peerId: PeerId): T {.public.} =
+proc `[]`*[T](peerBook: PeerBook[T], peerId: PeerId): T =
   ## Get all known metadata of a provided peer, or default(T) if missing
   peerBook.book.getOrDefault(peerId)
 
-proc `[]=`*[T](peerBook: PeerBook[T], peerId: PeerId, entry: T) {.public.} =
+proc `[]=`*[T](peerBook: PeerBook[T], peerId: PeerId, entry: T) =
   ## Set metadata for a given peerId.
 
   peerBook.book[peerId] = entry
@@ -101,7 +99,7 @@ proc `[]=`*[T](peerBook: PeerBook[T], peerId: PeerId, entry: T) {.public.} =
   for handler in peerBook.changeHandlers:
     handler(peerId)
 
-proc del*[T](peerBook: PeerBook[T], peerId: PeerId): bool {.public.} =
+proc del*[T](peerBook: PeerBook[T], peerId: PeerId): bool =
   ## Delete the provided peer from the book. Returns whether the peer was in the book
 
   if peerId notin peerBook.book:
@@ -113,14 +111,14 @@ proc del*[T](peerBook: PeerBook[T], peerId: PeerId): bool {.public.} =
       handler(peerId)
     return true
 
-proc contains*[T](peerBook: PeerBook[T], peerId: PeerId): bool {.public.} =
+proc contains*[T](peerBook: PeerBook[T], peerId: PeerId): bool =
   peerId in peerBook.book
 
-proc addHandler*[T](peerBook: PeerBook[T], handler: PeerBookChangeHandler) {.public.} =
+proc addHandler*[T](peerBook: PeerBook[T], handler: PeerBookChangeHandler) =
   ## Adds a callback that will be called everytime the book changes
   peerBook.changeHandlers.add(handler)
 
-proc len*[T](peerBook: PeerBook[T]): int {.public.} =
+proc len*[T](peerBook: PeerBook[T]): int =
   peerBook.book.len
 
 ##################
@@ -131,7 +129,7 @@ macro getTypeName(t: type): untyped =
   let typ = getTypeImpl(t)[1]
   newLit(repr(typ.owner()) & "." & repr(typ))
 
-proc `[]`*[T](p: PeerStore, typ: type[T]): T {.public.} =
+proc `[]`*[T](p: PeerStore, typ: type[T]): T =
   ## Get a book from the PeerStore (ex: peerStore[AddressBook])
   let name = getTypeName(T)
   result = T(p.books.getOrDefault(name))
@@ -144,7 +142,7 @@ proc `[]`*[T](p: PeerStore, typ: type[T]): T {.public.} =
     p.books[name] = result
   return result
 
-proc del*(peerStore: PeerStore, peerId: PeerId) {.public.} =
+proc del*(peerStore: PeerStore, peerId: PeerId) =
   ## Delete the provided peer from every book.
   for _, book in peerStore.books:
     book.deletor(peerId)

--- a/libp2p/protobuf/minprotobuf.nim
+++ b/libp2p/protobuf/minprotobuf.nim
@@ -9,8 +9,6 @@ import ../varint, ../utility, stew/endians2, results
 import ../utils/sequninit
 export results, utility
 
-{.push public.}
-
 type
   ProtoFieldKind* = enum
     ## Protobuf's field types enum

--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -227,13 +227,13 @@ method setup*(
 
 method run*(
     self: AutonatService, switch: Switch
-) {.public, async: (raises: [CancelledError]).} =
+) {.async: (raises: [CancelledError]).} =
   trace "Running AutonatService"
   await askConnectedPeers(self, switch)
 
 method stop*(
     self: AutonatService, switch: Switch
-): Future[bool] {.public, async: (raises: [CancelledError]).} =
+): Future[bool] {.async: (raises: [CancelledError]).} =
   info "Stopping AutonatService"
   let hasBeenStopped = await procCall Service(self).stop(switch)
   if hasBeenStopped:

--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -243,13 +243,13 @@ method setup*(
 
 method run*(
     self: AutonatV2Service, switch: Switch
-) {.public, async: (raises: [CancelledError]).} =
+) {.async: (raises: [CancelledError]).} =
   trace "Running AutonatV2Service"
   await askConnectedPeers(self, switch)
 
 method stop*(
     self: AutonatV2Service, switch: Switch
-): Future[bool] {.public, async: (raises: [CancelledError]).} =
+): Future[bool] {.async: (raises: [CancelledError]).} =
   trace "Stopping AutonatV2Service"
   let hasBeenStopped = await procCall Service(self).stop(switch)
   if not hasBeenStopped:

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -38,7 +38,7 @@ type
   IdentityInvalidMsgError* = object of IdentifyError
   IdentifyNoPubKeyError* = object of IdentifyError
 
-  IdentifyInfo* {.public.} = object
+  IdentifyInfo* = object
     pubkey*: Opt[PublicKey]
     peerId*: PeerId
     addrs*: seq[MultiAddress]
@@ -197,7 +197,7 @@ proc identify*(
       trace "Observed address is not valid.", observedAddr = observed
   return info
 
-proc new*(T: typedesc[IdentifyPush], handler: IdentifyPushHandler = nil): T {.public.} =
+proc new*(T: typedesc[IdentifyPush], handler: IdentifyPushHandler = nil): T =
   ## Create a IdentifyPush protocol. `handler` will be called every time
   ## a peer sends us new `PeerInfo`
   let identifypush = T(identifyHandler: handler)
@@ -237,7 +237,7 @@ proc init*(p: IdentifyPush) =
 
 proc push*(
     p: IdentifyPush, peerInfo: PeerInfo, conn: Connection
-) {.public, async: (raises: [CancelledError, LPStreamError]).} =
+) {.async: (raises: [CancelledError, LPStreamError]).} =
   ## Send new `peerInfo`s to a connection
   var pb = encodeMsg(peerInfo, conn.observedAddr, true)
   await conn.writeLp(pb.buffer)

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -53,9 +53,8 @@ type
     sendSignedPeerRecord*: bool
     observedAddrManager*: ObservedAddrManager
 
-  IdentifyPushHandler* = proc(peer: PeerId, newInfo: IdentifyInfo): Future[void] {.
-    gcsafe, raises: []
-  .}
+  IdentifyPushHandler* =
+    proc(peer: PeerId, newInfo: IdentifyInfo): Future[void] {.gcsafe, raises: [].}
 
   IdentifyPush* = ref object of LPProtocol
     identifyHandler: IdentifyPushHandler

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -54,7 +54,7 @@ type
     observedAddrManager*: ObservedAddrManager
 
   IdentifyPushHandler* = proc(peer: PeerId, newInfo: IdentifyInfo): Future[void] {.
-    gcsafe, raises: [], public
+    gcsafe, raises: []
   .}
 
   IdentifyPush* = ref object of LPProtocol

--- a/libp2p/protocols/kademlia/protobuf.nim
+++ b/libp2p/protocols/kademlia/protobuf.nim
@@ -10,7 +10,7 @@ import stew/[endians2, objects]
 import ../../crypto/crypto
 
 type
-  Record* {.public.} = object
+  Record* = object
     key*: seq[byte]
     value*: Opt[seq[byte]]
     timeReceived*: Opt[string]
@@ -31,7 +31,7 @@ type
     canConnect = 2 # Unused
     cannotConnect = 3 # Unused
 
-  Peer* {.public.} = object
+  Peer* = object
     id*: seq[byte]
     addrs*: seq[MultiAddress]
     connection*: ConnectionType
@@ -44,7 +44,7 @@ type
 
   # Ticket message for Service Discovery
   # Nested within Register message
-  Ticket* {.public.} = object
+  Ticket* = object
     advertisement*: seq[byte] # field 1 - Copy of the original advertisement
     tInit*: uint64 # field 2 - Ticket creation timestamp (Unix time in seconds)
     tMod*: uint64 # field 3 - Last modification timestamp (Unix time in seconds)
@@ -53,17 +53,17 @@ type
 
   # Register message for Service Discovery
   # Field 21 in the main Message
-  RegisterMessage* {.public.} = object
+  RegisterMessage* = object
     advertisement*: seq[byte] # field 1 - Encoded advertisement
     status*: Opt[RegistrationStatus] # field 2 - Registration status (response only)
     ticket*: Opt[Ticket] # field 3 - Optional ticket
 
   # GetAds message for Service Discovery
   # Field 22 in the main Message
-  GetAdsMessage* {.public.} = object
+  GetAdsMessage* = object
     advertisements*: seq[seq[byte]] # field 1 - List of encoded advertisements
 
-  Message* {.public.} = object
+  Message* = object
     msgType*: MessageType
     key*: seq[byte]
     record*: Opt[Record]

--- a/libp2p/protocols/mix/entry_connection.nim
+++ b/libp2p/protocols/mix/entry_connection.nim
@@ -39,7 +39,7 @@ chronicles.formatIt(MixEntryConnection):
 
 method readOnce*(
     s: MixEntryConnection, pbytes: pointer, nbytes: int
-): Future[int] {.async: (raises: [CancelledError, LPStreamError]), public.} =
+): Future[int] {.async: (raises: [CancelledError, LPStreamError]).} =
   if s.isEof:
     raise newLPStreamEOFError()
 
@@ -69,7 +69,7 @@ method readOnce*(
 
 method write*(
     self: MixEntryConnection, msg: seq[byte]
-): Future[void] {.async: (raises: [CancelledError, LPStreamError]), public.} =
+): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
   if msg.len() > DataSize:
     raise newException(LPStreamError, "exceeds max msg size of " & $DataSize & " bytes")
   await self.mixDialer(msg, self.codec, self.destination)

--- a/libp2p/protocols/mix/exit_connection.nim
+++ b/libp2p/protocols/mix/exit_connection.nim
@@ -11,7 +11,7 @@ type MixExitConnection* = ref object of Connection
 
 method readOnce*(
     self: MixExitConnection, pbytes: pointer, nbytes: int
-): Future[int] {.async: (raises: [CancelledError, LPStreamError]), public.} =
+): Future[int] {.async: (raises: [CancelledError, LPStreamError]).} =
   if self.message.len == 0:
     return 0 # Nothing else to read.
   if self.message.len < nbytes:
@@ -24,7 +24,7 @@ method readOnce*(
 
 method write*(
     self: MixExitConnection, msg: seq[byte]
-): Future[void] {.async: (raises: [CancelledError, LPStreamError]), public.} =
+): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
   if msg.len() > DataSize:
     raise newException(LPStreamError, "exceeds max msg size of " & $DataSize & " bytes")
   self.response.add(msg)

--- a/libp2p/protocols/mix/reply_connection.nim
+++ b/libp2p/protocols/mix/reply_connection.nim
@@ -16,12 +16,12 @@ type MixReplyConnection* = ref object of Connection
 
 method readExactly*(
     self: MixReplyConnection, pbytes: pointer, nbytes: int
-): Future[void] {.async: (raises: [CancelledError, LPStreamError]), public.} =
+): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
   raise newException(LPStreamError, "MixReplyConnection does not allow reading")
 
 method write*(
     self: MixReplyConnection, msg: seq[byte]
-): Future[void] {.async: (raises: [CancelledError, LPStreamError]), public.} =
+): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
   if msg.len() > DataSize:
     raise newException(LPStreamError, "exceeds max msg size of " & $DataSize & " bytes")
   await self.mixReplyDialer(self.surbs, msg)

--- a/libp2p/protocols/perf/client.nim
+++ b/libp2p/protocols/perf/client.nim
@@ -27,7 +27,7 @@ proc currentStats*(p: PerfClient): Stats =
 
 proc perf*(
     p: PerfClient, conn: Connection, sizeToWrite: uint64 = 0, sizeToRead: uint64 = 0
-): Future[Duration] {.public, async: (raises: [CancelledError, LPStreamError]).} =
+): Future[Duration] {.async: (raises: [CancelledError, LPStreamError]).} =
   trace "starting performance benchmark", conn, sizeToWrite, sizeToRead
 
   p.stats = Stats()

--- a/libp2p/protocols/perf/server.nim
+++ b/libp2p/protocols/perf/server.nim
@@ -16,7 +16,7 @@ logScope:
 
 type Perf* = ref object of LPProtocol
 
-proc new*(T: typedesc[Perf]): T {.public.} =
+proc new*(T: typedesc[Perf]): T =
   var p = T()
 
   proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =

--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -8,14 +8,12 @@
 import chronos, chronicles
 import bearssl/rand
 import
-  ../protobuf/minprotobuf,
   ../peerinfo,
   ../stream/connection,
   ../peerid,
   ../crypto/crypto,
   ../multiaddress,
   ../protocols/protocol,
-  ../utility,
   ../errors
 
 export chronicles, rand, connection
@@ -31,7 +29,7 @@ type
   PingError* = object of LPError
   WrongPingAckError* = object of PingError
 
-  PingHandler* {.public.} = proc(peer: PeerId): Future[void] {.gcsafe, raises: [].}
+  PingHandler* = proc(peer: PeerId): Future[void] {.gcsafe, raises: [].}
 
   Ping* = ref object of LPProtocol
     pingHandler*: PingHandler
@@ -39,7 +37,7 @@ type
 
 proc new*(
     T: typedesc[Ping], handler: PingHandler = nil, rng: ref HmacDrbgContext = newRng()
-): T {.public.} =
+): T =
   let ping = Ping(pinghandler: handler, rng: rng)
   ping.init()
   ping
@@ -66,7 +64,7 @@ method init*(p: Ping) =
 proc ping*(
     p: Ping, conn: Connection
 ): Future[Duration] {.
-    public, async: (raises: [CancelledError, LPStreamError, WrongPingAckError])
+    async: (raises: [CancelledError, LPStreamError, WrongPingAckError])
 .} =
   ## Sends ping to `conn`, returns the delay
 

--- a/libp2p/protocols/pubsub/errors.nim
+++ b/libp2p/protocols/pubsub/errors.nim
@@ -6,7 +6,7 @@
 
 import ../../utility
 
-type ValidationResult* {.pure, public.} = enum
+type ValidationResult* {.pure.} = enum
   Accept
   Reject
   Ignore

--- a/libp2p/protocols/pubsub/errors.nim
+++ b/libp2p/protocols/pubsub/errors.nim
@@ -4,7 +4,6 @@
 # this module will be further extended in PR
 # https://github.com/status-im/nim-libp2p/pull/107/
 
-
 type ValidationResult* {.pure.} = enum
   Accept
   Reject

--- a/libp2p/protocols/pubsub/errors.nim
+++ b/libp2p/protocols/pubsub/errors.nim
@@ -4,7 +4,6 @@
 # this module will be further extended in PR
 # https://github.com/status-im/nim-libp2p/pull/107/
 
-import ../../utility
 
 type ValidationResult* {.pure.} = enum
   Accept

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -25,7 +25,7 @@ logScope:
 
 const FloodSubCodec* = "/floodsub/1.0.0"
 
-type FloodSub* {.public.} = ref object of PubSub
+type FloodSub* = ref object of PubSub
   floodsub*: PeerTable # topic to remote peer map
   seen*: TimedCache[SaltedId]
     # Early filter for messages recently observed on the network

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -62,7 +62,7 @@ type
     meshFailurePenalty*: float64
     invalidMessageDeliveries*: float64
 
-  TopicParams* {.public.} = object
+  TopicParams* = object
     topicWeight*: float64
 
     # p1
@@ -100,7 +100,7 @@ type
     slowPeerPenalty*: float64 # penalty from repeated medium/low queue overflow drops
     behaviourPenalty*: float64 # the eventual penalty score
 
-  GossipSubParams* {.public.} = object
+  GossipSubParams* = object
     # explicit is used to check if the GossipSubParams instance was created by the user either passing params to GossipSubParams(...)
     # or GossipSubParams.init(...). In the first case explicit should be set to true when calling the Nim constructor.
     # In the second case, the param isn't necessary and should be always be set to true by init.

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -127,20 +127,20 @@ type
 
   PeerMessageDecodeError* = object of CatchableError
 
-  TopicHandler* {.public.} =
+  TopicHandler* =
     proc(topic: string, data: seq[byte]): Future[void] {.gcsafe, raises: [].}
 
-  ValidatorHandler* {.public.} = proc(
-    topic: string, message: Message
-  ): Future[ValidationResult] {.gcsafe, raises: [].}
+  ValidatorHandler* = proc(topic: string, message: Message): Future[ValidationResult] {.
+    gcsafe, raises: []
+  .}
 
   TopicPair* = tuple[topic: string, handler: TopicHandler]
 
-  MsgIdProvider* {.public.} = proc(m: Message): Result[MessageId, ValidationResult] {.
+  MsgIdProvider* = proc(m: Message): Result[MessageId, ValidationResult] {.
     noSideEffect, raises: [], gcsafe
   .}
 
-  SubscriptionValidator* {.public.} = proc(topic: string): bool {.raises: [], gcsafe.}
+  SubscriptionValidator* = proc(topic: string): bool {.raises: [], gcsafe.}
     ## Every time a peer send us a subscription (even to an unknown topic),
     ## we have to store it, which may be an attack vector.
     ## This callback can be used to reject topic we're not interested in
@@ -168,7 +168,7 @@ type
     requestsPartial*: bool
     supportsSendingPartial*: bool
 
-  PubSub* {.public.} = ref object of LPProtocol
+  PubSub* = ref object of LPProtocol
     switch*: Switch # the switch used to dial/connect to peers
     peerInfo*: PeerInfo # this peer's info
     topics*: Table[string, TopicData] # the topics that _we_ are interested in
@@ -559,7 +559,7 @@ method onTopicSubscription*(
   else:
     libp2p_pubsub_unsubscriptions.inc()
 
-proc unsubscribe*(p: PubSub, topic: string, handler: TopicHandler) {.public.} =
+proc unsubscribe*(p: PubSub, topic: string, handler: TopicHandler) =
   ## unsubscribe from a ``topic`` string
   ##
   p.topics.withValue(topic, topicData):
@@ -572,12 +572,12 @@ proc unsubscribe*(p: PubSub, topic: string, handler: TopicHandler) {.public.} =
 
     p.updateTopicMetrics(topic)
 
-proc unsubscribe*(p: PubSub, topics: openArray[TopicPair]) {.public.} =
+proc unsubscribe*(p: PubSub, topics: openArray[TopicPair]) =
   ## unsubscribe from a list of ``topic`` handlers
   for t in topics:
     p.unsubscribe(t.topic, t.handler)
 
-proc unsubscribeAll*(p: PubSub, topic: string) {.public, gcsafe.} =
+proc unsubscribeAll*(p: PubSub, topic: string) {.gcsafe.} =
   ## unsubscribe every `handler` from `topic`
   if topic notin p.topics:
     debug "unsubscribeAll called for an unknown topic", topic
@@ -594,7 +594,7 @@ proc subscribe*(
     handler: TopicHandler,
     requestsPartial: bool = false,
     supportsSendingPartial: bool = false,
-) {.public.} =
+) =
   ## subscribe to a topic
   ##
   ## ``topic``   - a string topic to subscribe to
@@ -660,7 +660,7 @@ method initPubSub*(p: PubSub) {.base, raises: [InitializationError].} =
 
 method addValidator*(
     p: PubSub, topic: varargs[string], hook: ValidatorHandler
-) {.base, public, gcsafe.} =
+) {.base, gcsafe.} =
   ## Add a validator to a `topic`. Each new message received in this
   ## will be sent to `hook`. `hook` can return either `Accept`,
   ## `Ignore` or `Reject` (which can descore the peer)
@@ -670,7 +670,7 @@ method addValidator*(
 
 method removeValidator*(
     p: PubSub, topic: varargs[string], hook: ValidatorHandler
-) {.base, public, gcsafe.} =
+) {.base, gcsafe.} =
   for t in topic:
     p.validators.withValue(t, validators):
       validators[].excl(hook)
@@ -782,10 +782,10 @@ proc init*[PubParams: object | bool](
 
   return pubsub
 
-proc addObserver*(p: PubSub, observer: PubSubObserver) {.public.} =
+proc addObserver*(p: PubSub, observer: PubSubObserver) =
   p.observers[] &= observer
 
-proc removeObserver*(p: PubSub, observer: PubSubObserver) {.public.} =
+proc removeObserver*(p: PubSub, observer: PubSubObserver) =
   let idx = p.observers[].find(observer)
   if idx != -1:
     p.observers[].del(idx)

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -636,7 +636,7 @@ method publish*(
     topic: string,
     data: seq[byte],
     publishParams: Opt[PublishParams] = Opt.none(PublishParams),
-): Future[int] {.base, async: (raises: []), public.} =
+): Future[int] {.base, async: (raises: []).} =
   ## publish to a ``topic``
   ##
   ## The return value is the number of neighbours that we attempted to send the
@@ -731,7 +731,7 @@ proc init*[PubParams: object | bool](
     parameters: PubParams = false,
     customConnCallbacks: Opt[CustomConnectionCallbacks] =
       Opt.none(CustomConnectionCallbacks),
-): P {.raises: [InitializationError], public.} =
+): P {.raises: [InitializationError].} =
   let pubsub =
     when PubParams is bool:
       P(

--- a/libp2p/services/autorelayservice.nim
+++ b/libp2p/services/autorelayservice.nim
@@ -143,7 +143,7 @@ method run*(
 
 method stop*(
     self: AutoRelayService, switch: Switch
-): Future[bool] {.public, async: (raises: [CancelledError]).} =
+): Future[bool] {.async: (raises: [CancelledError]).} =
   let hasBeenStopped = await procCall Service(self).stop(switch)
   if hasBeenStopped:
     self.running = false

--- a/libp2p/services/hpservice.nim
+++ b/libp2p/services/hpservice.nim
@@ -126,14 +126,12 @@ method setup*(
     self.autonatService.statusAndConfidenceHandler(self.onNewStatusHandler)
   return hasBeenSetup
 
-method run*(
-    self: HPService, switch: Switch
-) {.public, async: (raises: [CancelledError]).} =
+method run*(self: HPService, switch: Switch) {.async: (raises: [CancelledError]).} =
   await self.autonatService.run(switch)
 
 method stop*(
     self: HPService, switch: Switch
-): Future[bool] {.public, async: (raises: [CancelledError]).} =
+): Future[bool] {.async: (raises: [CancelledError]).} =
   discard await self.autonatService.stop(switch)
   if not isNil(self.newConnectedPeerHandler):
     switch.connManager.removePeerEventHandler(

--- a/libp2p/services/wildcardresolverservice.nim
+++ b/libp2p/services/wildcardresolverservice.nim
@@ -185,7 +185,7 @@ method setup*(
 
 method run*(
     self: WildcardAddressResolverService, switch: Switch
-) {.public, async: (raises: [CancelledError]).} =
+) {.async: (raises: [CancelledError]).} =
   ## Runs the WildcardAddressResolverService for a given switch.
   ##
   ## It updates the peer information for the provided switch by running the registered address mapper. Any other
@@ -196,7 +196,7 @@ method run*(
 
 method stop*(
     self: WildcardAddressResolverService, switch: Switch
-): Future[bool] {.public, async: (raises: [CancelledError]).} =
+): Future[bool] {.async: (raises: [CancelledError]).} =
   ## Stops the WildcardAddressResolverService.
   ##
   ## Handles the shutdown process of the WildcardAddressResolverService for a given switch.

--- a/libp2p/stream/bridgestream.nim
+++ b/libp2p/stream/bridgestream.nim
@@ -17,7 +17,7 @@ type
 
 method write*(
     s: BridgeStream, msg: seq[byte]
-): Future[void] {.public, async: (raises: [CancelledError, LPStreamError], raw: true).} =
+): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   s.writeHandler(msg)
 
 method closeImpl*(s: BridgeStream): Future[void] {.async: (raises: [], raw: true).} =

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -110,14 +110,14 @@ method initStream*(s: LPStream) {.base.} =
 
 method join*(
     s: LPStream
-): Future[void] {.base, async: (raises: [CancelledError], raw: true), public.} =
+): Future[void] {.base, async: (raises: [CancelledError], raw: true).} =
   ## Wait for the stream to be closed
   s.closeEvent.wait()
 
-method closed*(s: LPStream): bool {.base, public.} =
+method closed*(s: LPStream): bool {.base.} =
   s.isClosed
 
-method atEof*(s: LPStream): bool {.base, public.} =
+method atEof*(s: LPStream): bool {.base.} =
   s.isEof
 
 method readOnce*(
@@ -132,7 +132,7 @@ method readOnce*(
 
 method readExactly*(
     s: LPStream, pbytes: pointer, nbytes: int
-): Future[void] {.base, async: (raises: [CancelledError, LPStreamError]), public.} =
+): Future[void] {.base, async: (raises: [CancelledError, LPStreamError]).} =
   ## Waits for `nbytes` to be available, then read
   ## them and return them
   if s.atEof:
@@ -168,7 +168,7 @@ method readExactly*(
 
 method readLine*(
     s: LPStream, limit = 0, sep = "\r\n"
-): Future[string] {.base, async: (raises: [CancelledError, LPStreamError]), public.} =
+): Future[string] {.base, async: (raises: [CancelledError, LPStreamError]).} =
   ## Reads up to `limit` bytes are read, or a `sep` is found
   # TODO replace with something that exploits buffering better
   var lim = if limit <= 0: -1 else: limit
@@ -196,7 +196,7 @@ method readLine*(
 
 method readVarint*(
     conn: LPStream
-): Future[uint64] {.base, async: (raises: [CancelledError, LPStreamError]), public.} =
+): Future[uint64] {.base, async: (raises: [CancelledError, LPStreamError]).} =
   var buffer: array[10, byte]
 
   for i in 0 ..< len(buffer):
@@ -215,7 +215,7 @@ method readVarint*(
 
 method readLp*(
     s: LPStream, maxSize: int
-): Future[seq[byte]] {.base, async: (raises: [CancelledError, LPStreamError]), public.} =
+): Future[seq[byte]] {.base, async: (raises: [CancelledError, LPStreamError]).} =
   ## read length prefixed msg, with the length encoded as a varint
   let
     length = await s.readVarint()
@@ -260,7 +260,7 @@ method writeLp*(
 
 proc write*(
     s: LPStream, msg: string
-): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true), public.} =
+): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   s.write(msg.toBytes())
 
 method closeImpl*(s: LPStream): Future[void] {.async: (raises: [], raw: true), base.} =
@@ -274,7 +274,7 @@ method closeImpl*(s: LPStream): Future[void] {.async: (raises: [], raw: true), b
 
 method close*(
     s: LPStream
-): Future[void] {.async: (raises: [], raw: true), base, public.} =
+): Future[void] {.async: (raises: [], raw: true), base.} =
   ## close the stream - this may block, but will not raise exceptions
   ##
   if s.isClosed:
@@ -288,7 +288,7 @@ method close*(
   # itself must implement this - once-only check as well, with their own field
   closeImpl(s)
 
-proc closeWithEOF*(s: LPStream): Future[void] {.async: (raises: []), public.} =
+proc closeWithEOF*(s: LPStream): Future[void] {.async: (raises: []).} =
   ## Close the stream and wait for EOF - use this with half-closed streams where
   ## an EOF is expected to arrive from the other end.
   ##

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -123,7 +123,7 @@ method atEof*(s: LPStream): bool {.base.} =
 method readOnce*(
     s: LPStream, pbytes: pointer, nbytes: int
 ): Future[int] {.
-    base, async: (raises: [CancelledError, LPStreamError], raw: true), public
+    base, async: (raises: [CancelledError, LPStreamError], raw: true)
 .} =
   ## Reads whatever is available in the stream,
   ## up to `nbytes`. Will block if nothing is
@@ -234,7 +234,7 @@ method readLp*(
 method write*(
     s: LPStream, msg: seq[byte]
 ): Future[void] {.
-    async: (raises: [CancelledError, LPStreamError], raw: true), base, public
+    async: (raises: [CancelledError, LPStreamError], raw: true), base
 .} =
   # Write `msg` to stream, waiting for the write to be finished
   raiseAssert("[LPStream.write] abstract method not implemented!")
@@ -242,7 +242,7 @@ method write*(
 method writeLp*(
     s: LPStream, msg: openArray[byte]
 ): Future[void] {.
-    base, async: (raises: [CancelledError, LPStreamError], raw: true), public
+    base, async: (raises: [CancelledError, LPStreamError], raw: true)
 .} =
   ## Write `msg` with a varint-encoded length prefix
   let vbytes = PB.toBytes(msg.len().uint64)
@@ -254,7 +254,7 @@ method writeLp*(
 method writeLp*(
     s: LPStream, msg: string
 ): Future[void] {.
-    base, async: (raises: [CancelledError, LPStreamError], raw: true), public
+    base, async: (raises: [CancelledError, LPStreamError], raw: true)
 .} =
   writeLp(s, msg.toOpenArrayByte(0, msg.high))
 

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -122,9 +122,7 @@ method atEof*(s: LPStream): bool {.base.} =
 
 method readOnce*(
     s: LPStream, pbytes: pointer, nbytes: int
-): Future[int] {.
-    base, async: (raises: [CancelledError, LPStreamError], raw: true)
-.} =
+): Future[int] {.base, async: (raises: [CancelledError, LPStreamError], raw: true).} =
   ## Reads whatever is available in the stream,
   ## up to `nbytes`. Will block if nothing is
   ## available
@@ -233,17 +231,13 @@ method readLp*(
 
 method write*(
     s: LPStream, msg: seq[byte]
-): Future[void] {.
-    async: (raises: [CancelledError, LPStreamError], raw: true), base
-.} =
+): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true), base.} =
   # Write `msg` to stream, waiting for the write to be finished
   raiseAssert("[LPStream.write] abstract method not implemented!")
 
 method writeLp*(
     s: LPStream, msg: openArray[byte]
-): Future[void] {.
-    base, async: (raises: [CancelledError, LPStreamError], raw: true)
-.} =
+): Future[void] {.base, async: (raises: [CancelledError, LPStreamError], raw: true).} =
   ## Write `msg` with a varint-encoded length prefix
   let vbytes = PB.toBytes(msg.len().uint64)
   var buf = newSeqUninit[byte](msg.len() + vbytes.len)
@@ -253,9 +247,7 @@ method writeLp*(
 
 method writeLp*(
     s: LPStream, msg: string
-): Future[void] {.
-    base, async: (raises: [CancelledError, LPStreamError], raw: true)
-.} =
+): Future[void] {.base, async: (raises: [CancelledError, LPStreamError], raw: true).} =
   writeLp(s, msg.toOpenArrayByte(0, msg.high))
 
 proc write*(
@@ -272,9 +264,7 @@ method closeImpl*(s: LPStream): Future[void] {.async: (raises: [], raw: true), b
   trace "Closed stream", s, objName = s.objName, dir = $s.dir
   newFutureCompleted[void]()
 
-method close*(
-    s: LPStream
-): Future[void] {.async: (raises: [], raw: true), base.} =
+method close*(s: LPStream): Future[void] {.async: (raises: [], raw: true), base.} =
   ## close the stream - this may block, but will not raise exceptions
   ##
   if s.isClosed:

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -44,7 +44,7 @@ logScope:
 const ConcurrentUpgrades* = 4
 
 type
-  Switch* {.public.} = ref object of Dial
+  Switch* = ref object of Dial
     peerInfo*: PeerInfo
     connManager*: ConnManager
     transports*: seq[Transport]
@@ -83,9 +83,7 @@ method stop*(
   self.inUse = false
   return true
 
-proc addConnEventHandler*(
-    s: Switch, handler: ConnEventHandler, kind: ConnEventKind
-) {.public.} =
+proc addConnEventHandler*(s: Switch, handler: ConnEventHandler, kind: ConnEventKind) =
   ## Adds a ConnEventHandler, which will be triggered when
   ## a connection to a peer is created or dropped.
   ## There may be multiple connections per peer.
@@ -95,12 +93,10 @@ proc addConnEventHandler*(
 
 proc removeConnEventHandler*(
     s: Switch, handler: ConnEventHandler, kind: ConnEventKind
-) {.public.} =
+) =
   s.connManager.removeConnEventHandler(handler, kind)
 
-proc addPeerEventHandler*(
-    s: Switch, handler: PeerEventHandler, kind: PeerEventKind
-) {.public.} =
+proc addPeerEventHandler*(s: Switch, handler: PeerEventHandler, kind: PeerEventKind) =
   ## Adds a PeerEventHandler, which will be triggered when
   ## a peer connects or disconnects from us.
   ##
@@ -109,7 +105,7 @@ proc addPeerEventHandler*(
 
 proc removePeerEventHandler*(
     s: Switch, handler: PeerEventHandler, kind: PeerEventKind
-) {.public.} =
+) =
   s.connManager.removePeerEventHandler(handler, kind)
 
 method addTransport*(s: Switch, t: Transport) =
@@ -119,16 +115,14 @@ method addTransport*(s: Switch, t: Transport) =
 proc connectedPeers*(s: Switch, dir: Direction): seq[PeerId] =
   s.connManager.connectedPeers(dir)
 
-proc isConnected*(s: Switch, peerId: PeerId): bool {.public.} =
+proc isConnected*(s: Switch, peerId: PeerId): bool =
   ## returns true if the peer has one or more
   ## associated connections
   ##
 
   peerId in s.connManager
 
-proc disconnect*(
-    s: Switch, peerId: PeerId
-) {.public, async: (raises: [CancelledError]).} =
+proc disconnect*(s: Switch, peerId: PeerId) {.async: (raises: [CancelledError]).} =
   ## Disconnect from a peer, waiting for the connection(s) to be dropped
   await s.connManager.dropPeer(peerId)
 
@@ -139,9 +133,7 @@ method connect*(
     forceDial = false,
     reuseConnection = true,
     dir = Direction.Out,
-): Future[void] {.
-    public, async: (raises: [DialFailedError, CancelledError], raw: true)
-.} =
+): Future[void] {.async: (raises: [DialFailedError, CancelledError], raw: true).} =
   ## Connects to a peer without opening a stream to it
 
   s.dialer.connect(peerId, addrs, forceDial, reuseConnection, dir)
@@ -159,18 +151,14 @@ method connect*(
 
 method dial*(
     s: Switch, peerId: PeerId, protos: seq[string]
-): Future[Connection] {.
-    public, async: (raises: [DialFailedError, CancelledError], raw: true)
-.} =
+): Future[Connection] {.async: (raises: [DialFailedError, CancelledError], raw: true).} =
   ## Open a stream to a connected peer with the specified `protos`
 
   s.dialer.dial(peerId, protos)
 
 proc dial*(
     s: Switch, peerId: PeerId, proto: string
-): Future[Connection] {.
-    public, async: (raises: [DialFailedError, CancelledError], raw: true)
-.} =
+): Future[Connection] {.async: (raises: [DialFailedError, CancelledError], raw: true).} =
   ## Open a stream to a connected peer with the specified `proto`
 
   dial(s, peerId, @[proto])
@@ -181,9 +169,7 @@ method dial*(
     addrs: seq[MultiAddress],
     protos: seq[string],
     forceDial = false,
-): Future[Connection] {.
-    public, async: (raises: [DialFailedError, CancelledError], raw: true)
-.} =
+): Future[Connection] {.async: (raises: [DialFailedError, CancelledError], raw: true).} =
   ## Connected to a peer and open a stream
   ## with the specified `protos`
 
@@ -191,9 +177,7 @@ method dial*(
 
 proc dial*(
     s: Switch, peerId: PeerId, addrs: seq[MultiAddress], proto: string
-): Future[Connection] {.
-    public, async: (raises: [DialFailedError, CancelledError], raw: true)
-.} =
+): Future[Connection] {.async: (raises: [DialFailedError, CancelledError], raw: true).} =
   ## Connected to a peer and open a stream
   ## with the specified `proto`
 
@@ -321,7 +305,7 @@ proc accept(s: Switch, transport: Transport) {.async: (raises: []).} =
         raiseAssert "semaphore released without acquire"
       return
 
-proc stop*(s: Switch) {.public, async: (raises: [CancelledError]).} =
+proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
   ## Stop listening on every transport, and
   ## close every active connections
 
@@ -353,7 +337,7 @@ proc stop*(s: Switch) {.public, async: (raises: [CancelledError]).} =
 
   trace "Switch stopped"
 
-proc start*(s: Switch) {.public, async: (raises: [CancelledError, LPError]).} =
+proc start*(s: Switch) {.async: (raises: [CancelledError, LPError]).} =
   ## Start listening on every transport
 
   if s.started:

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -185,7 +185,7 @@ proc dial*(
 
 proc mount*[T: LPProtocol](
     s: Switch, proto: T, matcher: Matcher = nil
-) {.gcsafe, raises: [LPError], public.} =
+) {.gcsafe, raises: [LPError].} =
   ## mount a protocol to the switch
 
   if isNil(proto.handler):

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -89,7 +89,7 @@ proc new*(
     flags: set[ServerFlags] = {},
     upgrade: Upgrade,
     connectionsTimeout = 10.minutes,
-): T {.public.} =
+): T =
   let self = T(
     flags: flags,
     clientFlags:

--- a/libp2p/transports/tortransport.nim
+++ b/libp2p/transports/tortransport.nim
@@ -296,7 +296,7 @@ proc new*(
     rng: ref HmacDrbgContext,
     addresses: seq[MultiAddress] = @[],
     flags: set[ServerFlags] = {},
-): TorSwitch {.raises: [LPError], public.} =
+): TorSwitch {.raises: [LPError].} =
   var builder = SwitchBuilder.new().withRng(rng).withTransport(
       proc(config: TransportConfig): Transport =
         TorTransport.new(torServer, flags, config.upgr)

--- a/libp2p/transports/tortransport.nim
+++ b/libp2p/transports/tortransport.nim
@@ -70,7 +70,7 @@ proc new*(
     transportAddress: TransportAddress,
     flags: set[ServerFlags] = {},
     upgrade: Upgrade,
-): T {.public.} =
+): T =
   ## Creates a Tor transport
 
   let self = T(

--- a/libp2p/utility.nim
+++ b/libp2p/utility.nim
@@ -9,9 +9,6 @@ import results, chronos, sequtils
 
 export results
 
-## public pragma is marker of "public" api subject to stronger stability guarantees.
-template public*() {.pragma.}
-
 const ShortDumpMax = 12
 
 template compilesOr*(a, b: untyped): untyped =

--- a/tests/stubs/torstub.nim
+++ b/tests/stubs/torstub.nim
@@ -22,7 +22,7 @@ type TorServerStub* = ref object of RootObj
   tcpTransport: TcpTransport
   addrTable: Table[string, string]
 
-proc new*(T: typedesc[TorServerStub]): T {.public.} =
+proc new*(T: typedesc[TorServerStub]): T =
   T(
     tcpTransport: TcpTransport.new(flags = {ReuseAddr}, upgrade = Upgrade()),
     addrTable: initTable[string, string](),


### PR DESCRIPTION
`.public.` was not really useful for us... as of now we will generally adhere to [semver](https://semver.org/).