### PR TITLE
feat: boringssl

### DIFF
--- a/.pinned
+++ b/.pinned
@@ -1,4 +1,5 @@
 bearssl;https://github.com/status-im/nim-bearssl@#22c6a76ce015bc07e011562bdcfc51d9446c1e82
+boringssl;https://github.com/vacp2p/nim-boringssl@#2bf3b96cbaafda91409893508fb3f95be883b5a8
 chronicles;https://github.com/status-im/nim-chronicles@#e7f87336d2fa47b7752b42f0be4cabd5663a5e5c
 chronos;https://github.com/status-im/nim-chronos@#45f43a9ad8bd8bcf5903b42f365c1c879bd54240
 dnsclient;https://github.com/ba0f3/dnsclient.nim@#23214235d4784d24aceed99bbfe153379ea557c8
@@ -7,7 +8,7 @@ httputils;https://github.com/status-im/nim-http-utils@#f142cb2e8bd812dd002a6493b
 json_serialization;https://github.com/status-im/nim-json-serialization@#a6dcf03e04e179127a5fcb7e495d19a821d56c17
 metrics;https://github.com/status-im/nim-metrics@#a1296caf3ebb5f30f51a5feae7749a30df2824c2
 nimcrypto;https://github.com/cheatfate/nimcrypto@#721fb99ee099b632eb86dfad1f0d96ee87583774
-lsquic;https://github.com/vacp2p/nim-lsquic@#504c8c1574f1fc47d994ed7fc94f17a28d95d579
+lsquic;https://github.com/vacp2p/nim-lsquic@#48c800132f4d05192b52efec5f0e53d878ed4dec
 results;https://github.com/arnetheduck/nim-results@#df8113dda4c2d74d460a8fa98252b0b771bf1f27
 secp256k1;https://github.com/status-im/nim-secp256k1@#d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15
 serialization;https://github.com/status-im/nim-serialization@#f80cfd8657f272a2abd063d070b77f2a74f704cd

--- a/.pinned
+++ b/.pinned
@@ -1,5 +1,5 @@
 bearssl;https://github.com/status-im/nim-bearssl@#22c6a76ce015bc07e011562bdcfc51d9446c1e82
-boringssl;https://github.com/vacp2p/nim-boringssl@#2bf3b96cbaafda91409893508fb3f95be883b5a8
+boringssl;https://github.com/vacp2p/nim-boringssl@#f8111056182cf6abd9e35de77a919e873ef94652
 chronicles;https://github.com/status-im/nim-chronicles@#e7f87336d2fa47b7752b42f0be4cabd5663a5e5c
 chronos;https://github.com/status-im/nim-chronos@#45f43a9ad8bd8bcf5903b42f365c1c879bd54240
 dnsclient;https://github.com/ba0f3/dnsclient.nim@#23214235d4784d24aceed99bbfe153379ea557c8
@@ -8,7 +8,7 @@ httputils;https://github.com/status-im/nim-http-utils@#f142cb2e8bd812dd002a6493b
 json_serialization;https://github.com/status-im/nim-json-serialization@#a6dcf03e04e179127a5fcb7e495d19a821d56c17
 metrics;https://github.com/status-im/nim-metrics@#a1296caf3ebb5f30f51a5feae7749a30df2824c2
 nimcrypto;https://github.com/cheatfate/nimcrypto@#721fb99ee099b632eb86dfad1f0d96ee87583774
-lsquic;https://github.com/vacp2p/nim-lsquic@#48c800132f4d05192b52efec5f0e53d878ed4dec
+lsquic;https://github.com/vacp2p/nim-lsquic@#b9a60bbe52b2e5e586bd7220bf5b1238da680fc3
 results;https://github.com/arnetheduck/nim-results@#df8113dda4c2d74d460a8fa98252b0b771bf1f27
 secp256k1;https://github.com/status-im/nim-secp256k1@#d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15
 serialization;https://github.com/status-im/nim-serialization@#f80cfd8657f272a2abd063d070b77f2a74f704cd

--- a/.pinned
+++ b/.pinned
@@ -1,5 +1,5 @@
 bearssl;https://github.com/status-im/nim-bearssl@#22c6a76ce015bc07e011562bdcfc51d9446c1e82
-boringssl;https://github.com/vacp2p/nim-boringssl@#f8111056182cf6abd9e35de77a919e873ef94652
+boringssl;https://github.com/vacp2p/nim-boringssl@#1c91a4a2579123597df43bbdea70cc575957bdea
 chronicles;https://github.com/status-im/nim-chronicles@#e7f87336d2fa47b7752b42f0be4cabd5663a5e5c
 chronos;https://github.com/status-im/nim-chronos@#45f43a9ad8bd8bcf5903b42f365c1c879bd54240
 dnsclient;https://github.com/ba0f3/dnsclient.nim@#23214235d4784d24aceed99bbfe153379ea557c8
@@ -8,7 +8,7 @@ httputils;https://github.com/status-im/nim-http-utils@#f142cb2e8bd812dd002a6493b
 json_serialization;https://github.com/status-im/nim-json-serialization@#a6dcf03e04e179127a5fcb7e495d19a821d56c17
 metrics;https://github.com/status-im/nim-metrics@#a1296caf3ebb5f30f51a5feae7749a30df2824c2
 nimcrypto;https://github.com/cheatfate/nimcrypto@#721fb99ee099b632eb86dfad1f0d96ee87583774
-lsquic;https://github.com/vacp2p/nim-lsquic@#b9a60bbe52b2e5e586bd7220bf5b1238da680fc3
+lsquic;https://github.com/vacp2p/nim-lsquic@#0b9ee1f915963ab8384c701fda3c49a116b6f5fa
 results;https://github.com/arnetheduck/nim-results@#df8113dda4c2d74d460a8fa98252b0b771bf1f27
 secp256k1;https://github.com/status-im/nim-secp256k1@#d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15
 serialization;https://github.com/status-im/nim-serialization@#f80cfd8657f272a2abd063d070b77f2a74f704cd

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -10,8 +10,10 @@ skipDirs =
 
 requires "nim >= 2.0.0",
   "nimcrypto >= 0.6.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.7",
+  "https://github.com/vacp2p/nim-boringssl#v0.0.2",
   "chronicles >= 0.11.0", "chronos >= 4.2.2", "metrics", "secp256k1", "stew >= 0.4.2",
-  "unittest2", "results", "serialization", "lsquic >= 0.3.0",
+  "unittest2", "results", "serialization",
+  "https://github.com/vacp2p/nim-lsquic#48c800132f4d05192b52efec5f0e53d878ed4dec",
   "https://github.com/status-im/nim-websock#42c37b4172519566db016810eccfce8a02cc1cdf",
   "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
 

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -10,10 +10,9 @@ skipDirs =
 
 requires "nim >= 2.0.0",
   "nimcrypto >= 0.6.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.7",
-  "https://github.com/vacp2p/nim-boringssl#v0.0.3", "chronicles >= 0.11.0",
+  "https://github.com/vacp2p/nim-boringssl#v0.0.4", "chronicles >= 0.11.0",
   "chronos >= 4.2.2", "metrics", "secp256k1", "stew >= 0.4.2", "unittest2", "results",
-  "serialization",
-  "https://github.com/vacp2p/nim-lsquic#b9a60bbe52b2e5e586bd7220bf5b1238da680fc3",
+  "serialization", "lsquic >= 0.4.0",
   "https://github.com/status-im/nim-websock#42c37b4172519566db016810eccfce8a02cc1cdf",
   "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
 

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -10,10 +10,10 @@ skipDirs =
 
 requires "nim >= 2.0.0",
   "nimcrypto >= 0.6.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.7",
-  "https://github.com/vacp2p/nim-boringssl#v0.0.2",
-  "chronicles >= 0.11.0", "chronos >= 4.2.2", "metrics", "secp256k1", "stew >= 0.4.2",
-  "unittest2", "results", "serialization",
-  "https://github.com/vacp2p/nim-lsquic#48c800132f4d05192b52efec5f0e53d878ed4dec",
+  "https://github.com/vacp2p/nim-boringssl#v0.0.3", "chronicles >= 0.11.0",
+  "chronos >= 4.2.2", "metrics", "secp256k1", "stew >= 0.4.2", "unittest2", "results",
+  "serialization",
+  "https://github.com/vacp2p/nim-lsquic#b9a60bbe52b2e5e586bd7220bf5b1238da680fc3",
   "https://github.com/status-im/nim-websock#42c37b4172519566db016810eccfce8a02cc1cdf",
   "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
 

--- a/libp2p/transports/tls/certificate_ffi.nim
+++ b/libp2p/transports/tls/certificate_ffi.nim
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import lsquic/lsquic_ffi
+import boringssl
 import strutils
 import results
 import ../../utils/sequninit


### PR DESCRIPTION
## Summary

This PR adds `nim-boringssl` as a direct dependency and updates TLS certificate FFI code to import BoringSSL symbols directly instead of through `lsquic/lsquic_ffi`.

It also updates the `nim-lsquic` dependency pin to a specific commit compatible with this dependency split.

## Affected Areas

- [ ] Gossipsub
- [x] Transports  
  TLS certificate FFI now imports `boringssl` directly. QUIC/LSQUIC dependency pinning is updated.
- [ ] Peer Management / Discovery
- [ ] Protocol Logic
- [ ] Build / Tooling  
- [x] Other
  Updates `libp2p.nimble` and `.pinned` dependency declarations for `nim-boringssl` and `nim-lsquic`.
## Compatibility & Downstream Validation

Reference PRs / branches / commits demonstrating successful integration:

- **Nimbus:**  
- https://github.com/status-im/nimbus-eth2/pull/8406

- **Waku:**  
  Not yet validated.

- **Codex:**  
  Not yet validated.

## Impact on Library Users

Downstream users will now pull `vacp2p/nim-boringssl#v0.0.2` as a direct dependency of `nim-libp2p`.

The `lsquic` dependency is changed from the package constraint `lsquic >= 0.3.0` to a pinned GitHub commit. Users with custom lockfiles or pinned dependency sets may need to refresh their dependency pins.

No public `nim-libp2p` API change is intended.

## Risk Assessment

The main risk is dependency/build compatibility, especially for downstream projects or platforms sensitive to native TLS/QUIC linkage.

Runtime TLS certificate behavior is intended to remain unchanged, but the FFI import path now depends directly on `nim-boringssl`, so CI and downstream builds should verify that the new dependency layout resolves and links correctly.
