### PR TITLE
test(interop): transport fix

### DIFF
--- a/interop/transport-v2/main.nim
+++ b/interop/transport-v2/main.nim
@@ -1,12 +1,32 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import chronos, chronicles
+import chronos, chronicles, redis
 import ../../libp2p/[builders, protocols/ping]
 import ../unified_testing
 
 logScope:
   topics = "transport interop"
+
+# The transport interop plans (rust/go/js/python implementations) exchange the
+# listener multiaddr via RPUSH/LPOP on the namespaced list key.
+proc publishListenerAddr(client: Redis, testKey: string, sw: Switch) =
+  let addrs = sw.peerInfo.fullAddrs.tryGet()
+  if addrs.len == 0:
+    raise newException(CatchableError, "Listener has no addresses")
+  discard client.rPush(makeKey(testKey, ListenerMultiaddrSuffix), $addrs[0])
+
+proc fetchListenerAddr(
+    client: Redis, testKey: string, timeout: Duration
+): Future[MultiAddress] {.async.} =
+  let key = makeKey(testKey, ListenerMultiaddrSuffix)
+  var val: string
+  proc hasValue(): bool =
+    val = client.lPop(key)
+    val != redisNil and val.len > 0
+
+  pollUntil(hasValue(), timeout, 500.milliseconds, "Timeout waiting for Redis list: " & key)
+  MultiAddress.init(val).tryGet()
 
 proc runListener(config: BaseConfig) {.async.} =
   let
@@ -18,7 +38,7 @@ proc runListener(config: BaseConfig) {.async.} =
   defer:
     await switch.stop()
 
-  publishListenerMultiaddr(redisClient, config.testKey, switch)
+  publishListenerAddr(redisClient, config.testKey, switch)
   info "Published listener multiaddr"
 
   # Listener stays alive until terminated by the test harness.
@@ -37,7 +57,7 @@ proc runDialer(config: BaseConfig) {.async.} =
 
   let
     remoteAddr =
-      await fetchListenerMultiaddr(redisClient, config.testKey, config.testTimeout)
+      await fetchListenerAddr(redisClient, config.testKey, config.testTimeout)
     dialingStart = Moment.now()
     remotePeerId = await switch.connect(remoteAddr)
     stream = await switch.dial(remotePeerId, PingCodec)

--- a/interop/transport-v2/main.nim
+++ b/interop/transport-v2/main.nim
@@ -25,7 +25,9 @@ proc fetchListenerAddr(
     val = client.lPop(key)
     val != redisNil and val.len > 0
 
-  pollUntil(hasValue(), timeout, 500.milliseconds, "Timeout waiting for Redis list: " & key)
+  pollUntil(
+    hasValue(), timeout, 500.milliseconds, "Timeout waiting for Redis list: " & key
+  )
   MultiAddress.init(val).tryGet()
 
 proc runListener(config: BaseConfig) {.async.} =


### PR DESCRIPTION
## Summary

Fix transport interop tests that were broken by the unified-testing refactor (#2373).

The refactor switched the listener multiaddr Redis exchange from `RPUSH`/`LPOP` to `SET`/`GET`. Other implementations (rust, go, js, python) still `RPUSH` on the listener side, so any cross-impl pairing where nim was on the opposite end hit `WRONGTYPE Operation against a key holding the wrong kind of value` and exit code 255.

This wasn't caught at the time because #2373 was only verified nim vs nim, where both sides agreed on `SET`/`GET` and the tests passed.

This PR restores the list-based exchange in `interop/transport-v2/main.nim` only, with two local helpers (`publishListenerAddr` / `fetchListenerAddr`) that `RPUSH` on publish and poll `LPOP` on fetch. The shared `unified_testing.nim` helpers and the perf / hole-punch suites stay on `SET`/`GET` since those use different keys with different semantics.

## Affected Areas

- [x] Tests  
  Interop test binary only (`interop/transport-v2/main.nim`).

## Impact on Library Users

None.

## Risk Assessment

Low.

## References

- Verified locally against `rust-v0.56`, `go-v0.47-pre`, and `nim-v1.15` self-test: 21/21 passing on the unified-testing harness (both directions, tcp/ws + noise + yamux/mplex, plus quic-v1).