### PR TITLE
ci(docs): use stable nim version

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: jiro4989/setup-nim-action@v2
         with:
-          nim-version: '2.2.x'
+          nim-version: 'stable'
 
       - name: Generate doc
         run: |


### PR DESCRIPTION
this version of nim can be whatever as long as it builds docs. choosing `stable`...

fixes this:
<img width="782" height="181" alt="image" src="https://github.com/user-attachments/assets/a91b3bd6-a300-42e6-89ad-5c6b9a600fcb" />
