### PR TITLE
chore(connmanager): naming improvements

### DIFF
--- a/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_lifecycle_requests.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_lifecycle_requests.nim
@@ -244,11 +244,11 @@ proc createLibp2p(appCallbacks: AppCallbacks, config: Libp2pConfig): LibP2P =
 
   let limits =
     if config.maxIn > 0 and config.maxOut > 0:
-      Opt.some(LimitsConfig.maxInOut(config.maxIn, config.maxOut))
+      Opt.some(ConnectionLimits.maxInOut(config.maxIn, config.maxOut))
     elif config.maxConnections > 0:
-      Opt.some(LimitsConfig.maxTotal(config.maxConnections))
+      Opt.some(ConnectionLimits.maxTotal(config.maxConnections))
     else:
-      Opt.none(LimitsConfig)
+      Opt.none(ConnectionLimits)
 
   var switchBuilder = newStandardSwitchBuilder(
     privKey = privKey,

--- a/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_lifecycle_requests.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_lifecycle_requests.nim
@@ -242,7 +242,7 @@ proc createLibp2p(appCallbacks: AppCallbacks, config: Libp2pConfig): LibP2P =
   let transport = TransportType.fromCint(config.transport).valueOr:
     raiseAssert "invalid transport type"
 
-  let limits =
+  let connectionLimits =
     if config.maxIn > 0 and config.maxOut > 0:
       Opt.some(ConnectionLimits.maxInOut(config.maxIn, config.maxOut))
     elif config.maxConnections > 0:
@@ -255,7 +255,7 @@ proc createLibp2p(appCallbacks: AppCallbacks, config: Libp2pConfig): LibP2P =
     addrs = addrs,
     muxer = muxer,
     transport = transport,
-    limits = limits,
+    connectionLimits = connectionLimits,
     maxConnsPerPeer = config.maxConnsPerPeer,
     nameResolver = dnsResolver,
   )

--- a/examples/tutorial_5_connmanager.nim
+++ b/examples/tutorial_5_connmanager.nim
@@ -7,7 +7,7 @@
 ## and can optionally trim low-scoring peers via watermark logic.
 ##
 ## You'll find all configuration options in the `withMaxConnections`,
-## `withMaxInOut`, and `withWatermark` builder methods.
+## `withMaxInOut`, and `withWatermarkPolicy` builder methods.
 import chronos, strformat
 
 import libp2p
@@ -74,7 +74,7 @@ proc main() {.async.} =
       switch, "3. .withMaxInOut(30, 20)", "(in-limit: 30, out-limit: 20)"
     )
 
-  ## ### 4. `.withWatermark(10, 20)` — soft trimming, no hard cap
+  ## ### 4. `.withWatermarkPolicy(10, 20)` — soft trimming, no hard cap
   ##
   ## No semaphore is created — the switch **never blocks** an incoming
   ## connection based on count alone.  Instead, once the connected-peer count
@@ -83,14 +83,14 @@ proc main() {.async.} =
   ## the lowest-scoring peers.  Peers within the grace period (default 1 min)
   ## and protected peers are skipped during trimming.
   block:
-    let switch = createBaseBuilder().withWatermark(10, 20).build()
+    let switch = createBaseBuilder().withWatermarkPolicy(10, 20).build()
 
     await connectPeer(
-      switch, "4. .withWatermark(10, 20)",
+      switch, "4. .withWatermarkPolicy(10, 20)",
       "(no hard cap; trims to 10 once 20 are connected)",
     )
 
-  ## ### 5. `.withWatermark(10, 20, gracePeriod = 30.seconds, silencePeriod = 5.seconds)` — custom timing
+  ## ### 5. `.withWatermarkPolicy(10, 20, gracePeriod = 30.seconds, silencePeriod = 5.seconds)` — custom timing
   ##
   ## `gracePeriod` protects newly connected peers from being trimmed: any peer
   ## that connected less than `gracePeriod` ago is skipped when the connection
@@ -107,15 +107,15 @@ proc main() {.async.} =
   ## longer, while a short silence period allows more frequent pruning passes.
   block:
     let switch = createBaseBuilder()
-      .withWatermark(10, 20, gracePeriod = 30.seconds, silencePeriod = 5.seconds)
+      .withWatermarkPolicy(10, 20, gracePeriod = 30.seconds, silencePeriod = 5.seconds)
       .build()
 
     await connectPeer(
-      switch, "5. .withWatermark(gracePeriod=30s, silencePeriod=5s)",
+      switch, "5. .withWatermarkPolicy(gracePeriod=30s, silencePeriod=5s)",
       "(trims at 20; grace 30 s; silence 5 s)",
     )
 
-  ## ### 6. `.withWatermark(10, 20).withMaxConnections(30)` — hard cap + trimming
+  ## ### 6. `.withWatermarkPolicy(10, 20).withMaxConnections(30)` — hard cap + trimming
   ##
   ## A semaphore enforces an absolute ceiling of 30 connections while
   ## watermark trimming keeps the active peer count near 10 long before that
@@ -124,24 +124,25 @@ proc main() {.async.} =
   ## existing ones once the high-water mark is hit.
   block:
     let switch =
-      createBaseBuilder().withWatermark(10, 20).withMaxConnections(30).build()
+      createBaseBuilder().withWatermarkPolicy(10, 20).withMaxConnections(30).build()
 
     await connectPeer(
-      switch, "6. .withWatermark(10,20).withMaxConnections(30)",
+      switch, "6. .withWatermarkPolicy(10,20).withMaxConnections(30)",
       "(hard cap: 30; trims at 20)",
     )
 
-  ## ### 7. `.withWatermark(10, 20).withMaxInOut(30, 20)` — per-direction caps + trimming
+  ## ### 7. `.withWatermarkPolicy(10, 20).withMaxInOut(30, 20)` — per-direction caps + trimming
   ##
   ## The most granular configuration: two independent semaphores (30 incoming,
   ## 20 outgoing) combined with watermark trimming.  New connections are
   ## blocked by the per-direction caps, and existing connections are pruned
   ## asynchronously once the total peer count exceeds 20.
   block:
-    let switch = createBaseBuilder().withWatermark(10, 20).withMaxInOut(30, 20).build()
+    let switch =
+      createBaseBuilder().withWatermarkPolicy(10, 20).withMaxInOut(30, 20).build()
 
     await connectPeer(
-      switch, "7. .withWatermark(10,20).withMaxInOut(30,20)",
+      switch, "7. .withWatermarkPolicy(10,20).withMaxInOut(30,20)",
       "(in-limit: 30, out-limit: 20; trims at 20)",
     )
 
@@ -158,7 +159,7 @@ waitFor(main())
 ## | `.build()` | Shared limit at 50 (default `MaxConnections`) |
 ## | `.withMaxConnections(100)` | Shared limit at 100 |
 ## | `.withMaxInOut(30, 20)` | Separate limits: 30 incoming / 20 outgoing |
-## | `.withWatermark(10, 20)` | No hard cap; trims to 10 once 20 connected |
-## | `.withWatermark(10, 20, gracePeriod = 30.seconds, silencePeriod = 5.seconds)` | Custom trim timing: 30s grace, 5s cooldown |
-## | `.withWatermark(10, 20).withMaxConnections(30)` | Hard cap at 30 + trim at 20 |
-## | `.withWatermark(10, 20).withMaxInOut(30, 20)` | Separate limits + trim at 20 |
+## | `.withWatermarkPolicy(10, 20)` | No hard cap; trims to 10 once 20 connected |
+## | `.withWatermarkPolicy(10, 20, gracePeriod = 30.seconds, silencePeriod = 5.seconds)` | Custom trim timing: 30s grace, 5s cooldown |
+## | `.withWatermarkPolicy(10, 20).withMaxConnections(30)` | Hard cap at 30 + trim at 20 |
+## | `.withWatermarkPolicy(10, 20).withMaxInOut(30, 20)` | Separate limits + trim at 20 |

--- a/examples/tutorial_6_peerscoring.nim
+++ b/examples/tutorial_6_peerscoring.nim
@@ -18,10 +18,10 @@
 ## couple of seconds:
 ##
 ## ```nim
-## .withWatermark(
+## .withWatermarkPolicy(
 ##   lowWater = 2, highWater = 3,
 ##   gracePeriod = 100.millis, silencePeriod = 50.millis)
-## .withScoring(PeerScoring(decayResolution: 50.millis))
+## .withPeerScoring(PeerScoring(decayResolution: 50.millis))
 ## ```
 ##
 ## **Important:** trim is not time-based, it only runs when a new
@@ -55,13 +55,13 @@ proc createBaseBuilder(): SwitchBuilder =
 
 proc makeHost(): Switch =
   createBaseBuilder()
-    .withWatermark(
+    .withWatermarkPolicy(
       lowWater = LowWater,
       highWater = HighWater,
       gracePeriod = GracePeriod,
       silencePeriod = SilencePeriod,
     )
-    .withScoring(PeerScoring(decayResolution: DecayResolution))
+    .withPeerScoring(PeerScoring(decayResolution: DecayResolution))
     .build()
 
 proc makeClient(): Switch =
@@ -263,7 +263,7 @@ waitFor(main())
 ##
 ## | Scenario | API exercised | Outcome |
 ## |---|---|---|
-## | 1. Trim trigger | `withWatermark` | count drops from `highWater + 1` to `lowWater` after the next `storeMuxer` |
+## | 1. Trim trigger | `withWatermarkPolicy` | count drops from `highWater + 1` to `lowWater` after the next `storeMuxer` |
 ## | 2. Protect / Unprotect | `protect`, `unprotect`, `isProtected` | tagged peer survives trim; loses immunity once all tags removed |
 ## | 3. Static tags | `tagPeer`, `peerScore` | high-score peers survive; low/no-score peers pruned first |
 ## | 4. Decaying tags | `tagPeerDecaying`, `bumpDecayingTag`, `decayFixed` / `decayNone` / `decayLinear` | score decays per tick, can be bumped while live, must be re-tagged once removed |

--- a/examples/tutorial_6_peerscoring.nim
+++ b/examples/tutorial_6_peerscoring.nim
@@ -21,7 +21,7 @@
 ## .withWatermark(
 ##   lowWater = 2, highWater = 3,
 ##   gracePeriod = 100.millis, silencePeriod = 50.millis)
-## .withScoring(ScoringConfig(decayResolution: 50.millis))
+## .withScoring(PeerScoring(decayResolution: 50.millis))
 ## ```
 ##
 ## **Important:** trim is not time-based, it only runs when a new
@@ -61,7 +61,7 @@ proc makeHost(): Switch =
       gracePeriod = GracePeriod,
       silencePeriod = SilencePeriod,
     )
-    .withScoring(ScoringConfig(decayResolution: DecayResolution))
+    .withScoring(PeerScoring(decayResolution: DecayResolution))
     .build()
 
 proc makeClient(): Switch =

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -251,7 +251,7 @@ proc withRng*(b: SwitchBuilder, rng: ref HmacDrbgContext): SwitchBuilder =
   b.rng = rng
   b
 
-proc withLimits*(b: SwitchBuilder, limits: ConnectionLimits): SwitchBuilder =
+proc withConnectionLimits*(b: SwitchBuilder, limits: ConnectionLimits): SwitchBuilder =
   ## Set the connection limits for the switch. Construct `limits` via
   ## `ConnectionLimits.maxTotal` for a shared cap or `ConnectionLimits.maxInOut`
   ## for independent per-direction caps.
@@ -273,7 +273,7 @@ proc withMaxConnsPerPeer*(b: SwitchBuilder, maxConnsPerPeer: int): SwitchBuilder
   b.maxConnsPerPeer = maxConnsPerPeer
   b
 
-proc withWatermark*(
+proc withWatermarkPolicy*(
     b: SwitchBuilder,
     lowWater: int,
     highWater: int,
@@ -297,7 +297,7 @@ proc withWatermark*(
   )
   b
 
-proc withScoring*(
+proc withPeerScoring*(
     b: SwitchBuilder, scoring: PeerScoring = PeerScoring()
 ): SwitchBuilder =
   ## Configure connection scoring parameters.
@@ -551,7 +551,7 @@ proc newStandardSwitchBuilder*(
     secureManagers: openArray[SecureProtocol] = [SecureProtocol.Noise],
     inTimeout: Duration = 5.minutes,
     outTimeout: Duration = 5.minutes,
-    limits: Opt[ConnectionLimits] = Opt.none(ConnectionLimits),
+    connectionLimits: Opt[ConnectionLimits] = Opt.none(ConnectionLimits),
     maxConnsPerPeer = -1,
     nameResolver = Opt.none(NameResolver),
     sendSignedPeerRecord = false,
@@ -565,8 +565,8 @@ proc newStandardSwitchBuilder*(
     .withPeerStore(capacity = peerStoreCapacity)
     .withNoise()
 
-  limits.withValue(cfg):
-    b = b.withLimits(cfg)
+  connectionLimits.withValue(cfg):
+    b = b.withConnectionLimits(cfg)
 
   if maxConnsPerPeer >= 0: # issue#2328 must never be 0
     b = b.withMaxConnsPerPeer(maxConnsPerPeer)
@@ -616,7 +616,7 @@ proc newStandardSwitch*(
     secureManagers: openArray[SecureProtocol] = [SecureProtocol.Noise],
     inTimeout: Duration = 5.minutes,
     outTimeout: Duration = 5.minutes,
-    limits: Opt[ConnectionLimits] = Opt.none(ConnectionLimits),
+    connectionLimits: Opt[ConnectionLimits] = Opt.none(ConnectionLimits),
     maxConnsPerPeer = -1,
     nameResolver = Opt.none(NameResolver),
     sendSignedPeerRecord = false,
@@ -632,7 +632,7 @@ proc newStandardSwitch*(
     secureManagers = secureManagers,
     inTimeout = inTimeout,
     outTimeout = outTimeout,
-    limits = limits,
+    connectionLimits = connectionLimits,
     maxConnsPerPeer = maxConnsPerPeer,
     nameResolver = nameResolver,
     sendSignedPeerRecord = sendSignedPeerRecord,

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -44,7 +44,7 @@ import services/wildcardresolverservice
 
 export
   switch, peerid, peerinfo, peeraddrpolicy, connection, multiaddress, crypto, errors,
-  TLSPrivateKey, TLSCertificate, TLSFlags, ServerFlags, connmanager.LimitsConfig,
+  TLSPrivateKey, TLSCertificate, TLSFlags, ServerFlags, connmanager.ConnectionLimits,
   connmanager.maxTotal, connmanager.maxInOut
 
 const MemoryAutoAddress* = memorytransport.MemoryAutoAddress
@@ -76,9 +76,9 @@ type
     transports: seq[TransportBuilder]
     rng: ref HmacDrbgContext
     maxConnsPerPeer: int
-    limitsConfig: Opt[LimitsConfig]
-    watermarkConfig: Opt[WatermarkConfig]
-    scoringConfig: ScoringConfig
+    limits: Opt[ConnectionLimits]
+    watermark: Opt[WatermarkPolicy]
+    scoring: PeerScoring
     sendSignedPeerRecord: bool
     protoVersion: string
     agentVersion: string
@@ -110,9 +110,9 @@ proc new*(T: type[SwitchBuilder]): T =
     addresses: @[address],
     secureManagers: @[],
     maxConnsPerPeer: -1,
-    limitsConfig: Opt.none(LimitsConfig),
-    watermarkConfig: Opt.none(WatermarkConfig),
-    scoringConfig: ScoringConfig(),
+    limits: Opt.none(ConnectionLimits),
+    watermark: Opt.none(WatermarkPolicy),
+    scoring: PeerScoring(),
     protoVersion: ProtoVersion,
     agentVersion: AgentVersion,
     autotls: Opt.none(AutotlsService),
@@ -251,22 +251,22 @@ proc withRng*(b: SwitchBuilder, rng: ref HmacDrbgContext): SwitchBuilder =
   b.rng = rng
   b
 
-proc withLimits*(b: SwitchBuilder, limits: LimitsConfig): SwitchBuilder =
+proc withLimits*(b: SwitchBuilder, limits: ConnectionLimits): SwitchBuilder =
   ## Set the connection limits for the switch. Construct `limits` via
-  ## `LimitsConfig.maxTotal` for a shared cap or `LimitsConfig.maxInOut`
+  ## `ConnectionLimits.maxTotal` for a shared cap or `ConnectionLimits.maxInOut`
   ## for independent per-direction caps.
-  b.limitsConfig = Opt.some(limits)
+  b.limits = Opt.some(limits)
   b
 
 proc withMaxConnections*(b: SwitchBuilder, maxConnections: int): SwitchBuilder =
   ## Maximum concurrent connections of the switch. You should either use this,
   ## or `withMaxInOut <#withMaxInOut,SwitchBuilder,int,int>`_.
-  b.limitsConfig = Opt.some(LimitsConfig.maxTotal(maxConnections))
+  b.limits = Opt.some(ConnectionLimits.maxTotal(maxConnections))
   b
 
 proc withMaxInOut*(b: SwitchBuilder, maxIn: int, maxOut: int): SwitchBuilder =
   ## Maximum concurrent incoming and outgoing connections.
-  b.limitsConfig = Opt.some(LimitsConfig.maxInOut(maxIn, maxOut))
+  b.limits = Opt.some(ConnectionLimits.maxInOut(maxIn, maxOut))
   b
 
 proc withMaxConnsPerPeer*(b: SwitchBuilder, maxConnsPerPeer: int): SwitchBuilder =
@@ -287,8 +287,8 @@ proc withWatermark*(
   ## a hard semaphore cap and active trimming simultaneously.
   doAssert lowWater > 0, "lowWater must be > 0"
   doAssert highWater > lowWater, "highWater must be > lowWater"
-  b.watermarkConfig = Opt.some(
-    WatermarkConfig(
+  b.watermark = Opt.some(
+    WatermarkPolicy(
       lowWater: lowWater,
       highWater: highWater,
       gracePeriod: gracePeriod,
@@ -298,11 +298,11 @@ proc withWatermark*(
   b
 
 proc withScoring*(
-    b: SwitchBuilder, scoringConfig: ScoringConfig = ScoringConfig()
+    b: SwitchBuilder, scoring: PeerScoring = PeerScoring()
 ): SwitchBuilder =
   ## Configure connection scoring parameters.
-  doAssert scoringConfig.decayResolution > 0.seconds, "decayResolution must be > 0"
-  b.scoringConfig = scoringConfig
+  doAssert scoring.decayResolution > 0.seconds, "decayResolution must be > 0"
+  b.scoring = scoring
   b
 
 proc withPeerStore*(b: SwitchBuilder, capacity: int): SwitchBuilder =
@@ -437,9 +437,9 @@ proc build*(b: SwitchBuilder): Switch {.raises: [LPError].} =
 
   let connManager = ConnManager.new(
     maxConnsPerPeer = b.maxConnsPerPeer,
-    limits = b.limitsConfig,
-    watermark = b.watermarkConfig,
-    scoringConfig = b.scoringConfig,
+    limits = b.limits,
+    watermark = b.watermark,
+    scoring = b.scoring,
   )
 
   let ms = MultistreamSelect.new()
@@ -551,7 +551,7 @@ proc newStandardSwitchBuilder*(
     secureManagers: openArray[SecureProtocol] = [SecureProtocol.Noise],
     inTimeout: Duration = 5.minutes,
     outTimeout: Duration = 5.minutes,
-    limits: Opt[LimitsConfig] = Opt.none(LimitsConfig),
+    limits: Opt[ConnectionLimits] = Opt.none(ConnectionLimits),
     maxConnsPerPeer = -1,
     nameResolver = Opt.none(NameResolver),
     sendSignedPeerRecord = false,
@@ -616,7 +616,7 @@ proc newStandardSwitch*(
     secureManagers: openArray[SecureProtocol] = [SecureProtocol.Noise],
     inTimeout: Duration = 5.minutes,
     outTimeout: Duration = 5.minutes,
-    limits: Opt[LimitsConfig] = Opt.none(LimitsConfig),
+    limits: Opt[ConnectionLimits] = Opt.none(ConnectionLimits),
     maxConnsPerPeer = -1,
     nameResolver = Opt.none(NameResolver),
     sendSignedPeerRecord = false,

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -300,7 +300,7 @@ proc withWatermarkPolicy*(
 proc withPeerScoring*(
     b: SwitchBuilder, scoring: PeerScoring = PeerScoring()
 ): SwitchBuilder =
-  ## Configure connection scoring parameters.
+  ## Configure peer scoring parameters.
   doAssert scoring.decayResolution > 0.seconds, "decayResolution must be > 0"
   b.scoring = scoring
   b

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -32,13 +32,13 @@ type
     interval: Duration
     decayFn: DecayFn
 
-  ScoringConfig* = object ## Configuration for connection scoring parameters.
+  PeerScoring* = object ## Configuration for connection scoring parameters.
     outboundBonus*: int = 100
       ## `outboundBonus` is added to the score of every peer with an outbound connection
     decayResolution*: Duration = 1.minutes
       ## `decayResolution` controls how often ephemeral tag decay functions are applied
 
-  WatermarkConfig* = object
+  WatermarkPolicy* = object
     ## Configuration for hi/lo watermark connection management.
     ## When peer count exceeds `highWater`, a trim cycle runs until
     ## peer count drops to `lowWater`.
@@ -47,9 +47,9 @@ type
     gracePeriod*: Duration ## newly connected peers are exempt from trimming
     silencePeriod*: Duration ## minimum interval between trim cycles
 
-  LimitsConfig* = object
-    ## Configuration for connection limits. Construct via `LimitsConfig.maxTotal`
-    ## for a single shared cap, or `LimitsConfig.maxInOut` for independent
+  ConnectionLimits* = object
+    ## Configuration for connection limits. Construct via `ConnectionLimits.maxTotal`
+    ## for a single shared cap, or `ConnectionLimits.maxInOut` for independent
     ## inbound/outbound caps.
     maxConnections: int = -1
     maxIn: int = -1
@@ -108,12 +108,12 @@ type
     readyPeers: HashSet[PeerId]
     expectedConnectionsOverLimit*: Table[(PeerId, Direction), Future[Muxer]]
     peerStore*: PeerStore
-    watermark: Opt[WatermarkConfig]
+    watermark: Opt[WatermarkPolicy]
     connectedAt: Table[PeerId, Moment]
     protectedPeers: Table[PeerId, HashSet[string]]
     trimFut: Future[void]
     lastTrim: Moment
-    scoringConfig: ScoringConfig
+    scoring: PeerScoring
     staticTags: Table[PeerId, Table[string, int]]
     decayingTags: Table[PeerId, Table[string, DecayingTagValue]]
     decayLoopFut: Future[void]
@@ -140,16 +140,16 @@ proc decayNone*(): DecayFn =
   return proc(value: int, elapsed: Duration): int {.gcsafe, raises: [].} =
     value
 
-proc maxTotal*(T: type LimitsConfig, maxConnections: int): LimitsConfig =
-  ## Constructs LimitsConfig with single shared cap limit.
+proc maxTotal*(T: type ConnectionLimits, maxConnections: int): ConnectionLimits =
+  ## Constructs ConnectionLimits with single shared cap limit.
   doAssert maxConnections > 0, "maxConnections must be > 0"
-  LimitsConfig(maxConnections: maxConnections)
+  ConnectionLimits(maxConnections: maxConnections)
 
-proc maxInOut*(T: type LimitsConfig, maxIn: int, maxOut: int): LimitsConfig =
-  ## Constructs LimitsConfig with independent inbound/outbound caps.
+proc maxInOut*(T: type ConnectionLimits, maxIn: int, maxOut: int): ConnectionLimits =
+  ## Constructs ConnectionLimits with independent inbound/outbound caps.
   doAssert maxIn > 0, "maxIn must be > 0"
   doAssert maxOut > 0, "maxOut must be > 0"
-  LimitsConfig(maxIn: maxIn, maxOut: maxOut)
+  ConnectionLimits(maxIn: maxIn, maxOut: maxOut)
 
 proc newTooManyConnectionsError(): ref TooManyConnectionsError {.inline.} =
   result = newException(TooManyConnectionsError, "Too many connections")
@@ -157,24 +157,24 @@ proc newTooManyConnectionsError(): ref TooManyConnectionsError {.inline.} =
 proc new*(
     T: type ConnManager,
     maxConnsPerPeer: int = -1,
-    limits: Opt[LimitsConfig] = Opt.none(LimitsConfig),
-    watermark: Opt[WatermarkConfig] = Opt.none(WatermarkConfig),
-    scoringConfig: ScoringConfig = ScoringConfig(),
+    limits: Opt[ConnectionLimits] = Opt.none(ConnectionLimits),
+    watermark: Opt[WatermarkPolicy] = Opt.none(WatermarkPolicy),
+    scoring: PeerScoring = PeerScoring(),
 ): ConnManager =
   ## Creates a `ConnManager`.
   ##
   ## `maxConnsPerPeer` accepts `-1` to mean "use the default value".
   ##
-  ## `limits` selects the connection-cap strategy: `LimitsConfig.maxTotal(n)`
-  ## for a single shared cap, or `LimitsConfig.maxInOut(i, o)` for independent
+  ## `limits` selects the connection-cap strategy: `ConnectionLimits.maxTotal(n)`
+  ## for a single shared cap, or `ConnectionLimits.maxInOut(i, o)` for independent
   ## per-direction caps. When omitted, the total cap defaults to
-  ## `DefaultMaxConnections`. 
+  ## `DefaultMaxConnections`.
   ##
   ## When `watermark` is provided without `limits` the semaphore is omitted
   ## and hi/lo trimming is the only guard.  When both are provided the
   ## semaphore blocks new connections hard while trimming also prunes
   ## existing ones.
-  let cfg = limits.get(LimitsConfig())
+  let cfg = limits.get(ConnectionLimits())
   let hasWatermark = watermark.isSome
   let hasInOut = cfg.maxIn > 0 and cfg.maxOut > 0
   let hasTotal = cfg.maxConnections > 0
@@ -208,7 +208,7 @@ proc new*(
     inSema: inSema,
     outSema: outSema,
     watermark: watermark,
-    scoringConfig: scoringConfig,
+    scoring: scoring,
   )
 
 proc connCount*(c: ConnManager, peerId: PeerId): int {.inline.} =
@@ -608,7 +608,7 @@ proc peerScore*(c: ConnManager, peerId: PeerId): int =
   ##   + sum of all current decaying tag values
   var score = 0
   if not c.selectMuxer(peerId, Direction.Out).isNil:
-    score += c.scoringConfig.outboundBonus
+    score += c.scoring.outboundBonus
   c.staticTags.withValue(peerId, tags):
     for _, v in tags[]:
       score += v
@@ -635,7 +635,7 @@ proc applyDecay(c: ConnManager) =
 
 proc runDecayLoop(c: ConnManager) {.async: (raises: [CancelledError]).} =
   while c.decayingTags.len > 0:
-    await sleepAsync(c.scoringConfig.decayResolution)
+    await sleepAsync(c.scoring.decayResolution)
     c.applyDecay()
   c.decayLoopFut = nil
 

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -32,7 +32,7 @@ type
     interval: Duration
     decayFn: DecayFn
 
-  PeerScoring* = object ## Configuration for connection scoring parameters.
+  PeerScoring* = object ## Configuration for peer scoring parameters.
     outboundBonus*: int = 100
       ## `outboundBonus` is added to the score of every peer with an outbound connection
     decayResolution*: Duration = 1.minutes

--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -22,13 +22,13 @@ method newStream*(
 proc newMaxTotal(maxConnections = 10, maxConnsPerPeer = 1): ConnManager =
   ConnManager.new(
     maxConnsPerPeer = maxConnsPerPeer,
-    limits = Opt.some(LimitsConfig.maxTotal(maxConnections)),
+    limits = Opt.some(ConnectionLimits.maxTotal(maxConnections)),
   )
 
 proc newMaxInOut(maxIn: int, maxOut: int, maxConnsPerPeer = 1): ConnManager =
   ConnManager.new(
     maxConnsPerPeer = maxConnsPerPeer,
-    limits = Opt.some(LimitsConfig.maxInOut(maxIn, maxOut)),
+    limits = Opt.some(ConnectionLimits.maxInOut(maxIn, maxOut)),
   )
 
 proc newWatermark*(
@@ -39,15 +39,15 @@ proc newWatermark*(
     outboundBonus: int = 0,
     decayResolution = 1.minutes,
 ): ConnManager =
-  let wtCfg = WatermarkConfig(
+  let wtCfg = WatermarkPolicy(
     lowWater: lowWater,
     highWater: highWater,
     gracePeriod: gracePeriod,
     silencePeriod: silencePeriod,
   )
   let scCfg =
-    ScoringConfig(outboundBonus: outboundBonus, decayResolution: decayResolution)
-  ConnManager.new(watermark = Opt.some(wtCfg), scoringConfig = scCfg)
+    PeerScoring(outboundBonus: outboundBonus, decayResolution: decayResolution)
+  ConnManager.new(watermark = Opt.some(wtCfg), scoring = scCfg)
 
 proc storeMuxers(connMngr: ConnManager, count: uint): Future[seq[PeerId]] {.async.} =
   let peers = PeerId.random(count, rng).tryGet()
@@ -647,9 +647,9 @@ suite "Connection Manager: watermark with connection limiting":
     # semaphore stays exhausted and all further connection attempts are rejected.
     const maxConns = 3
     let connMngr = ConnManager.new(
-      limits = Opt.some(LimitsConfig.maxTotal(maxConns)),
+      limits = Opt.some(ConnectionLimits.maxTotal(maxConns)),
       watermark = Opt.some(
-        WatermarkConfig(
+        WatermarkPolicy(
           lowWater: 1, highWater: 2, gracePeriod: 0.seconds, silencePeriod: 0.seconds
         )
       ),

--- a/tests/libp2p/test_dialer.nim
+++ b/tests/libp2p/test_dialer.nim
@@ -32,7 +32,7 @@ suite "Dialer":
   asyncTest "Max connections reached":
     var switches: seq[Switch]
 
-    let dst = newStandardSwitch(limits = Opt.some(LimitsConfig.maxTotal(2)))
+    let dst = newStandardSwitch(limits = Opt.some(ConnectionLimits.maxTotal(2)))
     await dst.start()
     switches.add(dst)
 

--- a/tests/libp2p/test_dialer.nim
+++ b/tests/libp2p/test_dialer.nim
@@ -32,7 +32,8 @@ suite "Dialer":
   asyncTest "Max connections reached":
     var switches: seq[Switch]
 
-    let dst = newStandardSwitch(limits = Opt.some(ConnectionLimits.maxTotal(2)))
+    let dst =
+      newStandardSwitch(connectionLimits = Opt.some(ConnectionLimits.maxTotal(2)))
     await dst.start()
     switches.add(dst)
 

--- a/tests/libp2p/test_switch.nim
+++ b/tests/libp2p/test_switch.nim
@@ -717,7 +717,7 @@ suite "Switch":
 
   asyncTest "e2e total connection limits on incoming connections":
     var switches: seq[Switch]
-    let destSwitch = newStandardSwitch(limits = Opt.some(LimitsConfig.maxTotal(3)))
+    let destSwitch = newStandardSwitch(limits = Opt.some(ConnectionLimits.maxTotal(3)))
     switches.add(destSwitch)
     await destSwitch.start()
 
@@ -749,7 +749,7 @@ suite "Switch":
       switches.add(newStandardSwitch())
       await switches[i].start()
 
-    let srcSwitch = newStandardSwitch(limits = Opt.some(LimitsConfig.maxTotal(3)))
+    let srcSwitch = newStandardSwitch(limits = Opt.some(ConnectionLimits.maxTotal(3)))
     await srcSwitch.start()
 
     let dstSwitch = newStandardSwitch()
@@ -770,7 +770,8 @@ suite "Switch":
 
   asyncTest "e2e max incoming connection limits":
     var switches: seq[Switch]
-    let destSwitch = newStandardSwitch(limits = Opt.some(LimitsConfig.maxInOut(3, 1)))
+    let destSwitch =
+      newStandardSwitch(limits = Opt.some(ConnectionLimits.maxInOut(3, 1)))
     switches.add(destSwitch)
     await destSwitch.start()
 
@@ -802,7 +803,8 @@ suite "Switch":
       switches.add(newStandardSwitch())
       await switches[i].start()
 
-    let srcSwitch = newStandardSwitch(limits = Opt.some(LimitsConfig.maxInOut(1, 3)))
+    let srcSwitch =
+      newStandardSwitch(limits = Opt.some(ConnectionLimits.maxInOut(1, 3)))
     await srcSwitch.start()
 
     let dstSwitch = newStandardSwitch()

--- a/tests/libp2p/test_switch.nim
+++ b/tests/libp2p/test_switch.nim
@@ -717,7 +717,8 @@ suite "Switch":
 
   asyncTest "e2e total connection limits on incoming connections":
     var switches: seq[Switch]
-    let destSwitch = newStandardSwitch(limits = Opt.some(ConnectionLimits.maxTotal(3)))
+    let destSwitch =
+      newStandardSwitch(connectionLimits = Opt.some(ConnectionLimits.maxTotal(3)))
     switches.add(destSwitch)
     await destSwitch.start()
 
@@ -749,7 +750,8 @@ suite "Switch":
       switches.add(newStandardSwitch())
       await switches[i].start()
 
-    let srcSwitch = newStandardSwitch(limits = Opt.some(ConnectionLimits.maxTotal(3)))
+    let srcSwitch =
+      newStandardSwitch(connectionLimits = Opt.some(ConnectionLimits.maxTotal(3)))
     await srcSwitch.start()
 
     let dstSwitch = newStandardSwitch()
@@ -771,7 +773,7 @@ suite "Switch":
   asyncTest "e2e max incoming connection limits":
     var switches: seq[Switch]
     let destSwitch =
-      newStandardSwitch(limits = Opt.some(ConnectionLimits.maxInOut(3, 1)))
+      newStandardSwitch(connectionLimits = Opt.some(ConnectionLimits.maxInOut(3, 1)))
     switches.add(destSwitch)
     await destSwitch.start()
 
@@ -804,7 +806,7 @@ suite "Switch":
       await switches[i].start()
 
     let srcSwitch =
-      newStandardSwitch(limits = Opt.some(ConnectionLimits.maxInOut(1, 3)))
+      newStandardSwitch(connectionLimits = Opt.some(ConnectionLimits.maxInOut(1, 3)))
     await srcSwitch.start()
 
     let dstSwitch = newStandardSwitch()


### PR DESCRIPTION
## Summary
<!--
Provide a clear and concise description of the purpose of this PR.

Explain:
- What this PR does
- Why it is needed
- The problem it solves or the improvement it introduces
-->

in this pr i asked opus to help come up with better names for newly introduced types in connection manager. since new braking change is going to be introduced (these are new types anyway) it makes sense to do extra effort in order to have proper naming.

-----

opus reasoning:

Problems with the current names:
- **`LimitsConfig`** — "limits" is overloaded (size? rate? time? connections?). Without context the reader can't tell what's being limited.
- **`WatermarkConfig`** — "watermark" is jargon for the hi/lo trim trigger; the user-visible name doesn't hint at what the policy *does*.
- **`ScoringConfig`** — "scoring" is unanchored: what gets scored?
- All three carry a generic `Config` suffix that adds bytes without information when the root noun is already specific.


### Why these

- **`ConnectionLimits`** — names the subject (connections) and the role (limits). The static constructors `maxTotal` / `maxInOut` already read like English; `ConnectionLimits.maxTotal(50)` is unambiguous on first read. Drops `Config` because `Limits` is itself a noun.
- **`WatermarkPolicy`** — `Policy` signals "this is a set of behavior rules you tune," which matches what the type does (it controls when trimming fires and which peers are exempt). Keeps "Watermark" so the type aligns with the builder method `withWatermark`. Alternative: `TrimPolicy` if the team wants to describe the *effect* over the *mechanism* — but breaks symmetry with `withWatermark`.
- **`PeerScoring`** — pins down what is being scored. `withScoring(PeerScoring(...))` reads clearly even to a reader who hasn't opened `connmanager.nim`.

- why not `ConnectionScoring`? opus: If you'd prefer surface-level symmetry over operand accuracy, ConnectionScoring is the alternative — but it would be at odds with the rest of the connmanager API. I'd keep PeerScoring. - it is thinking about `peerScore`, `tagPeer`, `protectPeer`, etc..

 