### PR TITLE
feat(PeerInfo): add observer

### DIFF
--- a/libp2p/identify_pusher.nim
+++ b/libp2p/identify_pusher.nim
@@ -39,6 +39,7 @@ type
     peerInfo: PeerInfo
     onIdentifiedHandler: PeerEventHandler
     onLeftHandler: PeerEventHandler
+    onPeerInfoUpdated: PeerInfoObserver
 
 proc new*(
     T: type IdentifyPusher,
@@ -94,6 +95,13 @@ proc start*(p: IdentifyPusher) =
   ## Construct the IdentifyPush protocol and register the connection manager
   ## hooks that maintain `pushPeers`. The caller is responsible for mounting
   ## `p.identifyPush` on a Switch.
+
+  proc onPeerInfoUpdated(peerInfo: PeerInfo) {.gcsafe, raises: [].} =
+    p.broadcast()
+
+  p.onPeerInfoUpdated = onPeerInfoUpdated
+  p.peerInfo.addObserver(p.onPeerInfoUpdated)
+
   proc onIncomingPush(peerId: PeerId, info: IdentifyInfo) {.async.} =
     p.peerStore.updatePeerInfo(info)
     if IdentifyPushCodec in info.protos:
@@ -121,14 +129,16 @@ proc start*(p: IdentifyPusher) =
 
 proc stop*(p: IdentifyPusher) {.async: (raises: []).} =
   ## Cancel any in-flight pushes and unregister connection manager hooks.
-  if p.onIdentifiedHandler != nil:
+  if not p.onIdentifiedHandler.isNil:
     p.connManager.removePeerEventHandler(
       p.onIdentifiedHandler, PeerEventKind.Identified
     )
     p.onIdentifiedHandler = nil
-  if p.onLeftHandler != nil:
+  if not p.onLeftHandler.isNil:
     p.connManager.removePeerEventHandler(p.onLeftHandler, PeerEventKind.Left)
     p.onLeftHandler = nil
+  if not p.onPeerInfoUpdated.isNil:
+    p.peerInfo.removeObserver(p.onPeerInfoUpdated)
 
   let pending = move(p.ongoingSend)
   pending.cancelSoon()

--- a/libp2p/identify_pusher.nim
+++ b/libp2p/identify_pusher.nim
@@ -32,8 +32,9 @@ type
 
   IdentifyPusher* = ref object
     identifyPush*: IdentifyPush
-    pushPeers*: HashSet[PeerId]
-    ongoingSend*: seq[PushSendFut]
+    pushPeers: HashSet[PeerId]
+    started: bool
+    ongoingSend: seq[PushSendFut]
     connManager: ConnManager
     peerStore: PeerStore
     peerInfo: PeerInfo
@@ -48,6 +49,9 @@ proc new*(
     peerInfo: PeerInfo,
 ): T =
   T(connManager: connManager, peerStore: peerStore, peerInfo: peerInfo)
+
+proc pushPeers*(p: IdentifyPusher): seq[PeerId] =
+  return p.pushPeers.toSeq()
 
 proc sendOne(p: IdentifyPusher, peerId: PeerId) {.async: (raises: [CancelledError]).} =
   let muxer = p.connManager.selectMuxer(peerId)
@@ -80,7 +84,7 @@ proc broadcast*(p: IdentifyPusher) =
   ## connected peer that advertises the IdentifyPush protocol.
   ## Each send runs as a background future; this proc returns immediately
   ## without blocking the caller.
-  if p.identifyPush.isNil:
+  if not p.started:
     return
 
   for peerId in p.pushPeers.toSeq():
@@ -95,6 +99,10 @@ proc start*(p: IdentifyPusher) =
   ## Construct the IdentifyPush protocol and register the connection manager
   ## hooks that maintain `pushPeers`. The caller is responsible for mounting
   ## `p.identifyPush` on a Switch.
+  if p.started:
+    return
+
+  p.started = true
 
   proc onPeerInfoUpdated(peerInfo: PeerInfo) {.gcsafe, raises: [].} =
     p.broadcast()
@@ -129,6 +137,11 @@ proc start*(p: IdentifyPusher) =
 
 proc stop*(p: IdentifyPusher) {.async: (raises: []).} =
   ## Cancel any in-flight pushes and unregister connection manager hooks.
+  if not p.started:
+    return
+
+  p.started = false
+
   if not p.onIdentifiedHandler.isNil:
     p.connManager.removePeerEventHandler(
       p.onIdentifiedHandler, PeerEventKind.Identified

--- a/libp2p/identify_pusher.nim
+++ b/libp2p/identify_pusher.nim
@@ -77,7 +77,7 @@ proc sendOne(p: IdentifyPusher, peerId: PeerId) {.async: (raises: [CancelledErro
     trace "stream error during identify push", peerId, description = e.msg
   finally:
     if not stream.isNil:
-      await stream.closeWithEOF()
+      await noCancel stream.closeWithEOF()
 
 proc broadcast*(p: IdentifyPusher) =
   ## Send an IdentifyPush message with our current `peerInfo` to every
@@ -155,7 +155,7 @@ proc stop*(p: IdentifyPusher) {.async: (raises: [CancelledError]).} =
     p.onPeerInfoUpdated = nil
 
   let pending = move(p.ongoingSend)
-  await pending.cancelAndWait()
+  await noCancel pending.cancelAndWait()
 
   p.pushPeers.clear()
   p.identifyPush = nil

--- a/libp2p/identify_pusher.nim
+++ b/libp2p/identify_pusher.nim
@@ -135,7 +135,7 @@ proc start*(p: IdentifyPusher) =
   p.connManager.addPeerEventHandler(onIdentified, PeerEventKind.Identified)
   p.connManager.addPeerEventHandler(onLeft, PeerEventKind.Left)
 
-proc stop*(p: IdentifyPusher) {.async: (raises: []).} =
+proc stop*(p: IdentifyPusher) {.async: (raises: [CancelledError]).} =
   ## Cancel any in-flight pushes and unregister connection manager hooks.
   if not p.started:
     return
@@ -155,7 +155,7 @@ proc stop*(p: IdentifyPusher) {.async: (raises: []).} =
     p.onPeerInfoUpdated = nil
 
   let pending = move(p.ongoingSend)
-  pending.cancelSoon()
+  await pending.cancelAndWait()
 
   p.pushPeers.clear()
   p.identifyPush = nil

--- a/libp2p/identify_pusher.nim
+++ b/libp2p/identify_pusher.nim
@@ -139,6 +139,7 @@ proc stop*(p: IdentifyPusher) {.async: (raises: []).} =
     p.onLeftHandler = nil
   if not p.onPeerInfoUpdated.isNil:
     p.peerInfo.removeObserver(p.onPeerInfoUpdated)
+    p.onPeerInfoUpdated = nil
 
   let pending = move(p.ongoingSend)
   pending.cancelSoon()

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -79,19 +79,6 @@ proc data*(ma: MultiAddress): VBuffer =
   ## Returns the data buffer of the MultiAddress.
   return ma.data
 
-proc `<`*(a, b: MultiAddress): bool =
-  let bytesA = a.data.buffer
-  let bytesB = b.data.buffer
-
-  if bytesA.len < bytesB.len:
-    return true
-  if bytesA.len > bytesB.len:
-    return false
-
-  for i in 0 ..< bytesA.len:
-    if bytesA[i] != bytesB[i]:
-      return bytesA[i] < bytesB[i]
-
 proc hash*(a: MultiAddress): Hash =
   var h: Hash = 0
   h = h !& hash(a.data.buffer)
@@ -1048,6 +1035,19 @@ proc `==`*(m1: var MultiAddress, m2: MultiAddress): bool =
   ## Check of two MultiAddress are equal
   m1.data == m2.data
 
+proc `<`*(a, b: MultiAddress): bool =
+  let bytesA = a.data.buffer
+  let bytesB = b.data.buffer
+
+  if bytesA.len < bytesB.len:
+    return true
+  if bytesA.len > bytesB.len:
+    return false
+
+  for i in 0 ..< bytesA.len:
+    if bytesA[i] != bytesB[i]:
+      return bytesA[i] < bytesB[i]
+    
 proc matchPart(pat: MaPattern, protos: seq[MultiCodec]): MaPatResult =
   var empty: seq[MultiCodec]
   var pcs = protos

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -79,6 +79,19 @@ proc data*(ma: MultiAddress): VBuffer =
   ## Returns the data buffer of the MultiAddress.
   return ma.data
 
+proc `<`*(a, b: MultiAddress): bool =
+  let bytesA = a.data.buffer
+  let bytesB = b.data.buffer
+
+  if bytesA.len < bytesB.len:
+    return true
+  if bytesA.len > bytesB.len:
+    return false
+
+  for i in 0 ..< bytesA.len:
+    if bytesA[i] != bytesB[i]:
+      return bytesA[i] < bytesB[i]
+
 proc hash*(a: MultiAddress): Hash =
   var h: Hash = 0
   h = h !& hash(a.data.buffer)

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -1047,7 +1047,7 @@ proc `<`*(a, b: MultiAddress): bool =
   for i in 0 ..< bytesA.len:
     if bytesA[i] != bytesB[i]:
       return bytesA[i] < bytesB[i]
-    
+
 proc matchPart(pat: MaPattern, protos: seq[MultiCodec]): MaPatResult =
   var empty: seq[MultiCodec]
   var pcs = protos

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -27,7 +27,7 @@ type
   .} ## A proc that expected to resolve the listen addresses into dialable addresses
 
   PeerInfoObserver* = proc(p: PeerInfo) {.gcsafe, raises: [].}
-    ## Invoked after each `PeerInfo.update()`.
+    ## Invoked after `PeerInfo.update()` changes the resolved `addrs`.
 
   PeerInfo* = ref object
     peerId*: PeerId

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -75,7 +75,7 @@ proc update*(p: PeerInfo) {.async: (raises: [CancelledError]).} =
       for observer in p.observers:
         observer(p)
 
-  var newAddrs = await p.expandAddrs()
+  let newAddrs = await p.expandAddrs()
 
   hasChanged = p.addrs.sorted() != newAddrs.sorted()
   p.addrs = newAddrs

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -3,7 +3,7 @@
 
 {.push raises: [].}
 
-import std/sequtils
+import std/[sequtils, algorithm]
 import pkg/[chronos, chronicles, results]
 import
   peerid,
@@ -65,17 +65,20 @@ proc expandAddrs*(
   var addrs = p.listenAddrs
   for mapper in p.addressMappers:
     addrs = await mapper(addrs)
-  p.addressPolicy.filterAddrs(addrs)
+  addrs = p.addressPolicy.filterAddrs(addrs)
+  return addrs
 
 proc update*(p: PeerInfo) {.async: (raises: [CancelledError]).} =
+  var hasChanged: bool
   defer:
-    for observer in p.observers:
-      observer(p)
+    if hasChanged:
+      for observer in p.observers:
+        observer(p)
 
-  p.addrs = p.listenAddrs
-  for mapper in p.addressMappers:
-    p.addrs = await mapper(p.addrs)
-  p.addrs = p.addressPolicy.filterAddrs(p.addrs)
+  var newAddrs = await p.expandAddrs()
+
+  hasChanged = p.addrs.sorted() != newAddrs.sorted()
+  p.addrs = newAddrs
 
   p.signedPeerRecord = SignedPeerRecord.init(
     p.privateKey, PeerRecord.init(p.peerId, p.addrs)

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -26,6 +26,9 @@ type
     gcsafe, async: (raises: [CancelledError])
   .} ## A proc that expected to resolve the listen addresses into dialable addresses
 
+  PeerInfoObserver* = proc(p: PeerInfo) {.gcsafe, raises: [].}
+    ## Invoked after each `PeerInfo.update()`.
+
   PeerInfo* = ref object
     peerId*: PeerId
     listenAddrs*: seq[MultiAddress]
@@ -42,6 +45,7 @@ type
     privateKey*: PrivateKey
     publicKey*: PublicKey
     signedPeerRecord*: SignedPeerRecord
+    observers: seq[PeerInfoObserver]
 
 func shortLog*(p: PeerInfo): auto =
   (
@@ -64,6 +68,10 @@ proc expandAddrs*(
   p.addressPolicy.filterAddrs(addrs)
 
 proc update*(p: PeerInfo) {.async: (raises: [CancelledError]).} =
+  defer:
+    for observer in p.observers:
+      observer(p)
+
   p.addrs = p.listenAddrs
   for mapper in p.addressMappers:
     p.addrs = await mapper(p.addrs)
@@ -74,6 +82,14 @@ proc update*(p: PeerInfo) {.async: (raises: [CancelledError]).} =
   ).valueOr:
     info "Can't update the signed peer record"
     return
+
+proc addObserver*(p: PeerInfo, observer: PeerInfoObserver) =
+  if observer.isNil:
+    return
+  p.observers.add(observer)
+
+proc removeObserver*(p: PeerInfo, observer: PeerInfoObserver) =
+  p.observers.keepItIf(it != observer)
 
 proc addrs*(p: PeerInfo): seq[MultiAddress] =
   p.addrs

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -187,13 +187,6 @@ proc dial*(
 
   dial(s, peerId, addrs, @[proto])
 
-proc updateAddrs*(s: Switch) {.async: (raises: [CancelledError]).} =
-  ## Refresh `peerInfo.addrs` via the address mappers and notify connected
-  ## peers via IdentifyPush. Call this when listen addresses change.
-  await s.peerInfo.update()
-  if not s.identifyPusher.isNil:
-    s.identifyPusher.broadcast()
-
 proc mount*[T: LPProtocol](
     s: Switch, proto: T, matcher: Matcher = nil
 ) {.gcsafe, raises: [LPError].} =

--- a/libp2p/utils/future.nim
+++ b/libp2p/utils/future.nim
@@ -35,6 +35,12 @@ template newFutureCompleted*[T](): auto =
   fut.complete()
   fut
 
+template cancelAndWait*[T](futs: seq[T]): auto =  
+  var cancelFuts = newSeqOfCap[Future[void]](futs.len)
+  for fut in futs:
+    cancelFuts.add(fut.cancelAndWait())
+  allFutures(cancelFuts)
+
 template cancelSoon*[T](futs: seq[T]) =
   for fut in futs:
     fut.cancelSoon()

--- a/libp2p/utils/future.nim
+++ b/libp2p/utils/future.nim
@@ -35,7 +35,7 @@ template newFutureCompleted*[T](): auto =
   fut.complete()
   fut
 
-template cancelAndWait*[T](futs: seq[T]): auto =  
+template cancelAndWait*[T](futs: seq[T]): auto =
   var cancelFuts = newSeqOfCap[Future[void]](futs.len)
   for fut in futs:
     cancelFuts.add(fut.cancelAndWait())

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -365,7 +365,7 @@ suite "Identify":
       # switch2 starts listening on new address
       let extra = MultiAddress.init("/ip4/127.0.0.1/tcp/999").tryGet()
       switch2.peerInfo.listenAddrs.add(extra)
-      switch2.peerInfo.update()
+      await switch2.peerInfo.update()
 
       # switch1 should receive new address
       checkUntilTimeout:

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -3,7 +3,6 @@
 
 {.used.}
 
-import std/sets
 import chronos, chronicles
 import
   ../../../libp2p/[

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -357,7 +357,7 @@ suite "Identify":
       checkUntilTimeout:
         codecs in switch1.peerStore[ProtoBook][switch2.peerInfo.peerId]
 
-    asyncTest "broadcasts on updateAddrs":
+    asyncTest "broadcasts on PeerInfo.update()":
       checkUntilTimeout:
         switch1.peerInfo.peerId in switch2.identifyPusher.pushPeers
         switch2.peerInfo.peerId in switch1.identifyPusher.pushPeers
@@ -365,7 +365,7 @@ suite "Identify":
       # switch2 starts listening on new address
       let extra = MultiAddress.init("/ip4/127.0.0.1/tcp/999").tryGet()
       switch2.peerInfo.listenAddrs.add(extra)
-      await switch2.updateAddrs()
+      switch2.peerInfo.update()
 
       # switch1 should receive new address
       checkUntilTimeout:

--- a/tests/libp2p/test_peer_info.nim
+++ b/tests/libp2p/test_peer_info.nim
@@ -75,3 +75,37 @@ suite "PeerInfo":
       PeerInfo.new(seckey, multiAddresses, addressMappers = @[addressMapper])
     waitFor peerInfo.update()
     check peerInfo.addrs == multiAddresses2
+
+  test "Observers fire on update":
+    let
+      seckey = PrivateKey.random(ECDSA, rng[]).get()
+      multiAddresses = @[MultiAddress.init("/ip4/0.0.0.0/tcp/24").tryGet()]
+      peerInfo = PeerInfo.new(seckey, multiAddresses)
+
+    var
+      callsA = 0
+      callsB = 0
+      seenAddrs: seq[MultiAddress]
+
+    proc obsA(p: PeerInfo) {.gcsafe, raises: [].} =
+      inc callsA
+      seenAddrs = p.addrs
+
+    proc obsB(p: PeerInfo) {.gcsafe, raises: [].} =
+      inc callsB
+
+    peerInfo.addObserver(obsA)
+    peerInfo.addObserver(obsB)
+    peerInfo.addObserver(nil) # nil guard: must be no-op
+
+    waitFor peerInfo.update()
+    check:
+      callsA == 1
+      callsB == 1
+      seenAddrs == peerInfo.addrs
+
+    peerInfo.removeObserver(obsA)
+    waitFor peerInfo.update()
+    check:
+      callsA == 1
+      callsB == 2

--- a/tests/libp2p/test_peer_info.nim
+++ b/tests/libp2p/test_peer_info.nim
@@ -98,15 +98,15 @@ suite "PeerInfo":
     peerInfo.addObserver(obsB)
     peerInfo.addObserver(nil) # nil guard: must be no-op
 
-    # updated triggers observers initially 
-    # (PeerInfo.new does not set up  `.addrs` property initially)
+    # updated triggers observers initially
+    # (PeerInfo.new does not set up `.addrs` property initially)
     waitFor peerInfo.update()
     check:
       callsA == 1
       callsB == 1
       seenAddrs == peerInfo.addrs
 
-    # updated won't trigger observers since `.addrs ` was not changed
+    # update won't trigger observers since `.addrs` was not changed
     waitFor peerInfo.update()
     check:
       callsA == 1

--- a/tests/libp2p/test_peer_info.nim
+++ b/tests/libp2p/test_peer_info.nim
@@ -78,7 +78,7 @@ suite "PeerInfo":
 
   test "Observers fire on update":
     let
-      seckey = PrivateKey.random(ECDSA, rng[]).get()
+      seckey = PrivateKey.random(ECDSA, rng()).get()
       multiAddresses = @[MultiAddress.init("/ip4/0.0.0.0/tcp/24").tryGet()]
       peerInfo = PeerInfo.new(seckey, multiAddresses)
 

--- a/tests/libp2p/test_peer_info.nim
+++ b/tests/libp2p/test_peer_info.nim
@@ -105,7 +105,7 @@ suite "PeerInfo":
       callsA == 1
       callsB == 1
       seenAddrs == peerInfo.addrs
-    
+
     # updated won't trigger observers since `.addrs ` was not changed
     waitFor peerInfo.update()
     check:

--- a/tests/libp2p/test_peer_info.nim
+++ b/tests/libp2p/test_peer_info.nim
@@ -79,7 +79,7 @@ suite "PeerInfo":
   test "Observers fire on update":
     let
       seckey = PrivateKey.random(ECDSA, rng()).get()
-      multiAddresses = @[MultiAddress.init("/ip4/0.0.0.0/tcp/24").tryGet()]
+      multiAddresses = @[MultiAddress.init("/ip4/0.0.0.0/tcp/24").get()]
       peerInfo = PeerInfo.new(seckey, multiAddresses)
 
     var
@@ -98,13 +98,23 @@ suite "PeerInfo":
     peerInfo.addObserver(obsB)
     peerInfo.addObserver(nil) # nil guard: must be no-op
 
+    # updated triggers observers initially 
+    # (PeerInfo.new does not set up  `.addrs` property initially)
     waitFor peerInfo.update()
     check:
       callsA == 1
       callsB == 1
       seenAddrs == peerInfo.addrs
+    
+    # updated won't trigger observers since `.addrs ` was not changed
+    waitFor peerInfo.update()
+    check:
+      callsA == 1
+      callsB == 1
 
+    # removed observer is not triggered with new update
     peerInfo.removeObserver(obsA)
+    peerInfo.listenAddrs &= MultiAddress.init("/ip4/0.0.0.0/tcp/25").get()
     waitFor peerInfo.update()
     check:
       callsA == 1


### PR DESCRIPTION
## Summary
<!--
Provide a clear and concise description of the purpose of this PR.

Explain:
- What this PR does
- Why it is needed
- The problem it solves or the improvement it introduces
-->

this pr adds an observer-like pattern for PeerInfo changes. since there are many places where peer info is updated, and the identify pusher needs the latest peer info each time it pushes to peers, the most flexible approach is to listen for peer info changes - wherever they originate now or in the future.

## Affected Areas
<!--
Indicate which parts of the codebase are impacted.
Check all that apply and briefly describe the scope of the changes.
-->

- [X] PeerInfo
- [x] IdentifyPusher  
 

## Compatibility & Downstream Validation
<!--
For PRs affecting behavior on existing features, provide evidence that
dependent projects build and function correctly with these changes.
-->

internal changes only.


## Impact on Library Users
<!--
Describe how this affects downstream users of nim-libp2p.

Examples:
- API changes
- Behavior changes
- Performance implications
- Migration requirements
- No impact (internal refactor)
-->

not impact, internal changes only.

## Risk Assessment
<!--
Identify potential risks introduced by this change.

Consider:
- Backward compatibility
- Network behavior changes
- Performance regressions
- Security implications
-->

low.

## References
<!--
Link to related:
- Issues
- Specs
- Design discussions
- Prior PRs
-->

continuation of effort for: https://github.com/vacp2p/nim-libp2p/pull/2412
