### PR TITLE
fix(autotls): withAutotls independent ordering

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -82,7 +82,7 @@ type
     autonatV2Client: AutonatV2Client
     autonatV2Service*: Opt[AutonatV2Service]
     hpService*: Opt[HPService]
-    autotls: Opt[AutotlsService]
+    autotlsConfig: Opt[AutotlsConfig]
     circuitRelay: Opt[Relay]
     rdv: Opt[RendezVous]
     kad: Opt[KadInfo]
@@ -107,7 +107,7 @@ proc new*(T: type[SwitchBuilder]): T =
     scoring: PeerScoring(),
     protoVersion: ProtoVersion,
     agentVersion: AgentVersion,
-    autotls: Opt.none(AutotlsService),
+    autotlsConfig: Opt.none(AutotlsConfig),
     circuitRelay: Opt.none(Relay),
     rdv: Opt.none(RendezVous),
     kad: Opt.none(KadInfo),
@@ -325,7 +325,7 @@ when defined(libp2p_autotls_support):
   proc withAutotls*(
       b: SwitchBuilder, config: AutotlsConfig = AutotlsConfig.new()
   ): SwitchBuilder =
-    b.autotls = Opt.some(AutotlsService.new(config = config))
+    b.autotlsConfig = Opt.some(config)
     b
 
 proc withCircuitRelay*(b: SwitchBuilder, r: Relay = Relay.new()): SwitchBuilder =
@@ -413,8 +413,13 @@ proc build*(b: SwitchBuilder): Switch {.raises: [LPError].} =
   let ms = MultistreamSelect.new()
   let muxedUpgrade = MuxedUpgrade.new(b.muxers, secureManagerInstances, ms, connManager)
 
-  b.autotls.withValue(autotlsService):
-    b.services.add(autotlsService)
+  var autotlsOpt = Opt.none(AutotlsService)
+  when defined(libp2p_autotls_support):
+    b.autotlsConfig.withValue(config):
+      autotlsOpt = Opt.some(AutotlsService.new(b.rng, config))
+
+  autotlsOpt.withValue(autotlsSvc):
+    b.services.add(autotlsSvc)
 
   let transports = block:
     var transports: seq[Transport]
@@ -424,7 +429,7 @@ proc build*(b: SwitchBuilder): Switch {.raises: [LPError].} =
           TransportConfig(
             upgr: muxedUpgrade,
             privateKey: seckey,
-            autotls: b.autotls,
+            autotls: autotlsOpt,
             connManager: connManager,
           )
         )

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -85,7 +85,7 @@ type
     hpService*: Opt[HPService]
     autotlsConfig: Opt[AutotlsConfig]
     circuitRelay: Opt[Relay]
-    rdv: Opt[RendezVous]
+    rdvConfig: Opt[RendezVousConfig]
     kad: Opt[KadInfo]
     services: seq[Service]
     observedAddrManager: ObservedAddrManager
@@ -110,7 +110,7 @@ proc new*(T: type[SwitchBuilder]): T =
     agentVersion: AgentVersion,
     autotlsConfig: Opt.none(AutotlsConfig),
     circuitRelay: Opt.none(Relay),
-    rdv: Opt.none(RendezVous),
+    rdvConfig: Opt.none(RendezVousConfig),
     kad: Opt.none(KadInfo),
     enableWildcardResolver: true,
     addressPolicy: defaultAddressPolicy,
@@ -333,13 +333,10 @@ proc withCircuitRelay*(b: SwitchBuilder, r: Relay = Relay.new()): SwitchBuilder 
   b.circuitRelay = Opt.some(r)
   b
 
-proc withRendezVous*(b: SwitchBuilder, rdv: RendezVous): SwitchBuilder =
-  var lrdv = rdv
-  if rdv.isNil():
-    doAssert not b.rng.isNil, "use withRng() before calling withRendezVous()"
-    lrdv = RendezVous.new(b.rng)
-
-  b.rdv = Opt.some(lrdv)
+proc withRendezVous*(
+    b: SwitchBuilder, config: RendezVousConfig = RendezVousConfig.new()
+): SwitchBuilder =
+  b.rdvConfig = Opt.some(config)
   b
 
 proc withKademlia*(
@@ -495,7 +492,8 @@ proc build*(b: SwitchBuilder): Switch {.raises: [LPError].} =
     relay.setup(switch)
     switch.mount(relay)
 
-  b.rdv.withValue(rdvService):
+  b.rdvConfig.withValue(rdvCfg):
+    let rdvService = RendezVous.new(b.rng, rdvCfg)
     rdvService.setup(switch)
     switch.mount(rdvService)
 

--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -45,6 +45,36 @@ const
 type PeerRecordValidator*[E] =
   proc(_: E, spr: seq[byte], peerId: PeerId): Result[void, string] {.gcsafe.}
 
+type RendezVousConfig* = ref object
+  minDuration*: Duration
+  maxDuration*: Duration
+  minTTL*: uint64
+  maxTTL*: uint64
+
+proc new*(
+    T: typedesc[RendezVousConfig],
+    minDuration: Duration = MinimumDuration,
+    maxDuration: Duration = MaximumDuration,
+): T =
+  var minD = minDuration
+  var maxD = maxDuration
+  if minD < MinimumAcceptedDuration:
+    warn "TTL too short: 1 minute minimum"
+    minD = MinimumAcceptedDuration
+  if maxD > MaximumDuration:
+    warn "TTL too long: 72 hours maximum"
+    maxD = MaximumDuration
+  if minD >= maxD:
+    warn "Minimum TTL longer than maximum"
+    minD = MinimumAcceptedDuration
+    maxD = MaximumDuration
+  T(
+    minDuration: minD,
+    maxDuration: maxD,
+    minTTL: minD.seconds.uint64,
+    maxTTL: maxD.seconds.uint64,
+  )
+
 type
   AdvertiseError* = object of LPError
   RendezVousError* = object of LPError
@@ -63,6 +93,7 @@ type
     # namespace in the offsettedqueue.
     namespaces*: Table[string, seq[int]]
     rng*: ref HmacDrbgContext
+    config*: RendezVousConfig
     salt*: string
     expiredDT*: Moment
     registerDeletionLoop*: Future[void]
@@ -72,10 +103,6 @@ type
     peers*: seq[PeerId]
     cookiesSaved*: Table[PeerId, Table[string, seq[byte]]]
     switch*: Switch
-    minDuration*: Duration
-    maxDuration*: Duration
-    minTTL*: uint64
-    maxTTL*: uint64
     peerRecordValidator*: PeerRecordValidator[E]
 
   RendezVous* = GenericRendezVous[PeerRecord]
@@ -161,7 +188,7 @@ proc save*[E](
     rdv.registered.add(
       RegisteredData(
         peerId: peerId,
-        expiration: Moment.now() + r.ttl.get(rdv.minTTL).int64.seconds,
+        expiration: Moment.now() + r.ttl.get(rdv.config.minTTL).int64.seconds,
         data: r,
       )
     )
@@ -177,8 +204,8 @@ proc register*[E](
   libp2p_rendezvous_register.inc()
   if r.ns.len < MinimumNamespaceLen or r.ns.len > MaximumNamespaceLen:
     return conn.sendRegisterResponseError(InvalidNamespace)
-  let ttl = r.ttl.get(rdv.minTTL)
-  if ttl < rdv.minTTL or ttl > rdv.maxTTL:
+  let ttl = r.ttl.get(rdv.config.minTTL)
+  if ttl < rdv.config.minTTL or ttl > rdv.config.maxTTL:
     return conn.sendRegisterResponseError(InvalidTTL)
   let pr = rdv.peerRecordValidator(peerRecord, r.signedPeerRecord, conn.peerId)
   if pr.isErr():
@@ -314,7 +341,7 @@ proc advertise*[E](
   if ns.len < MinimumNamespaceLen or ns.len > MaximumNamespaceLen:
     raise newException(AdvertiseError, "Invalid namespace")
 
-  if ttl < rdv.minDuration or ttl > rdv.maxDuration:
+  if ttl < rdv.config.minDuration or ttl > rdv.config.maxDuration:
     raise newException(AdvertiseError, "Invalid time to live: " & $ttl)
 
   let
@@ -333,7 +360,7 @@ proc advertise*[E](
 method advertise*(
     rdv: RendezVous, ns: string, ttl: Opt[Duration] = Opt.none(Duration)
 ) {.base, async: (raises: [CancelledError, AdvertiseError]).} =
-  let lttl = ttl.get(rdv.minDuration)
+  let lttl = ttl.get(rdv.config.minDuration)
   if rdv.switch.isNil:
     # I don't like this, but adding this as i don't understand why we have a constructor without switch as arg
     raise newException(AdvertiseError, "Rendezvous not setup with a switch")
@@ -427,8 +454,8 @@ proc request*[E](
       for r in registrations:
         if limit == 0:
           break
-        let ttl = r.ttl.get(rdv.maxTTL + 1)
-        if ttl > rdv.maxTTL:
+        let ttl = r.ttl.get(rdv.config.maxTTL + 1)
+        if ttl > rdv.config.maxTTL:
           continue
         let
           spr = SignedPayload[E].decode(r.signedPeerRecord).valueOr:
@@ -440,7 +467,7 @@ proc request*[E](
               s[pr.peerId]
             except exceptions.KeyError:
               raiseAssert "checked with hasKey"
-          if (prSaved.seqNo == pr.seqNo and rSaved.ttl.get(rdv.maxTTL) < ttl) or
+          if (prSaved.seqNo == pr.seqNo and rSaved.ttl.get(rdv.config.maxTTL) < ttl) or
               prSaved.seqNo < pr.seqNo:
             s[pr.peerId] = (pr, r)
         else:
@@ -514,40 +541,16 @@ proc setup*[E](rdv: GenericRendezVous[E], switch: Switch) =
 proc new*(
     T: typedesc[RendezVous],
     rng: ref HmacDrbgContext,
-    minDuration = MinimumDuration,
-    maxDuration = MaximumDuration,
-    codec: string,
+    config: RendezVousConfig = RendezVousConfig.new(),
 ): T =
-  var minD = minDuration
-  var maxD = maxDuration
-  if minD < MinimumAcceptedDuration:
-    warn "TTL too short: 1 minute minimum"
-    minD = MinimumAcceptedDuration
-
-  if maxD > MaximumDuration:
-    warn "TTL too long: 72 hours maximum"
-    maxD = MaximumDuration
-
-  if minD >= maxD:
-    warn "Minimum TTL longer than maximum"
-    minD = MinimumAcceptedDuration
-    maxD = MaximumDuration
-
-  let
-    minTTL = minD.seconds.uint64
-    maxTTL = maxD.seconds.uint64
-
   let rdv = GenericRendezVous[PeerRecord](
     rng: rng,
+    config: config,
     salt: string.fromBytes(generateBytes(rng[], 8)),
     registered: initOffsettedSeq[RegisteredData](),
     expiredDT: Moment.now() - 1.days,
     #registerEvent: newAsyncEvent(),
     sema: newAsyncSemaphore(SemaphoreDefaultSize),
-    minDuration: minDuration,
-    maxDuration: maxDuration,
-    minTTL: minTTL,
-    maxTTL: maxTTL,
     peerRecordValidator: checkPeerRecord,
   )
   logScope:
@@ -580,27 +583,18 @@ proc new*(
     finally:
       await conn.close()
 
-  info "Rendezvous protocol initialized", codec
+  info "Rendezvous protocol initialized"
   rdv.handler = handleStream
-  rdv.codec = codec
+  rdv.codec = RendezVousCodec
   return rdv
-
-proc new*(
-    T: typedesc[RendezVous],
-    rng: ref HmacDrbgContext,
-    minDuration = MinimumDuration,
-    maxDuration = MaximumDuration,
-): T =
-  T.new(rng, minDuration, maxDuration, RendezVousCodec)
 
 proc new*(
     T: typedesc[RendezVous],
     switch: Switch,
     rng: ref HmacDrbgContext,
-    minDuration = MinimumDuration,
-    maxDuration = MaximumDuration,
+    config: RendezVousConfig = RendezVousConfig.new(),
 ): T =
-  let rdv = T.new(rng, minDuration, maxDuration, RendezVousCodec)
+  let rdv = T.new(rng, config)
   rdv.setup(switch)
   return rdv
 

--- a/tests/integration/test_autotls_integration.nim
+++ b/tests/integration/test_autotls_integration.nim
@@ -75,14 +75,14 @@ when defined(linux) and defined(amd64) and defined(libp2p_autotls_support):
 
       let switch = SwitchBuilder
         .new()
-        .withRng(rng)
-        .withAddress(MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet())
-        .withTcpTransport()
         .withAutotls(
           config = AutotlsConfig.new(
             acmeServerURL = parseUri(LetsEncryptURLStaging), renewCheckTime = 1.seconds
           )
         )
+        .withRng(rng)
+        .withAddress(MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet())
+        .withTcpTransport()
         .withYamux()
         .withNoise()
         .build()

--- a/tests/integration/test_ws_integration.nim
+++ b/tests/integration/test_ws_integration.nim
@@ -44,6 +44,7 @@ suite "WebSocket transport integration":
 
     let switch2 = SwitchBuilder
       .new()
+      .withAutotls()
       .withRng(rng)
       .withAddresses(
         @[
@@ -53,7 +54,6 @@ suite "WebSocket transport integration":
       )
       .withTcpTransport()
       .withWsTransport()
-      .withAutotls()
       .withYamux()
       .withNoise()
       .build()

--- a/tests/libp2p/discovery/test_rendezvous.nim
+++ b/tests/libp2p/discovery/test_rendezvous.nim
@@ -70,35 +70,16 @@ type CustomRendezVous = GenericRendezVous[CustomPeerRecord]
 
 proc new*(
     T: typedesc[CustomRendezVous],
-    minD = rendezvous.MinimumDuration,
-    maxD = rendezvous.MaximumDuration,
+    config: RendezVousConfig = RendezVousConfig.new(),
     peerRecordValidator: PeerRecordValidator[CustomPeerRecord] = checkCustomPeerRecord,
 ): T =
-  var minDuration = minD
-  var maxDuration = maxD
-  if minDuration < rendezvous.MinimumAcceptedDuration:
-    minDuration = rendezvous.MinimumAcceptedDuration
-
-  if maxDuration > rendezvous.MaximumDuration:
-    maxDuration = rendezvous.MaximumDuration
-
-  if minDuration >= maxDuration:
-    minDuration = rendezvous.MinimumAcceptedDuration
-    maxDuration = rendezvous.MaximumDuration
-
-  let
-    minTTL = minDuration.seconds.uint64
-    maxTTL = maxDuration.seconds.uint64
   let rdv = T(
     rng: rng,
+    config: config,
     salt: string.fromBytes(generateBytes(rng[], 8)),
     registered: initOffsettedSeq[RegisteredData](),
     expiredDT: Moment.now() - 1.days,
     sema: newAsyncSemaphore(SemaphoreDefaultSize),
-    minDuration: minDuration,
-    maxDuration: maxDuration,
-    minTTL: minTTL,
-    maxTTL: maxTTL,
     peerRecordValidator: peerRecordValidator,
   )
   let pr = CustomPeerRecord.init(
@@ -146,7 +127,7 @@ proc advertise*(
     raise newException(AdvertiseError, "Failed to sign Custom Peer Record")
   let sprBuff = se.encode().valueOr:
     raise newException(AdvertiseError, "Wrong Signed Peer Record")
-  await rdv.advertise(namespace, rdv.minDuration, rdv.peers, sprBuff)
+  await rdv.advertise(namespace, rdv.config.minDuration, rdv.peers, sprBuff)
 
 suite "RendezVous":
   teardown:

--- a/tests/libp2p/discovery/test_rendezvous_errors.nim
+++ b/tests/libp2p/discovery/test_rendezvous_errors.nim
@@ -23,7 +23,9 @@ suite "RendezVous Errors":
   asyncTest "Various local error":
     let rdv = RendezVous.new(
       rng(),
-      RendezVousConfig.new(minDuration = MinimumAcceptedDuration, maxDuration = MaximumDuration),
+      RendezVousConfig.new(
+        minDuration = MinimumAcceptedDuration, maxDuration = MaximumDuration
+      ),
     )
     expect AdvertiseError:
       discard await rendezvous.request(

--- a/tests/libp2p/discovery/test_rendezvous_errors.nim
+++ b/tests/libp2p/discovery/test_rendezvous_errors.nim
@@ -22,7 +22,8 @@ suite "RendezVous Errors":
 
   asyncTest "Various local error":
     let rdv = RendezVous.new(
-      rng(), minDuration = MinimumAcceptedDuration, maxDuration = MaximumDuration
+      rng(),
+      RendezVousConfig.new(minDuration = MinimumAcceptedDuration, maxDuration = MaximumDuration),
     )
     expect AdvertiseError:
       discard await rendezvous.request(

--- a/tests/libp2p/discovery/utils.nim
+++ b/tests/libp2p/discovery/utils.nim
@@ -26,7 +26,7 @@ proc createSwitch*(): Switch =
     .withNoise()
     .build()
 
-proc createSwitch*(config: RendezVousConfig = RendezVousConfig.new()): RendezVous =
+proc createSwitch*(config: RendezVousConfig): RendezVous =
   let switch = SwitchBuilder
     .new()
     .withRendezVous(config)
@@ -45,7 +45,7 @@ proc setupNodes*(count: int): seq[RendezVous] =
   doAssert(count > 0, "Count must be greater than 0")
   var rdvs: seq[RendezVous] = @[]
   for x in 0 ..< count:
-    rdvs.add(createSwitch())
+    rdvs.add(createSwitch(RendezVousConfig.new()))
   return rdvs
 
 proc setupRendezvousNodeWithPeerNodes*(count: int): (RendezVous, seq[RendezVous]) =

--- a/tests/libp2p/discovery/utils.nim
+++ b/tests/libp2p/discovery/utils.nim
@@ -6,6 +6,7 @@ import
   ../../../libp2p/[
     builders,
     crypto/crypto,
+    multistream,
     peerid,
     protobuf/minprotobuf,
     protocols/rendezvous,
@@ -25,31 +26,26 @@ proc createSwitch*(): Switch =
     .withNoise()
     .build()
 
-proc createSwitch*(rdv: RendezVous): Switch =
-  var lrdv = rdv
-  if rdv.isNil():
-    lrdv = RendezVous.new(rng)
-
-  SwitchBuilder
+proc createSwitch*(config: RendezVousConfig = RendezVousConfig.new()): RendezVous =
+  let switch = SwitchBuilder
     .new()
+    .withRendezVous(config)
     .withRng(rng)
     .withAddresses(@[MultiAddress.init(MemoryAutoAddress).tryGet()])
     .withMemoryTransport()
     .withMplex()
     .withNoise()
-    .withRendezVous(lrdv)
     .build()
+  for h in switch.ms.handlers:
+    if RendezVousCodec in h.protos:
+      return RendezVous(h.protocol)
+  doAssert false, "RendezVous not mounted"
 
 proc setupNodes*(count: int): seq[RendezVous] =
   doAssert(count > 0, "Count must be greater than 0")
-
   var rdvs: seq[RendezVous] = @[]
-
   for x in 0 ..< count:
-    var rdv: RendezVous = RendezVous.new(rng)
-    discard createSwitch(rdv)
-    rdvs.add(rdv)
-
+    rdvs.add(createSwitch())
   return rdvs
 
 proc setupRendezvousNodeWithPeerNodes*(count: int): (RendezVous, seq[RendezVous]) =


### PR DESCRIPTION
## Summary
`.withAutotls()` no longer depends on `withRng` being declared first, rng is set on `build`.

## References
#2408 