### PR TITLE
chore: add Makefile targets for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
-.PHONY: all build deps cbind clean
+.PHONY: all build deps test testpath testmultiformatexts testintegration cbind clean
+
+NIMBLE ?= nimble
+TEST_PATH ?=
 
 all: build
 
 nimble.lock:
-	nimble lock
+	$(NIMBLE) lock
 
 nix/deps.nix: nimble.lock
 	./tools/gen-deps.sh nimble.lock nix/deps.nix
@@ -12,6 +15,24 @@ deps: nix/deps.nix
 
 build: deps
 	nix build
+
+test:
+	$(NIMBLE) test
+
+testmultiformatexts:
+	$(NIMBLE) testmultiformatexts
+
+testintegration:
+	$(NIMBLE) testintegration
+
+testpath:
+ifndef TEST_PATH
+	$(error TEST_PATH is required. Usage: make testpath TEST_PATH=quic)
+endif
+ifeq ($(strip $(TEST_PATH)),)
+	$(error TEST_PATH is required. Usage: make testpath TEST_PATH=quic)
+endif
+	$(NIMBLE) testpath $(TEST_PATH)
 
 # Delegate to cbind/Makefile
 cbind:

--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ You'll find the nim-libp2p documentation [here](https://vacp2p.github.io/nim-lib
 See the [development guide](docs/development.md) to get started with the project and testing.
 For more details, refer to the [documentation](docs/README.md).
 
+Common test commands are also available via the top-level `Makefile`:
+
+```sh
+make test
+make testpath TEST_PATH=quic
+make testintegration
+```
+
 ## Contributors
 
 Thanks to everyone who has contributed to nim-libp2p. Your support and efforts are greatly appreciated.

--- a/docs/development.md
+++ b/docs/development.md
@@ -54,22 +54,26 @@ Run unit tests:
 
 ```sh
 # run all the unit tests
-nimble test
+make test
 
 # run tests matching a path substring:
 # - Directory name: "transports" matches all tests in transports/
 # - Partial filename: "quic" matches test_quic.nim, test_quic_stream.nim, etc.
 # - Exact filename: "test_ws.nim" matches only that specific file
 # - Full path: "libp2p/transports/test_tcp" matches libp2p/transports/test_tcp.nim
-nimble testpath quic
-nimble testpath transports/test_ws
-nimble testpath mix
+make testpath TEST_PATH=quic
+make testpath TEST_PATH=transports/test_ws
+make testpath TEST_PATH=mix
 # etc ...
 
 # run specific test suites
-nimble testmultiformatexts
-nimble testintegration
+make testmultiformatexts
+make testintegration
 ```
+
+These `make` targets delegate to the existing `nimble` tasks, so `nimble test`,
+`nimble testpath <path>`, `nimble testmultiformatexts`, and
+`nimble testintegration` still work too.
 
 For faster iteration during development, you can bypass nimble overhead by compiling the test file directly:
 


### PR DESCRIPTION
## Summary
Add top-level make targets for the common test flows so contributors do not need to remember the matching 
imble commands.

This adds:
- make test
- make testpath TEST_PATH=...
- make testmultiformatexts
- make testintegration

Also updates the README and development guide with the new commands.

Closes #1867

## Impact on Library Users
No runtime impact. This is a contributor workflow/documentation improvement.

## Additional Notes
I could only dry-run the Makefile wiring locally because 
imble is not installed on PATH in this environment.