### PR TITLE
fix(pubsub): track pending sends without adding  backpressure

### DIFF
--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -427,7 +427,7 @@ proc clearSendPriorityQueue(p: PubSubPeer) =
     )
 
 proc sendMsgContinue(conn: Connection, msgFut: Future[void]) {.async: (raises: []).} =
-  # Continuation for a pending `sendMsg` future from below
+  # Continuation for a pending transport write from below
   try:
     await msgFut
     trace "sent pubsub message to remote", conn
@@ -438,8 +438,7 @@ proc sendMsgContinue(conn: Connection, msgFut: Future[void]) {.async: (raises: [
     await conn.close() # This will clean up the send connection
 
 proc sendMsgSlow(p: PubSubPeer, msg: seq[byte]) {.async: (raises: [CancelledError]).} =
-  # Slow path of `sendMsg` where msg is held in memory while send connection is
-  # being set up
+  # Slow path where msg is held in memory while send connection is being set up.
   if p.sendConn == nil:
     # Wait for a send conn to be setup. `connectOnce` will
     # complete this even if the sendConn setup failed
@@ -456,6 +455,8 @@ proc sendMsgSlow(p: PubSubPeer, msg: seq[byte]) {.async: (raises: [CancelledErro
 proc sendMsg(
     p: PubSubPeer, msg: seq[byte], useCustomConn: bool = false
 ): Future[void] {.async: (raises: []).} =
+  ## Starts a transport write and returns its lifecycle future for internal
+  ## queue accounting. Do not await this from receive-handler paths.
   type ConnectionType = enum
     ctCustom
     ctSend
@@ -480,16 +481,20 @@ proc sendMsg(
       conntype = $connType, conn = conn, encoded = shortLog(msg)
     let f = conn.writeLp(msg)
     if not f.completed():
-      sendMsgContinue(conn, f)
+      await sendMsgContinue(conn, f)
     else:
       if f.failed():
         trace "sending encoded msg to peer failed", description = f.error.msg
+        await conn.close()
       else:
         trace "sent pubsub message to remote", conn
-      f
   else:
     trace "sending encoded msg to peer via slow path"
-    sendMsgSlow(p, msg)
+    try:
+      await sendMsgSlow(p, msg)
+    except CancelledError:
+      trace "sending encoded msg via slow path was cancelled"
+      discard
 
 proc disconnectPeer(p: PubSubPeer): Future[void] =
   if not p.disconnected:
@@ -508,7 +513,7 @@ proc sendHighPriorityMessage(
     p.rpcmessagequeue.sendPriorityQueue.addLast(f)
     when defined(pubsubpeer_queue_metrics):
       libp2p_gossipsub_high_priority_queue_size.inc(labelValues = [$p.peerId])
-  return f
+  return newFutureCompleted[void]()
 
 proc enqueueNonHighPriorityMessage(
     p: PubSubPeer, msg: seq[byte], useCustomConn: bool, priority: MessagePriority

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -426,12 +426,17 @@ proc clearSendPriorityQueue(p: PubSubPeer) =
       value = p.rpcmessagequeue.sendPriorityQueue.len.int64, labelValues = [$p.peerId]
     )
 
-proc sendMsgContinue(conn: Connection, msgFut: Future[void]) {.async: (raises: []).} =
+proc sendMsgContinue(
+    conn: Connection, msgFut: Future[void].Raising([CancelledError, LPStreamError])
+) {.async: (raises: [CancelledError]).} =
   # Continuation for a pending transport write from below
   try:
     await msgFut
     trace "sent pubsub message to remote", conn
-  except CatchableError as exc:
+  except CancelledError as exc:
+    trace "sendMsgContinue cancelled", conn, description = exc.msg
+    raise exc
+  except LPStreamError as exc:
     trace "Unexpected exception in sendMsgContinue", conn, description = exc.msg
     # Next time sendConn is used, it will be have its close flag set and thus
     # will be recycled
@@ -454,7 +459,7 @@ proc sendMsgSlow(p: PubSubPeer, msg: seq[byte]) {.async: (raises: [CancelledErro
 
 proc sendMsg(
     p: PubSubPeer, msg: seq[byte], useCustomConn: bool = false
-): Future[void] {.async: (raises: []).} =
+): Future[void] {.async: (raises: [CancelledError]).} =
   ## Starts a transport write and returns its lifecycle future for internal
   ## queue accounting. Do not await this from receive-handler paths.
   type ConnectionType = enum
@@ -480,21 +485,10 @@ proc sendMsg(
     trace "sending encoded msg to peer",
       conntype = $connType, conn = conn, encoded = shortLog(msg)
     let f = conn.writeLp(msg)
-    if not f.completed():
-      await sendMsgContinue(conn, f)
-    else:
-      if f.failed():
-        trace "sending encoded msg to peer failed", description = f.error.msg
-        await conn.close()
-      else:
-        trace "sent pubsub message to remote", conn
+    await sendMsgContinue(conn, f)
   else:
     trace "sending encoded msg to peer via slow path"
-    try:
-      await sendMsgSlow(p, msg)
-    except CancelledError:
-      trace "sending encoded msg via slow path was cancelled"
-      discard
+    await sendMsgSlow(p, msg)
 
 proc disconnectPeer(p: PubSubPeer): Future[void] =
   if not p.disconnected:

--- a/tests/libp2p/pubsub/test_priority_queues.nim
+++ b/tests/libp2p/pubsub/test_priority_queues.nim
@@ -127,11 +127,11 @@ suite "Priority queue behavior":
   teardown:
     checkTrackers()
 
-  asyncTest "High priority sends return immediately even while writes stay pending":
+  asyncTest "Pending high priority sends delay lower priority messages":
     let disconnectRequestedForTest = new bool
 
     let peer = createTestPeer(
-      maxHigh = 2, onEvent = newDisconnectRecorder(disconnectRequestedForTest)
+      maxHigh = 3, onEvent = newDisconnectRecorder(disconnectRequestedForTest)
     )
     let conn = createPendingConnection()
     defer:
@@ -139,15 +139,18 @@ suite "Priority queue behavior":
 
     peer.sendConn = conn
 
-    # These writes stay pending, but sendEncoded itself now completes immediately.
+    # These sends stay pending, keeping the high-priority backlog visible until
+    # the underlying transport write completes.
     let f1 = peer.sendEncoded(@[1'u8, 2, 3], MessagePriority.High)
     let f2 = peer.sendEncoded(@[1'u8, 2, 3], MessagePriority.High)
     let f3 = peer.sendEncoded(@[1'u8, 2, 3], MessagePriority.High)
+    let mediumFut = peer.sendEncoded(@[4'u8, 5, 6], MessagePriority.Medium)
 
     check:
       f1.finished
       f2.finished
       f3.finished
+      mediumFut.finished
       conn.pendingWrites.len == 3
       not conn.pendingWrites[0].finished
       not conn.pendingWrites[1].finished
@@ -165,11 +168,11 @@ suite "Priority queue behavior":
     check:
       not disconnectRequestedForTest[]
 
-  asyncTest "Medium priority sends fast-path even behind a pending high write":
+  asyncTest "Medium priority messages wait while high priority send is pending":
     let disconnectRequestedForTest = new bool
 
     let peer = createTestPeer(
-      maxMedium = 2, onEvent = newDisconnectRecorder(disconnectRequestedForTest)
+      maxMedium = 4, onEvent = newDisconnectRecorder(disconnectRequestedForTest)
     )
     let conn = createRecorderConnection()
     defer:
@@ -178,10 +181,10 @@ suite "Priority queue behavior":
     peer.sendConn = conn
 
     let highMsg = @[1'u8, 2, 3]
-    let mediumMsgs = @[@[10'u8, 0, 0], @[11'u8, 0, 0], @[12'u8, 0, 0], @[13'u8, 0, 0]]
+    let mediumMsgs = @[@[10'u8, 0, 0], @[11'u8, 0, 0]]
 
-    # The first high-priority write remains pending on the connection, but later
-    # medium-priority sends still take the fast path and complete immediately.
+    # The first high-priority send remains pending on the connection, but later
+    # medium-priority messages are queued until it completes.
     let highFut = peer.sendEncoded(highMsg, MessagePriority.High)
     check highFut.finished
 
@@ -189,24 +192,22 @@ suite "Priority queue behavior":
       let f = peer.sendEncoded(msg, MessagePriority.Medium)
       check f.finished
 
-    check conn.writes ==
-      @[highMsg, mediumMsgs[0], mediumMsgs[1], mediumMsgs[2], mediumMsgs[3]]
+    check conn.writes == @[highMsg]
 
     conn.releaseFirstWrite()
 
-    await callbacksDrained(conn.firstWriteFut)
+    checkUntilTimeout:
+      conn.writes == @[highMsg, mediumMsgs[0], mediumMsgs[1]]
 
     check:
-      conn.writes ==
-        @[highMsg, mediumMsgs[0], mediumMsgs[1], mediumMsgs[2], mediumMsgs[3]]
       not disconnectRequestedForTest[]
       peer.hasSendConn()
 
-  asyncTest "Low priority sends fast-path even behind a pending high write":
+  asyncTest "Low priority messages wait while high priority send is pending":
     let disconnectRequestedForTest = new bool
 
     let peer = createTestPeer(
-      maxLow = 2, onEvent = newDisconnectRecorder(disconnectRequestedForTest)
+      maxLow = 4, onEvent = newDisconnectRecorder(disconnectRequestedForTest)
     )
     let conn = createRecorderConnection()
     defer:
@@ -215,10 +216,10 @@ suite "Priority queue behavior":
     peer.sendConn = conn
 
     let highMsg = @[1'u8, 2, 3]
-    let lowMsgs = @[@[20'u8, 0, 0], @[21'u8, 0, 0], @[22'u8, 0, 0], @[23'u8, 0, 0]]
+    let lowMsgs = @[@[20'u8, 0, 0], @[21'u8, 0, 0]]
 
-    # The first high-priority write remains pending on the connection, but later
-    # low-priority sends still take the fast path and complete immediately.
+    # The first high-priority send remains pending on the connection, but later
+    # low-priority messages are queued until it completes.
     let highFut = peer.sendEncoded(highMsg, MessagePriority.High)
     check highFut.finished
 
@@ -226,14 +227,14 @@ suite "Priority queue behavior":
       let f = peer.sendEncoded(msg, MessagePriority.Low)
       check f.finished
 
-    check conn.writes == @[highMsg, lowMsgs[0], lowMsgs[1], lowMsgs[2], lowMsgs[3]]
+    check conn.writes == @[highMsg]
 
     conn.releaseFirstWrite()
 
-    await callbacksDrained(conn.firstWriteFut)
+    checkUntilTimeout:
+      conn.writes == @[highMsg, lowMsgs[0], lowMsgs[1]]
 
     check:
-      conn.writes == @[highMsg, lowMsgs[0], lowMsgs[1], lowMsgs[2], lowMsgs[3]]
       not disconnectRequestedForTest[]
       peer.hasSendConn()
 


### PR DESCRIPTION
## Summary

This updates pubsub peer sending so pending transport writes are tracked by the peer queue.

Before this change, `sendMsg` started `conn.writeLp(msg)` but did not keep the returned future. This meant pubsub could think a peer had no pending send even when the transport was still writing. As a result, more messages could keep being sent to the same peer and build up inside the transport buffers.

This is especially problematic for QUIC, where bandwidth can look fine while message latency grows because messages spend more time waiting in hidden queues.

With this change:

- `sendMsg` returns a future that represents the actual write lifecycle.
- high-priority sends store that future in the peer queue when the write is still pending.
- `sendEncoded`, `broadcast`, and `publish` still get fire-and-forget behavior and do not wait for the transport write to finish.
- medium/low priority peer queue processing can now see pending high-priority sends and wait before sending more messages to that peer.

With this, pubsub will be aware of slow peer sends without adding backpressure to publishers or receive handlers.

## Affected Areas

- [x] Gossipsub  
  Pubsub peer send queue behavior is updated so pending sends are tracked correctly.
- [ ] Transports
- [ ] Peer Management / Discovery
- [x] Protocol Logic  
  Internal message scheduling between high, medium, and low priority pubsub messages is affected.
- [ ] Build / Tooling
- [ ] Other

## Impact on Library Users

No API changes.

`publish`, `broadcast`, and normal pubsub send paths remain fire-and-forget. This PR should not make application publishing wait for network writes.

The behavior change is internal: pubsub now tracks pending per-peer sends and avoids sending lower-priority messages to a peer while a high-priority send is still pending.

Expected impact:

- reduced hidden transport buffering for slow peers
- better queue visibility through existing pubsub peer queue metrics
- no migration required for downstream users

## Risk Assessment

Risk is moderate because this changes internal pubsub send scheduling.

Main behavior risk:

- medium and low priority messages may be delayed more consistently behind pending high-priority sends for the same peer.

This is intended, but it can affect timing-sensitive tests or workloads.

### KEEP THIS INTO ACCOUNT WHILE REVIEWING CODE:
Backpressure risk:
- this PR should not add caller backpressure.
- `sendEncoded`, `broadcast`, and `publish` still return without waiting for transport writes.
- receive handlers should not block on pubsub writes.

Network behavior risk:
- slow peers may see more delayed or dropped medium/low priority messages when their queues fill.
- this is preferable to silently accumulating latency inside transport buffers.
