### PR TITLE
refactor(rng): make the rng a libp2p type

### DIFF
--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -224,7 +224,7 @@ proc libp2p_new_private_key(
 
   initializeLibrary()
 
-  let key = PrivateKey.random(scheme, newRng()[]).valueOr:
+  let key = PrivateKey.random(scheme, newRng()).valueOr:
     echo "Could not generate private key"
     return RET_ERR.cint
 

--- a/cbind/types.nim
+++ b/cbind/types.nim
@@ -24,7 +24,7 @@ type TopicHandlerEntry* = tuple[handler: TopicHandler, userData: pointer]
 
 type LibP2P* = ref object
   switch*: Switch
-  rng*: ref HmacDrbgContext
+  rng*: Rng
   gossipSub*: Opt[GossipSub]
   kad*: Opt[KadDHT]
   relayClient*: Opt[RelayClient]

--- a/examples/helloworld.nim
+++ b/examples/helloworld.nim
@@ -28,7 +28,7 @@ proc new(T: typedesc[TestProto]): T =
 ##
 # Helper to create a switch/node
 ##
-proc createSwitch(ma: MultiAddress, rng: ref HmacDrbgContext): Switch =
+proc createSwitch(ma: MultiAddress, rng: Rng): Switch =
   var switch = SwitchBuilder
     .new()
     .withRng(rng)

--- a/examples/tutorial_1_connect.nim
+++ b/examples/tutorial_1_connect.nim
@@ -36,7 +36,7 @@ import libp2p/protocols/ping
 ## [chronos](https://github.com/status-im/nim-chronos) the asynchronous framework used by `nim-libp2p`
 ##
 ## Next, we'll create a helper procedure to create our switches. A switch needs a bit of configuration, and it will be easier to do this configuration only once:
-proc createSwitch(ma: MultiAddress, rng: ref HmacDrbgContext): Switch =
+proc createSwitch(ma: MultiAddress, rng: Rng): Switch =
   var switch = SwitchBuilder
     .new()
     .withRng(rng)

--- a/examples/tutorial_3_protobuf.nim
+++ b/examples/tutorial_3_protobuf.nim
@@ -135,10 +135,10 @@ proc fetch(p: MetricProto, conn: Connection): Future[MetricList] {.async.} =
 proc main() {.async.} =
   let rng = newRng()
   proc randomMetricGenerator(): Future[MetricList] {.async: (raises: [CancelledError]).} =
-    let metricCount = rng[].generate(uint32) mod 16
+    let metricCount = rng.generate(uint32) mod 16
     for i in 0 ..< metricCount + 1:
       result.metrics.add(
-        Metric(name: "metric_" & $i, value: float(rng[].generate(uint16)) / 1000.0)
+        Metric(name: "metric_" & $i, value: float(rng.generate(uint16)) / 1000.0)
       )
     return result
 

--- a/examples/tutorial_4_gossipsub.nim
+++ b/examples/tutorial_4_gossipsub.nim
@@ -72,7 +72,7 @@ proc decode(_: type MetricList, buf: seq[byte]): Result[MetricList, ProtoError] 
 
 type Node = tuple[switch: Switch, gossip: GossipSub, hostname: string]
 
-proc oneNode(node: Node, rng: ref HmacDrbgContext) {.async.} =
+proc oneNode(node: Node, rng: Rng) {.async.} =
   # This procedure will handle one of the node of the network
   node.gossip.addValidator(
     ["metrics"],
@@ -104,10 +104,10 @@ proc oneNode(node: Node, rng: ref HmacDrbgContext) {.async.} =
   for _ in 0 ..< 10:
     await sleepAsync(500.milliseconds)
     var metricList = MetricList(hostname: node.hostname)
-    let metricCount = rng[].generate(uint32) mod 4
+    let metricCount = rng.generate(uint32) mod 4
     for i in 0 ..< metricCount + 1:
       metricList.metrics.add(
-        Metric(name: "metric_" & $i, value: float(rng[].generate(uint16)) / 1000.0)
+        Metric(name: "metric_" & $i, value: float(rng.generate(uint16)) / 1000.0)
       )
 
     discard await node.gossip.publish("metrics", encode(metricList).buffer)

--- a/libp2p/autotls/acme/client.nim
+++ b/libp2p/autotls/acme/client.nim
@@ -27,13 +27,13 @@ when defined(libp2p_autotls_support):
 
   proc new*(
       T: typedesc[ACMEClient],
-      rng: ref HmacDrbgContext,
+      rng: Rng,
       api: ACMEApi = ACMEApi.new(acmeServerURL = parseUri(LetsEncryptURL)),
       key: Opt[KeyPair] = Opt.none(KeyPair),
       kid: Kid = Kid(""),
   ): T {.raises: [].} =
     let key = key.valueOr:
-      KeyPair.random(PKScheme.RSA, rng[]).get()
+      KeyPair.random(PKScheme.RSA, rng).get()
     T(api: api, key: key, kid: kid)
 
   proc getOrInitKid*(

--- a/libp2p/autotls/mockservice.nim
+++ b/libp2p/autotls/mockservice.nim
@@ -12,7 +12,7 @@ when defined(libp2p_autotls_support):
 
   proc new*(
       T: typedesc[MockAutotlsService],
-      rng: ref HmacDrbgContext,
+      rng: Rng,
       config: AutotlsConfig = AutotlsConfig.new(),
   ): T =
     T(

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -129,9 +129,7 @@ when defined(libp2p_autotls_support):
     )
 
   proc new*(
-      T: typedesc[AutotlsService],
-      rng: Rng,
-      config: AutotlsConfig = AutotlsConfig.new(),
+      T: typedesc[AutotlsService], rng: Rng, config: AutotlsConfig = AutotlsConfig.new()
   ): T =
     T(
       acmeClient: ACMEClient.new(

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -4,7 +4,7 @@
 {.push raises: [].}
 
 import chronos, chronicles, net, results
-import chronos/apps/http/httpclient, bearssl/rand
+import chronos/apps/http/httpclient
 
 import
   ./acme/client,
@@ -63,7 +63,7 @@ type AutotlsService* = ref object of Service
   config*: AutotlsConfig
   managerFut: Future[void]
   peerInfo: PeerInfo
-  rng*: ref HmacDrbgContext
+  rng*: Rng
 
 when defined(libp2p_autotls_support):
   import json, sequtils, bearssl/pem
@@ -130,7 +130,7 @@ when defined(libp2p_autotls_support):
 
   proc new*(
       T: typedesc[AutotlsService],
-      rng: ref HmacDrbgContext,
+      rng: Rng,
       config: AutotlsConfig = AutotlsConfig.new(),
   ): T =
     T(
@@ -229,7 +229,7 @@ when defined(libp2p_autotls_support):
       return false
 
     trace "Notifying challenge completion to ACME and downloading cert"
-    let certKeyPair = KeyPair.random(PKScheme.RSA, self.rng[]).get()
+    let certKeyPair = KeyPair.random(PKScheme.RSA, self.rng).get()
 
     let certificate = await acmeClient.getCertificate(
       domain, certKeyPair, dns01Challenge, self.config.acmeRetries,

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -200,7 +200,13 @@ proc withWsTransport*(
   b.withTransport(
     proc(config: TransportConfig): Transport =
       WsTransport.new(
-        config.upgr, tlsPrivateKey, tlsCertificate, config.autotls, tlsFlags, flags
+        config.upgr,
+        tlsPrivateKey,
+        tlsCertificate,
+        config.autotls,
+        rng = config.rng,
+        tlsFlags = tlsFlags,
+        flags = flags,
       )
   )
 

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -52,7 +52,7 @@ type
     privateKey*: PrivateKey
     autotls*: Opt[AutotlsService]
     connManager*: ConnManager
-    rng*: ref HmacDrbgContext
+    rng*: Rng
 
   SecureProtocol* {.pure.} = enum
     Noise
@@ -67,7 +67,7 @@ type
     secureManagers: seq[SecureProtocol]
     muxers: seq[MuxerProvider]
     transports: seq[TransportBuilder]
-    rng: ref HmacDrbgContext
+    rng: Rng
     maxConnsPerPeer: int
     limits: Opt[ConnectionLimits]
     watermark: Opt[WatermarkPolicy]
@@ -216,7 +216,7 @@ proc withMemoryTransport*(b: SwitchBuilder): SwitchBuilder =
       MemoryTransport.new(config.upgr, config.rng)
   )
 
-proc withRng*(b: SwitchBuilder, rng: ref HmacDrbgContext): SwitchBuilder =
+proc withRng*(b: SwitchBuilder, rng: Rng): SwitchBuilder =
   b.rng = rng
   b
 
@@ -380,7 +380,7 @@ proc build*(b: SwitchBuilder): Switch {.raises: [LPError].} =
   if b.rng == nil: # newRng could fail
     raise newException(Defect, "Cannot initialize RNG")
 
-  let pkRes = PrivateKey.random(b.rng[])
+  let pkRes = PrivateKey.random(b.rng)
   let seckey = b.privKey.get(otherwise = pkRes.expect("Expected default Private Key"))
 
   if b.secureManagers.len == 0:

--- a/libp2p/crypto/crypto.nim
+++ b/libp2p/crypto/crypto.nim
@@ -155,10 +155,7 @@ template orError*(exp: untyped, err: untyped): untyped =
     err
 
 proc random*(
-    T: typedesc[PrivateKey],
-    scheme: PKScheme,
-    rng: Rng,
-    bits = RsaDefaultKeySize,
+    T: typedesc[PrivateKey], scheme: PKScheme, rng: Rng, bits = RsaDefaultKeySize
 ): CryptoResult[PrivateKey] =
   ## Generate random private key for scheme ``scheme``.
   ##
@@ -217,10 +214,7 @@ proc random*(
     err(SchemeError)
 
 proc random*(
-    T: typedesc[KeyPair],
-    scheme: PKScheme,
-    rng: Rng,
-    bits = RsaDefaultKeySize,
+    T: typedesc[KeyPair], scheme: PKScheme, rng: Rng, bits = RsaDefaultKeySize
 ): CryptoResult[KeyPair] =
   ## Generate random key pair for scheme ``scheme``.
   ##

--- a/libp2p/crypto/crypto.nim
+++ b/libp2p/crypto/crypto.nim
@@ -65,17 +65,18 @@ when supported(PKScheme.ECDSA):
   # These used to be declared in `crypto` itself
   export ecnist.ephemeral, ecnist.ECDHEScheme
 
-import bearssl/rand, bearssl/hash as bhash
 import ../protobuf/minprotobuf, ../vbuffer, ../multihash, ../multicodec
 import nimcrypto/[rijndael, twofish, sha2, hash, hmac]
 # We use `ncrutils` for constant-time hexadecimal encoding/decoding procedures.
 import nimcrypto/utils as ncrutils
 import ../utility
+import rng
 import results
 export results, utility
+export rng except bearSslDrbg, bearSslDrbgRef, bearSslPrng
 
 # This is workaround for Nim's `import` bug
-export rijndael, twofish, sha2, hash, hmac, ncrutils, rand
+export rijndael, twofish, sha2, hash, hmac, ncrutils
 
 type
   DigestSheme* = enum
@@ -153,78 +154,10 @@ template orError*(exp: untyped, err: untyped): untyped =
   exp.mapErr do(_: auto) -> auto:
     err
 
-proc newRng*(): ref HmacDrbgContext =
-  # You should only create one instance of the RNG per application / library
-  # Ref is used so that it can be shared between components
-  # TODO consider moving to bearssl
-  var seeder = prngSeederSystem(nil)
-  if seeder == nil:
-    return nil
-
-  var rng = (ref HmacDrbgContext)()
-  hmacDrbgInit(rng[], addr sha256Vtable, nil, 0)
-  if seeder(addr rng.vtable) == 0:
-    return nil
-  rng
-
-proc shuffle*[T](rng: ref HmacDrbgContext, x: var openArray[T]) =
-  if x.len == 0:
-    return
-
-  var randValues = newSeqUninit[byte](len(x) * 2)
-  hmacDrbgGenerate(rng[], randValues)
-
-  for i in countdown(x.high, 1):
-    let
-      rand = randValues[i * 2].int32 or (randValues[i * 2 + 1].int32 shl 8)
-      y = rand mod i
-    swap(x[i], x[y])
-
-proc randBelow(rng: ref HmacDrbgContext, max: uint32): int =
-  ## Returns a uniformly random integer in the range [0, max).
-  ## Uses 32-bit rejection sampling to eliminate modulo bias and to
-  ## support max values larger than 65536.
-  # threshold = 2^32 mod max. In uint32 arithmetic: (0 - umax) mod umax.
-  # Values in [0, threshold) are rejected to eliminate modulo bias.
-  let threshold = (0'u32 - max) mod max
-  while true:
-    var bytes: array[4, byte]
-    hmacDrbgGenerate(rng[], bytes)
-    let r =
-      bytes[0].uint32 or (bytes[1].uint32 shl 8) or (bytes[2].uint32 shl 16) or
-      (bytes[3].uint32 shl 24)
-    if r >= threshold:
-      return (r mod max).int
-
-proc pick*[T](rng: ref HmacDrbgContext, x: openArray[T], n: int): Opt[seq[T]] =
-  doAssert n >= 0, "n must be non-negative"
-  if x.len == 0:
-    return Opt.none(seq[T])
-  if n == 0:
-    return Opt.some(newSeq[T]())
-
-  var indices = newSeq[int](x.len)
-  for i in 0 ..< x.len:
-    indices[i] = i
-
-  let count = min(n, x.len)
-  var output = newSeq[T](count)
-  for i in 0 ..< count:
-    let j = i + rng.randBelow((x.len - i).uint32)
-    swap(indices[i], indices[j])
-    output[i] = x[indices[i]]
-  Opt.some(output)
-
-proc pickOne*[T](rng: ref HmacDrbgContext, x: openArray[T]): Opt[T] =
-  if x.len == 0:
-    return Opt.none(T)
-
-  Opt.some(x[rng.randBelow(x.len.uint32)])
-
 proc random*(
     T: typedesc[PrivateKey],
     scheme: PKScheme,
-    rng: var HmacDrbgContext,
+    rng: Rng,
     bits = RsaDefaultKeySize,
 ): CryptoResult[PrivateKey] =
   ## Generate random private key for scheme ``scheme``.
@@ -259,7 +192,7 @@ proc random*(
       err(SchemeError)
 
 proc random*(
-    T: typedesc[PrivateKey], rng: var HmacDrbgContext, bits = RsaDefaultKeySize
+    T: typedesc[PrivateKey], rng: Rng, bits = RsaDefaultKeySize
 ): CryptoResult[PrivateKey] =
   ## Generate random private key using default public-key cryptography scheme.
   ##
@@ -286,7 +219,7 @@ proc random*(
 proc random*(
     T: typedesc[KeyPair],
     scheme: PKScheme,
-    rng: var HmacDrbgContext,
+    rng: Rng,
     bits = RsaDefaultKeySize,
 ): CryptoResult[KeyPair] =
   ## Generate random key pair for scheme ``scheme``.
@@ -340,7 +273,7 @@ proc random*(
       err(SchemeError)
 
 proc random*(
-    T: typedesc[KeyPair], rng: var HmacDrbgContext, bits = RsaDefaultKeySize
+    T: typedesc[KeyPair], rng: Rng, bits = RsaDefaultKeySize
 ): CryptoResult[KeyPair] =
   ## Generate random private pair of keys using default public-key cryptography
   ## scheme.

--- a/libp2p/crypto/curve25519.nim
+++ b/libp2p/crypto/curve25519.nim
@@ -70,9 +70,7 @@ proc public*(private: Curve25519Key): Curve25519Key =
 proc random*(_: type[Curve25519Key], rng: Rng): Curve25519Key =
   var res: Curve25519Key
   let defaultBrEc = ecGetDefault()
-  let len = ecKeygen(
-    bearSslPrng(rng), defaultBrEc, nil, addr res[0], EC_curve25519
-  )
+  let len = ecKeygen(bearSslPrng(rng), defaultBrEc, nil, addr res[0], EC_curve25519)
   # Per bearssl documentation, the keygen only fails if the curve is
   # unrecognised -
   doAssert len == Curve25519KeySize, "Could not generate curve"

--- a/libp2p/crypto/curve25519.nim
+++ b/libp2p/crypto/curve25519.nim
@@ -11,9 +11,10 @@
 
 {.push raises: [].}
 
-import bearssl/[ec, rand]
+import bearssl/ec
 import results
 from stew/assign2 import assign
+import rng
 export results
 
 const Curve25519KeySize* = 32
@@ -66,11 +67,11 @@ proc mulgen(_: type[Curve25519], dst: var Curve25519Key, point: Curve25519Key) =
 proc public*(private: Curve25519Key): Curve25519Key =
   Curve25519.mulgen(result, private)
 
-proc random*(_: type[Curve25519Key], rng: var HmacDrbgContext): Curve25519Key =
+proc random*(_: type[Curve25519Key], rng: Rng): Curve25519Key =
   var res: Curve25519Key
   let defaultBrEc = ecGetDefault()
   let len = ecKeygen(
-    PrngClassPointerConst(addr rng.vtable), defaultBrEc, nil, addr res[0], EC_curve25519
+    bearSslPrng(rng), defaultBrEc, nil, addr res[0], EC_curve25519
   )
   # Per bearssl documentation, the keygen only fails if the curve is
   # unrecognised -

--- a/libp2p/crypto/ecnist.nim
+++ b/libp2p/crypto/ecnist.nim
@@ -232,11 +232,7 @@ proc random*(
   var ecimp = ecGetDefault()
   var res = new EcPrivateKey
   if ecKeygen(
-    bearSslPrng(rng),
-    ecimp,
-    addr res.key,
-    addr res.buffer[0],
-    safeConvert[cint](kind),
+    bearSslPrng(rng), ecimp, addr res.key, addr res.buffer[0], safeConvert[cint](kind)
   ) == 0:
     err(EcKeyGenError)
   else:
@@ -258,9 +254,7 @@ proc getPublicKey*(seckey: EcPrivateKey): EcResult[EcPublicKey] =
   else:
     err(EcKeyIncorrectError)
 
-proc random*(
-    T: typedesc[EcKeyPair], kind: EcCurveKind, rng: Rng
-): EcResult[T] =
+proc random*(T: typedesc[EcKeyPair], kind: EcCurveKind, rng: Rng): EcResult[T] =
   ## Generate new random EC private and public keypair using BearSSL's
   ## HMAC-SHA256-DRBG algorithm.
   ##

--- a/libp2p/crypto/ecnist.nim
+++ b/libp2p/crypto/ecnist.nim
@@ -20,6 +20,7 @@ import results
 import ../utils/sequninit
 
 import ../utility
+import rng
 
 export results
 
@@ -221,7 +222,7 @@ proc clear*[T: EcPKI | EcKeyPair](pki: var T) =
     pki.pubkey.key.curve = 0
 
 proc random*(
-    T: typedesc[EcPrivateKey], kind: EcCurveKind, rng: var HmacDrbgContext
+    T: typedesc[EcPrivateKey], kind: EcCurveKind, rng: Rng
 ): EcResult[EcPrivateKey] =
   ## Generate new random EC private key using BearSSL's HMAC-SHA256-DRBG
   ## algorithm.
@@ -231,7 +232,7 @@ proc random*(
   var ecimp = ecGetDefault()
   var res = new EcPrivateKey
   if ecKeygen(
-    PrngClassPointerConst(addr rng.vtable),
+    bearSslPrng(rng),
     ecimp,
     addr res.key,
     addr res.buffer[0],
@@ -258,7 +259,7 @@ proc getPublicKey*(seckey: EcPrivateKey): EcResult[EcPublicKey] =
     err(EcKeyIncorrectError)
 
 proc random*(
-    T: typedesc[EcKeyPair], kind: EcCurveKind, rng: var HmacDrbgContext
+    T: typedesc[EcKeyPair], kind: EcCurveKind, rng: Rng
 ): EcResult[T] =
   ## Generate new random EC private and public keypair using BearSSL's
   ## HMAC-SHA256-DRBG algorithm.
@@ -1005,7 +1006,7 @@ proc verify*[T: byte | char](
 
 type ECDHEScheme* = EcCurveKind
 
-proc ephemeral*(scheme: ECDHEScheme, rng: var HmacDrbgContext): EcResult[EcKeyPair] =
+proc ephemeral*(scheme: ECDHEScheme, rng: Rng): EcResult[EcKeyPair] =
   ## Generate ephemeral keys used to perform ECDHE.
   var keypair: EcKeyPair
   if scheme == Secp256r1:
@@ -1016,7 +1017,7 @@ proc ephemeral*(scheme: ECDHEScheme, rng: var HmacDrbgContext): EcResult[EcKeyPa
     keypair = ?EcKeyPair.random(Secp521r1, rng)
   ok(keypair)
 
-proc ephemeral*(scheme: string, rng: var HmacDrbgContext): EcResult[EcKeyPair] =
+proc ephemeral*(scheme: string, rng: Rng): EcResult[EcKeyPair] =
   ## Generate ephemeral keys used to perform ECDHE using string encoding.
   ##
   ## Currently supported encoding strings are P-256, P-384, P-521, if encoding

--- a/libp2p/crypto/ed25519/ed25519.nim
+++ b/libp2p/crypto/ed25519/ed25519.nim
@@ -7,8 +7,8 @@
 
 {.push raises: [].}
 
-import bearssl/rand
 import constants
+import ../rng
 import nimcrypto/[hash, sha2]
 # We use `ncrutils` for constant-time hexadecimal encoding/decoding procedures.
 import nimcrypto/utils as ncrutils
@@ -20,7 +20,7 @@ import ../../utility
 export results
 
 # This workaround needed because of some bugs in Nim Static[T].
-export hash, sha2, rand
+export hash, sha2
 
 const
   EdPrivateKeySize* = 64 ## Size in octets (bytes) of serialized ED25519 private key.
@@ -2178,14 +2178,14 @@ proc checkScalar*(scalar: openArray[byte]): uint32 =
     c = -1
   result = NEQ(z, 0'u32) and LT0(c)
 
-proc random*(t: typedesc[EdPrivateKey], rng: var HmacDrbgContext): EdPrivateKey =
+proc random*(t: typedesc[EdPrivateKey], rng: Rng): EdPrivateKey =
   ## Generate new random ED25519 private key using the given random number generator
   var
     point: GeP3
     pk: array[EdPublicKeySize, byte]
     res: EdPrivateKey
 
-  hmacDrbgGenerate(rng, res.data.toOpenArray(0, 31))
+  rng.generate(res.data.toOpenArray(0, 31))
 
   var hh = sha512.digest(res.data.toOpenArray(0, 31))
   hh.data[0] = hh.data[0] and 0xF8'u8
@@ -2218,14 +2218,14 @@ proc fromSeed*(t: typedesc[EdPrivateKey], seed: openArray[byte]): EdPrivateKey =
 
   res
 
-proc random*(t: typedesc[EdKeyPair], rng: var HmacDrbgContext): EdKeyPair =
+proc random*(t: typedesc[EdKeyPair], rng: Rng): EdKeyPair =
   ## Generate new random ED25519 private and public keypair using OS specific
   ## CSPRNG.
   var
     point: GeP3
     res: EdKeyPair
 
-  hmacDrbgGenerate(rng, res.seckey.data.toOpenArray(0, 31))
+  rng.generate(res.seckey.data.toOpenArray(0, 31))
 
   var hh = sha512.digest(res.seckey.data.toOpenArray(0, 31))
   hh.data[0] = hh.data[0] and 0xF8'u8

--- a/libp2p/crypto/rng.nim
+++ b/libp2p/crypto/rng.nim
@@ -25,6 +25,15 @@ proc newRng*(): Rng =
     return nil
   rng
 
+proc newBearSslRng*(drbg: ref HmacDrbgContext): Rng =
+  ## Wrap an existing BearSSL HMAC-DRBG context.
+  ##
+  ## This is a temporary compatibility API for the BearSSL to BoringSSL
+  ## migration. New code should use `newRng`.
+  if isNil(drbg):
+    return nil
+  Rng(drbg: drbg)
+
 template bearSslDrbg*(rng: Rng): untyped =
   rng.drbg[]
 
@@ -37,7 +46,8 @@ template bearSslPrng*(rng: Rng): untyped =
 proc generate*[T](rng: Rng, v: var T) =
   ## Fill `v` with random data. `v` must be a simple type.
   doAssert not isNil(rng), "Rng is nil"
-  static: doAssert supportsCopyMem(T)
+  static:
+    doAssert supportsCopyMem(T)
 
   when sizeof(v) > 0:
     when T is bool:
@@ -50,7 +60,8 @@ proc generate*[T](rng: Rng, v: var T) =
 proc generate*[V](rng: Rng, v: var openArray[V]) =
   ## Fill `v` with random data. `V` must be a simple type.
   doAssert not isNil(rng), "Rng is nil"
-  static: doAssert supportsCopyMem(V) and sizeof(V) > 0
+  static:
+    doAssert supportsCopyMem(V) and sizeof(V) > 0
 
   when V is bool:
     for b in v.mitems:

--- a/libp2p/crypto/rng.nim
+++ b/libp2p/crypto/rng.nim
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.push raises: [].}
+
+import typetraits
+import bearssl/[rand, hash]
+import ../utils/sequninit
+import ../utility
+
+type Rng* = ref object
+  drbg: ref HmacDrbgContext
+
+proc newRng*(): Rng =
+  ## Create a new randomness source for libp2p.
+  ##
+  ## BearSSL remains the temporary backend in this migration phase.
+  let seeder = prngSeederSystem(nil)
+  if seeder == nil:
+    return nil
+
+  let rng = Rng(drbg: (ref HmacDrbgContext)())
+  hmacDrbgInit(rng.drbg[], addr sha256Vtable, nil, 0)
+  if seeder(PrngClassPointerConst(addr rng.drbg[].vtable)) == 0:
+    return nil
+  rng
+
+template bearSslDrbg*(rng: Rng): untyped =
+  rng.drbg[]
+
+template bearSslDrbgRef*(rng: Rng): untyped =
+  rng.drbg
+
+template bearSslPrng*(rng: Rng): untyped =
+  PrngClassPointerConst(addr rng.drbg[].vtable)
+
+proc generate*[T](rng: Rng, v: var T) =
+  ## Fill `v` with random data. `v` must be a simple type.
+  doAssert not isNil(rng), "Rng is nil"
+  static: doAssert supportsCopyMem(T)
+
+  when sizeof(v) > 0:
+    when T is bool:
+      var tmp: byte
+      hmacDrbgGenerate(rng.drbg[], addr tmp, uint sizeof(tmp))
+      v = (tmp and 1'u8) == 1
+    else:
+      hmacDrbgGenerate(rng.drbg[], addr v, uint sizeof(v))
+
+proc generate*[V](rng: Rng, v: var openArray[V]) =
+  ## Fill `v` with random data. `V` must be a simple type.
+  doAssert not isNil(rng), "Rng is nil"
+  static: doAssert supportsCopyMem(V) and sizeof(V) > 0
+
+  when V is bool:
+    for b in v.mitems:
+      rng.generate(b)
+  else:
+    if v.len > 0:
+      hmacDrbgGenerate(rng.drbg[], addr v[0], uint v.len * sizeof(V))
+
+template generate*[V](rng: Rng, v: var seq[V]) =
+  rng.generate(v.toOpenArray(0, v.high()))
+
+proc generateBytes*(rng: Rng, n: int): seq[byte] =
+  if n > 0:
+    result = newSeqUninit[byte](n)
+    rng.generate(result)
+
+proc generate*(rng: Rng, T: type): T {.noinit.} =
+  ## Create a new instance of `T` filled with random data.
+  rng.generate(result)
+
+proc shuffle*[T](rng: Rng, x: var openArray[T]) =
+  if x.len == 0:
+    return
+
+  var randValues = newSeqUninit[byte](len(x) * 2)
+  rng.generate(randValues)
+
+  for i in countdown(x.high, 1):
+    let
+      rand = randValues[i * 2].int32 or (randValues[i * 2 + 1].int32 shl 8)
+      y = rand mod i
+    swap(x[i], x[y])
+
+proc randBelow(rng: Rng, max: uint32): int =
+  ## Returns a uniformly random integer in the range [0, max).
+  ## Uses 32-bit rejection sampling to eliminate modulo bias and to
+  ## support max values larger than 65536.
+  let threshold = (0'u32 - max) mod max
+  while true:
+    var bytes: array[4, byte]
+    rng.generate(bytes)
+    let r =
+      bytes[0].uint32 or (bytes[1].uint32 shl 8) or (bytes[2].uint32 shl 16) or
+      (bytes[3].uint32 shl 24)
+    if r >= threshold:
+      return (r mod max).int
+
+proc pick*[T](rng: Rng, x: openArray[T], n: int): Opt[seq[T]] =
+  doAssert n >= 0, "n must be non-negative"
+  if x.len == 0:
+    return Opt.none(seq[T])
+  if n == 0:
+    return Opt.some(newSeq[T]())
+
+  var indices = newSeq[int](x.len)
+  for i in 0 ..< x.len:
+    indices[i] = i
+
+  let count = min(n, x.len)
+  var output = newSeq[T](count)
+  for i in 0 ..< count:
+    let j = i + rng.randBelow((x.len - i).uint32)
+    swap(indices[i], indices[j])
+    output[i] = x[indices[i]]
+  Opt.some(output)
+
+proc pickOne*[T](rng: Rng, x: openArray[T]): Opt[T] =
+  if x.len == 0:
+    return Opt.none(T)
+
+  Opt.some(x[rng.randBelow(x.len.uint32)])

--- a/libp2p/crypto/rsa.nim
+++ b/libp2p/crypto/rsa.nim
@@ -98,10 +98,7 @@ template trimZeroes(b: seq[byte], pt, ptlen: untyped) =
     ptlen -= 1
 
 proc random*[T: RsaKP](
-    t: typedesc[T],
-    rng: Rng,
-    bits = DefaultKeySize,
-    pubexp = DefaultPublicExponent,
+    t: typedesc[T], rng: Rng, bits = DefaultKeySize, pubexp = DefaultPublicExponent
 ): RsaResult[T] =
   ## Generate new random RSA private key using BearSSL's HMAC-SHA256-DRBG
   ## algorithm.

--- a/libp2p/crypto/rsa.nim
+++ b/libp2p/crypto/rsa.nim
@@ -16,6 +16,7 @@ import stew/ctops
 # We use `ncrutils` for constant-time hexadecimal encoding/decoding procedures.
 import nimcrypto/utils as ncrutils
 import ../utils/sequninit
+import rng
 
 export Asn1Error, results
 
@@ -98,7 +99,7 @@ template trimZeroes(b: seq[byte], pt, ptlen: untyped) =
 
 proc random*[T: RsaKP](
     t: typedesc[T],
-    rng: var HmacDrbgContext,
+    rng: Rng,
     bits = DefaultKeySize,
     pubexp = DefaultPublicExponent,
 ): RsaResult[T] =
@@ -124,7 +125,7 @@ proc random*[T: RsaKP](
   var keygen = rsaKeygenGetDefault()
 
   if keygen(
-    addr rng.vtable,
+    bearSslPrng(rng),
     addr res.seck,
     addr res.buffer[sko],
     addr res.pubk,

--- a/libp2p/crypto/secp.nim
+++ b/libp2p/crypto/secp.nim
@@ -3,11 +3,11 @@
 
 {.push raises: [].}
 
-import bearssl/rand
 import secp256k1, results, stew/byteutils, nimcrypto/[hash, sha2]
 import ../utils/sequninit
+import rng as libp2p_rng
 
-export sha2, results, rand
+export sha2, results
 
 const
   SkRawPrivateKeySize* = 256 div 8 ## Size of private key in octets (bytes)
@@ -22,18 +22,16 @@ type
   SkSignature* = distinct secp256k1.SkSignature
   SkKeyPair* = distinct secp256k1.SkKeyPair
 
-proc random*(t: typedesc[SkPrivateKey], rng: var HmacDrbgContext): SkPrivateKey =
+proc random*(t: typedesc[SkPrivateKey], rng: libp2p_rng.Rng): SkPrivateKey =
   #TODO is there a better way?
-  var rngPtr = addr rng
   proc callRng(data: var openArray[byte]) =
-    hmacDrbgGenerate(rngPtr[], data)
+    rng.generate(data)
 
   SkPrivateKey(SkSecretKey.random(callRng))
 
-proc random*(t: typedesc[SkKeyPair], rng: var HmacDrbgContext): SkKeyPair =
-  let rngPtr = addr rng
+proc random*(t: typedesc[SkKeyPair], rng: libp2p_rng.Rng): SkKeyPair =
   proc callRng(data: var openArray[byte]) =
-    hmacDrbgGenerate(rngPtr[], data)
+    rng.generate(data)
 
   SkKeyPair(secp256k1.SkKeyPair.random(callRng))
 

--- a/libp2p/peerid.nim
+++ b/libp2p/peerid.nim
@@ -192,9 +192,7 @@ proc random*(t: typedesc[PeerId], rng: Rng): Result[PeerId, cstring] =
   let randomKey = PrivateKey.random(Secp256k1, rng)[]
   PeerId.init(randomKey).orError(cstring("failed to generate random key"))
 
-proc random*(
-    t: typedesc[PeerId], count: uint, rng: Rng
-): Result[seq[PeerId], cstring] =
+proc random*(t: typedesc[PeerId], count: uint, rng: Rng): Result[seq[PeerId], cstring] =
   ## Create `count` peer ids with random public keys.
   var peers = newSeqOfCap[PeerId](count)
   for _ in 0 ..< count:

--- a/libp2p/peerid.nim
+++ b/libp2p/peerid.nim
@@ -187,13 +187,13 @@ func init*(t: typedesc[PeerId], seckey: PrivateKey): Result[PeerId, cstring] =
   ## Create new peer id from private key ``seckey``.
   PeerId.init(?seckey.getPublicKey().orError(cstring("invalid private key")))
 
-proc random*(t: typedesc[PeerId], rng: ref HmacDrbgContext): Result[PeerId, cstring] =
+proc random*(t: typedesc[PeerId], rng: Rng): Result[PeerId, cstring] =
   ## Create new peer id with random public key.
-  let randomKey = PrivateKey.random(Secp256k1, rng[])[]
+  let randomKey = PrivateKey.random(Secp256k1, rng)[]
   PeerId.init(randomKey).orError(cstring("failed to generate random key"))
 
 proc random*(
-    t: typedesc[PeerId], count: uint, rng: ref HmacDrbgContext
+    t: typedesc[PeerId], count: uint, rng: Rng
 ): Result[seq[PeerId], cstring] =
   ## Create `count` peer ids with random public keys.
   var peers = newSeqOfCap[PeerId](count)

--- a/libp2p/peeridauth/client.nim
+++ b/libp2p/peeridauth/client.nim
@@ -20,7 +20,7 @@ export Domain
 
 type PeerIDAuthClient* = ref object of RootObj
   session: HttpSessionRef
-  rng: ref HmacDrbgContext
+  rng: Rng
 
 type PeerIDAuthError* = object of LPError
 
@@ -51,11 +51,11 @@ type SigParam = object
   k: string
   v: seq[byte]
 
-proc new*(T: typedesc[PeerIDAuthClient], rng: ref HmacDrbgContext): PeerIDAuthClient =
+proc new*(T: typedesc[PeerIDAuthClient], rng: Rng): PeerIDAuthClient =
   PeerIDAuthClient(session: HttpSessionRef.new(), rng: rng)
 
 proc sampleChar(
-    ctx: var HmacDrbgContext, choices: string
+    ctx: Rng, choices: string
 ): char {.raises: [ValueError].} =
   ## Samples a random character from the input string using the DRBG context
   if choices.len == 0:
@@ -65,9 +65,8 @@ proc sampleChar(
   return choices[uint32(idx mod uint32(choices.len))]
 
 proc randomChallenge(
-    rng: ref HmacDrbgContext, challengeLen: int = ChallengeDefaultLen
+    rng: Rng, challengeLen: int = ChallengeDefaultLen
 ): PeerIDAuthChallenge {.raises: [PeerIDAuthError].} =
-  var rng = rng[]
   var challenge = ""
   try:
     for _ in 0 ..< challengeLen:

--- a/libp2p/peeridauth/client.nim
+++ b/libp2p/peeridauth/client.nim
@@ -54,9 +54,7 @@ type SigParam = object
 proc new*(T: typedesc[PeerIDAuthClient], rng: Rng): PeerIDAuthClient =
   PeerIDAuthClient(session: HttpSessionRef.new(), rng: rng)
 
-proc sampleChar(
-    ctx: Rng, choices: string
-): char {.raises: [ValueError].} =
+proc sampleChar(ctx: Rng, choices: string): char {.raises: [ValueError].} =
   ## Samples a random character from the input string using the DRBG context
   if choices.len == 0:
     raise newException(ValueError, "Cannot sample from an empty string")

--- a/libp2p/peeridauth/mockclient.nim
+++ b/libp2p/peeridauth/mockclient.nim
@@ -15,7 +15,7 @@ type MockPeerIDAuthClient* = ref object of PeerIDAuthClient
   mockedBody*: seq[byte]
 
 proc new*(
-    T: typedesc[MockPeerIDAuthClient], rng: ref HmacDrbgContext
+    T: typedesc[MockPeerIDAuthClient], rng: Rng
 ): MockPeerIDAuthClient {.raises: [].} =
   MockPeerIDAuthClient(session: HttpSessionRef.new(), rng: rng)
 

--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -33,7 +33,7 @@ type
     answers: Deque[NetworkReachability]
     autonatClient: AutonatClient
     statusAndConfidenceHandler: StatusAndConfidenceHandler
-    rng: ref HmacDrbgContext
+    rng: Rng
     scheduleInterval: Opt[Duration]
     askNewConnectedPeers: bool
     numPeersToAsk: int
@@ -49,7 +49,7 @@ type
 proc new*(
     T: typedesc[AutonatService],
     autonatClient: AutonatClient,
-    rng: ref HmacDrbgContext,
+    rng: Rng,
     scheduleInterval: Opt[Duration] = Opt.none(Duration),
     askNewConnectedPeers = true,
     numPeersToAsk: int = 5,

--- a/libp2p/protocols/connectivity/autonatv2/client.nim
+++ b/libp2p/protocols/connectivity/autonatv2/client.nim
@@ -26,7 +26,7 @@ const
 type AutonatV2Client* = ref object of LPProtocol
   dialer*: Dial
   dialBackTimeout: Duration
-  rng: ref HmacDrbgContext
+  rng: Rng
   expectedNonces: Table[Nonce, Opt[MultiAddress]]
 
 proc handleDialBack(
@@ -52,7 +52,7 @@ proc handleDialBack(
 
 proc new*(
     T: typedesc[AutonatV2Client],
-    rng: ref HmacDrbgContext,
+    rng: Rng,
     dialBackTimeout: Duration = DefaultDialBackTimeout,
 ): T =
   let client = T(rng: rng, dialBackTimeout: dialBackTimeout)
@@ -147,7 +147,7 @@ method sendDialRequest*(
 .} =
   ## Dials peer with `pid` and requests that it tries connecting to `testAddrs`
 
-  let nonce = self.rng[].generate(Nonce)
+  let nonce = self.rng.generate(Nonce)
   self.expectedNonces[nonce] = Opt.none(MultiAddress)
 
   var dialResp: DialResponse

--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -50,7 +50,7 @@ type
     networkReachability*: NetworkReachability
     answers: Deque[NetworkReachability]
     client*: AutonatV2Client
-    rng: ref HmacDrbgContext
+    rng: Rng
 
   StatusAndConfidenceHandler* = proc(
     networkReachability: NetworkReachability,
@@ -78,7 +78,7 @@ proc new*(
 
 proc new*(
     T: typedesc[AutonatV2Service],
-    rng: ref HmacDrbgContext,
+    rng: Rng,
     client: AutonatV2Client = AutonatV2Client.new(),
     config: AutonatV2ServiceConfig = AutonatV2ServiceConfig.new(),
 ): T =

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -54,7 +54,7 @@ proc new*(
     switch: Switch,
     bootstrapNodes: seq[(PeerId, seq[MultiAddress])] = @[],
     config: KadDHTConfig = KadDHTConfig.new(),
-    rng: ref HmacDrbgContext,
+    rng: Rng,
     client: bool = false,
     codec: string = KadCodec,
 ): K {.raises: [].} =

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -2,7 +2,7 @@
 # Copyright (c) Status Research & Development GmbH
 
 import algorithm, sequtils
-import bearssl/rand, chronos, chronicles, results
+import chronos, chronicles, results
 import ./types
 import ./kademlia_metrics
 import ../../peerid
@@ -143,7 +143,7 @@ proc isStale*(bucket: Bucket): bool =
       return true
   return false
 
-proc randomKeyInBucket*(selfId: Key, bucketIndex: int, rng: ref HmacDrbgContext): Key =
+proc randomKeyInBucket*(selfId: Key, bucketIndex: int, rng: Rng): Key =
   var raw = selfId
 
   # zero out higher bits
@@ -161,12 +161,12 @@ proc randomKeyInBucket*(selfId: Key, bucketIndex: int, rng: ref HmacDrbgContext)
   let lsbMask = (1'u8 shl tgtBitInByte) - 1
   if lsbMask != 0:
     var rb: array[1, byte]
-    hmacDrbgGenerate(rng[], rb)
+    rng.generate(rb)
     raw[tgtByte] = (raw[tgtByte] and not lsbMask) or (rb[0] and lsbMask)
 
   # randomize remaining bytes
   if tgtByte + 1 < raw.len:
-    hmacDrbgGenerate(rng[], raw.toOpenArray(tgtByte + 1, raw.len - 1))
+    rng.generate(raw.toOpenArray(tgtByte + 1, raw.len - 1))
 
   return raw
 
@@ -176,7 +176,7 @@ proc allKeys*(bucket: Bucket): seq[Key] {.inline.} =
 proc allKeys*(rtable: RoutingTable): seq[Key] {.inline.} =
   rtable.buckets.mapIt(it.allKeys()).concat()
 
-proc randomKey*(bucket: Bucket, rng: ref HmacDrbgContext): Opt[Key] =
+proc randomKey*(bucket: Bucket, rng: Rng): Opt[Key] =
   rng.pickOne(bucket.peers).map(
     proc(e: NodeEntry): Key =
       e.nodeId

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -363,7 +363,7 @@ proc new*(
 
 type KadDHT* = ref object of LPProtocol
   switch*: Switch
-  rng*: ref HmacDrbgContext
+  rng*: Rng
   rtable*: RoutingTable
   maintenanceLoop*: Future[void]
   republishLoop*: Future[void]

--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -6,7 +6,6 @@
 {.push raises: [].}
 
 import chronos, chronicles
-import bearssl/rand
 import
   ../peerinfo,
   ../stream/connection,
@@ -16,7 +15,7 @@ import
   ../protocols/protocol,
   ../errors
 
-export chronicles, rand, connection
+export chronicles, rng, connection
 
 logScope:
   topics = "libp2p ping"
@@ -33,9 +32,9 @@ type
 
   Ping* = ref object of LPProtocol
     pingHandler*: PingHandler
-    rng: ref HmacDrbgContext
+    rng: Rng
 
-proc new*(T: typedesc[Ping], handler: PingHandler = nil, rng: ref HmacDrbgContext): T =
+proc new*(T: typedesc[Ping], handler: PingHandler = nil, rng: Rng): T =
   let ping = Ping(pinghandler: handler, rng: rng)
   ping.init()
   ping
@@ -72,7 +71,7 @@ proc ping*(
     randomBuf: array[PingSize, byte]
     resultBuf: array[PingSize, byte]
 
-  hmacDrbgGenerate(p.rng[], randomBuf)
+  p.rng.generate(randomBuf)
 
   let startTime = Moment.now()
 

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -236,6 +236,6 @@ method publish*(
 method initPubSub*(f: FloodSub) {.raises: [InitializationError].} =
   procCall PubSub(f).initPubSub()
   f.seen = TimedCache[SaltedId].init(2.minutes)
-  hmacDrbgGenerate(f.rng[], f.seenSalt)
+  f.rng.generate(f.seenSalt)
 
   f.init()

--- a/libp2p/protocols/pubsub/gossipsub/extension_preamble.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_preamble.nim
@@ -58,9 +58,7 @@ proc doAssert(config: PreambleExtensionConfig) =
   )
 
 proc new*(
-    T: typedesc[PreambleExtension],
-    config: PreambleExtensionConfig,
-    rng: Rng,
+    T: typedesc[PreambleExtension], config: PreambleExtensionConfig, rng: Rng
 ): PreambleExtension =
   config.doAssert()
   PreambleExtension(rng: rng, config: config)

--- a/libp2p/protocols/pubsub/gossipsub/extension_preamble.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_preamble.nim
@@ -31,7 +31,7 @@ type
     bandwidthTracking: BandwidthTracking
 
   PreambleExtension* = ref object of Extension
-    rng: ref HmacDrbgContext
+    rng: Rng
     config: PreambleExtensionConfig
     supportingPeers: seq[PeerId]
     preambleBudgetUsed: Table[PeerId, int]
@@ -60,7 +60,7 @@ proc doAssert(config: PreambleExtensionConfig) =
 proc new*(
     T: typedesc[PreambleExtension],
     config: PreambleExtensionConfig,
-    rng: ref HmacDrbgContext,
+    rng: Rng,
 ): PreambleExtension =
   config.doAssert()
   PreambleExtension(rng: rng, config: config)

--- a/libp2p/protocols/pubsub/gossipsub/extensions.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extensions.nim
@@ -34,7 +34,7 @@ type ExtensionsState* = ref object
 
 proc new*(
     T: typedesc[ExtensionsState],
-    rng: ref HmacDrbgContext,
+    rng: Rng,
     updatePeerBehaviorPenalty: UpdatePeerBehaviorPenaltyProc = noopBehaviorPenaltyProc,
     testExtensionConfig: Opt[TestExtensionConfig] = Opt.none(TestExtensionConfig),
     partialMessageExtensionConfig: Opt[PartialMessageExtensionConfig] =

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -196,7 +196,7 @@ type
       ## lead to issues, from descoring to connection drops
       ##
       ## defaults to 1mB
-    rng*: ref HmacDrbgContext
+    rng*: Rng
 
     knownTopics*: HashSet[string]
     customConnCallbacks*: Opt[CustomConnectionCallbacks]
@@ -702,7 +702,7 @@ proc init*[PubParams: object | bool](
     msgIdProvider: MsgIdProvider = defaultMsgIdProvider,
     subscriptionValidator: SubscriptionValidator = nil,
     maxMessageSize: int = 1024 * 1024,
-    rng: ref HmacDrbgContext,
+    rng: Rng,
     parameters: PubParams = false,
     customConnCallbacks: Opt[CustomConnectionCallbacks] =
       Opt.none(CustomConnectionCallbacks),

--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -540,9 +540,7 @@ proc setup*[E](rdv: GenericRendezVous[E], switch: Switch) =
   rdv.switch.addPeerEventHandler(handlePeer, Left)
 
 proc new*(
-    T: typedesc[RendezVous],
-    rng: Rng,
-    config: RendezVousConfig = RendezVousConfig.new(),
+    T: typedesc[RendezVous], rng: Rng, config: RendezVousConfig = RendezVousConfig.new()
 ): T =
   let rdv = GenericRendezVous[PeerRecord](
     rng: rng,

--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -5,7 +5,7 @@
 
 import tables, sequtils, sugar, sets
 import metrics except collect
-import chronos, chronicles, bearssl/rand, stew/[byteutils, objects]
+import chronos, chronicles, stew/[byteutils, objects]
 import
   ./protobuf,
   ../protocol,
@@ -13,6 +13,7 @@ import
   ../../switch,
   ../../dial,
   ../../routing_record,
+  ../../crypto/rng,
   ../../utils/heartbeat,
   ../../utils/future,
   ../../stream/connection,
@@ -92,7 +93,7 @@ type
     # the value is the index sequence corresponding to this
     # namespace in the offsettedqueue.
     namespaces*: Table[string, seq[int]]
-    rng*: ref HmacDrbgContext
+    rng*: Rng
     config*: RendezVousConfig
     salt*: string
     expiredDT*: Moment
@@ -540,13 +541,13 @@ proc setup*[E](rdv: GenericRendezVous[E], switch: Switch) =
 
 proc new*(
     T: typedesc[RendezVous],
-    rng: ref HmacDrbgContext,
+    rng: Rng,
     config: RendezVousConfig = RendezVousConfig.new(),
 ): T =
   let rdv = GenericRendezVous[PeerRecord](
     rng: rng,
     config: config,
-    salt: string.fromBytes(generateBytes(rng[], 8)),
+    salt: string.fromBytes(generateBytes(rng, 8)),
     registered: initOffsettedSeq[RegisteredData](),
     expiredDT: Moment.now() - 1.days,
     #registerEvent: newAsyncEvent(),
@@ -591,7 +592,7 @@ proc new*(
 proc new*(
     T: typedesc[RendezVous],
     switch: Switch,
-    rng: ref HmacDrbgContext,
+    rng: Rng,
     config: RendezVousConfig = RendezVousConfig.new(),
 ): T =
   let rdv = T.new(rng, config)

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -6,7 +6,6 @@
 import std/strformat
 import chronos
 import chronicles
-import bearssl/[rand, hash]
 import stew/[endians2, byteutils]
 import nimcrypto/[utils, sha2, hmac]
 import ../../stream/[connection]
@@ -71,7 +70,7 @@ type
     rs: Curve25519Key
 
   Noise* = ref object of Secure
-    rng: ref HmacDrbgContext
+    rng: Rng
     localPrivateKey: PrivateKey
     localPublicKey: seq[byte]
     noiseKeys: KeyPair
@@ -102,7 +101,7 @@ func shortLog*(conn: NoiseConnection): auto =
 chronicles.formatIt(NoiseConnection):
   shortLog(it)
 
-proc genKeyPair(rng: var HmacDrbgContext): KeyPair =
+proc genKeyPair(rng: Rng): KeyPair =
   result.privateKey = Curve25519Key.random(rng)
   result.publicKey = result.privateKey.public()
 
@@ -231,7 +230,7 @@ template write_e(): untyped =
   trace "noise write e"
   # Sets e (which must be empty) to GENERATE_KEYPAIR().
   # Appends e.public_key to the buffer. Calls MixHash(e.public_key).
-  hs.e = genKeyPair(p.rng[])
+  hs.e = genKeyPair(p.rng)
   hs.ss.mixHash(hs.e.publicKey)
 
   hs.e.publicKey.getBytes
@@ -607,7 +606,7 @@ method init*(p: Noise) {.gcsafe.} =
 
 proc new*(
     T: typedesc[Noise],
-    rng: ref HmacDrbgContext,
+    rng: Rng,
     privateKey: PrivateKey,
     outgoing: bool = true,
     commonPrologue: seq[byte] = @[],
@@ -623,7 +622,7 @@ proc new*(
     outgoing: outgoing,
     localPrivateKey: privateKey,
     localPublicKey: pkBytes,
-    noiseKeys: genKeyPair(rng[]),
+    noiseKeys: genKeyPair(rng),
     commonPrologue: commonPrologue,
   )
 

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -58,7 +58,7 @@ proc new*(
     switch: Switch,
     bootstrapNodes: seq[(PeerId, seq[MultiAddress])] = @[],
     config: KadDHTConfig = KadDHTConfig.new(),
-    rng: ref HmacDrbgContext,
+    rng: Rng,
     client: bool = false,
     codec: string = ExtendedServiceDiscoveryCodec,
     services: seq[ServiceInfo] = @[],

--- a/libp2p/services/autorelayservice.nim
+++ b/libp2p/services/autorelayservice.nim
@@ -23,7 +23,7 @@ type
     peerAvailable: AsyncEvent
     onReservation: OnReservationHandler
     addressMapper: AddressMapper
-    rng: ref HmacDrbgContext
+    rng: Rng
 
 proc isRunning*(self: AutoRelayService): bool =
   return self.running
@@ -160,7 +160,7 @@ proc new*(
     maxNumRelays: int,
     client: RelayClient,
     onReservation: OnReservationHandler,
-    rng: ref HmacDrbgContext,
+    rng: Rng,
 ): T =
   T(
     maxNumRelays: maxNumRelays,

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -8,7 +8,6 @@
 {.push raises: [].}
 
 import std/[options, tables, sequtils, sets]
-import bearssl/rand
 import chronos, chronicles, metrics
 
 import
@@ -30,7 +29,8 @@ import
   identify_pusher,
   errors,
   utility,
-  dialer
+  dialer,
+  crypto/rng
 
 export connmanager, upgrade, dialer, peerstore, identify_pusher
 
@@ -58,7 +58,7 @@ type
     nameResolver*: NameResolver
     started: bool
     services*: seq[Service]
-    rng*: ref HmacDrbgContext
+    rng*: Rng
     identifyPusher*: IdentifyPusher
 
   UpgradeError* = object of LPError
@@ -424,7 +424,7 @@ proc newSwitch*(
     peerStore: PeerStore,
     nameResolver: NameResolver = nil,
     services = newSeq[Service](),
-    rng: ref HmacDrbgContext = nil,
+    rng: Rng = nil,
 ): Switch {.raises: [LPError].} =
   if secureManagers.len == 0:
     raise newException(LPError, "Provide at least one secure manager")

--- a/libp2p/transports/memorytransport.nim
+++ b/libp2p/transports/memorytransport.nim
@@ -22,12 +22,12 @@ logScope:
   topics = "libp2p memorytransport"
 
 type MemoryTransport* = ref object of Transport
-  rng: ref HmacDrbgContext
+  rng: Rng
   connections: seq[Connection]
   listener: Opt[MemoryListener]
 
 proc new*(
-    T: typedesc[MemoryTransport], upgrade: Upgrade = Upgrade(), rng: ref HmacDrbgContext
+    T: typedesc[MemoryTransport], upgrade: Upgrade = Upgrade(), rng: Rng
 ): T =
   let self = T(upgrader: upgrade, rng: rng)
   procCall Transport(self).initialize()
@@ -40,7 +40,7 @@ proc listenAddress(self: MemoryTransport, ma: MultiAddress): MultiAddress =
   # when special address is used `/memorytransport/*` use any free address.
   # here we assume that any random generated address will be free.
   var randomBuf: array[10, byte]
-  hmacDrbgGenerate(self.rng[], randomBuf)
+  self.rng.generate(randomBuf)
 
   return MultiAddress.init("/memorytransport/" & toHex(randomBuf)).get()
 

--- a/libp2p/transports/memorytransport.nim
+++ b/libp2p/transports/memorytransport.nim
@@ -26,9 +26,7 @@ type MemoryTransport* = ref object of Transport
   connections: seq[Connection]
   listener: Opt[MemoryListener]
 
-proc new*(
-    T: typedesc[MemoryTransport], upgrade: Upgrade = Upgrade(), rng: Rng
-): T =
+proc new*(T: typedesc[MemoryTransport], upgrade: Upgrade = Upgrade(), rng: Rng): T =
   let self = T(upgrader: upgrade, rng: rng)
   procCall Transport(self).initialize()
   self

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -279,7 +279,7 @@ type QuicTransport* = ref object of Transport
   client: Opt[QuicClient]
   privateKey: PrivateKey
   connections: HashSet[P2PConnection]
-  rng: ref HmacDrbgContext
+  rng: Rng
   certGenerator: CertGenerator
 
 proc makeCertificateVerifier(): CertificateVerifier =

--- a/libp2p/transports/tortransport.nim
+++ b/libp2p/transports/tortransport.nim
@@ -293,7 +293,7 @@ type TorSwitch* = ref object of Switch
 proc new*(
     T: typedesc[TorSwitch],
     torServer: TransportAddress,
-    rng: ref HmacDrbgContext,
+    rng: Rng,
     addresses: seq[MultiAddress] = @[],
     flags: set[ServerFlags] = {},
 ): TorSwitch {.raises: [LPError].} =

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -16,6 +16,7 @@ import
   ../multistream,
   ../multiaddress,
   ../utility,
+  ../crypto/rng,
   ../stream/connection,
   ../upgrademngrs/upgrade,
   websock/websock
@@ -141,7 +142,7 @@ type WsTransport* = ref object of Transport
   flags: set[ServerFlags]
   handshakeTimeout: Duration
   factories: seq[ExtFactory]
-  rng: ref HmacDrbgContext
+  rng: Rng
 
 proc secure*(self: WsTransport): bool =
   not (isNil(self.tlsPrivateKey) or isNil(self.tlsCertificate))
@@ -180,7 +181,8 @@ method start*(
 
   await procCall Transport(self).start(addrs)
 
-  self.wsserver = WSServer.new(factories = self.factories, rng = self.rng)
+  self.wsserver =
+    WSServer.new(factories = self.factories, rng = bearSslDrbgRef(self.rng))
 
   for i, ma in addrs:
     let isWss =
@@ -410,7 +412,7 @@ proc new*(
     tlsFlags: set[TLSFlags] = {},
     flags: set[ServerFlags] = {},
     factories: openArray[ExtFactory] = [],
-    rng: ref HmacDrbgContext = nil,
+    rng: Rng = nil,
     handshakeTimeout = DefaultHeadersTimeout,
 ): T {.raises: [].} =
   ## Creates a secure WebSocket transport
@@ -434,7 +436,7 @@ proc new*(
     upgrade: Upgrade,
     flags: set[ServerFlags] = {},
     factories: openArray[ExtFactory] = [],
-    rng: ref HmacDrbgContext = nil,
+    rng: Rng = nil,
     handshakeTimeout = DefaultHeadersTimeout,
 ): T {.raises: [].} =
   ## Creates a clear-text WebSocket transport

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -386,7 +386,12 @@ method dial*(
     debug "creating websocket",
       address = initAddress, secure = secure, hostName = hostname
     transp = await WebSocket.connect(
-      initAddress, "", secure = secure, hostName = hostname, flags = self.tlsFlags
+      initAddress,
+      "",
+      secure = secure,
+      hostName = hostname,
+      flags = self.tlsFlags,
+      rng = bearSslDrbgRef(self.rng),
     )
     return await self.connHandler(transp, secure, Direction.Out)
   except CancelledError as e:
@@ -409,13 +414,15 @@ proc new*(
     tlsPrivateKey: TLSPrivateKey,
     tlsCertificate: TLSCertificate,
     autotls: Opt[AutotlsService],
+    rng: Rng,
     tlsFlags: set[TLSFlags] = {},
     flags: set[ServerFlags] = {},
     factories: openArray[ExtFactory] = [],
-    rng: Rng = nil,
     handshakeTimeout = DefaultHeadersTimeout,
 ): T {.raises: [].} =
   ## Creates a secure WebSocket transport
+
+  doAssert not rng.isNil, "Rng is nil"
 
   let self = T(
     upgrader: upgrade,
@@ -434,9 +441,9 @@ proc new*(
 proc new*(
     T: typedesc[WsTransport],
     upgrade: Upgrade,
+    rng: Rng,
     flags: set[ServerFlags] = {},
     factories: openArray[ExtFactory] = [],
-    rng: Rng = nil,
     handshakeTimeout = DefaultHeadersTimeout,
 ): T {.raises: [].} =
   ## Creates a clear-text WebSocket transport

--- a/performance/test_node/utils.nim
+++ b/performance/test_node/utils.nim
@@ -33,7 +33,7 @@ proc msgIdProvider*(m: Message): Result[MessageId, ValidationResult] =
   ok(($m.data.hash).toBytes())
 
 proc setupNode*(
-    nodeId: int, rng: ref HmacDrbgContext, transport: TransportType = TransportType.TCP
+    nodeId: int, rng: Rng, transport: TransportType = TransportType.TCP
 ): (Switch, GossipSub, Ping) =
   let
     myPort = 5000 + nodeId

--- a/simulation/main.nim
+++ b/simulation/main.nim
@@ -163,9 +163,7 @@ proc publishNewMessage(
     res = await gossipSub.publish(topic, nowBytes)
   return (now, res)
 
-proc initializeGossipsub(
-    switch: Switch, anonymize: bool, rng: Rng
-): GossipSub =
+proc initializeGossipsub(switch: Switch, anonymize: bool, rng: Rng): GossipSub =
   return GossipSub.init(
     switch = switch,
     triggerSelf = parseBool(getEnv("SELFTRIGGER", "true")),

--- a/simulation/main.nim
+++ b/simulation/main.nim
@@ -164,7 +164,7 @@ proc publishNewMessage(
   return (now, res)
 
 proc initializeGossipsub(
-    switch: Switch, anonymize: bool, rng: ref HmacDrbgContext
+    switch: Switch, anonymize: bool, rng: Rng
 ): GossipSub =
   return GossipSub.init(
     switch = switch,
@@ -176,7 +176,7 @@ proc initializeGossipsub(
   )
 
 proc connectGossipsubPeers(
-    switch: Switch, addrs: seq[string], connectTo: int, rng: ref HmacDrbgContext
+    switch: Switch, addrs: seq[string], connectTo: int, rng: Rng
 ): Future[Result[int, string]] {.async.} =
   var multiAddrs = addrs
 

--- a/tests/integration/test_autotls_integration.nim
+++ b/tests/integration/test_autotls_integration.nim
@@ -29,7 +29,7 @@ when defined(linux) and defined(amd64) and defined(libp2p_autotls_support):
       checkTrackers()
 
     asyncTest "request challenge without ACMEClient (ACMEApi only)":
-      let key = KeyPair.random(PKScheme.RSA, rng[]).get()
+      let key = KeyPair.random(PKScheme.RSA, rng()).get()
       let acmeApi = ACMEApi.new(acmeServerURL = parseUri(LetsEncryptURLStaging))
       defer:
         await acmeApi.close()
@@ -80,7 +80,7 @@ when defined(linux) and defined(amd64) and defined(libp2p_autotls_support):
             acmeServerURL = parseUri(LetsEncryptURLStaging), renewCheckTime = 1.seconds
           )
         )
-        .withRng(rng)
+        .withRng(rng())
         .withAddress(MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet())
         .withTcpTransport()
         .withYamux()

--- a/tests/integration/test_peer_id_auth_integration.nim
+++ b/tests/integration/test_peer_id_auth_integration.nim
@@ -23,8 +23,8 @@ suite "PeerID Auth":
     checkTrackers()
 
   asyncSetup:
-    client = PeerIDAuthClient.new(rng)
-    peerInfo = PeerInfo.new(PrivateKey.random(PKScheme.RSA, rng[]).get())
+    client = PeerIDAuthClient.new(rng())
+    peerInfo = PeerInfo.new(PrivateKey.random(PKScheme.RSA, rng()).get())
 
   asyncTest "test peerID send":
     let payload = %*{

--- a/tests/integration/test_ws_integration.nim
+++ b/tests/integration/test_ws_integration.nim
@@ -34,7 +34,7 @@ suite "WebSocket transport integration":
 
     let switch1 = SwitchBuilder
       .new()
-      .withRng(rng)
+      .withRng(rng())
       .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0/wss").tryGet()])
       .withNameResolver(DnsResolver.new(DefaultDnsServers))
       .withWsTransport()
@@ -45,7 +45,7 @@ suite "WebSocket transport integration":
     let switch2 = SwitchBuilder
       .new()
       .withAutotls()
-      .withRng(rng)
+      .withRng(rng())
       .withAddresses(
         @[
           MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet(),

--- a/tests/interop/test_autonatv2.nim
+++ b/tests/interop/test_autonatv2.nim
@@ -13,7 +13,7 @@ import ../tools/[unittest, crypto]
 proc createSwitch(address: string, withAutonatV2: bool = true): Switch =
   var builder = SwitchBuilder
     .new()
-    .withRng(rng)
+    .withRng(rng())
     .withAddresses(@[MultiAddress.init(address).get()])
     .withTcpTransport()
     .withYamux()

--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -27,7 +27,7 @@ when defined(libp2p_autotls_support):
 
     asyncSetup:
       api = await MockACMEApi.new()
-      key = KeyPair.random(PKScheme.RSA, rng[]).get()
+      key = KeyPair.random(PKScheme.RSA, rng()).get()
 
     asyncTest "register to acme server":
       api.mockedResponses.add(
@@ -94,7 +94,7 @@ when defined(libp2p_autotls_support):
     asyncTest "register with unsupported keys":
       let unsupportedSchemes = [PKScheme.Ed25519, PKScheme.Secp256k1, PKScheme.ECDSA]
       for scheme in unsupportedSchemes:
-        let unsupportedKey = KeyPair.random(scheme, rng[]).get()
+        let unsupportedKey = KeyPair.random(scheme, rng()).get()
         expect(ACMEError):
           discard await api.requestRegister(unsupportedKey)
 
@@ -185,7 +185,7 @@ when defined(libp2p_autotls_support):
         "some-domain",
         parseUri("http://example.com/some-finalize-url"),
         parseUri("http://example.com/some-order-url"),
-        KeyPair.random(PKScheme.RSA, rng[]).get,
+        KeyPair.random(PKScheme.RSA, rng()).get,
         key,
         "kid",
       )
@@ -204,7 +204,7 @@ when defined(libp2p_autotls_support):
         "some-domain",
         parseUri("http://example.com/some-finalize-url"),
         parseUri("http://example.com/some-order-url"),
-        KeyPair.random(PKScheme.RSA, rng[]).get,
+        KeyPair.random(PKScheme.RSA, rng()).get,
         key,
         "kid",
         retries = 1,
@@ -229,7 +229,7 @@ when defined(libp2p_autotls_support):
         "some-domain",
         parseUri("http://example.com/some-finalize-url"),
         parseUri("http://example.com/some-order-url"),
-        KeyPair.random(PKScheme.RSA, rng[]).get,
+        KeyPair.random(PKScheme.RSA, rng()).get,
         key,
         "kid",
       )
@@ -322,7 +322,7 @@ when defined(libp2p_autotls_support):
         discard await api.requestFinalize(
           "some-domain",
           parseUri("http://example.com/some-finalize-url"),
-          KeyPair.random(PKScheme.RSA, rng[]).get,
+          KeyPair.random(PKScheme.RSA, rng()).get,
           key,
           "kid",
         )
@@ -398,5 +398,5 @@ when defined(libp2p_autotls_support):
       )
       expect(ACMEError):
         discard await acme.getCertificate(
-          api.Domain("some.domain"), KeyPair.random(PKScheme.RSA, rng[]).get, challenge
+          api.Domain("some.domain"), KeyPair.random(PKScheme.RSA, rng()).get, challenge
         )

--- a/tests/libp2p/autotls/test_peer_id_auth.nim
+++ b/tests/libp2p/autotls/test_peer_id_auth.nim
@@ -20,12 +20,12 @@ suite "PeerID Auth Client":
     checkTrackers()
 
   asyncSetup:
-    client = MockPeerIDAuthClient.new(rng)
+    client = MockPeerIDAuthClient.new(rng())
     client.mockedHeaders = HttpTable.init()
-    peerInfo = PeerInfo.new(PrivateKey.random(PKScheme.RSA, rng[]).get())
+    peerInfo = PeerInfo.new(PrivateKey.random(PKScheme.RSA, rng()).get())
 
   asyncTest "request authentication":
-    let serverPrivateKey = PrivateKey.random(PKScheme.RSA, rng[]).get()
+    let serverPrivateKey = PrivateKey.random(PKScheme.RSA, rng()).get()
     let serverPubkey = serverPrivateKey.getPublicKey().get()
     let b64serverPubkey = serverPubkey.pubkeyBytes().encode(safe = true)
     client.mockedHeaders.add(
@@ -51,7 +51,7 @@ suite "PeerID Auth Client":
     )
 
     let uri = parseUri("https://example.com/some/uri")
-    let serverPrivateKey = PrivateKey.random(PKScheme.RSA, rng[]).get()
+    let serverPrivateKey = PrivateKey.random(PKScheme.RSA, rng()).get()
     let serverPubkey = serverPrivateKey.getPublicKey().get()
     let authorizationResponse = await client.requestAuthorization(
       peerInfo, uri, "some-challenge-client", "some-challenge-server", serverPubkey,

--- a/tests/libp2p/crypto/test_crypto.nim
+++ b/tests/libp2p/crypto/test_crypto.nim
@@ -4,7 +4,7 @@
 
 from std/strutils import toUpper
 import std/[sequtils, algorithm]
-import bearssl/hash, nimcrypto/utils
+import bearssl/[hash, rand], nimcrypto/utils
 import ../../../libp2p/crypto/[crypto, chacha20poly1305, curve25519, hkdf]
 import ../../tools/[unittest, crypto]
 
@@ -631,6 +631,20 @@ suite "Key interface test suite":
     let original = cards.toSeq().sorted()
     rng().shuffle(cards)
     check cards.toSeq().sorted() == original
+
+  test "newBearSslRng wraps existing HMAC-DRBG context":
+    var seed = [byte 1, 2, 3, 4, 5, 6, 7, 8]
+    let ctx = (ref HmacDrbgContext)()
+    var expectedCtx: HmacDrbgContext
+    hmacDrbgInit(ctx[], addr sha256Vtable, addr seed[0], uint seed.len)
+    hmacDrbgInit(expectedCtx, addr sha256Vtable, addr seed[0], uint seed.len)
+
+    let wrapped = newBearSslRng(ctx)
+    var got, expected: array[32, byte]
+    wrapped.generate(got)
+    hmacDrbgGenerate(expectedCtx, addr expected[0], uint expected.len)
+
+    check got == expected
 
   test "pickOne returns none for empty sequence":
     let x: seq[int] = @[]

--- a/tests/libp2p/crypto/test_crypto.nim
+++ b/tests/libp2p/crypto/test_crypto.nim
@@ -405,9 +405,9 @@ suite "Key interface test suite":
     var bmsg = cast[seq[byte]](msg)
 
     for i in 0 ..< 5:
-      var seckey = PrivateKey.random(ECDSA, rng[]).get()
+      var seckey = PrivateKey.random(ECDSA, rng()).get()
       var pubkey = seckey.getPublicKey().get()
-      var pair = KeyPair.random(ECDSA, rng[]).get()
+      var pair = KeyPair.random(ECDSA, rng()).get()
       var sig1 = pair.seckey.sign(bmsg).get()
       var sig2 = seckey.sign(bmsg).get()
       var sersig1 = sig1.getBytes()
@@ -425,9 +425,9 @@ suite "Key interface test suite":
         recsig2.verify(bmsg, recpub2) == true
 
     for i in 0 ..< 5:
-      var seckey = PrivateKey.random(Ed25519, rng[]).get()
+      var seckey = PrivateKey.random(Ed25519, rng()).get()
       var pubkey = seckey.getPublicKey().get()
-      var pair = KeyPair.random(Ed25519, rng[]).get()
+      var pair = KeyPair.random(Ed25519, rng()).get()
       var sig1 = pair.seckey.sign(bmsg).get()
       var sig2 = seckey.sign(bmsg).get()
       var sersig1 = sig1.getBytes()
@@ -445,9 +445,9 @@ suite "Key interface test suite":
         recsig2.verify(bmsg, recpub2) == true
 
     for i in 0 ..< 2:
-      var seckey = PrivateKey.random(RSA, rng[], 2048).get()
+      var seckey = PrivateKey.random(RSA, rng(), 2048).get()
       var pubkey = seckey.getPublicKey().get()
-      var pair = KeyPair.random(RSA, rng[], 2048).get()
+      var pair = KeyPair.random(RSA, rng(), 2048).get()
       var sig1 = pair.seckey.sign(bmsg).get()
       var sig2 = seckey.sign(bmsg).get()
       var sersig1 = sig1.getBytes()
@@ -628,32 +628,31 @@ suite "Key interface test suite":
 
   test "shuffle":
     var cards = ["Ace", "King", "Queen", "Jack", "Ten"]
-    var rng = (ref HmacDrbgContext)()
-    hmacDrbgInit(rng[], addr sha256Vtable, nil, 0)
-    rng.shuffle(cards)
-    check cards == ["King", "Ten", "Ace", "Queen", "Jack"]
+    let original = cards.toSeq().sorted()
+    rng().shuffle(cards)
+    check cards.toSeq().sorted() == original
 
   test "pickOne returns none for empty sequence":
     let x: seq[int] = @[]
-    check rng.pickOne(x).isNone()
+    check rng().pickOne(x).isNone()
 
   test "pickOne returns the only element of a singleton":
-    check rng.pickOne(@[42]).get() == 42
+    check rng().pickOne(@[42]).get() == 42
 
   test "pickOne returns an element from the sequence":
     let xs = @[11, 22, 33, 44, 55]
-    let picked = rng.pickOne(xs).get()
+    let picked = rng().pickOne(xs).get()
     check picked in xs
 
   test "pick returns none for empty sequence":
-    check rng.pick(newSeq[int](), 3).isNone()
+    check rng().pick(newSeq[int](), 3).isNone()
 
   test "pick returns empty when n is zero":
-    check rng.pick(@[1, 2, 3], 0).get().len == 0
+    check rng().pick(@[1, 2, 3], 0).get().len == 0
 
   test "pick returns n distinct elements from the sequence":
     let xs = @[11, 22, 33, 44, 55]
-    let picked = rng.pick(xs, 3).get()
+    let picked = rng().pick(xs, 3).get()
     check picked.len == 3
     for x in picked:
       check x in xs
@@ -661,31 +660,31 @@ suite "Key interface test suite":
 
   test "pick returns all elements when n >= len":
     let xs = @[11, 22, 33]
-    let picked = rng.pick(xs, 10).get()
+    let picked = rng().pick(xs, 10).get()
     check picked.len == xs.len
     check picked.sorted() == xs.sorted()
 
   test "pick returns some for non-empty sequence with n > 0":
-    check rng.pick(@[11, 22, 33], 2).isSome()
+    check rng().pick(@[11, 22, 33], 2).isSome()
 
   test "pick result contains no duplicates":
     let xs = @[11, 22, 33, 44, 55, 66, 77, 88]
-    let picked = rng.pick(xs, 5).get()
+    let picked = rng().pick(xs, 5).get()
     check picked == picked.deduplicate()
 
   test "pick result is a subset of the input":
     let xs = @[11, 22, 33, 44, 55]
-    let picked = rng.pick(xs, 4).get()
+    let picked = rng().pick(xs, 4).get()
     for x in picked:
       check x in xs
 
   test "pick n=1 returns a single element":
     let xs = @[11, 22, 33]
-    let picked = rng.pick(xs, 1).get()
+    let picked = rng().pick(xs, 1).get()
     check picked.len == 1
     check picked[0] in xs
 
   test "pickOne result is always in the sequence":
     let xs = @[100, 200, 300, 400, 500]
     for _ in 0 ..< 20:
-      check rng.pickOne(xs).get() in xs
+      check rng().pickOne(xs).get() in xs

--- a/tests/libp2p/crypto/test_ecnist.nim
+++ b/tests/libp2p/crypto/test_ecnist.nim
@@ -288,7 +288,7 @@ suite "EC NIST-P256/384/521 test suite":
     for i in 0 ..< TestsCount:
       var rkey1, rkey2: EcPrivateKey
       var skey2 = newSeq[byte](256)
-      var key = EcPrivateKey.random(Secp256r1, rng[]).expect("random key")
+      var key = EcPrivateKey.random(Secp256r1, rng()).expect("random key")
       var skey1 = key.getBytes().expect("bytes")
       check:
         key.toBytes(skey2).expect("bytes") > 0
@@ -310,7 +310,7 @@ suite "EC NIST-P256/384/521 test suite":
     for i in 0 ..< TestsCount:
       var rkey1, rkey2: EcPublicKey
       var skey2 = newSeq[byte](256)
-      var pair = EcKeyPair.random(Secp256r1, rng[]).expect("random key")
+      var pair = EcKeyPair.random(Secp256r1, rng()).expect("random key")
       var skey1 = pair.pubkey.getBytes().expect("bytes")
       check:
         pair.pubkey.toBytes(skey2).expect("bytes") > 0
@@ -329,8 +329,8 @@ suite "EC NIST-P256/384/521 test suite":
 
   test "[secp256r1] ECDHE test":
     for i in 0 ..< TestsCount:
-      var kp1 = EcKeyPair.random(Secp256r1, rng[]).expect("random key")
-      var kp2 = EcKeyPair.random(Secp256r1, rng[]).expect("random key")
+      var kp1 = EcKeyPair.random(Secp256r1, rng()).expect("random key")
+      var kp2 = EcKeyPair.random(Secp256r1, rng()).expect("random key")
       var shared1 = kp2.pubkey.scalarMul(kp1.seckey)
       var shared2 = kp1.pubkey.scalarMul(kp2.seckey)
       check:
@@ -386,7 +386,7 @@ suite "EC NIST-P256/384/521 test suite":
   test "[secp256r1] Generate/Sign/Serialize/Deserialize/Verify test":
     var message = "message to sign"
     for i in 0 ..< TestsCount:
-      var kp = EcKeyPair.random(Secp256r1, rng[]).expect("random key")
+      var kp = EcKeyPair.random(Secp256r1, rng()).expect("random key")
       var sig = kp.seckey.sign(message).expect("signature")
       var sersk = kp.seckey.getBytes().expect("bytes")
       var serpk = kp.pubkey.getBytes().expect("bytes")
@@ -403,7 +403,7 @@ suite "EC NIST-P256/384/521 test suite":
     for i in 0 ..< TestsCount:
       var rkey1, rkey2: EcPrivateKey
       var skey2 = newSeq[byte](256)
-      var key = EcPrivateKey.random(Secp384r1, rng[]).expect("random key")
+      var key = EcPrivateKey.random(Secp384r1, rng()).expect("random key")
       var skey1 = key.getBytes().expect("bytes")
       check:
         key.toBytes(skey2).expect("bytes") > 0
@@ -425,7 +425,7 @@ suite "EC NIST-P256/384/521 test suite":
     for i in 0 ..< TestsCount:
       var rkey1, rkey2: EcPublicKey
       var skey2 = newSeq[byte](256)
-      var pair = EcKeyPair.random(Secp384r1, rng[]).expect("random key")
+      var pair = EcKeyPair.random(Secp384r1, rng()).expect("random key")
       var skey1 = pair.pubkey.getBytes().expect("bytes")
       check:
         pair.pubkey.toBytes(skey2).expect("bytes") > 0
@@ -444,8 +444,8 @@ suite "EC NIST-P256/384/521 test suite":
 
   test "[secp384r1] ECDHE test":
     for i in 0 ..< TestsCount:
-      var kp1 = EcKeyPair.random(Secp384r1, rng[]).expect("random key")
-      var kp2 = EcKeyPair.random(Secp384r1, rng[]).expect("random key")
+      var kp1 = EcKeyPair.random(Secp384r1, rng()).expect("random key")
+      var kp2 = EcKeyPair.random(Secp384r1, rng()).expect("random key")
       var shared1 = kp2.pubkey.scalarMul(kp1.seckey)
       var shared2 = kp1.pubkey.scalarMul(kp2.seckey)
       check:
@@ -501,7 +501,7 @@ suite "EC NIST-P256/384/521 test suite":
   test "[secp384r1] Generate/Sign/Serialize/Deserialize/Verify test":
     var message = "message to sign"
     for i in 0 ..< TestsCount:
-      var kp = EcKeyPair.random(Secp384r1, rng[]).expect("random key")
+      var kp = EcKeyPair.random(Secp384r1, rng()).expect("random key")
       var sig = kp.seckey.sign(message).expect("signature")
       var sersk = kp.seckey.getBytes().expect("bytes")
       var serpk = kp.pubkey.getBytes().expect("bytes")
@@ -518,7 +518,7 @@ suite "EC NIST-P256/384/521 test suite":
     for i in 0 ..< TestsCount:
       var rkey1, rkey2: EcPrivateKey
       var skey2 = newSeq[byte](256)
-      var key = EcPrivateKey.random(Secp521r1, rng[]).expect("random key")
+      var key = EcPrivateKey.random(Secp521r1, rng()).expect("random key")
       var skey1 = key.getBytes().expect("bytes")
       check:
         key.toBytes(skey2).expect("bytes") > 0
@@ -540,7 +540,7 @@ suite "EC NIST-P256/384/521 test suite":
     for i in 0 ..< TestsCount:
       var rkey1, rkey2: EcPublicKey
       var skey2 = newSeq[byte](256)
-      var pair = EcKeyPair.random(Secp521r1, rng[]).expect("random key")
+      var pair = EcKeyPair.random(Secp521r1, rng()).expect("random key")
       var skey1 = pair.pubkey.getBytes().expect("bytes")
       check:
         pair.pubkey.toBytes(skey2).expect("bytes") > 0
@@ -559,8 +559,8 @@ suite "EC NIST-P256/384/521 test suite":
 
   test "[secp521r1] ECDHE test":
     for i in 0 ..< TestsCount:
-      var kp1 = EcKeyPair.random(Secp521r1, rng[]).expect("random key")
-      var kp2 = EcKeyPair.random(Secp521r1, rng[]).expect("random key")
+      var kp1 = EcKeyPair.random(Secp521r1, rng()).expect("random key")
+      var kp2 = EcKeyPair.random(Secp521r1, rng()).expect("random key")
       var shared1 = kp2.pubkey.scalarMul(kp1.seckey)
       var shared2 = kp1.pubkey.scalarMul(kp2.seckey)
       check:
@@ -616,7 +616,7 @@ suite "EC NIST-P256/384/521 test suite":
   test "[secp521r1] Generate/Sign/Serialize/Deserialize/Verify test":
     var message = "message to sign"
     for i in 0 ..< TestsCount:
-      var kp = EcKeyPair.random(Secp521r1, rng[]).expect("random key")
+      var kp = EcKeyPair.random(Secp521r1, rng()).expect("random key")
       var sig = kp.seckey.sign(message).expect("signature")
       var sersk = kp.seckey.getBytes().expect("bytes")
       var serpk = kp.pubkey.getBytes().expect("bytes")
@@ -631,7 +631,7 @@ suite "EC NIST-P256/384/521 test suite":
 
   test "Private key toBytes returns EcInsufficientTargetSize for undersized buffer":
     for curve in [Secp256r1, Secp384r1, Secp521r1]:
-      let key = EcPrivateKey.random(curve, rng[]).expect("random key")
+      let key = EcPrivateKey.random(curve, rng()).expect("random key")
       # Determine correct size first, then use a buffer one byte too small.
       var full = newSeq[byte](512)
       let needed = key.toBytes(full).expect("bytes")
@@ -641,7 +641,7 @@ suite "EC NIST-P256/384/521 test suite":
 
   test "Public key toBytes returns EcInsufficientTargetSize for undersized buffer":
     for curve in [Secp256r1, Secp384r1, Secp521r1]:
-      let pair = EcKeyPair.random(curve, rng[]).expect("random key")
+      let pair = EcKeyPair.random(curve, rng()).expect("random key")
       # Determine correct size first, then use a buffer one byte too small.
       var full = newSeq[byte](512)
       let needed = pair.pubkey.toBytes(full).expect("bytes")

--- a/tests/libp2p/crypto/test_ed25519.nim
+++ b/tests/libp2p/crypto/test_ed25519.nim
@@ -105,7 +105,7 @@ suite "Ed25519 test suite":
     for i in 0 ..< TestsCount:
       var rkey1, rkey2: EdPrivateKey
       var skey2 = newSeq[byte](256)
-      var key = EdPrivateKey.random(rng[])
+      var key = EdPrivateKey.random(rng())
       var skey1 = key.getBytes()
       check:
         key.toBytes(skey2) > 0
@@ -129,7 +129,7 @@ suite "Ed25519 test suite":
     for i in 0 ..< TestsCount:
       var rkey1, rkey2: EdPublicKey
       var skey2 = newSeq[byte](256)
-      var pair = EdKeyPair.random(rng[])
+      var pair = EdKeyPair.random(rng())
       var skey1 = pair.pubkey.getBytes()
       check:
         pair.pubkey.toBytes(skey2) > 0
@@ -166,7 +166,7 @@ suite "Ed25519 test suite":
   test "Generate/Sign/Serialize/Deserialize/Verify test":
     var message = "message to sign"
     for i in 0 ..< TestsCount:
-      var kp = EdKeyPair.random(rng[])
+      var kp = EdKeyPair.random(rng())
       var sig = kp.seckey.sign(message)
       var sersk = kp.seckey.getBytes()
       var serpk = kp.pubkey.getBytes()
@@ -199,7 +199,7 @@ suite "Ed25519 test suite":
 
   test "fromSeed produces same key as random() with same seed":
     # Generate a random key, extract its seed, recreate with fromSeed
-    let randomKey = EdPrivateKey.random(rng[])
+    let randomKey = EdPrivateKey.random(rng())
     var seed: array[32, byte]
     copyMem(addr seed[0], unsafeAddr randomKey.data[0], 32)
     let recreated = EdPrivateKey.fromSeed(seed)

--- a/tests/libp2p/crypto/test_pki_filter.nim
+++ b/tests/libp2p/crypto/test_pki_filter.nim
@@ -118,12 +118,12 @@ const
 suite "Public key infrastructure filtering test suite":
   test RSATestMessage:
     when not (supported(PKScheme.RSA)):
-      let sk2048 = PrivateKey.random(PKScheme.RSA, rng[], 2048)
-      let sk3072 = PrivateKey.random(PKScheme.RSA, rng[], 3072)
-      let sk4096 = PrivateKey.random(PKScheme.RSA, rng[], 4096)
-      let kp2048 = KeyPair.random(PKScheme.RSA, rng[], 2048)
-      let kp3072 = KeyPair.random(PKScheme.RSA, rng[], 3072)
-      let kp4096 = KeyPair.random(PKScheme.RSA, rng[], 4096)
+      let sk2048 = PrivateKey.random(PKScheme.RSA, rng(), 2048)
+      let sk3072 = PrivateKey.random(PKScheme.RSA, rng(), 3072)
+      let sk4096 = PrivateKey.random(PKScheme.RSA, rng(), 4096)
+      let kp2048 = KeyPair.random(PKScheme.RSA, rng(), 2048)
+      let kp3072 = KeyPair.random(PKScheme.RSA, rng(), 3072)
+      let kp4096 = KeyPair.random(PKScheme.RSA, rng(), 4096)
       let sk = PrivateKey.init(fromHex(stripSpaces(RSA_PrivateKey)))
       let pk = PublicKey.init(fromHex(stripSpaces(RSA_PublicKey)))
       check:
@@ -144,8 +144,8 @@ suite "Public key infrastructure filtering test suite":
         sk.error == CryptoError.KeyError
         pk.error == CryptoError.KeyError
     else:
-      let sk2048 = PrivateKey.random(PKScheme.RSA, rng[], 2048)
-      let kp2048 = KeyPair.random(PKScheme.RSA, rng[], 2048)
+      let sk2048 = PrivateKey.random(PKScheme.RSA, rng(), 2048)
+      let kp2048 = KeyPair.random(PKScheme.RSA, rng(), 2048)
       let sk = PrivateKey.init(fromHex(stripSpaces(RSA_PrivateKey)))
       let pk = PublicKey.init(fromHex(stripSpaces(RSA_PublicKey)))
       check:
@@ -156,8 +156,8 @@ suite "Public key infrastructure filtering test suite":
 
   test EcdsaTestMessage:
     when not (supported(PKScheme.ECDSA)):
-      let rsk = PrivateKey.random(PKScheme.ECDSA, rng[])
-      let rkp = KeyPair.random(PKScheme.ECDSA, rng[])
+      let rsk = PrivateKey.random(PKScheme.ECDSA, rng())
+      let rkp = KeyPair.random(PKScheme.ECDSA, rng())
       let sk = PrivateKey.init(fromHex(stripSpaces(ECDSA_PrivateKey)))
       let pk = PublicKey.init(fromHex(stripSpaces(ECDSA_PublicKey)))
       check:
@@ -170,8 +170,8 @@ suite "Public key infrastructure filtering test suite":
         sk.error == CryptoError.KeyError
         pk.error == CryptoError.KeyError
     else:
-      let rsk = PrivateKey.random(PKScheme.ECDSA, rng[])
-      let rkp = KeyPair.random(PKScheme.ECDSA, rng[])
+      let rsk = PrivateKey.random(PKScheme.ECDSA, rng())
+      let rkp = KeyPair.random(PKScheme.ECDSA, rng())
       let sk = PrivateKey.init(fromHex(stripSpaces(ECDSA_PrivateKey)))
       let pk = PublicKey.init(fromHex(stripSpaces(ECDSA_PublicKey)))
       check:
@@ -182,8 +182,8 @@ suite "Public key infrastructure filtering test suite":
 
   test EdTestMessage:
     when not (supported(PKScheme.Ed25519)):
-      let rsk = PrivateKey.random(PKScheme.Ed25519, rng[])
-      let rkp = KeyPair.random(PKScheme.Ed25519, rng[])
+      let rsk = PrivateKey.random(PKScheme.Ed25519, rng())
+      let rkp = KeyPair.random(PKScheme.Ed25519, rng())
       let sk = PrivateKey.init(fromHex(stripSpaces(ED25519_PrivateKey)))
       let pk = PublicKey.init(fromHex(stripSpaces(ED25519_PublicKey)))
       check:
@@ -196,8 +196,8 @@ suite "Public key infrastructure filtering test suite":
         sk.error == CryptoError.KeyError
         pk.error == CryptoError.KeyError
     else:
-      let rsk = PrivateKey.random(PKScheme.Ed25519, rng[])
-      let rkp = KeyPair.random(PKScheme.Ed25519, rng[])
+      let rsk = PrivateKey.random(PKScheme.Ed25519, rng())
+      let rkp = KeyPair.random(PKScheme.Ed25519, rng())
       let sk = PrivateKey.init(fromHex(stripSpaces(ED25519_PrivateKey)))
       let pk = PublicKey.init(fromHex(stripSpaces(ED25519_PublicKey)))
       check:
@@ -208,8 +208,8 @@ suite "Public key infrastructure filtering test suite":
 
   test SecpTestMessage:
     when not (supported(PKScheme.Secp256k1)):
-      let rsk = PrivateKey.random(PKScheme.Secp256k1, rng[])
-      let rkp = KeyPair.random(PKScheme.Secp256k1, rng[])
+      let rsk = PrivateKey.random(PKScheme.Secp256k1, rng())
+      let rkp = KeyPair.random(PKScheme.Secp256k1, rng())
       let sk = PrivateKey.init(fromHex(stripSpaces(SECP256k1_PrivateKey)))
       let pk = PublicKey.init(fromHex(stripSpaces(SECP256k1_PublicKey)))
       check:
@@ -222,8 +222,8 @@ suite "Public key infrastructure filtering test suite":
         sk.error == CryptoError.KeyError
         pk.error == CryptoError.KeyError
     else:
-      let rsk = PrivateKey.random(PKScheme.Secp256k1, rng[])
-      let rkp = KeyPair.random(PKScheme.Secp256k1, rng[])
+      let rsk = PrivateKey.random(PKScheme.Secp256k1, rng())
+      let rkp = KeyPair.random(PKScheme.Secp256k1, rng())
       let sk = PrivateKey.init(fromHex(stripSpaces(SECP256k1_PrivateKey)))
       let pk = PublicKey.init(fromHex(stripSpaces(SECP256k1_PublicKey)))
       check:

--- a/tests/libp2p/crypto/test_rsa.nim
+++ b/tests/libp2p/crypto/test_rsa.nim
@@ -354,7 +354,7 @@ suite "RSA 2048/3072/4096 test suite":
   test "[rsa2048] Private key serialize/deserialize test":
     var rkey1, rkey2: RsaPrivateKey
     var skey2 = newSeq[byte](4096)
-    var key = RsaPrivateKey.random(rng[], 2048).expect("random failed")
+    var key = RsaPrivateKey.random(rng(), 2048).expect("random failed")
     var skey1 = key.getBytes().expect("bytes")
     check key.toBytes(skey2).expect("bytes") > 0
     check:
@@ -371,7 +371,7 @@ suite "RSA 2048/3072/4096 test suite":
   test "[rsa3072] Private key serialize/deserialize test":
     var rkey1, rkey2: RsaPrivateKey
     var skey2 = newSeq[byte](4096)
-    var key = RsaPrivateKey.random(rng[], 3072).expect("random failed")
+    var key = RsaPrivateKey.random(rng(), 3072).expect("random failed")
     var skey1 = key.getBytes().expect("bytes")
     check key.toBytes(skey2).expect("bytes") > 0
     check:
@@ -390,7 +390,7 @@ suite "RSA 2048/3072/4096 test suite":
     when defined(release):
       var rkey1, rkey2: RsaPrivateKey
       var skey2 = newSeq[byte](4096)
-      var key = RsaPrivateKey.random(rng[], 4096).expect("random failed")
+      var key = RsaPrivateKey.random(rng(), 4096).expect("random failed")
       var skey1 = key.getBytes().expect("bytes")
       check key.toBytes(skey2).expect("bytes") > 0
       check:
@@ -409,7 +409,7 @@ suite "RSA 2048/3072/4096 test suite":
   test "[rsa2048] Public key serialize/deserialize test":
     var rkey1, rkey2: RsaPublicKey
     var skey2 = newSeq[byte](4096)
-    var pair = RsaKeyPair.random(rng[], 2048).expect("random failed")
+    var pair = RsaKeyPair.random(rng(), 2048).expect("random failed")
     var skey1 = pair.pubkey.getBytes().expect("bytes")
     check:
       pair.pubkey.toBytes(skey2).expect("bytes") > 0
@@ -426,7 +426,7 @@ suite "RSA 2048/3072/4096 test suite":
   test "[rsa3072] Public key serialize/deserialize test":
     var rkey1, rkey2: RsaPublicKey
     var skey2 = newSeq[byte](4096)
-    var pair = RsaKeyPair.random(rng[], 3072).expect("random failed")
+    var pair = RsaKeyPair.random(rng(), 3072).expect("random failed")
     var skey1 = pair.pubkey.getBytes().expect("bytes")
     check:
       pair.pubkey.toBytes(skey2).expect("bytes") > 0
@@ -444,7 +444,7 @@ suite "RSA 2048/3072/4096 test suite":
     when defined(release):
       var rkey1, rkey2: RsaPublicKey
       var skey2 = newSeq[byte](4096)
-      var pair = RsaKeyPair.random(rng[], 4096).expect("random failed")
+      var pair = RsaKeyPair.random(rng(), 4096).expect("random failed")
       var skey1 = pair.pubkey.getBytes().expect("bytes")
       check:
         pair.pubkey.toBytes(skey2).expect("bytes") > 0
@@ -462,7 +462,7 @@ suite "RSA 2048/3072/4096 test suite":
 
   test "[rsa2048] Generate/Sign/Serialize/Deserialize/Verify test":
     var message = "message to sign"
-    var kp = RsaKeyPair.random(rng[], 2048).expect("RsaPrivateKey.random failed")
+    var kp = RsaKeyPair.random(rng(), 2048).expect("RsaPrivateKey.random failed")
     var sig = kp.seckey.sign(message).expect("signature")
     var sersk = kp.seckey.getBytes().expect("bytes")
     var serpk = kp.pubkey.getBytes().expect("bytes")
@@ -477,7 +477,7 @@ suite "RSA 2048/3072/4096 test suite":
 
   test "[rsa3072] Generate/Sign/Serialize/Deserialize/Verify test":
     var message = "message to sign"
-    var kp = RsaKeyPair.random(rng[], 3072).expect("RsaPrivateKey.random failed")
+    var kp = RsaKeyPair.random(rng(), 3072).expect("RsaPrivateKey.random failed")
     var sig = kp.seckey.sign(message).expect("signature")
     var sersk = kp.seckey.getBytes().expect("bytes")
     var serpk = kp.pubkey.getBytes().expect("bytes")
@@ -493,7 +493,7 @@ suite "RSA 2048/3072/4096 test suite":
   test "[rsa4096] Generate/Sign/Serialize/Deserialize/Verify test":
     when defined(release):
       var message = "message to sign"
-      var kp = RsaKeyPair.random(rng[], 4096).expect("RsaPrivateKey.random failed")
+      var kp = RsaKeyPair.random(rng(), 4096).expect("RsaPrivateKey.random failed")
       var sig = kp.seckey.sign(message).expect("signature")
       var sersk = kp.seckey.getBytes().expect("bytes")
       var serpk = kp.pubkey.getBytes().expect("bytes")
@@ -578,7 +578,7 @@ suite "RSA 2048/3072/4096 test suite":
         csig.verify(Messages[4 + (i + 1) mod 2], pubkey) == false
 
   test "[rsa512] not allowed test":
-    var key1 = RsaPrivateKey.random(rng[], 512)
+    var key1 = RsaPrivateKey.random(rng(), 512)
     let prvser = fromHex(stripSpaces(NotAllowedPrivateKeys[0]))
     let pubser = fromHex(stripSpaces(NotAllowedPublicKeys[0]))
     var key2 = RsaPrivateKey.init(prvser)
@@ -592,7 +592,7 @@ suite "RSA 2048/3072/4096 test suite":
       key3.error == RsaKeyIncorrectError
 
   test "[rsa1024] not allowed test":
-    var key1 = RsaPrivateKey.random(rng[], 1024)
+    var key1 = RsaPrivateKey.random(rng(), 1024)
     let prvser = fromHex(stripSpaces(NotAllowedPrivateKeys[1]))
     let pubser = fromHex(stripSpaces(NotAllowedPublicKeys[1]))
     var key2 = RsaPrivateKey.init(prvser)

--- a/tests/libp2p/crypto/test_secp256k1.nim
+++ b/tests/libp2p/crypto/test_secp256k1.nim
@@ -13,7 +13,7 @@ suite "Secp256k1 testing suite":
     for i in 0 ..< TestsCount:
       var rkey1, rkey2: SkPrivateKey
       var skey2 = newSeq[byte](256)
-      var key = SkPrivateKey.random(rng[])
+      var key = SkPrivateKey.random(rng())
       var skey1 = key.getBytes()
       check:
         key.toBytes(skey2).expect("bytes len") > 0
@@ -31,7 +31,7 @@ suite "Secp256k1 testing suite":
     for i in 0 ..< TestsCount:
       var rkey1, rkey2: SkPublicKey
       var skey2 = newSeq[byte](256)
-      var pair = SkKeyPair.random(rng[])
+      var pair = SkKeyPair.random(rng())
       var skey1 = pair.pubkey.getBytes()
       check:
         pair.pubkey.toBytes(skey2).expect("bytes len") > 0
@@ -47,7 +47,7 @@ suite "Secp256k1 testing suite":
   test "Generate/Sign/Serialize/Deserialize/Verify test":
     var message = "message to sign"
     for i in 0 ..< TestsCount:
-      var kp = SkKeyPair.random(rng[])
+      var kp = SkKeyPair.random(rng())
       var sig = kp.seckey.sign(message)
       var sersk = kp.seckey.getBytes()
       var serpk = kp.pubkey.getBytes()

--- a/tests/libp2p/discovery/test_rendezvous.nim
+++ b/tests/libp2p/discovery/test_rendezvous.nim
@@ -74,16 +74,16 @@ proc new*(
     peerRecordValidator: PeerRecordValidator[CustomPeerRecord] = checkCustomPeerRecord,
 ): T =
   let rdv = T(
-    rng: rng,
+    rng: rng(),
     config: config,
-    salt: string.fromBytes(generateBytes(rng[], 8)),
+    salt: string.fromBytes(generateBytes(rng(), 8)),
     registered: initOffsettedSeq[RegisteredData](),
     expiredDT: Moment.now() - 1.days,
     sema: newAsyncSemaphore(SemaphoreDefaultSize),
     peerRecordValidator: peerRecordValidator,
   )
   let pr = CustomPeerRecord.init(
-    PeerId.init(PrivateKey.random(ECDSA, rng[]).get()).tryGet(), 0
+    PeerId.init(PrivateKey.random(ECDSA, rng()).get()).tryGet(), 0
   )
   logScope:
     topics = "libp2p discovery rendezvous"

--- a/tests/libp2p/discovery/utils.nim
+++ b/tests/libp2p/discovery/utils.nim
@@ -19,7 +19,7 @@ import ../../tools/[crypto]
 proc createSwitch*(): Switch =
   SwitchBuilder
     .new()
-    .withRng(rng)
+    .withRng(rng())
     .withAddresses(@[MultiAddress.init(MemoryAutoAddress).tryGet()])
     .withMemoryTransport()
     .withMplex()
@@ -30,7 +30,7 @@ proc createSwitch*(config: RendezVousConfig): RendezVous =
   let switch = SwitchBuilder
     .new()
     .withRendezVous(config)
-    .withRng(rng)
+    .withRng(rng())
     .withAddresses(@[MultiAddress.init(MemoryAutoAddress).tryGet()])
     .withMemoryTransport()
     .withMplex()
@@ -90,7 +90,7 @@ proc populatePeerRegistrations*(
     targetRdv.registered.s.add(record)
 
 proc createCorruptedSignedPeerRecord*(peerId: PeerId): SignedPeerRecord =
-  let wrongPrivKey = PrivateKey.random(rng[]).tryGet()
+  let wrongPrivKey = PrivateKey.random(rng()).tryGet()
   let record = PeerRecord.init(peerId, @[])
   SignedPeerRecord.init(wrongPrivKey, record).tryGet()
 

--- a/tests/libp2p/kademlia/test_builder.nim
+++ b/tests/libp2p/kademlia/test_builder.nim
@@ -16,7 +16,7 @@ suite "KadDHT Switch Builder":
   asyncTest "Build switch with withKademlia":
     var switch1 = SwitchBuilder
       .new()
-      .withRng(rng)
+      .withRng(rng())
       .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
       .withTcpTransport()
       .withMplex()
@@ -26,7 +26,7 @@ suite "KadDHT Switch Builder":
 
     var switch2 = SwitchBuilder
       .new()
-      .withRng(rng)
+      .withRng(rng())
       .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
       .withTcpTransport()
       .withMplex()
@@ -45,7 +45,7 @@ suite "KadDHT Switch Builder":
   asyncTest "Use Kad as a client only":
     var switch1 = SwitchBuilder
       .new()
-      .withRng(rng)
+      .withRng(rng())
       .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
       .withTcpTransport()
       .withMplex()
@@ -55,7 +55,7 @@ suite "KadDHT Switch Builder":
 
     var switch2 = SwitchBuilder
       .new()
-      .withRng(rng)
+      .withRng(rng())
       .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
       .withTcpTransport()
       .withMplex()

--- a/tests/libp2p/kademlia/test_routing_table.nim
+++ b/tests/libp2p/kademlia/test_routing_table.nim
@@ -38,7 +38,7 @@ suite "KadDHT Routing Table":
     let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     var rt = RoutingTable.new(selfId, config)
     for _ in 0 ..< config.replication + 5:
-      let kid = randomKeyInBucket(selfId, TargetBucket, rng)
+      let kid = randomKeyInBucket(selfId, TargetBucket, rng())
       discard rt.insert(kid)
 
     check TargetBucket < rt.buckets.len
@@ -50,7 +50,7 @@ suite "KadDHT Routing Table":
     let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     var rt = RoutingTable.new(selfId, config)
     for _ in 0 ..< config.replication + 10:
-      let kid = randomKeyInBucket(selfId, TargetBucket, rng)
+      let kid = randomKeyInBucket(selfId, TargetBucket, rng())
       discard rt.insert(kid)
 
     check rt.buckets[TargetBucket].peers.len == config.replication
@@ -58,7 +58,7 @@ suite "KadDHT Routing Table":
     # new entry should evict oldest entry
     let (oldest, _) = rt.buckets[TargetBucket].oldestPeer()
 
-    check rt.insert(randomKeyInBucket(selfId, TargetBucket, rng))
+    check rt.insert(randomKeyInBucket(selfId, TargetBucket, rng()))
 
     let (oldestAfterInsert, _) = rt.buckets[TargetBucket].oldestPeer()
 
@@ -70,9 +70,9 @@ suite "KadDHT Routing Table":
     let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     var rt = RoutingTable.new(selfId, config)
 
-    let key1 = randomKeyInBucket(selfId, TargetBucket, rng)
-    let key2 = randomKeyInBucket(selfId, TargetBucket, rng)
-    let key3 = randomKeyInBucket(selfId, TargetBucket, rng)
+    let key1 = randomKeyInBucket(selfId, TargetBucket, rng())
+    let key2 = randomKeyInBucket(selfId, TargetBucket, rng())
+    let key3 = randomKeyInBucket(selfId, TargetBucket, rng())
 
     discard rt.insert(key1)
     discard rt.insert(key2)
@@ -132,7 +132,7 @@ suite "KadDHT Routing Table":
 
   test "randomKeyInBucket returns id at correct distance":
     let selfId = testKey(0)
-    var rid = randomKeyInBucket(selfId, TargetBucket, rng)
+    var rid = randomKeyInBucket(selfId, TargetBucket, rng())
     let idx = bucketIndex(selfId, rid, Opt.some(noOpHasher))
     check:
       idx == TargetBucket
@@ -140,16 +140,16 @@ suite "KadDHT Routing Table":
 
   test "randomKey returns none for empty bucket":
     var bucket: Bucket
-    check randomKey(bucket, rng).isNone()
+    check randomKey(bucket, rng()).isNone()
 
   test "randomKey returns the only peer in a single-peer bucket":
     let selfId = testKey(0)
     let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     var rt = RoutingTable.new(selfId, config)
-    let key = randomKeyInBucket(selfId, TargetBucket, rng)
+    let key = randomKeyInBucket(selfId, TargetBucket, rng())
     discard rt.insert(key)
 
-    let picked = randomKey(rt.buckets[TargetBucket], rng)
+    let picked = randomKey(rt.buckets[TargetBucket], rng())
     check:
       picked.isSome()
       picked.get() == key
@@ -160,11 +160,11 @@ suite "KadDHT Routing Table":
     var rt = RoutingTable.new(selfId, config)
     var keys: seq[Key]
     for _ in 0 ..< config.replication:
-      let k = randomKeyInBucket(selfId, TargetBucket, rng)
+      let k = randomKeyInBucket(selfId, TargetBucket, rng())
       keys.add(k)
       discard rt.insert(k)
 
-    let picked = randomKey(rt.buckets[TargetBucket], rng)
+    let picked = randomKey(rt.buckets[TargetBucket], rng())
     check:
       picked.isSome()
       keys.contains(picked.get())

--- a/tests/libp2p/kademlia/test_xordistance.nim
+++ b/tests/libp2p/kademlia/test_xordistance.nim
@@ -58,7 +58,7 @@ suite "KadDHT XOR Distance":
 
 suite "Key conversion":
   test "PeerId to DHT Key extracts multihash bytes":
-    let peerId = PeerId.init(KeyPair.random(ECDSA, rng[]).get().pubkey).get()
+    let peerId = PeerId.init(KeyPair.random(ECDSA, rng()).get().pubkey).get()
 
     let key = peerId.toKey()
 

--- a/tests/libp2p/kademlia/utils.nim
+++ b/tests/libp2p/kademlia/utils.nim
@@ -36,7 +36,7 @@ method select*(
 proc createSwitch*(): Switch =
   SwitchBuilder
     .new()
-    .withRng(rng)
+    .withRng(rng())
     .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
     .withTcpTransport()
     .withMplex()

--- a/tests/libp2p/protocols/test_autonat.nim
+++ b/tests/libp2p/protocols/test_autonat.nim
@@ -19,7 +19,7 @@ import ../../tools/[unittest, crypto]
 proc createAutonatSwitch(nameResolver: NameResolver = nil): Switch =
   var builder = SwitchBuilder
     .new()
-    .withRng(rng)
+    .withRng(rng())
     .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
     .withTcpTransport()
     .withMplex()

--- a/tests/libp2p/protocols/test_autonat_service.nim
+++ b/tests/libp2p/protocols/test_autonat_service.nim
@@ -25,7 +25,7 @@ proc createSwitch(
 ): Switch =
   var builder = SwitchBuilder
     .new()
-    .withRng(rng)
+    .withRng(rng())
     .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()], false)
     .withTcpTransport()
     .withMaxConnsPerPeer(maxConnsPerPeer)
@@ -57,7 +57,7 @@ suite "Autonat Service":
     let autonatClientStub = AutonatClientStub.new(expectedDials = 3)
     autonatClientStub.answer = NotReachable
 
-    let autonatService = AutonatService.new(autonatClientStub, rng)
+    let autonatService = AutonatService.new(autonatClientStub, rng())
 
     let switch1 = createSwitch(Opt.some(autonatService))
     let switch2 = createSwitch()
@@ -86,7 +86,7 @@ suite "Autonat Service":
 
   asyncTest "Peer must be reachable":
     let autonatService =
-      AutonatService.new(AutonatClient.new(), rng, Opt.some(1.seconds))
+      AutonatService.new(AutonatClient.new(), rng(), Opt.some(1.seconds))
 
     let switch1 = createSwitch(Opt.some(autonatService))
     let switch2 = createSwitch()
@@ -134,7 +134,7 @@ suite "Autonat Service":
     let autonatClientStub = AutonatClientStub.new(expectedDials = 6)
     autonatClientStub.answer = NotReachable
 
-    let autonatService = AutonatService.new(autonatClientStub, rng, Opt.some(1.seconds))
+    let autonatService = AutonatService.new(autonatClientStub, rng(), Opt.some(1.seconds))
 
     let switch1 = createSwitch(Opt.some(autonatService))
     let switch2 = createSwitch()
@@ -181,7 +181,7 @@ suite "Autonat Service":
 
   asyncTest "Peer must be reachable when one connected peer has autonat disabled":
     let autonatService = AutonatService.new(
-      AutonatClient.new(), rng, Opt.some(1.seconds), maxQueueSize = 2
+      AutonatClient.new(), rng(), Opt.some(1.seconds), maxQueueSize = 2
     )
 
     let switch1 = createSwitch(Opt.some(autonatService))
@@ -226,7 +226,7 @@ suite "Autonat Service":
     autonatClientStub.answer = NotReachable
 
     let autonatService =
-      AutonatService.new(autonatClientStub, rng, Opt.some(1.seconds), maxQueueSize = 3)
+      AutonatService.new(autonatClientStub, rng(), Opt.some(1.seconds), maxQueueSize = 3)
 
     let switch1 = createSwitch(Opt.some(autonatService))
     let switch2 = createSwitch()
@@ -274,7 +274,7 @@ suite "Autonat Service":
   asyncTest "Calling setup and stop twice must work":
     let switch = createSwitch()
     let autonatService = AutonatService.new(
-      AutonatClientStub.new(expectedDials = 0), rng, Opt.some(1.seconds)
+      AutonatClientStub.new(expectedDials = 0), rng(), Opt.some(1.seconds)
     )
 
     check (await autonatService.setup(switch)) == true
@@ -287,7 +287,7 @@ suite "Autonat Service":
 
   asyncTest "Must bypass maxConnectionsPerPeer limit":
     let autonatService = AutonatService.new(
-      AutonatClient.new(), rng, Opt.some(1.seconds), maxQueueSize = 1
+      AutonatClient.new(), rng(), Opt.some(1.seconds), maxQueueSize = 1
     )
 
     let switch1 = createSwitch(Opt.some(autonatService), maxConnsPerPeer = 1)
@@ -330,13 +330,13 @@ suite "Autonat Service":
 
   asyncTest "Must work when peers ask each other at the same time with max 1 conn per peer":
     let autonatService1 = AutonatService.new(
-      AutonatClient.new(), rng, Opt.some(500.millis), maxQueueSize = 3
+      AutonatClient.new(), rng(), Opt.some(500.millis), maxQueueSize = 3
     )
     let autonatService2 = AutonatService.new(
-      AutonatClient.new(), rng, Opt.some(500.millis), maxQueueSize = 3
+      AutonatClient.new(), rng(), Opt.some(500.millis), maxQueueSize = 3
     )
     let autonatService3 = AutonatService.new(
-      AutonatClient.new(), rng, Opt.some(500.millis), maxQueueSize = 3
+      AutonatClient.new(), rng(), Opt.some(500.millis), maxQueueSize = 3
     )
 
     let switch1 = createSwitch(Opt.some(autonatService1), maxConnsPerPeer = 1)
@@ -389,10 +389,10 @@ suite "Autonat Service":
 
   asyncTest "Must work for one peer when two peers ask each other at the same time with max 1 conn per peer":
     let autonatService1 = AutonatService.new(
-      AutonatClient.new(), rng, Opt.some(500.millis), maxQueueSize = 3
+      AutonatClient.new(), rng(), Opt.some(500.millis), maxQueueSize = 3
     )
     let autonatService2 = AutonatService.new(
-      AutonatClient.new(), rng, Opt.some(500.millis), maxQueueSize = 3
+      AutonatClient.new(), rng(), Opt.some(500.millis), maxQueueSize = 3
     )
 
     let switch1 = createSwitch(Opt.some(autonatService1), maxConnsPerPeer = 1)
@@ -438,7 +438,7 @@ suite "Autonat Service":
 
   asyncTest "Must work with low maxConnections":
     let autonatService = AutonatService.new(
-      AutonatClient.new(), rng, Opt.some(1.seconds), maxQueueSize = 1
+      AutonatClient.new(), rng(), Opt.some(1.seconds), maxQueueSize = 1
     )
 
     let switch1 = createSwitch(Opt.some(autonatService), maxConns = 4)
@@ -488,7 +488,7 @@ suite "Autonat Service":
     )
 
   asyncTest "Peer must not ask an incoming peer":
-    let autonatService = AutonatService.new(AutonatClient.new(), rng)
+    let autonatService = AutonatService.new(AutonatClient.new(), rng())
 
     let switch1 = createSwitch(Opt.some(autonatService))
     let switch2 = createSwitch()

--- a/tests/libp2p/protocols/test_autonat_service.nim
+++ b/tests/libp2p/protocols/test_autonat_service.nim
@@ -134,7 +134,8 @@ suite "Autonat Service":
     let autonatClientStub = AutonatClientStub.new(expectedDials = 6)
     autonatClientStub.answer = NotReachable
 
-    let autonatService = AutonatService.new(autonatClientStub, rng(), Opt.some(1.seconds))
+    let autonatService =
+      AutonatService.new(autonatClientStub, rng(), Opt.some(1.seconds))
 
     let switch1 = createSwitch(Opt.some(autonatService))
     let switch2 = createSwitch()
@@ -225,8 +226,9 @@ suite "Autonat Service":
     let autonatClientStub = AutonatClientStub.new(expectedDials = 6)
     autonatClientStub.answer = NotReachable
 
-    let autonatService =
-      AutonatService.new(autonatClientStub, rng(), Opt.some(1.seconds), maxQueueSize = 3)
+    let autonatService = AutonatService.new(
+      autonatClientStub, rng(), Opt.some(1.seconds), maxQueueSize = 3
+    )
 
     let switch1 = createSwitch(Opt.some(autonatService))
     let switch2 = createSwitch()

--- a/tests/libp2p/protocols/test_autonat_v2.nim
+++ b/tests/libp2p/protocols/test_autonat_v2.nim
@@ -26,7 +26,7 @@ proc setupAutonat(
     src = newStandardSwitchBuilder(addrs = srcAddrs, rng = rng()).build()
     dst =
       newStandardSwitchBuilder(rng = rng()).withAutonatV2Server(config = config).build()
-    client = AutonatV2Client.new(rng)
+    client = AutonatV2Client.new(rng())
 
   client.setup(src)
   src.mount(client)
@@ -272,7 +272,7 @@ suite "AutonatV2":
     let
       src = newStandardSwitchBuilder(rng = rng()).build()
       dst = newStandardSwitchBuilder(rng = rng()).build()
-      client = AutonatV2Client.new(rng)
+      client = AutonatV2Client.new(rng())
       autonatV2Mock = AutonatV2Mock.new()
       reqAddrs = @[MultiAddress.init("/ip4/127.0.0.1/tcp/4040").get()]
 

--- a/tests/libp2p/protocols/test_autonat_v2_service.nim
+++ b/tests/libp2p/protocols/test_autonat_v2_service.nim
@@ -25,7 +25,7 @@ proc createSwitch(
 ): Switch =
   var builder = SwitchBuilder
     .new()
-    .withRng(rng)
+    .withRng(rng())
     .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()], false)
     .withTcpTransport()
     .withMaxConnsPerPeer(maxConnsPerPeer)
@@ -105,7 +105,7 @@ proc newService(
         ),
         expectedDials = expectedDials,
       )
-  (AutonatV2Service.new(rng, client = client, config = config), client)
+  (AutonatV2Service.new(rng(), client = client, config = config), client)
 
 const AutonatV2ReachabilityConfidenceMetric =
   "libp2p_autonat_v2_reachability_confidence"

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -51,7 +51,7 @@ suite "Identify":
         MultiAddress.init("/ip4/0.0.0.0/tcp/0").get(),
         MultiAddress.init("/ip6/::/tcp/0").get(),
       ]
-      remoteSecKey = PrivateKey.random(ECDSA, rng[]).get()
+      remoteSecKey = PrivateKey.random(ECDSA, rng()).get()
       remotePeerInfo =
         PeerInfo.new(remoteSecKey, ma, ["/test/proto1/1.0.0", "/test/proto2/1.0.0"])
 
@@ -132,7 +132,7 @@ suite "Identify":
       conn = await transport2.dial(transport1.addrs[0])
 
       expect IdentityNoMatchError:
-        let pi2 = PeerInfo.new(PrivateKey.random(ECDSA, rng[]).get())
+        let pi2 = PeerInfo.new(PrivateKey.random(ECDSA, rng()).get())
         discard await msDial.select(conn, IdentifyCodec)
         discard await identifyProto2.identify(conn, pi2.peerId)
 
@@ -261,7 +261,7 @@ suite "Identify":
           switch2.peerInfo.protocols
 
       let oldPeerId = switch2.peerInfo.peerId
-      switch2.peerInfo = PeerInfo.new(PrivateKey.random(rng[]).get())
+      switch2.peerInfo = PeerInfo.new(PrivateKey.random(rng()).get())
 
       await identifyPush2.push(switch2.peerInfo, conn)
 
@@ -287,7 +287,7 @@ suite "Identify":
       server = SwitchBuilder
         .new()
         .withAddresses(@[quicAddress, tcpAddress])
-        .withRng(rng)
+        .withRng(rng())
         .withMplex()
         .withTcpTransport()
         .withQuicTransport()
@@ -295,7 +295,7 @@ suite "Identify":
         .build()
 
       # Client switch to dial and identify
-      client = newStandardSwitch(addrs = @[tcpAddress], rng = rng)
+      client = newStandardSwitch(addrs = @[tcpAddress], rng = rng())
 
     await server.start()
     await client.start()

--- a/tests/libp2p/protocols/test_noise.nim
+++ b/tests/libp2p/protocols/test_noise.nim
@@ -54,7 +54,7 @@ proc createSwitch(
     ma: MultiAddress, outgoing: bool, plaintext: bool = false
 ): (Switch, PeerInfo) =
   var
-    privateKey = PrivateKey.random(ECDSA, rng[]).get()
+    privateKey = PrivateKey.random(ECDSA, rng()).get()
     peerInfo = PeerInfo.new(privateKey, @[ma])
 
   proc createMplex(conn: Connection): Muxer =
@@ -69,7 +69,7 @@ proc createSwitch(
       if plaintext:
         [Secure(PlainText.new())]
       else:
-        [Secure(Noise.new(rng, privateKey, outgoing = outgoing))]
+        [Secure(Noise.new(rng(), privateKey, outgoing = outgoing))]
     connManager = ConnManager.new()
     ms = MultistreamSelect.new()
     muxedUpgrade = MuxedUpgrade.new(muxers, secureManagers, ms)
@@ -86,9 +86,9 @@ suite "Noise":
   asyncTest "e2e: handle write + noise":
     let
       server = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
-      serverPrivKey = PrivateKey.random(ECDSA, rng[]).get()
+      serverPrivKey = PrivateKey.random(ECDSA, rng()).get()
       serverInfo = PeerInfo.new(serverPrivKey, server)
-      serverNoise = Noise.new(rng, serverPrivKey, outgoing = false)
+      serverNoise = Noise.new(rng(), serverPrivKey, outgoing = false)
 
     let transport1: TcpTransport = TcpTransport.new(upgrade = Upgrade())
     asyncSpawn transport1.start(server)
@@ -105,8 +105,8 @@ suite "Noise":
     let
       acceptFut = acceptHandler()
       transport2: TcpTransport = TcpTransport.new(upgrade = Upgrade())
-      clientPrivKey = PrivateKey.random(ECDSA, rng[]).get()
-      clientNoise = Noise.new(rng, clientPrivKey, outgoing = true)
+      clientPrivKey = PrivateKey.random(ECDSA, rng()).get()
+      clientNoise = Noise.new(rng(), clientPrivKey, outgoing = true)
       conn = await transport2.dial(transport1.addrs[0])
 
     let sconn = await clientNoise.secure(conn, Opt.some(serverInfo.peerId))
@@ -125,8 +125,8 @@ suite "Noise":
   asyncTest "e2e: handle write + noise (wrong prologue)":
     let
       server = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
-      serverPrivKey = PrivateKey.random(ECDSA, rng[]).get()
-      serverNoise = Noise.new(rng, serverPrivKey, outgoing = false)
+      serverPrivKey = PrivateKey.random(ECDSA, rng()).get()
+      serverNoise = Noise.new(rng(), serverPrivKey, outgoing = false)
 
     let transport1: TcpTransport = TcpTransport.new(upgrade = Upgrade())
 
@@ -142,9 +142,9 @@ suite "Noise":
     let
       handlerWait = acceptHandler()
       transport2: TcpTransport = TcpTransport.new(upgrade = Upgrade())
-      clientPrivKey = PrivateKey.random(ECDSA, rng[]).get()
+      clientPrivKey = PrivateKey.random(ECDSA, rng()).get()
       clientNoise = Noise.new(
-        rng, clientPrivKey, outgoing = true, commonPrologue = @[1'u8, 2'u8, 3'u8]
+        rng(), clientPrivKey, outgoing = true, commonPrologue = @[1'u8, 2'u8, 3'u8]
       )
       conn = await transport2.dial(transport1.addrs[0])
 
@@ -160,9 +160,9 @@ suite "Noise":
   asyncTest "e2e: handle read + noise":
     let
       server = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
-      serverPrivKey = PrivateKey.random(ECDSA, rng[]).get()
+      serverPrivKey = PrivateKey.random(ECDSA, rng()).get()
       serverInfo = PeerInfo.new(serverPrivKey, server)
-      serverNoise = Noise.new(rng, serverPrivKey, outgoing = false)
+      serverNoise = Noise.new(rng(), serverPrivKey, outgoing = false)
 
     let transport1: TcpTransport = TcpTransport.new(upgrade = Upgrade())
     asyncSpawn transport1.start(server)
@@ -181,8 +181,8 @@ suite "Noise":
     let
       acceptFut = acceptHandler()
       transport2: TcpTransport = TcpTransport.new(upgrade = Upgrade())
-      clientPrivKey = PrivateKey.random(ECDSA, rng[]).get()
-      clientNoise = Noise.new(rng, clientPrivKey, outgoing = true)
+      clientPrivKey = PrivateKey.random(ECDSA, rng()).get()
+      clientNoise = Noise.new(rng(), clientPrivKey, outgoing = true)
       conn = await transport2.dial(transport1.addrs[0])
     let sconn = await clientNoise.secure(conn, Opt.some(serverInfo.peerId))
 
@@ -196,13 +196,13 @@ suite "Noise":
   asyncTest "e2e: handle read + noise fragmented":
     let
       server = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
-      serverPrivKey = PrivateKey.random(ECDSA, rng[]).get()
+      serverPrivKey = PrivateKey.random(ECDSA, rng()).get()
       serverInfo = PeerInfo.new(serverPrivKey, server)
-      serverNoise = Noise.new(rng, serverPrivKey, outgoing = false)
+      serverNoise = Noise.new(rng(), serverPrivKey, outgoing = false)
       readTask = newFuture[void]()
 
     var hugePayload = newSeq[byte](0xFFFFF)
-    hmacDrbgGenerate(rng[], hugePayload)
+    rng().generate(hugePayload)
     trace "Sending huge payload", size = hugePayload.len
 
     let
@@ -221,8 +221,8 @@ suite "Noise":
     let
       acceptFut = acceptHandler()
       transport2: TcpTransport = TcpTransport.new(upgrade = Upgrade())
-      clientPrivKey = PrivateKey.random(ECDSA, rng[]).get()
-      clientNoise = Noise.new(rng, clientPrivKey, outgoing = true)
+      clientPrivKey = PrivateKey.random(ECDSA, rng()).get()
+      clientNoise = Noise.new(rng(), clientPrivKey, outgoing = true)
       conn = await transport2.dial(transport1.addrs[0])
     let sconn = await clientNoise.secure(conn, Opt.some(serverInfo.peerId))
 

--- a/tests/libp2p/protocols/test_perf.nim
+++ b/tests/libp2p/protocols/test_perf.nim
@@ -17,7 +17,7 @@ proc createSwitch(
     useYamux: bool = false,
 ): Switch =
   var builder = SwitchBuilder.new()
-  builder = builder.withRng(rng).withNoise()
+  builder = builder.withRng(rng()).withNoise()
 
   if useQuic:
     builder = builder.withQuicTransport().withAddresses(

--- a/tests/libp2p/protocols/test_relay_v1.nim
+++ b/tests/libp2p/protocols/test_relay_v1.nim
@@ -99,7 +99,7 @@ suite "Circuit Relay":
     r = Relay.new(circuitRelayV1 = true)
     src = SwitchBuilder
       .new()
-      .withRng(rng)
+      .withRng(rng())
       .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
       .withTcpTransport()
       .withMplex()
@@ -108,7 +108,7 @@ suite "Circuit Relay":
       .build()
     dst = SwitchBuilder
       .new()
-      .withRng(rng)
+      .withRng(rng())
       .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
       .withTcpTransport()
       .withMplex()
@@ -117,7 +117,7 @@ suite "Circuit Relay":
       .build()
     srelay = SwitchBuilder
       .new()
-      .withRng(rng)
+      .withRng(rng())
       .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
       .withTcpTransport()
       .withMplex()

--- a/tests/libp2p/protocols/test_relay_v2.nim
+++ b/tests/libp2p/protocols/test_relay_v2.nim
@@ -18,7 +18,7 @@ import ../../tools/[unittest, crypto]
 proc createSwitch(r: Relay = nil, useYamux: bool = false): Switch =
   var builder = SwitchBuilder
     .new()
-    .withRng(rng)
+    .withRng(rng())
     .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
     .withTcpTransport()
 

--- a/tests/libp2p/pubsub/extensions/test_extension_partial_message.nim
+++ b/tests/libp2p/pubsub/extensions/test_extension_partial_message.nim
@@ -89,7 +89,7 @@ proc handlePartialMessage(
   ext.onHandleRPC(peerId, RPCMsg(partialMessageExtension: Opt.some(rpc)))
 
 suite "GossipSub Extensions :: Partial Message Extension":
-  let peerId = PeerId.random(rng).get()
+  let peerId = PeerId.random(rng()).get()
   let groupId = "group-id-1".toBytes
 
   test "isSupported":
@@ -278,7 +278,7 @@ suite "GossipSub Extensions :: Partial Message Extension":
         # but in this test this list is ignored because test is publishing to selected peers.
     )
     var ext = PartialMessageExtension.new(cr.config())
-    let selectedPeerId = PeerId.random(rng).get()
+    let selectedPeerId = PeerId.random(rng()).get()
 
     # must subscribe all peers with partial capability
     ext.subscribe(peerId, topic, true)
@@ -327,7 +327,7 @@ suite "GossipSub Extensions :: Partial Message Extension":
     const topic = "logos-partial"
     var cr = CallbackRecorder()
     var ext = PartialMessageExtension.new(cr.config())
-    let publisherPeerId = PeerId.random(rng).get()
+    let publisherPeerId = PeerId.random(rng()).get()
 
     # publisher sent metadata for this group but is not subscribed to the topic
     ext.handlePartialMessage(
@@ -401,8 +401,8 @@ suite "GossipSub Extensions :: Partial Message Extension":
     # the stateOnlyPeer is intentionally not subscribed, it is reached
     # only through groupState.peerState.keys and receives metadata-only.
     const topic = "logos-partial"
-    let publishTargetPeerId = PeerId.random(rng).get()
-    let stateOnlyPeerId = PeerId.random(rng).get()
+    let publishTargetPeerId = PeerId.random(rng()).get()
+    let stateOnlyPeerId = PeerId.random(rng()).get()
     var cr = CallbackRecorder(publishToPeers: @[publishTargetPeerId])
     var ext = PartialMessageExtension.new(cr.config())
 

--- a/tests/libp2p/pubsub/extensions/test_extension_pingpong.nim
+++ b/tests/libp2p/pubsub/extensions/test_extension_pingpong.nim
@@ -26,7 +26,7 @@ proc handlePingPong(ext: PingPongExtension, peerId: PeerId, ping: seq[byte]) =
   ext.onHandleRPC(peerId, RPCMsg.withPing(ping))
 
 suite "GossipSub Extensions :: PingPong Extension":
-  let peerId = PeerId.random(rng).get()
+  let peerId = PeerId.random(rng()).get()
 
   test "isSupported":
     let ext = PingPongExtension.new()
@@ -94,7 +94,7 @@ suite "GossipSub Extensions :: PingPong Extension":
     var cr = CallbackRecorder()
     let ext = PingPongExtension.new(cr.config(peerBudgetBytes = 5))
 
-    let peerId2 = PeerId.random(rng).get()
+    let peerId2 = PeerId.random(rng()).get()
 
     # exhaust budget for peerId
     ext.handlePingPong(peerId, @[1'u8, 2, 3, 4, 5])
@@ -112,7 +112,7 @@ suite "GossipSub Extensions :: PingPong Extension":
     var cr = CallbackRecorder()
     let ext = PingPongExtension.new(cr.config(peerBudgetBytes = 5))
 
-    let peerId2 = PeerId.random(rng).get()
+    let peerId2 = PeerId.random(rng()).get()
 
     # exhaust budget for both peers
     ext.handlePingPong(peerId, @[1'u8, 2, 3, 4, 5])

--- a/tests/libp2p/pubsub/extensions/test_extension_preamble.nim
+++ b/tests/libp2p/pubsub/extensions/test_extension_preamble.nim
@@ -68,8 +68,8 @@ proc receiveIDontWant(ext: PreambleExtension, peerId: PeerId, msgIds: seq[Messag
   ext.onHandleRPC(peerId, RPCMsg.withControl(ControlMessage.withIDontWant(msgIds)))
 
 suite "GossipSub Extensions :: Preamble Extension":
-  let peerId = PeerId.random(rng).get()
-  let peerId2 = PeerId.random(rng).get()
+  let peerId = PeerId.random(rng()).get()
+  let peerId2 = PeerId.random(rng()).get()
   let msgId1: MessageId = @[1'u8, 2, 3]
   let msgId2: MessageId = @[4'u8, 5, 6]
 
@@ -348,7 +348,7 @@ suite "GossipSub Extensions :: Preamble Extension":
   test "preambleMsgReceived: removes message from ongoingIWantReceives":
     var cr = CallbackRecorder() # meshPeers empty → non-mesh
     let ext = PreambleExtension.new(cr.makeConfig(), rng())
-    let nonMeshPeer = PeerId.random(rng).get()
+    let nonMeshPeer = PeerId.random(rng()).get()
     ext.onNegotiated(nonMeshPeer)
 
     ext.receivePreamble(nonMeshPeer, @[makePreamble(msgId1)])

--- a/tests/libp2p/pubsub/extensions/test_extension_test.nim
+++ b/tests/libp2p/pubsub/extensions/test_extension_test.nim
@@ -28,10 +28,10 @@ suite "GossipSub Extensions :: Test Extension":
 
     let ext = TestExtension.new(TestExtensionConfig(onNegotiated: onNegotiatedCb))
 
-    let peerId1 = PeerId.random(rng).get()
+    let peerId1 = PeerId.random(rng()).get()
     ext.onNegotiated(peerId1)
     check negotiatedPeers == @[peerId1]
 
-    let peerId2 = PeerId.random(rng).get()
+    let peerId2 = PeerId.random(rng()).get()
     ext.onNegotiated(peerId2)
     check negotiatedPeers == @[peerId1, peerId2]

--- a/tests/libp2p/pubsub/extensions/test_extensions.nim
+++ b/tests/libp2p/pubsub/extensions/test_extensions.nim
@@ -26,7 +26,7 @@ proc createBehaviorPenaltyProc*(): (ref seq[PeerId], UpdatePeerBehaviorPenaltyPr
   (peers, cb)
 
 suite "GossipSub Extensions :: State":
-  let peerId = PeerId.random(rng).get()
+  let peerId = PeerId.random(rng()).get()
 
   test "default unconfigured state":
     var state = ExtensionsState.new(rng())
@@ -75,7 +75,7 @@ suite "GossipSub Extensions :: State":
 
     var peers = newSeq[PeerId]()
     for i in 0 ..< 5:
-      let pid = PeerId.random(rng).get()
+      let pid = PeerId.random(rng()).get()
       state.handleRPC(pid, makeRPC())
       state.handleRPC(pid, makeRPC())
       peers.add(pid)
@@ -99,7 +99,7 @@ suite "GossipSub Extensions :: State":
     var state = ExtensionsState.new(rng(), behaviorPenaltyCb)
 
     for i in 0 ..< 5:
-      let pid = PeerId.random(rng).get()
+      let pid = PeerId.random(rng()).get()
       state.handleRPC(pid, makeRPC())
 
       # when peer is removed state is cleared, so second handleRPC()
@@ -111,7 +111,7 @@ suite "GossipSub Extensions :: State":
 
   test "isControlSent tracks addPeer and removePeer":
     var state = ExtensionsState.new(rng())
-    let pid = PeerId.random(rng).get()
+    let pid = PeerId.random(rng()).get()
 
     # initially false
     check not state.isControlSent(pid)
@@ -135,7 +135,7 @@ suite "GossipSub Extensions :: State":
   test "addPeer called twice does not trigger duplicate onNegotiated":
     var ext = RecordingExtension()
     var state = ExtensionsState.new(rng(), externalExtensions = @[Extension(ext)])
-    let pid = PeerId.random(rng).get()
+    let pid = PeerId.random(rng()).get()
 
     # peer sends extensions first (path A: handleRPC then addPeer)
     state.handleRPC(pid, makeRPC(ControlExtensions(testExtension: Opt.some(true))))
@@ -149,7 +149,7 @@ suite "GossipSub Extensions :: State":
   test "onNegotiated fires again after removePeer":
     var ext = RecordingExtension()
     var state = ExtensionsState.new(rng(), externalExtensions = @[Extension(ext)])
-    let pid = PeerId.random(rng).get()
+    let pid = PeerId.random(rng()).get()
 
     state.handleRPC(pid, makeRPC(ControlExtensions(testExtension: Opt.some(true))))
     state.addPeer(pid)
@@ -185,7 +185,7 @@ suite "GossipSub Extensions :: State":
     check ext.negotiatedPeers.len == 0
 
     # assert that onNegotiated is called (handleRPC, then addPeer)
-    let peerId1 = PeerId.random(rng).get()
+    let peerId1 = PeerId.random(rng()).get()
     state.handleRPC(peerId1, makeRPC(ControlExtensions(testExtension: Opt.some(true))))
     check ext.handledRPC.len == 3
     check ext.negotiatedPeers.len == 0
@@ -193,7 +193,7 @@ suite "GossipSub Extensions :: State":
     check ext.negotiatedPeers == @[peerId1]
 
     # assert that onNegotiated is called (addPeer, then handleRPC)
-    let peerId2 = PeerId.random(rng).get()
+    let peerId2 = PeerId.random(rng()).get()
     state.addPeer(peerId2)
     check ext.negotiatedPeers.len == 1
     state.handleRPC(peerId2, makeRPC(ControlExtensions(testExtension: Opt.some(true))))

--- a/tests/libp2p/pubsub/test_behavior.nim
+++ b/tests/libp2p/pubsub/test_behavior.nim
@@ -149,8 +149,8 @@ suite "GossipSub Behavior":
 
     # And some peers have signed peer records in the SPRBook
     let
-      mockPrivKey0 = PrivateKey.random(ECDSA, rng[]).tryGet()
-      mockPrivKey2 = PrivateKey.random(ECDSA, rng[]).tryGet()
+      mockPrivKey0 = PrivateKey.random(ECDSA, rng()).tryGet()
+      mockPrivKey2 = PrivateKey.random(ECDSA, rng()).tryGet()
       mockAddr = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet()
       peerRecord0 = PeerRecord.init(peers[0].peerId, @[mockAddr], 1)
       peerRecord2 = PeerRecord.init(peers[2].peerId, @[mockAddr], 1)

--- a/tests/libp2p/pubsub/test_mcache.nim
+++ b/tests/libp2p/pubsub/test_mcache.nim
@@ -10,7 +10,7 @@ import
 import ../../tools/[unittest, crypto]
 
 proc randomPeerId(): PeerId =
-  PeerId.init(PrivateKey.random(ECDSA, rng[]).get()).get()
+  PeerId.init(PrivateKey.random(ECDSA, rng).get()).get()
 
 const MsgIdGenSuccess = "msg id generation success"
 

--- a/tests/libp2p/pubsub/test_mcache.nim
+++ b/tests/libp2p/pubsub/test_mcache.nim
@@ -10,7 +10,7 @@ import
 import ../../tools/[unittest, crypto]
 
 proc randomPeerId(): PeerId =
-  PeerId.init(PrivateKey.random(ECDSA, rng).get()).get()
+  PeerId.init(PrivateKey.random(ECDSA, rng()).get()).get()
 
 const MsgIdGenSuccess = "msg id generation success"
 

--- a/tests/libp2p/pubsub/test_message.nim
+++ b/tests/libp2p/pubsub/test_message.nim
@@ -22,7 +22,7 @@ suite "Message":
   test "signature":
     var seqno = 11'u64
     let
-      peer = PeerInfo.new(PrivateKey.random(ECDSA, rng[]).get())
+      peer = PeerInfo.new(PrivateKey.random(ECDSA, rng()).get())
       msg = Message.init(Opt.some(peer), @[], topic, Opt.some(seqno), sign = true)
 
     check verify(msg)
@@ -30,7 +30,7 @@ suite "Message":
   test "signature with missing key":
     let
       seqno = 11'u64
-      seckey = PrivateKey.random(Ed25519, rng[]).get()
+      seckey = PrivateKey.random(Ed25519, rng()).get()
       peer = PeerInfo.new(seckey)
     check peer.peerId.hasPublicKey() == true
     var msg = Message.init(Opt.some(peer), @[], topic, Opt.some(seqno), sign = true)
@@ -41,7 +41,7 @@ suite "Message":
   test "signature without inlined pubkey in peerId":
     let
       seqno = 11'u64
-      peer = PeerInfo.new(PrivateKey.random(RSA, rng[]).get())
+      peer = PeerInfo.new(PrivateKey.random(RSA, rng()).get())
     var msg = Message.init(Opt.some(peer), @[], topic, Opt.some(seqno), sign = true)
     msg.key = @[]
     # shouldn't work since there's no key field

--- a/tests/libp2p/pubsub/utils.nim
+++ b/tests/libp2p/pubsub/utils.nim
@@ -84,7 +84,7 @@ proc voidPeerHandler(
 
 proc randomPeerId*(): PeerId =
   try:
-    PeerId.init(PrivateKey.random(ECDSA, rng[]).get()).tryGet()
+    PeerId.init(PrivateKey.random(ECDSA, rng()).get()).tryGet()
   except CatchableError as exc:
     raise newException(Defect, exc.msg)
 

--- a/tests/libp2p/service_discovery/test_ext_peer_records.nim
+++ b/tests/libp2p/service_discovery/test_ext_peer_records.nim
@@ -12,7 +12,7 @@ import ../../tools/[unittest, crypto]
 suite "Extended peer record":
   test "Encoding roundtrip test":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
       peerId = PeerId.init(privKey).tryGet()
       multiAddresses = @[
         MultiAddress.init("/ip4/0.0.0.0/tcp/24").tryGet(),
@@ -45,7 +45,7 @@ suite "Extended peer record":
 suite "Signed Extended Peer Record":
   test "Encoding roundtrip test":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
       peerId = PeerId.init(privKey).tryGet()
       multiAddresses = @[
         MultiAddress.init("/ip4/0.0.0.0/tcp/24").tryGet(),
@@ -68,8 +68,8 @@ suite "Signed Extended Peer Record":
 
   test "Can't use mismatched public key":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
-      privKey2 = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
+      privKey2 = PrivateKey.random(rng()).tryGet()
       peerId = PeerId.init(privKey).tryGet()
       multiAddresses = @[
         MultiAddress.init("/ip4/0.0.0.0/tcp/24").tryGet(),
@@ -90,7 +90,7 @@ suite "Signed Extended Peer Record":
 
   test "Decode doesn't fail if some addresses are invalid":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
       peerId = PeerId.init(privKey).tryGet()
       multiAddresses =
         @[MultiAddress(), MultiAddress.init("/ip4/0.0.0.0/tcp/25").tryGet()]
@@ -106,7 +106,7 @@ suite "Signed Extended Peer Record":
 
   test "Decode doesn't fail if there are no addresses":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
       peerId = PeerId.init(privKey).tryGet()
       multiAddresses = newSeq[MultiAddress]()
       services = @[ServiceInfo(id: "test_service", data: @[])]
@@ -121,7 +121,7 @@ suite "Signed Extended Peer Record":
 
   test "Decode fails if all addresses are invalid":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
       peerId = PeerId.init(privKey).tryGet()
       multiAddresses = @[MultiAddress(), MultiAddress()]
       services = @[ServiceInfo(id: "test_service", data: @[])]
@@ -131,7 +131,7 @@ suite "Signed Extended Peer Record":
 
   test "Decode doesn't fail if there are no services":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
       peerId = PeerId.init(privKey).tryGet()
       multiAddresses =
         @[MultiAddress(), MultiAddress.init("/ip4/0.0.0.0/tcp/25").tryGet()]

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -1021,7 +1021,7 @@ suite "Service Discovery Registrar - acceptAdvertisement seqNo handling":
     let disco =
       setupServiceDiscoveryNode(discoConfig = ServiceDiscoveryConfig.new(fReturn = 3))
     let serviceId = makeServiceId()
-    let privateKey = PrivateKey.random(rng[]).get()
+    let privateKey = PrivateKey.random(rng()).get()
     let peerId = PeerId.init(privateKey).get()
     let now = Moment.now()
 
@@ -1051,7 +1051,7 @@ suite "Service Discovery Registrar - acceptAdvertisement seqNo handling":
     let disco =
       setupServiceDiscoveryNode(discoConfig = ServiceDiscoveryConfig.new(fReturn = 3))
     let serviceId = makeServiceId()
-    let privateKey = PrivateKey.random(rng[]).get()
+    let privateKey = PrivateKey.random(rng()).get()
     let peerId = PeerId.init(privateKey).get()
     let now = Moment.now()
 
@@ -1092,7 +1092,7 @@ suite "Service Discovery Registrar - acceptAdvertisement seqNo handling":
     let disco =
       setupServiceDiscoveryNode(discoConfig = ServiceDiscoveryConfig.new(fReturn = 3))
     let serviceId = makeServiceId()
-    let privateKey = PrivateKey.random(rng[]).get()
+    let privateKey = PrivateKey.random(rng()).get()
     let peerId = PeerId.init(privateKey).get()
     let now = Moment.now()
 
@@ -1196,7 +1196,7 @@ suite "Service Discovery Registrar - updateExistingAd":
 
   test "higher seqNo replaces ad, updates timestamps and IP tree, returns true":
     let registrar = Registrar.new()
-    let privateKey = PrivateKey.random(rng[]).get()
+    let privateKey = PrivateKey.random(rng()).get()
     let oldAd = makeAdvertisement(privateKey = privateKey, seqNo = 1)
     let newAd = makeAdvertisement(privateKey = privateKey, seqNo = 2)
     var ads = @[oldAd]
@@ -1215,7 +1215,7 @@ suite "Service Discovery Registrar - updateExistingAd":
 
   test "higher seqNo with address swap removes old IP and inserts new one":
     let registrar = Registrar.new()
-    let privateKey = PrivateKey.random(rng[]).get()
+    let privateKey = PrivateKey.random(rng()).get()
     let oldAd = makeAdvertisement(
       privateKey = privateKey, seqNo = 1, addrs = @[makeMultiAddress("10.0.0.1")]
     )
@@ -1235,7 +1235,7 @@ suite "Service Discovery Registrar - updateExistingAd":
 
   test "lower seqNo leaves cache and timestamps unchanged, returns false":
     let registrar = Registrar.new()
-    let privateKey = PrivateKey.random(rng[]).get()
+    let privateKey = PrivateKey.random(rng()).get()
     let currentAd = makeAdvertisement(privateKey = privateKey, seqNo = 10)
     let staleAd = makeAdvertisement(privateKey = privateKey, seqNo = 5)
     var ads = @[currentAd]

--- a/tests/libp2p/service_discovery/test_signatures.nim
+++ b/tests/libp2p/service_discovery/test_signatures.nim
@@ -9,25 +9,25 @@ import ./utils
 
 suite "Ticket - sign and verify":
   test "sign succeeds and verify passes with matching key":
-    let key = PrivateKey.random(rng[]).get()
+    let key = PrivateKey.random(rng()).get()
     var t = makeTicket()
     check:
       t.sign(key).isOk()
       t.verify(key.getPublicKey().get())
 
   test "verify fails with a different key":
-    let key = PrivateKey.random(rng[]).get()
-    let wrongKey = PrivateKey.random(rng[]).get()
+    let key = PrivateKey.random(rng()).get()
+    let wrongKey = PrivateKey.random(rng()).get()
     let t = signedTicket(key)
     check not t.verify(wrongKey.getPublicKey().get())
 
   test "verify fails on empty signature (unsigned ticket)":
-    let key = PrivateKey.random(rng[]).get()
+    let key = PrivateKey.random(rng()).get()
     let t = makeTicket() # never signed → signature = @[]
     check not t.verify(key.getPublicKey().get())
 
   test "verify fails with corrupted signature bytes":
-    let key = PrivateKey.random(rng[]).get()
+    let key = PrivateKey.random(rng()).get()
     var t = signedTicket(key)
     t.signature[0] = t.signature[0] xor 0xFF
     check not t.verify(key.getPublicKey().get())
@@ -37,25 +37,25 @@ suite "Ticket - tamper detection":
   # Mutating any covered field must break verification.
 
   test "tampered advertisement bytes":
-    let key = PrivateKey.random(rng[]).get()
+    let key = PrivateKey.random(rng()).get()
     var t = signedTicket(key)
     t.advertisement[0] = t.advertisement[0] xor 0xFF
     check not t.verify(key.getPublicKey().get())
 
   test "tampered tInit":
-    let key = PrivateKey.random(rng[]).get()
+    let key = PrivateKey.random(rng()).get()
     var t = signedTicket(key)
     t.tInit = t.tInit + 1.secs
     check not t.verify(key.getPublicKey().get())
 
   test "tampered tMod":
-    let key = PrivateKey.random(rng[]).get()
+    let key = PrivateKey.random(rng()).get()
     var t = signedTicket(key)
     t.tMod = t.tMod + 1.secs
     check not t.verify(key.getPublicKey().get())
 
   test "tampered tWaitFor":
-    let key = PrivateKey.random(rng[]).get()
+    let key = PrivateKey.random(rng()).get()
     var t = signedTicket(key)
     t.tWaitFor = t.tWaitFor + 1.secs
     check not t.verify(key.getPublicKey().get())
@@ -63,7 +63,7 @@ suite "Ticket - tamper detection":
 suite "Ticket - boundary values":
   test "all-zero time fields sign and verify correctly":
     # tInit=0, tMod=0, tWaitFor=0 are valid; must not be treated as unsigned
-    let key = PrivateKey.random(rng[]).get()
+    let key = PrivateKey.random(rng()).get()
     var t = Ticket(
       advertisement: @[0xAB'u8],
       tInit: Moment.low,
@@ -76,7 +76,7 @@ suite "Ticket - boundary values":
       t.verify(key.getPublicKey().get())
 
   test "empty advertisement bytes sign and verify correctly":
-    let key = PrivateKey.random(rng[]).get()
+    let key = PrivateKey.random(rng()).get()
     var t = Ticket(
       advertisement: @[],
       tInit: Moment.init(1000, Second),
@@ -90,8 +90,8 @@ suite "Ticket - boundary values":
 
   test "re-signing overwrites previous signature":
     # Signing twice must not leave a ticket that verifies against the first key
-    let key1 = PrivateKey.random(rng[]).get()
-    let key2 = PrivateKey.random(rng[]).get()
+    let key1 = PrivateKey.random(rng()).get()
+    let key2 = PrivateKey.random(rng()).get()
     var t = makeTicket()
     check:
       t.sign(key1).isOk()

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -25,7 +25,7 @@ export protobuf, registrar, routing_table_manager, types
 trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
 
 proc randomPeerId*(): PeerId =
-  PeerId.init(PrivateKey.random(rng[]).get()).get()
+  PeerId.init(PrivateKey.random(rng()).get()).get()
 
 proc makeServiceId*(id: byte = 1'u8): ServiceId =
   @[id, 2'u8, 3, 4]
@@ -53,7 +53,7 @@ proc makeMultiAddress*(ip: string): MultiAddress =
 
 proc makeAdvertisement*(
     serviceId: string = $1,
-    privateKey: PrivateKey = PrivateKey.random(rng[]).get(),
+    privateKey: PrivateKey = PrivateKey.random(rng()).get(),
     addrs: seq[MultiAddress] = @[],
     seqNo: uint64 = Moment.now().epochSeconds.uint64,
 ): Advertisement =

--- a/tests/libp2p/services/test_autorelay.nim
+++ b/tests/libp2p/services/test_autorelay.nim
@@ -18,7 +18,7 @@ import ../../tools/[unittest, crypto]
 proc createSwitch(r: Relay, autorelay: Service = nil): Switch =
   var builder = SwitchBuilder
     .new()
-    .withRng(rng)
+    .withRng(rng())
     .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
     .withTcpTransport()
     .withMplex()
@@ -59,7 +59,7 @@ suite "Autorelay":
         addresses == buildRelayMA(switchRelay, switchClient)
       fut.complete()
 
-    autorelay = AutoRelayService.new(3, relayClient, checkMA, rng)
+    autorelay = AutoRelayService.new(3, relayClient, checkMA, rng())
     switchClient = createSwitch(relayClient, autorelay)
     await allFutures(switchClient.start(), switchRelay.start())
     await switchClient.connect(switchRelay.peerInfo.peerId, switchRelay.peerInfo.addrs)
@@ -78,7 +78,7 @@ suite "Autorelay":
         address == buildRelayMA(switchRelay, switchClient)
       fut.complete()
 
-    let autorelay = AutoRelayService.new(3, relayClient, checkMA, rng)
+    let autorelay = AutoRelayService.new(3, relayClient, checkMA, rng())
     switchClient = createSwitch(relayClient, autorelay)
     await allFutures(switchClient.start(), switchRelay.start())
     await sleepAsync(250.millis)
@@ -143,7 +143,7 @@ suite "Autorelay":
             relayMA in addresses
         allChecksCompleted.complete()
 
-    let autorelay = AutoRelayService.new(maxNumRelays = 2, relayClient, checkMA, rng)
+    let autorelay = AutoRelayService.new(maxNumRelays = 2, relayClient, checkMA, rng())
     switchClient = createSwitch(relayClient, autorelay)
     await allFutures(switchClient.start(), rel1.start(), rel2.start(), rel3.start())
     await switchClient.connect(rel1.peerInfo.peerId, rel1.peerInfo.addrs)

--- a/tests/libp2p/services/test_hp.nim
+++ b/tests/libp2p/services/test_hp.nim
@@ -173,11 +173,13 @@ suite "Hole Punching":
 
     let autonatClientStub1 = AutonatClientStub.new(expectedDials = 1)
     autonatClientStub1.answer = NotReachable
-    let autonatService1 = AutonatService.new(autonatClientStub1, rng(), maxQueueSize = 1)
+    let autonatService1 =
+      AutonatService.new(autonatClientStub1, rng(), maxQueueSize = 1)
 
     let autonatClientStub2 = AutonatClientStub.new(expectedDials = 1)
     autonatClientStub2.answer = answer
-    let autonatService2 = AutonatService.new(autonatClientStub2, rng(), maxQueueSize = 1)
+    let autonatService2 =
+      AutonatService.new(autonatClientStub2, rng(), maxQueueSize = 1)
 
     let relayClient1 = RelayClient.new()
     let relayClient2 = RelayClient.new()

--- a/tests/libp2p/services/test_hp.nim
+++ b/tests/libp2p/services/test_hp.nim
@@ -20,7 +20,7 @@ proc createSwitch(
 ): Switch {.raises: [LPError].} =
   var builder = SwitchBuilder
     .new()
-    .withRng(rng)
+    .withRng(rng())
     .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
     .withTcpTransport()
     .withMplex()
@@ -46,7 +46,7 @@ suite "Hole Punching":
   asyncTest "Direct connection must work when peer address is public":
     let autonatClientStub = AutonatClientStub.new(expectedDials = 1)
     autonatClientStub.answer = NotReachable
-    let autonatService = AutonatService.new(autonatClientStub, rng, maxQueueSize = 1)
+    let autonatService = AutonatService.new(autonatClientStub, rng(), maxQueueSize = 1)
 
     let relayClient = RelayClient.new()
     let privatePeerRelayAddr = newFuture[seq[MultiAddress]]()
@@ -57,7 +57,7 @@ suite "Hole Punching":
       if not privatePeerRelayAddr.completed():
         privatePeerRelayAddr.complete(address)
 
-    let autoRelayService = AutoRelayService.new(1, relayClient, checkMA, rng)
+    let autoRelayService = AutoRelayService.new(1, relayClient, checkMA, rng())
 
     let hpservice = HPService.new(autonatService, autoRelayService)
 
@@ -106,7 +106,7 @@ suite "Hole Punching":
   asyncTest "Direct connection must work when peer address is public and dns is used":
     let autonatClientStub = AutonatClientStub.new(expectedDials = 1)
     autonatClientStub.answer = NotReachable
-    let autonatService = AutonatService.new(autonatClientStub, rng, maxQueueSize = 1)
+    let autonatService = AutonatService.new(autonatClientStub, rng(), maxQueueSize = 1)
 
     let relayClient = RelayClient.new()
     let privatePeerRelayAddr = newFuture[seq[MultiAddress]]()
@@ -117,7 +117,7 @@ suite "Hole Punching":
       if not privatePeerRelayAddr.completed():
         privatePeerRelayAddr.complete(address)
 
-    let autoRelayService = AutoRelayService.new(1, relayClient, checkMA, rng)
+    let autoRelayService = AutoRelayService.new(1, relayClient, checkMA, rng())
 
     let hpservice = HPService.new(autonatService, autoRelayService)
 
@@ -173,11 +173,11 @@ suite "Hole Punching":
 
     let autonatClientStub1 = AutonatClientStub.new(expectedDials = 1)
     autonatClientStub1.answer = NotReachable
-    let autonatService1 = AutonatService.new(autonatClientStub1, rng, maxQueueSize = 1)
+    let autonatService1 = AutonatService.new(autonatClientStub1, rng(), maxQueueSize = 1)
 
     let autonatClientStub2 = AutonatClientStub.new(expectedDials = 1)
     autonatClientStub2.answer = answer
-    let autonatService2 = AutonatService.new(autonatClientStub2, rng, maxQueueSize = 1)
+    let autonatService2 = AutonatService.new(autonatClientStub2, rng(), maxQueueSize = 1)
 
     let relayClient1 = RelayClient.new()
     let relayClient2 = RelayClient.new()
@@ -187,8 +187,8 @@ suite "Hole Punching":
       if not privatePeerRelayAddr1.completed():
         privatePeerRelayAddr1.complete(address)
 
-    let autoRelayService1 = AutoRelayService.new(1, relayClient1, checkMA, rng)
-    let autoRelayService2 = AutoRelayService.new(1, relayClient2, nil, rng)
+    let autoRelayService1 = AutoRelayService.new(1, relayClient1, checkMA, rng())
+    let autoRelayService2 = AutoRelayService.new(1, relayClient2, nil, rng())
 
     let hpservice1 = HPService.new(autonatService1, autoRelayService1)
     let hpservice2 = HPService.new(autonatService2, autoRelayService2)

--- a/tests/libp2p/services/test_private_addr_filter.nim
+++ b/tests/libp2p/services/test_private_addr_filter.nim
@@ -101,7 +101,7 @@ suite "KadDHT updatePeers address policy":
   test "updatePeers stores all addresses with default policy":
     let switch = SwitchBuilder
       .new()
-      .withRng(rng)
+      .withRng(rng())
       .withAddresses(@[ma("/ip4/127.0.0.1/tcp/0")])
       .withTcpTransport()
       .withMplex()
@@ -129,7 +129,7 @@ suite "KadDHT updatePeers address policy":
   test "updatePeers filters private addresses when addressPolicy is set":
     let switch = SwitchBuilder
       .new()
-      .withRng(rng)
+      .withRng(rng())
       .withAddresses(@[ma("/ip4/127.0.0.1/tcp/0")])
       .withTcpTransport()
       .withMplex()
@@ -155,7 +155,7 @@ suite "KadDHT updatePeers address policy":
   test "updatePeers does not add peer to AddressBook when all addresses filtered":
     let switch = SwitchBuilder
       .new()
-      .withRng(rng)
+      .withRng(rng())
       .withAddresses(@[ma("/ip4/127.0.0.1/tcp/0")])
       .withTcpTransport()
       .withMplex()
@@ -183,7 +183,7 @@ suite "SwitchBuilder withPrivateAddressFilter outbound":
     # The filter should remove it, leaving no announced addresses.
     let switch = SwitchBuilder
       .new()
-      .withRng(rng)
+      .withRng(rng())
       .withAddresses(@[ma("/ip4/127.0.0.1/tcp/0")], false)
       # disable wildcard resolver
       .withTcpTransport()
@@ -203,7 +203,7 @@ suite "SwitchBuilder withPrivateAddressFilter outbound":
     let publicAddr = ma("/ip4/1.2.3.4/tcp/4001")
     let switch = SwitchBuilder
       .new()
-      .withRng(rng)
+      .withRng(rng())
       .withAddresses(@[ma("/ip4/127.0.0.1/tcp/0")], false)
       .withTcpTransport()
       .withMplex()
@@ -227,7 +227,7 @@ suite "SwitchBuilder withPrivateAddressFilter outbound":
     # Without calling withPrivateAddressFilter, private addresses pass through
     let switch = SwitchBuilder
       .new()
-      .withRng(rng)
+      .withRng(rng())
       .withAddresses(@[ma("/ip4/127.0.0.1/tcp/0")], false)
       .withTcpTransport()
       .withMplex()

--- a/tests/libp2p/services/test_wildcard_resolver.nim
+++ b/tests/libp2p/services/test_wildcard_resolver.nim
@@ -30,7 +30,7 @@ proc getAddressesMock(
 proc createSwitch(svc: Service, addrs: seq[MultiAddress]): Switch =
   SwitchBuilder
     .new()
-    .withRng(rng)
+    .withRng(rng())
     .withAddresses(addrs, false)
     .withTcpTransport()
     .withMplex()

--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -50,7 +50,7 @@ proc newWatermark*(
   ConnManager.new(watermark = Opt.some(wtCfg), scoring = scCfg)
 
 proc storeMuxers(connMngr: ConnManager, count: uint): Future[seq[PeerId]] {.async.} =
-  let peers = PeerId.random(count, rng).tryGet()
+  let peers = PeerId.random(count, rng()).tryGet()
   await allFuturesRaising(peers.mapIt(connMngr.storeMuxer(makeMuxer(it))))
   return peers
 
@@ -58,7 +58,7 @@ suite "Connection Manager":
   teardown:
     checkTrackers()
 
-  let peerId = PeerId.random(rng).tryGet()
+  let peerId = PeerId.random(rng()).tryGet()
 
   asyncTest "add and retrieve a muxer":
     let connMngr = newMaxTotal()
@@ -76,7 +76,7 @@ suite "Connection Manager":
   asyncTest "get all connections":
     let connMngr = newMaxTotal()
 
-    let peers = PeerId.random(5, rng).tryGet()
+    let peers = PeerId.random(5, rng()).tryGet()
     let muxs = peers.mapIt(makeMuxer(it))
     for mux in muxs:
       await connMngr.storeMuxer(mux)
@@ -198,7 +198,7 @@ suite "Connection Manager":
     await waitedConn1.cancelAndWait()
     let
       waitedConn2 = connMngr.expectConnection(peerId, In)
-      waitedConn3 = connMngr.expectConnection(PeerId.random(rng).tryGet(), In)
+      waitedConn3 = connMngr.expectConnection(PeerId.random(rng()).tryGet(), In)
       conn = makeMuxer(peerId)
     await connMngr.storeMuxer(conn)
     check (await waitedConn2) == conn
@@ -394,7 +394,7 @@ suite "Connection Manager":
     var muxs: seq[Muxer]
     for i in 0 ..< 3:
       let slot = connMngr.getOutgoingSlot()
-      let muxer = makeMuxer(PeerId.random(rng).tryGet(), Direction.In)
+      let muxer = makeMuxer(PeerId.random(rng()).tryGet(), Direction.In)
 
       slot.trackMuxer(muxer)
       muxs.add(muxer)
@@ -414,7 +414,7 @@ suite "Connection Manager maxConnsPerPeer":
   teardown:
     checkTrackers()
 
-  let peerId = PeerId.random(rng).tryGet()
+  let peerId = PeerId.random(rng()).tryGet()
   const defaultMaxConnsPerPeer = 2
 
   proc runTest(maxConnsPerPeer: int, numberOfMuxersToConnect: int) {.async.} =
@@ -453,7 +453,7 @@ suite "Connection Manager Watermark":
   teardown:
     checkTrackers()
 
-  let peerId = PeerId.random(rng).tryGet()
+  let peerId = PeerId.random(rng()).tryGet()
 
   asyncTest "trim fires when peer count exceeds highWater":
     const peersToConnect = 5
@@ -559,7 +559,7 @@ suite "Connection Manager Scoring":
     checkTrackers()
 
   const tag = "λ"
-  let peerId = PeerId.random(rng).tryGet()
+  let peerId = PeerId.random(rng()).tryGet()
 
   asyncTest "peerScore returns 0 for unknown peer":
     let cm = newWatermark(1, 2)
@@ -637,24 +637,24 @@ suite "Connection Manager Scoring":
 
   asyncTest "watermark trim prunes lowest-score peer first":
     let cm = newWatermark(1, 2)
-    let highScorePeer = PeerId.random(rng).tryGet()
-    let lowScorePeer1 = PeerId.random(rng).tryGet()
+    let highScorePeer = PeerId.random(rng()).tryGet()
+    let lowScorePeer1 = PeerId.random(rng()).tryGet()
     await cm.storeMuxer(makeMuxer(highScorePeer))
     cm.tagPeer(highScorePeer, "destacado", 500)
     await cm.storeMuxer(makeMuxer(lowScorePeer1))
     # store a third peer to trigger trim (count=3 > highWater=2)
-    await cm.storeMuxer(makeMuxer(PeerId.random(rng).tryGet()))
+    await cm.storeMuxer(makeMuxer(PeerId.random(rng()).tryGet()))
     check cm.contains(highScorePeer)
     check cm.getConnections().len == 1
     await cm.close()
 
   asyncTest "outbound peer survives watermark trim over inbound peers":
     let cm = newWatermark(1, 2, outboundBonus = 500)
-    let outboundPeer = PeerId.random(rng).tryGet()
+    let outboundPeer = PeerId.random(rng()).tryGet()
     await cm.storeMuxer(makeMuxer(outboundPeer, Direction.Out))
-    await cm.storeMuxer(makeMuxer(PeerId.random(rng).tryGet(), Direction.In))
+    await cm.storeMuxer(makeMuxer(PeerId.random(rng()).tryGet(), Direction.In))
     # add one more over the high water to trigger the trim
-    await cm.storeMuxer(makeMuxer(PeerId.random(rng).tryGet(), Direction.In))
+    await cm.storeMuxer(makeMuxer(PeerId.random(rng()).tryGet(), Direction.In))
     check cm.contains(outboundPeer)
     check cm.getConnections().len == 1
     await cm.close()
@@ -681,7 +681,7 @@ suite "Connection Manager: watermark with connection limiting":
     # protecting before storeMuxer ensures the peer is already shielded when
     # trim fires on the 3rd store (peer count 3 > highWater 2).
     for _ in 0 ..< maxConns:
-      let peerId = PeerId.random(rng).tryGet()
+      let peerId = PeerId.random(rng()).tryGet()
       let slot = await connMngr.getIncomingSlot()
       let muxer = makeMuxer(peerId)
       connMngr.protect(peerId, "keep-forever")

--- a/tests/libp2p/test_peer_id.nim
+++ b/tests/libp2p/test_peer_id.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import nimcrypto/utils, stew/base58, bearssl/hash
+import nimcrypto/utils, stew/base58
 import ../../libp2p/[crypto/crypto, peerid]
 import ../tools/[unittest, crypto]
 
@@ -232,12 +232,10 @@ suite "Peer testing suite":
           ekey3 == pubkey
           ekey4 == pubkey
   test "Test PeerId.random() proc":
-    # generate a random peer with a deterministic ssed 
-    var rng = (ref HmacDrbgContext)()
-    hmacDrbgInit(rng[], addr sha256Vtable, nil, 0)
-    var randomPeer1 = PeerId.random(rng)
+    var randomPeer1 = PeerId.random(rng())
     check:
-      $randomPeer1.get() == "16Uiu2HAmCxpSTFDNdWiu1MLScu7inPhcbbGfPvuvRPD1e51gw1Xr"
+      randomPeer1.isOk()
+      randomPeer1.get().validate()
 
     # generate a random peer with a new random seed
     var randomPeer2 = PeerId.random(rng())

--- a/tests/libp2p/test_peer_info.nim
+++ b/tests/libp2p/test_peer_info.nim
@@ -14,7 +14,7 @@ import ../tools/[unittest, crypto]
 
 suite "PeerInfo":
   test "Should init with private key":
-    let seckey = PrivateKey.random(ECDSA, rng[]).get()
+    let seckey = PrivateKey.random(ECDSA, rng()).get()
     var peerInfo = PeerInfo.new(seckey)
     var peerId = PeerId.init(seckey).get()
 
@@ -27,7 +27,7 @@ suite "PeerInfo":
       ExpectedPayloadType = @[(byte) 0x03, (byte) 0x01]
 
     let
-      seckey = PrivateKey.random(rng[]).tryGet()
+      seckey = PrivateKey.random(rng()).tryGet()
       peerId = PeerId.init(seckey).get()
       multiAddresses = @[
         MultiAddress.init("/ip4/0.0.0.0/tcp/24").tryGet(),
@@ -57,7 +57,7 @@ suite "PeerInfo":
 
   test "Public address mapping":
     let
-      seckey = PrivateKey.random(ECDSA, rng[]).get()
+      seckey = PrivateKey.random(ECDSA, rng()).get()
       multiAddresses = @[
         MultiAddress.init("/ip4/0.0.0.0/tcp/24").tryGet(),
         MultiAddress.init("/ip4/0.0.0.0/tcp/25").tryGet(),

--- a/tests/libp2p/test_peer_store.nim
+++ b/tests/libp2p/test_peer_store.nim
@@ -11,14 +11,14 @@ suite "PeerStore":
   # Testvars
   let
     # Peer 1
-    keyPair1 = KeyPair.random(ECDSA, rng[]).get()
+    keyPair1 = KeyPair.random(ECDSA, rng()).get()
     peerId1 = PeerId.init(keyPair1.seckey).get()
     multiaddrStr1 =
       "/ip4/127.0.0.1/udp/1234/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"
     multiaddr1 = MultiAddress.init(multiaddrStr1).get()
     testcodec1 = "/nim/libp2p/test/0.0.1-beta1"
     # Peer 2
-    keyPair2 = KeyPair.random(ECDSA, rng[]).get()
+    keyPair2 = KeyPair.random(ECDSA, rng()).get()
     peerId2 = PeerId.init(keyPair2.seckey).get()
     multiaddrStr2 =
       "/ip4/0.0.0.0/tcp/1234/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"
@@ -118,7 +118,7 @@ suite "PeerStore":
     var peerStore = PeerStore.new(nil, capacity = 20)
 
     for i in 0 ..< 30:
-      let randomPeerId = PeerId.init(KeyPair.random(ECDSA, rng[]).get().pubkey).get()
+      let randomPeerId = PeerId.init(KeyPair.random(ECDSA, rng()).get().pubkey).get()
       peerStore[AgentBook][randomPeerId] = "gds"
       peerStore.cleanup(randomPeerId)
 
@@ -128,7 +128,7 @@ suite "PeerStore":
     var peerStore = PeerStore.new(nil, capacity = -1)
 
     for i in 0 ..< 30:
-      let randomPeerId = PeerId.init(KeyPair.random(ECDSA, rng[]).get().pubkey).get()
+      let randomPeerId = PeerId.init(KeyPair.random(ECDSA, rng()).get().pubkey).get()
       peerStore[AgentBook][randomPeerId] = "gds"
       peerStore.cleanup(randomPeerId)
 

--- a/tests/libp2p/test_routing_record.nim
+++ b/tests/libp2p/test_routing_record.nim
@@ -10,7 +10,7 @@ import ../tools/[unittest, crypto]
 suite "Routing record":
   test "Encode -> decode test":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
       peerId = PeerId.init(privKey).tryGet()
       multiAddresses = @[
         MultiAddress.init("/ip4/0.0.0.0/tcp/24").tryGet(),
@@ -46,7 +46,7 @@ suite "Routing record":
 suite "Signed Routing Record":
   test "Encode -> decode test":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
       peerId = PeerId.init(privKey).tryGet()
       multiAddresses = @[
         MultiAddress.init("/ip4/0.0.0.0/tcp/24").tryGet(),
@@ -68,8 +68,8 @@ suite "Signed Routing Record":
 
   test "Can't use mismatched public key":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
-      privKey2 = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
+      privKey2 = PrivateKey.random(rng()).tryGet()
       peerId = PeerId.init(privKey).tryGet()
       multiAddresses = @[
         MultiAddress.init("/ip4/0.0.0.0/tcp/24").tryGet(),
@@ -84,7 +84,7 @@ suite "Signed Routing Record":
 
   test "Decode doesn't fail if some addresses are invalid":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
       peerId = PeerId.init(privKey).tryGet()
       multiAddresses =
         @[MultiAddress(), MultiAddress.init("/ip4/0.0.0.0/tcp/25").tryGet()]
@@ -97,7 +97,7 @@ suite "Signed Routing Record":
 
   test "Decode doesn't fail if there are no addresses":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
       peerId = PeerId.init(privKey).tryGet()
       multiAddresses = newSeq[MultiAddress]()
       routingRecord = PeerRecord.init(peerId, multiAddresses, 42)
@@ -109,7 +109,7 @@ suite "Signed Routing Record":
 
   test "Decode fails if all addresses are invalid":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
       peerId = PeerId.init(privKey).tryGet()
       multiAddresses = @[MultiAddress(), MultiAddress()]
       routingRecord = PeerRecord.init(peerId, multiAddresses, 42)

--- a/tests/libp2p/test_signed_envelope.nim
+++ b/tests/libp2p/test_signed_envelope.nim
@@ -10,7 +10,7 @@ import ../tools/[unittest, crypto]
 suite "Signed envelope":
   test "Encode -> decode -> encode -> decode test":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
       envelope =
         Envelope.init(privKey, @[byte 12, 0], "payload".toBytes(), "domain").tryGet()
       buffer = envelope.encode().tryGet()
@@ -70,7 +70,7 @@ proc payloadType*(T: typedesc[DummyPayload]): seq[byte] =
 suite "Signed payload":
   test "Simple encode -> decode":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
       dummyPayload = DummyPayload(awesome: 12.byte)
       signed = SignedDummy.init(privKey, dummyPayload).tryGet()
       encoded = signed.encode().tryGet()
@@ -82,7 +82,7 @@ suite "Signed payload":
 
   test "Invalid payload":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
       dummyPayload = DummyPayload(awesome: 30.byte)
       signed = SignedDummy.init(privKey, dummyPayload).tryGet()
       encoded = signed.encode().tryGet()
@@ -91,7 +91,7 @@ suite "Signed payload":
 
   test "Invalid payload type":
     let
-      privKey = PrivateKey.random(rng[]).tryGet()
+      privKey = PrivateKey.random(rng()).tryGet()
       dummyPayload = DummyPayload(awesome: 30.byte)
       signed = Envelope
         .init(privKey, @[55.byte], dummyPayload.encode(), DummyPayload.payloadDomain)

--- a/tests/libp2p/test_switch.nim
+++ b/tests/libp2p/test_switch.nim
@@ -510,10 +510,10 @@ suite "Switch":
     let switch1 = newStandardSwitch(maxConnsPerPeer = 2, rng = rng())
 
     # use same private keys to emulate two connection from same peer
-    let privKey = PrivateKey.random(rng[]).tryGet()
-    let switch2 = newStandardSwitch(privKey = Opt.some(privKey), rng = rng)
+    let privKey = PrivateKey.random(rng()).tryGet()
+    let switch2 = newStandardSwitch(privKey = Opt.some(privKey), rng = rng())
 
-    let switch3 = newStandardSwitch(privKey = Opt.some(privKey), rng = rng)
+    let switch3 = newStandardSwitch(privKey = Opt.some(privKey), rng = rng())
 
     var step = 0
     var kinds: set[PeerEventKind]
@@ -570,7 +570,7 @@ suite "Switch":
   asyncTest "e2e should allow dropping peer from connection events":
     # use same private keys to emulate two connection from same peer
     let
-      privateKey = PrivateKey.random(rng[]).tryGet()
+      privateKey = PrivateKey.random(rng()).tryGet()
       peerInfo = PeerInfo.new(privateKey)
 
     var switches: seq[Switch]
@@ -589,13 +589,13 @@ suite "Switch":
       except DialFailedError:
         raiseAssert "Unexpected DialFailedError in connection event hook"
 
-    switches.add(newStandardSwitch(rng = rng))
+    switches.add(newStandardSwitch(rng = rng()))
 
     switches[0].addConnEventHandler(hook, ConnEventKind.Connected)
     switches[0].addConnEventHandler(hook, ConnEventKind.Disconnected)
     await switches[0].start()
 
-    switches.add(newStandardSwitch(privKey = Opt.some(privateKey), rng = rng))
+    switches.add(newStandardSwitch(privKey = Opt.some(privateKey), rng = rng()))
     await switches[1].connect(switches[0].peerInfo.peerId, switches[0].peerInfo.addrs)
     onConnect.done()
 
@@ -604,7 +604,7 @@ suite "Switch":
     await allFuturesRaising(switches.mapIt(it.stop()))
 
   asyncTest "e2e should allow dropping multiple connections for peer from connection events":
-    let privateKey = PrivateKey.random(rng[]).tryGet()
+    let privateKey = PrivateKey.random(rng()).tryGet()
     let peerInfo = PeerInfo.new(privateKey)
 
     var switches: seq[Switch]
@@ -619,14 +619,14 @@ suite "Switch":
         allDisconnected.done()
 
     # Start first switch
-    switches.add(newStandardSwitch(maxConnsPerPeer = 10, rng = rng))
+    switches.add(newStandardSwitch(maxConnsPerPeer = 10, rng = rng()))
     switches[0].addConnEventHandler(hook, ConnEventKind.Connected)
     switches[0].addConnEventHandler(hook, ConnEventKind.Disconnected)
     await switches[0].start()
 
     # Connect remaining switches sequentially
     for i in 1 .. 5:
-      switches.add(newStandardSwitch(privKey = Opt.some(privateKey), rng = rng))
+      switches.add(newStandardSwitch(privKey = Opt.some(privateKey), rng = rng()))
       switches[i].addConnEventHandler(hook, ConnEventKind.Connected)
       switches[i].addConnEventHandler(hook, ConnEventKind.Disconnected)
       await switches[i].connect(switches[0].peerInfo.peerId, switches[0].peerInfo.addrs)
@@ -662,7 +662,7 @@ suite "Switch":
 
     await switch.start()
 
-    var peerId = PeerId.init(PrivateKey.random(ECDSA, rng[]).get()).get()
+    var peerId = PeerId.init(PrivateKey.random(ECDSA, rng()).get()).get()
     expect DialFailedError:
       await switch.connect(peerId, transport.addrs)
 
@@ -720,7 +720,7 @@ suite "Switch":
       newStandardSwitch(secureManagers = [SecureProtocol.Noise], rng = rng())
     await switch2.start()
     let someAddr = MultiAddress.init("/ip4/127.128.0.99").get()
-    let seckey = PrivateKey.random(ECDSA, rng[]).get()
+    let seckey = PrivateKey.random(ECDSA, rng()).get()
     let somePeer = PeerInfo.new(seckey, [someAddr])
     expect(DialFailedError):
       discard await switch2.dial(somePeer.peerId, somePeer.addrs, TestCodec)
@@ -1047,7 +1047,7 @@ suite "Switch":
       srcWsSwitch = SwitchBuilder
         .new()
         .withAddress(wsAddress)
-        .withRng(rng)
+        .withRng(rng())
         .withMplex()
         .withTransport(
           proc(config: TransportConfig): Transport =
@@ -1060,7 +1060,7 @@ suite "Switch":
       destSwitch = SwitchBuilder
         .new()
         .withAddresses(@[tcpAddress, wsAddress])
-        .withRng(rng)
+        .withRng(rng())
         .withMplex()
         .withTransport(
           proc(config: TransportConfig): Transport =
@@ -1100,7 +1100,7 @@ suite "Switch":
       srcSwitch = SwitchBuilder
         .new()
         .withAddress(quicAddress1)
-        .withRng(rng)
+        .withRng(rng())
         .withQuicTransport()
         .withNoise()
         .build()
@@ -1108,7 +1108,7 @@ suite "Switch":
       destSwitch = SwitchBuilder
         .new()
         .withAddress(quicAddress2)
-        .withRng(rng)
+        .withRng(rng())
         .withQuicTransport()
         .withNoise()
         .build()
@@ -1131,7 +1131,7 @@ suite "Switch":
       destSwitch = SwitchBuilder
         .new()
         .withAddresses(@[tcpAddress, wsAddress, quicAddress])
-        .withRng(rng)
+        .withRng(rng())
         .withMplex()
         .withTransport(
           proc(config: TransportConfig): Transport =
@@ -1148,7 +1148,7 @@ suite "Switch":
       srcWsSwitch = SwitchBuilder
         .new()
         .withAddress(wsAddress)
-        .withRng(rng)
+        .withRng(rng())
         .withMplex()
         .withTransport(
           proc(config: TransportConfig): Transport =

--- a/tests/libp2p/test_switch.nim
+++ b/tests/libp2p/test_switch.nim
@@ -1051,7 +1051,7 @@ suite "Switch":
         .withMplex()
         .withTransport(
           proc(config: TransportConfig): Transport =
-            WsTransport.new(config.upgr)
+            WsTransport.new(config.upgr, config.rng)
         )
         .withNameResolver(resolver)
         .withNoise()
@@ -1064,7 +1064,7 @@ suite "Switch":
         .withMplex()
         .withTransport(
           proc(config: TransportConfig): Transport =
-            WsTransport.new(config.upgr)
+            WsTransport.new(config.upgr, config.rng)
         )
         .withTcpTransport()
         .withNoise()
@@ -1135,7 +1135,7 @@ suite "Switch":
         .withMplex()
         .withTransport(
           proc(config: TransportConfig): Transport =
-            WsTransport.new(config.upgr)
+            WsTransport.new(config.upgr, config.rng)
         )
         .withTcpTransport()
         .withQuicTransport()
@@ -1152,7 +1152,7 @@ suite "Switch":
         .withMplex()
         .withTransport(
           proc(config: TransportConfig): Transport =
-            WsTransport.new(config.upgr)
+            WsTransport.new(config.upgr, config.rng)
         )
         .withNoise()
         .build()

--- a/tests/libp2p/transports/test_quic.nim
+++ b/tests/libp2p/transports/test_quic.nim
@@ -14,7 +14,7 @@ import ./utils
 
 proc quicTransProvider(): Transport {.gcsafe, raises: [].} =
   try:
-    return QuicTransport.new(Upgrade(), PrivateKey.random(ECDSA, rng[]).tryGet())
+    return QuicTransport.new(Upgrade(), PrivateKey.random(ECDSA, rng()).tryGet())
   except ResultError[crypto.CryptoError]:
     raiseAssert "should not happen"
 
@@ -120,7 +120,7 @@ suite "Quic transport":
     let addr1 = MultiAddress.init("/ip4/127.0.0.1/udp/0/quic-v1").get()
     let addr2 = MultiAddress.init("/ip4/127.0.0.1/udp/0/quic-v1").get()
 
-    let key = PrivateKey.random(ECDSA, rng[]).tryGet()
+    let key = PrivateKey.random(ECDSA, rng()).tryGet()
     let server = QuicTransport.new(Upgrade(), key)
     await server.start(@[addr1, addr2])
     defer:
@@ -171,7 +171,7 @@ suite "Quic transport":
 
   asyncTest "peer ID extraction from certificate":
     # Create server with known private key
-    let serverPrivateKey = PrivateKey.random(ECDSA, rng[]).tryGet()
+    let serverPrivateKey = PrivateKey.random(ECDSA, rng()).tryGet()
     let expectedPeerId = PeerId.init(serverPrivateKey).tryGet()
 
     let server = await createQuicTransport(

--- a/tests/libp2p/transports/test_tor.nim
+++ b/tests/libp2p/transports/test_tor.nim
@@ -160,7 +160,7 @@ suite "Tor transport":
       )
       .tryGet()
 
-    let serverSwitch = TorSwitch.new(torServer, rng, @[ma], {ReuseAddr})
+    let serverSwitch = TorSwitch.new(torServer, rng(), @[ma], {ReuseAddr})
 
     # setup the custom proto
     let testProto = TestProto.new()
@@ -173,7 +173,7 @@ suite "Tor transport":
 
     proc startClient() {.async.} =
       let clientSwitch =
-        TorSwitch.new(torServer = torServer, rng = rng, flags = {ReuseAddr})
+        TorSwitch.new(torServer = torServer, rng = rng(), flags = {ReuseAddr})
 
       let conn = await clientSwitch.dial(serverPeerId, serverAddress, TestCodec)
 
@@ -190,7 +190,8 @@ suite "Tor transport":
     await serverSwitch.stop()
 
   test "It's not possible to add another transport in TorSwitch":
-    let torSwitch = TorSwitch.new(torServer = torServer, rng = rng, flags = {ReuseAddr})
+    let torSwitch =
+      TorSwitch.new(torServer = torServer, rng = rng(), flags = {ReuseAddr})
     expect(AssertionDefect):
       torSwitch.addTransport(TcpTransport.new(upgrade = Upgrade()))
     waitFor torSwitch.stop()

--- a/tests/libp2p/transports/test_ws.nim
+++ b/tests/libp2p/transports/test_ws.nim
@@ -22,7 +22,7 @@ import ./connection_tests
 import ./stream_tests
 
 proc wsTransProvider(): Transport =
-  WsTransport.new(Upgrade())
+  WsTransport.new(Upgrade(), rng())
 
 # Generate cert only once to reduce execution time
 var secureKey {.threadvar.}: TLSPrivateKey
@@ -35,7 +35,8 @@ proc wsSecureTransProvider(): Transport {.gcsafe, raises: [].} =
     secureKey,
     secureCert,
     Opt.none(AutotlsService),
-    {TLSFlags.NoVerifyHost, TLSFlags.NoVerifyServerName},
+    rng(),
+    tlsFlags = {TLSFlags.NoVerifyHost, TLSFlags.NoVerifyServerName},
   )
 
 proc streamProvider(conn: Connection, handle: bool = true): Muxer =
@@ -103,7 +104,7 @@ suite "WebSocket transport":
     let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/wss").tryGet()]
 
     # Generate cert with known keypair so we can derive the PeerId (used as CN in cert)
-    let testKeyPair = KeyPair.random(PKScheme.RSA, rng[]).get()
+    let testKeyPair = KeyPair.random(PKScheme.RSA, rng()).get()
     let expectedPeerId = PeerId.init(testKeyPair.pubkey).tryGet()
     let (secureKey, secureCert) = tlsCertGenerator(Opt.some(testKeyPair))
 
@@ -112,7 +113,8 @@ suite "WebSocket transport":
       secureKey,
       secureCert,
       Opt.none(AutotlsService),
-      {TLSFlags.NoVerifyHost},
+      rng(),
+      tlsFlags = {TLSFlags.NoVerifyHost},
     )
 
     const correctPattern = mapAnd(TCP, mapEq("wss"))
@@ -162,7 +164,7 @@ when defined(libp2p_autotls_support):
     asyncTest "autotls certificate is used when manual tlscertificate is not spcified":
       let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
 
-      let key = KeyPair.random(PKScheme.RSA, rng[]).get()
+      let key = KeyPair.random(PKScheme.RSA, rng()).get()
       let (privkey, cert) = tlsCertGenerator(Opt.some(key))
       let autotls = MockAutotlsService.new(rng())
       autotls.mockedKey = privkey
@@ -174,6 +176,7 @@ when defined(libp2p_autotls_support):
         nil, # TLSPrivateKey
         nil, # TLSCertificate
         Opt.some(AutotlsService(autotls)),
+        rng(),
       )
       await wstransport.start(ma)
       defer:
@@ -189,7 +192,7 @@ when defined(libp2p_autotls_support):
     asyncTest "manually set tlscertificate is preferred over autotls when both are specified":
       let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
 
-      let key = KeyPair.random(PKScheme.RSA, rng[]).get()
+      let key = KeyPair.random(PKScheme.RSA, rng()).get()
       let (privkey, cert) = tlsCertGenerator(Opt.some(key))
       let autotls = MockAutotlsService.new(rng())
       autotls.mockedKey = privkey
@@ -200,7 +203,7 @@ when defined(libp2p_autotls_support):
       let (manualKey, manualCert) = tlsCertGenerator()
 
       let wstransport = WsTransport.new(
-        Upgrade(), manualKey, manualCert, Opt.some(AutotlsService(autotls))
+        Upgrade(), manualKey, manualCert, Opt.some(AutotlsService(autotls)), rng()
       )
       await wstransport.start(ma)
       defer:
@@ -220,6 +223,7 @@ when defined(libp2p_autotls_support):
         nil, # TLSPrivateKey
         nil, # TLSCertificate
         Opt.none(AutotlsService),
+        rng(),
       )
       await wstransport.start(ma)
       defer:

--- a/tests/libp2p/transports/tls/test_certificate.nim
+++ b/tests/libp2p/transports/tls/test_certificate.nim
@@ -13,7 +13,7 @@ suite "Certificate roundtrip tests":
   test "generate then parse with DER ecoding":
     let schemes = @[Ed25519, Secp256k1, ECDSA]
     for scheme in schemes:
-      let keypair = KeyPair.random(scheme, rng[]).tryGet()
+      let keypair = KeyPair.random(scheme, rng()).tryGet()
       let peerId = PeerId.init(keypair.pubkey).tryGet()
 
       let certX509 = generateX509(keypair, encodingFormat = EncodingFormat.DER)
@@ -24,7 +24,7 @@ suite "Certificate roundtrip tests":
         cert.verify()
 
   test "gnerate with invalid validity time":
-    let keypair = KeyPair.random(Ed25519, rng[]).tryGet()
+    let keypair = KeyPair.random(Ed25519, rng()).tryGet()
 
     # past
     var validFrom = (now() - 3.days).toTime()
@@ -118,7 +118,7 @@ suite "utilities test":
     check 157766400 == dt.toUnix()
 
   test "KeyPair to cert_key_t":
-    let key = KeyPair.random(PKScheme.RSA, rng[]).get()
+    let key = KeyPair.random(PKScheme.RSA, rng()).get()
 
     let rawSeckey: seq[byte] = key.seckey.getRawBytes.valueOr:
       raiseAssert "Failed to get seckey raw bytes (DER)"

--- a/tests/libp2p/transports/utils.nim
+++ b/tests/libp2p/transports/utils.nim
@@ -68,7 +68,7 @@ proc invalidCertGenerator*(
     kp: KeyPair
 ): CertificateX509 {.gcsafe, raises: [TLSCertificateError].} =
   try:
-    let keyNew = PrivateKey.random(ECDSA, rng[]).get()
+    let keyNew = PrivateKey.random(ECDSA, rng()).get()
     let pubkey = keyNew.getPublicKey().get()
     # invalidKp has pubkey that does not match seckey
     let invalidKp = KeyPair(seckey: kp.seckey, pubkey: pubkey)
@@ -84,7 +84,7 @@ proc createQuicTransport*(
 ): Future[QuicTransport] {.async.} =
   let key =
     if privateKey.isNone:
-      PrivateKey.random(ECDSA, rng[]).tryGet()
+      PrivateKey.random(ECDSA, rng()).tryGet()
     else:
       privateKey.get()
 

--- a/tests/tools/crypto.nim
+++ b/tests/tools/crypto.nim
@@ -4,13 +4,13 @@
 import chronos/streams/tlsstream, stew/byteutils
 import ../../libp2p/[crypto/crypto, transports/tls/certificate]
 
-var rngSingleton {.threadvar.}: ref HmacDrbgContext
+var rngSingleton {.threadvar.}: Rng
 rngSingleton = newRng()
 
-proc getRng(): ref HmacDrbgContext =
+proc getRng(): Rng =
   rngSingleton
 
-template rng*(): ref HmacDrbgContext =
+template rng*(): Rng =
   getRng()
 
 proc tlsCertGenerator*(
@@ -18,7 +18,7 @@ proc tlsCertGenerator*(
 ): (TLSPrivateKey, TLSCertificate) {.gcsafe, raises: [].} =
   try:
     let keyPair = kp.valueOr:
-      KeyPair.random(PKScheme.RSA, rng()[]).get()
+      KeyPair.random(PKScheme.RSA, rng()).get()
     let certX509 = generateX509(keyPair, encodingFormat = EncodingFormat.PEM)
 
     let secureKey = TLSPrivateKey.init(string.fromBytes(certX509.privateKey))


### PR DESCRIPTION
## Summary

Introduce a libp2p-owned `Rng` type and move public RNG usage away from BearSSL’s `HmacDrbgContext`.

This PR:
- Adds `libp2p/crypto/rng.nim` with `Rng`, `newRng`, `generate`, `generateBytes`, `shuffle`, `pick`, and `pickOne`.
- Updates libp2p APIs, tests, examples, cbind, transports, and protocol code to accept `Rng` instead of `ref/var HmacDrbgContext`.
- Keeps BearSSL as the temporary internal RNG backend while removing BearSSL RNG types from most public libp2p call sites.
- `withRng` receives a `Rng`. Users of BearSSL can either pass a `newRng` (which will use bearssl) or wrap their exsiting HmacDrbgContext with `newBearSslRng`

This is needed as the first step toward replacing BearSSL with BoringSSL while keeping libp2p code dependent on its own randomness abstraction.


Follow-up PRs will move Noise symmetric primitives, RSA, ECNIST, PEM handling, and final production RNG backend to BoringSSL, as well as make nim-websock agnostic of the rng used.

## Affected Areas

- [x] Gossipsub  
  RNG type updates in pubsub/gossipsub extension code and tests.

- [x] Transports  
  RNG plumbing updated for memory, QUIC, Tor, and WebSocket transports. WebSocket still bridges internally to nim-websock’s BearSSL RNG API.

- [x] Peer Management / Discovery  
  Peer ID generation, Kademlia, rendezvous, service discovery, and related tests now use `Rng`.

- [x] Protocol Logic  
  Noise, ping, AutoNAT, AutoNAT v2, mix, autorelay, and peer ID auth RNG call sites updated.

- [x] Build / Tooling  
  cbind, examples, simulations, performance helpers, and tests updated for the new RNG type.

- [x] Other  
  Crypto key generation APIs now accept `Rng`; BearSSL remains the temporary backend internally.

## Compatibility & Downstream Validation

Reference PRs / branches / commits demonstrating successful integration:

- **Nimbus:**  
  Not run yet.

- **Waku:**  
  Not run yet.

- **Codex:**  
  Not run yet.

## Impact on Library Users

This is an intentional breaking API change for users passing BearSSL RNG contexts directly.

Users should migrate from:

```nim
ref HmacDrbgContext
var HmacDrbgContext
```
to:
```
Rng
newRng()
```
Existing serialized keys, peer IDs, signatures, protocol wire formats, and cryptographic behavior are intended to remain unchanged. BearSSL is still used internally as the RNG backend in this PR.

## Risk Assessment
Main risk is downstream source compatibility because public APIs now accept Rng instead of BearSSL HmacDrbgContext.

Runtime behavior should remain stable because the temporary backend is still BearSSL HMAC-DRBG. WebSocket transport still depends on nim-websock’s BearSSL RNG interface internally, so full BearSSL removal is not part of this PR.

Security-sensitive risk is low if RNG plumbing is correct, but this touches key generation, peer ID generation, protocol nonces, and randomized tests, so downstream compile validation is important.
