### PR TITLE
chore: use >= to choose boringssl dependency

### DIFF
--- a/.pinned
+++ b/.pinned
@@ -8,7 +8,7 @@ httputils;https://github.com/status-im/nim-http-utils@#f142cb2e8bd812dd002a6493b
 json_serialization;https://github.com/status-im/nim-json-serialization@#a6dcf03e04e179127a5fcb7e495d19a821d56c17
 metrics;https://github.com/status-im/nim-metrics@#a1296caf3ebb5f30f51a5feae7749a30df2824c2
 nimcrypto;https://github.com/cheatfate/nimcrypto@#721fb99ee099b632eb86dfad1f0d96ee87583774
-lsquic;https://github.com/vacp2p/nim-lsquic@#0b9ee1f915963ab8384c701fda3c49a116b6f5fa
+lsquic;https://github.com/vacp2p/nim-lsquic@#00e4b7dfaa197cd120267aa897b33b0914166b45
 results;https://github.com/arnetheduck/nim-results@#df8113dda4c2d74d460a8fa98252b0b771bf1f27
 secp256k1;https://github.com/status-im/nim-secp256k1@#d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15
 serialization;https://github.com/status-im/nim-serialization@#f80cfd8657f272a2abd063d070b77f2a74f704cd

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -10,9 +10,9 @@ skipDirs =
 
 requires "nim >= 2.0.0",
   "nimcrypto >= 0.6.0", "dnsclient >= 0.3.0 & < 0.4.0", "bearssl >= 0.2.7",
-  "https://github.com/vacp2p/nim-boringssl#v0.0.4", "chronicles >= 0.11.0",
+  "https://github.com/vacp2p/nim-boringssl >= 0.0.4", "chronicles >= 0.11.0",
   "chronos >= 4.2.2", "metrics", "secp256k1", "stew >= 0.4.2", "unittest2", "results",
-  "serialization", "lsquic >= 0.4.0",
+  "serialization", "lsquic >= 0.4.1",
   "https://github.com/status-im/nim-websock#42c37b4172519566db016810eccfce8a02cc1cdf",
   "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2"
 


### PR DESCRIPTION
## Summary
Use `>=` instead of a fixed version for boringssl