### PR TITLE
fix(ci): codecov test clashing T type

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -504,8 +504,7 @@ proc build*(b: SwitchBuilder): Switch {.raises: [LPError].} =
     rdvService.setup(switch)
     switch.mount(rdvService)
 
-  if b.kad.isSome():
-    let kadInfo = b.kad.get()
+  b.kad.withValue(kadInfo):
     kadInfo.config.addressPolicy = b.addressPolicy
     let kad = KadDHT.new(
       switch, bootstrapNodes = kadInfo.bootstrapNodes, config = kadInfo.config

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -504,7 +504,8 @@ proc build*(b: SwitchBuilder): Switch {.raises: [LPError].} =
     rdvService.setup(switch)
     switch.mount(rdvService)
 
-  b.kad.withValue(kadInfo):
+  if b.kad.isSome():
+    let kadInfo = b.kad.get()
     kadInfo.config.addressPolicy = b.addressPolicy
     let kad = KadDHT.new(
       switch, bootstrapNodes = kadInfo.bootstrapNodes, config = kadInfo.config

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -47,20 +47,22 @@ proc maintainBuckets(kad: KadDHT) {.async: (raises: [CancelledError]).} =
   heartbeat "Refreshing buckets", kad.config.bucketRefreshTime, sleepFirst = true:
     await kad.refreshTable(kad.rtable, false)
 
+# K instead of T to avoid clashing with the T type param in withValue[T] when
+# called inside a withValue block, which causes a compiler error under --lineDir:on
 proc new*(
-    T: typedesc[KadDHT],
+    K: typedesc[KadDHT],
     switch: Switch,
     bootstrapNodes: seq[(PeerId, seq[MultiAddress])] = @[],
     config: KadDHTConfig = KadDHTConfig.new(),
     rng: ref HmacDrbgContext = newRng(),
     client: bool = false,
     codec: string = KadCodec,
-): T {.raises: [].} =
+): K {.raises: [].} =
   var rtable = RoutingTable.new(
     switch.peerInfo.peerId.toKey(),
     config = RoutingTableConfig.new(replication = config.replication),
   )
-  let kad = T(
+  let kad = K(
     rng: rng,
     switch: switch,
     rtable: rtable,


### PR DESCRIPTION
## Summary

Fixes a Nim compiler bug triggered when compiling with `--lineDir:on` (used during codecov CI runs). The `withValue[T]` template in `utility.nim` has a type parameter `T` that clashes with the `T` parameter name in `KadDHT.new*(T: typedesc[KadDHT], ...): T`, causing the compiler to fail with `cannot instantiate: 'Opt[T]'; Maybe generic arguments are missing?` at `builders.nim:509`.

The fix replaces the `b.kad.withValue(kadInfo):` call with an explicit `if b.kad.isSome(): let kadInfo = b.kad.get()` block, avoiding the template expansion entirely. Semantics are identical.

## Affected Areas

- [ ] Gossipsub
- [ ] Transports
- [ ] Peer Management / Discovery
- [ ] Protocol Logic
- [x] Build / Tooling  
  Fixes codecov CI step (`nimble test` with `NIMFLAGS="--lineDir:on --passC:-fprofile-arcs ..."`)
- [ ] Other

## Compatibility & Downstream Validation

No behavior change — this is a compiler-compatibility fix with identical runtime semantics.

- **Nimbus:** N/A  
- **Waku:** N/A  
- **Codex:** N/A  

## Impact on Library Users

No impact — internal change. `SwitchBuilder.withKademlia()` and `build()` behave identically.

## Risk Assessment

No backward compatibility concerns. The `Opt.get()` call is equivalent to the `withValue` template's `temp.get()` in the same `isSome()` guard. No behavior or API changes.

## References

- Similar fix for `awaitBatch[T]` → `awaitBatch[Fut]` rename on `feat/kad/add-provider-rejection` branch (`96a400e91`)
- Nim issue: template type parameter `T` shadowing `typedesc[T]` proc parameter under `--lineDir:on`

## Additional Notes

The bug is latent in the codebase and only surfaces under `--lineDir:on` (which the codecov step adds via `NIMFLAGS`). Other `withValue` blocks in `builders.nim` (e.g. `autonatV2ServerConfig`) also call `T: typedesc` procs but don't store the result in a `let` binding requiring type inference, so they're not affected.