### PR TITLE
feat: identify pusher

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -474,6 +474,7 @@ proc build*(b: SwitchBuilder): Switch {.raises: [LPError].} =
   )
 
   switch.mount(identify)
+  switch.setupIdentifyPush()
 
   if not isNil(b.autonatV2Client):
     b.autonatV2Client.setup(switch)

--- a/libp2p/identify_pusher.nim
+++ b/libp2p/identify_pusher.nim
@@ -66,7 +66,8 @@ proc sendOne(p: IdentifyPusher, peerId: PeerId) {.async: (raises: [CancelledErro
   except MuxerError as e:
     trace "failed to open stream for identify push", peerId, description = e.msg
   except MultiStreamError as e:
-    trace "multistream negotiation failed for identify push", peerId, description = e.msg
+    trace "multistream negotiation failed for identify push",
+      peerId, description = e.msg
   except LPStreamError as e:
     trace "stream error during identify push", peerId, description = e.msg
   finally:
@@ -80,7 +81,7 @@ proc broadcast*(p: IdentifyPusher) =
   ## without blocking the caller.
   if p.identifyPush.isNil:
     return
-  
+
   for peerId in p.pushPeers.toSeq():
     let fut = p.sendOne(peerId)
     p.ongoingSend.add(fut)
@@ -110,9 +111,7 @@ proc start*(p: IdentifyPusher) =
     else:
       p.pushPeers.excl(peerId)
 
-  proc onLeft(
-      peerId: PeerId, event: PeerEvent
-  ) {.async: (raises: [CancelledError]).} =
+  proc onLeft(peerId: PeerId, event: PeerEvent) {.async: (raises: [CancelledError]).} =
     p.pushPeers.excl(peerId)
 
   p.onIdentifiedHandler = onIdentified

--- a/libp2p/identify_pusher.nim
+++ b/libp2p/identify_pusher.nim
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## `IdentifyPusher` — orchestrates the IdentifyPush protocol.
+##
+## Tracks which connected peers advertise the IdentifyPush codec, keeps that
+## set in sync with connect / disconnect / re-identify events, and broadcasts
+## our updated `PeerInfo` to every tracked peer when triggered.
+
+{.push raises: [].}
+
+import std/[sets, sequtils]
+import chronos, chronicles
+import
+  ./protocols/identify,
+  ./peerinfo,
+  ./peerid,
+  ./peerstore,
+  ./connmanager,
+  ./multistream,
+  ./stream/connection,
+  ./muxers/muxer,
+  ./utils/future
+
+export identify
+
+logScope:
+  topics = "libp2p identifypusher"
+
+type
+  PushSendFut = Future[void].Raising([CancelledError])
+
+  IdentifyPusher* = ref object
+    identifyPush*: IdentifyPush
+    pushPeers*: HashSet[PeerId]
+    ongoingSend*: seq[PushSendFut]
+    connManager: ConnManager
+    peerStore: PeerStore
+    peerInfo: PeerInfo
+    onIdentifiedHandler: PeerEventHandler
+    onLeftHandler: PeerEventHandler
+
+proc new*(
+    T: type IdentifyPusher,
+    connManager: ConnManager,
+    peerStore: PeerStore,
+    peerInfo: PeerInfo,
+): T =
+  T(connManager: connManager, peerStore: peerStore, peerInfo: peerInfo)
+
+proc sendOne(p: IdentifyPusher, peerId: PeerId) {.async: (raises: [CancelledError]).} =
+  let muxer = p.connManager.selectMuxer(peerId)
+  if muxer.isNil:
+    return
+  var stream: Connection
+  try:
+    stream = await muxer.newStream()
+    if stream.isNil:
+      trace "could not open new stream", peerId
+      return
+
+    if await MultistreamSelect.select(stream, IdentifyPushCodec):
+      await p.identifyPush.push(p.peerInfo, stream)
+  except CancelledError as e:
+    raise e
+  except MuxerError as e:
+    trace "failed to open stream for identify push", peerId, description = e.msg
+  except MultiStreamError as e:
+    trace "multistream negotiation failed for identify push", peerId, description = e.msg
+  except LPStreamError as e:
+    trace "stream error during identify push", peerId, description = e.msg
+  finally:
+    if not stream.isNil:
+      await stream.closeWithEOF()
+
+proc broadcast*(p: IdentifyPusher) =
+  ## Send an IdentifyPush message with our current `peerInfo` to every
+  ## connected peer that advertises the IdentifyPush protocol.
+  ## Each send runs as a background future; this proc returns immediately
+  ## without blocking the caller.
+  if p.identifyPush.isNil:
+    return
+  
+  for peerId in p.pushPeers.toSeq():
+    let fut = p.sendOne(peerId)
+    p.ongoingSend.add(fut)
+    fut.addCallback proc(udata: pointer) =
+      let idx = p.ongoingSend.find(fut)
+      if idx >= 0:
+        p.ongoingSend.del(idx)
+
+proc start*(p: IdentifyPusher) =
+  ## Construct the IdentifyPush protocol and register the connection manager
+  ## hooks that maintain `pushPeers`. The caller is responsible for mounting
+  ## `p.identifyPush` on a Switch.
+  proc onIncomingPush(peerId: PeerId, info: IdentifyInfo) {.async.} =
+    p.peerStore.updatePeerInfo(info)
+    if IdentifyPushCodec in info.protos:
+      p.pushPeers.incl(peerId)
+    else:
+      p.pushPeers.excl(peerId)
+
+  p.identifyPush = IdentifyPush.new(onIncomingPush)
+
+  proc onIdentified(
+      peerId: PeerId, event: PeerEvent
+  ) {.async: (raises: [CancelledError]).} =
+    if IdentifyPushCodec in p.peerStore[ProtoBook][peerId]:
+      p.pushPeers.incl(peerId)
+    else:
+      p.pushPeers.excl(peerId)
+
+  proc onLeft(
+      peerId: PeerId, event: PeerEvent
+  ) {.async: (raises: [CancelledError]).} =
+    p.pushPeers.excl(peerId)
+
+  p.onIdentifiedHandler = onIdentified
+  p.onLeftHandler = onLeft
+  p.connManager.addPeerEventHandler(onIdentified, PeerEventKind.Identified)
+  p.connManager.addPeerEventHandler(onLeft, PeerEventKind.Left)
+
+proc stop*(p: IdentifyPusher) {.async: (raises: []).} =
+  ## Cancel any in-flight pushes and unregister connection manager hooks.
+  if p.onIdentifiedHandler != nil:
+    p.connManager.removePeerEventHandler(
+      p.onIdentifiedHandler, PeerEventKind.Identified
+    )
+    p.onIdentifiedHandler = nil
+  if p.onLeftHandler != nil:
+    p.connManager.removePeerEventHandler(p.onLeftHandler, PeerEventKind.Left)
+    p.onLeftHandler = nil
+
+  let pending = move(p.ongoingSend)
+  pending.cancelSoon()
+
+  p.pushPeers.clear()
+  p.identifyPush = nil

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -226,6 +226,8 @@ proc init*(p: IdentifyPush) =
         if receivedPeerId != conn.peerId:
           raise newException(IdentityNoMatchError, "Peer ids don't match")
         identInfo.peerId = receivedPeerId
+      else:
+        identInfo.peerId = conn.peerId
 
       trace "triggering peer event", peerInfo = conn.peerId
       if not isNil(p.identifyHandler):

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -30,7 +30,7 @@ const
   IdentifyCodec* = "/ipfs/id/1.0.0"
   IdentifyPushCodec* = "/ipfs/id/push/1.0.0"
   ProtoVersion* = "ipfs/0.1.0"
-  AgentVersion* = "nim-libp2p/0.0.1"
+  AgentVersion* = "nim-libp2p"
   identifyAddrsLogMax = 5
 
 type

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -13,7 +13,7 @@ export routing_table, protobuf, types, find, get, put, provider, ping, kademlia_
 logScope:
   topics = "kad-dht"
 
-const KadCodec = "/ipfs/kad/1.0.0"
+const KadCodec* = "/ipfs/kad/1.0.0"
 
 proc refreshTable*(
     kad: KadDHT, rtable: RoutingTable, forceRefresh = false

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -19,6 +19,7 @@ import
   multistream,
   multiaddress,
   protocols/protocol,
+  protocols/identify,
   protocols/secure/secure,
   peerinfo,
   ./muxers/muxer,
@@ -26,11 +27,12 @@ import
   nameresolving/nameresolver,
   peerid,
   peerstore,
+  identify_pusher,
   errors,
   utility,
   dialer
 
-export connmanager, upgrade, dialer, peerstore
+export connmanager, upgrade, dialer, peerstore, identify_pusher
 
 logScope:
   topics = "libp2p switch"
@@ -57,6 +59,7 @@ type
     started: bool
     services*: seq[Service]
     rng*: ref HmacDrbgContext
+    identifyPusher*: IdentifyPusher
 
   UpgradeError* = object of LPError
 
@@ -184,6 +187,13 @@ proc dial*(
 
   dial(s, peerId, addrs, @[proto])
 
+proc updateAddrs*(s: Switch) {.async: (raises: [CancelledError]).} =
+  ## Refresh `peerInfo.addrs` via the address mappers and notify connected
+  ## peers via IdentifyPush. Call this when listen addresses change.
+  await s.peerInfo.update()
+  if not s.identifyPusher.isNil:
+    s.identifyPusher.broadcast()
+
 proc mount*[T: LPProtocol](
     s: Switch, proto: T, matcher: Matcher = nil
 ) {.gcsafe, raises: [LPError].} =
@@ -200,6 +210,19 @@ proc mount*[T: LPProtocol](
 
   s.ms.addHandler(proto.codecs, proto, matcher)
   s.peerInfo.protocols.add(proto.codec)
+
+  if s.started and not s.identifyPusher.isNil and proto.codec != IdentifyPushCodec:
+    s.identifyPusher.broadcast()
+
+proc setupIdentifyPush*(s: Switch) {.raises: [LPError].} =
+  ## Construct, mount and wire the IdentifyPush protocol to this switch.
+  ## After this call, the switch automatically tracks which connected peers
+  ## support IdentifyPush and broadcasts updates when our protocols or
+  ## addresses change.
+  let pusher = IdentifyPusher.new(s.connManager, s.peerStore, s.peerInfo)
+  pusher.start()
+  s.identifyPusher = pusher
+  s.mount(pusher.identifyPush)
 
 proc upgrader(
     switch: Switch, trans: Transport, conn: Connection
@@ -325,6 +348,9 @@ proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
 
   # close and cleanup all connections
   await s.connManager.close()
+
+  if not s.identifyPusher.isNil:
+    await s.identifyPusher.stop()
 
   for transp in s.transports:
     try:

--- a/tests/libp2p/kademlia/test_builder.nim
+++ b/tests/libp2p/kademlia/test_builder.nim
@@ -40,7 +40,7 @@ suite "KadDHT Switch Builder":
     defer:
       await allFutures(switch1.stop(), switch2.stop())
     check:
-       switch1.ms.handlers.anyIt(KadCodec in it.protos)
+      switch1.ms.handlers.anyIt(KadCodec in it.protos)
 
   asyncTest "Use Kad as a client only":
     var switch1 = SwitchBuilder

--- a/tests/libp2p/kademlia/test_builder.nim
+++ b/tests/libp2p/kademlia/test_builder.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import chronos
+import chronos, std/sequtils
 import ../../../libp2p/[switch, builders]
 import ../../../libp2p/protocols/kademlia
 import ../../tools/[unittest, crypto]
@@ -40,7 +40,7 @@ suite "KadDHT Switch Builder":
     defer:
       await allFutures(switch1.stop(), switch2.stop())
     check:
-      switch1.ms.handlers[1].protos[0] == "/ipfs/kad/1.0.0"
+       switch1.ms.handlers.anyIt(KadCodec in it.protos)
 
   asyncTest "Use Kad as a client only":
     var switch1 = SwitchBuilder

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -3,6 +3,7 @@
 
 {.used.}
 
+import std/sets
 import chronos, chronicles
 import
   ../../../libp2p/[
@@ -312,3 +313,70 @@ suite "Identify":
     # The client's peerStore should now have the server's info including addresses via identify
     let storedAddrs = client.peerStore[AddressBook][server.peerInfo.peerId]
     check countAddressesWithPattern(storedAddrs, QUIC_V1) == 1
+
+  suite "Auto identify push":
+    var
+      switch1 {.threadvar.}: Switch
+      switch2 {.threadvar.}: Switch
+
+    asyncSetup:
+      let ma = @[MultiAddress.init("/ip4/127.0.0.1/tcp/0").get()]
+      switch1 = newStandardSwitch(addrs = ma)
+      switch2 = newStandardSwitch(addrs = ma)
+      await switch1.start()
+      await switch2.start()
+      await switch1.connect(switch2.peerInfo.peerId, switch2.peerInfo.addrs)
+
+    asyncTeardown:
+      await switch1.stop()
+      await switch2.stop()
+
+    asyncTest "tracks peers that advertise IdentifyPush":
+      checkUntilTimeout:
+        switch1.peerInfo.peerId in switch2.identifyPusher.pushPeers
+        switch2.peerInfo.peerId in switch1.identifyPusher.pushPeers
+
+    asyncTest "broadcasts on mount of new protocol":
+      # wait until both sides have identified each other
+      checkUntilTimeout:
+        switch1.peerInfo.peerId in switch2.identifyPusher.pushPeers
+        switch2.peerInfo.peerId in switch1.identifyPusher.pushPeers
+
+      # mount new protocol to switch2
+      let codecs = "/test/new-protocol/1.0.0"
+      proc dummyHandler(
+          conn: Connection, proto: string
+      ): Future[void] {.async: (raises: [CancelledError]).} =
+        await conn.close()
+
+      let dummy = LPProtocol.new(@[codecs], dummyHandler)
+      await dummy.start()
+      switch2.mount(dummy)
+
+      # switch1 should get information about new protocol
+      checkUntilTimeout:
+        codecs in switch1.peerStore[ProtoBook][switch2.peerInfo.peerId]
+
+    asyncTest "broadcasts on updateAddrs":
+      checkUntilTimeout:
+        switch1.peerInfo.peerId in switch2.identifyPusher.pushPeers
+        switch2.peerInfo.peerId in switch1.identifyPusher.pushPeers
+
+      # switch2 starts listening on new address
+      let extra = MultiAddress.init("/ip4/127.0.0.1/tcp/999").tryGet()
+      switch2.peerInfo.listenAddrs.add(extra)
+      await switch2.updateAddrs()
+
+      # switch1 should receive new address
+      checkUntilTimeout:
+        extra in switch1.peerStore[AddressBook][switch2.peerInfo.peerId]
+
+    asyncTest "removes peer on disconnect":
+      checkUntilTimeout:
+        switch1.peerInfo.peerId in switch2.identifyPusher.pushPeers
+        switch2.peerInfo.peerId in switch1.identifyPusher.pushPeers
+
+      await switch1.disconnect(switch2.peerInfo.peerId)
+
+      checkUntilTimeout:
+        switch2.peerInfo.peerId notin switch1.identifyPusher.pushPeers


### PR DESCRIPTION
## Summary
<!--
Provide a clear and concise description of the purpose of this PR.

Explain:
- What this PR does
- Why it is needed
- The problem it solves or the improvement it introduces
-->

this pr is main effort for adding auto identify push on peer changes. 
currently peer broadcasts new peer info when new protocol is mounted via `mount` or when `swtich.updateAddrs()` is called. 

following prs could address improvements for identify push to happen really automatically, avoiding need for n `swtich.updateAddrs()` 


## Affected Areas
<!--
Indicate which parts of the codebase are impacted.
Check all that apply and briefly describe the scope of the changes.
-->

- [x] Switch  
  <!-- e.g. scoring changes, message validation, peer handling -->


## Impact on Library Users
<!--
Describe how this affects downstream users of nim-libp2p.

Examples:
- API changes
- Behavior changes
- Performance implications
- Migration requirements
- No impact (internal refactor)
-->

identify push is currently by default added to switch. all peers will have this.

## Risk Assessment
<!--
Identify potential risks introduced by this change.

Consider:
- Backward compatibility
- Network behavior changes
- Performance regressions
- Security implications
-->

low.

## References
<!--
Link to related:
- Issues
- Specs
- Design discussions
- Prior PRs
-->

`ift-ts:p2p:ift:2026q2-nimlibp2p-maintenance:identify-push`

## Additional Notes
<!--
Optional: any extra context reviewers should be aware of.
-->