### PR TITLE
chore: makefile instead of nimble

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
           if [[ '${{ matrix.platform.cc }}' == 'clang' ]]; then
             export NIMFLAGS="${NIMFLAGS} --cc:clang"
           fi
-          nimble test
+          make test
 
       - name: Fix xml newlines
         if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Run test suite with coverage flags
         run: |
           export NIMFLAGS="--lineDir:on --passC:-fprofile-arcs --passC:-ftest-coverage --passL:-fprofile-arcs --passL:-ftest-coverage"
-          nimble test
+          make test
 
       - name: Run coverage
         run: |

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -163,11 +163,11 @@ jobs:
           if [[ '${{ matrix.config.cc }}' == 'clang' ]]; then
             export NIMFLAGS="${NIMFLAGS} --cc:clang"
           fi
-          nimble test -- -d:chronicles_log_level=DEBUG
+          export NIMFLAGS="${NIMFLAGS} -d:chronicles_log_level=DEBUG"
+          make test
 
       - name: Run integration tests
         if: ${{ matrix.config.os == 'linux' && matrix.config.cpu == 'amd64' }}
         run: |
-          nim --version
-          nimble --version
-          nim r -d:libp2p_autotls_support -d:chronicles_log_level=DEBUG tests/integration/test_all.nim
+          export NIMFLAGS="${NIMFLAGS} -d:chronicles_log_level=DEBUG"
+          make testintegration

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -170,4 +170,4 @@ jobs:
         if: ${{ matrix.config.os == 'linux' && matrix.config.cpu == 'amd64' }}
         run: |
           export NIMFLAGS="${NIMFLAGS} -d:chronicles_log_level=DEBUG"
-          make testintegration
+          make test_integration

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -23,8 +23,20 @@ jobs:
     name: Delete github action cache
     runs-on: ubuntu-latest
     continue-on-error: true
+    permissions:
+      actions: write
     steps:
-      - uses: toshimaru/delete-action-cache@main
+      - name: Delete caches for this ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REF: ${{ github.ref }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -u
+          gh cache list -R "$REPO" --ref "$REF" --limit 100 --json id --jq '.[].id' \
+            | while read -r id; do
+                gh cache delete -R "$REPO" "$id" || echo "skipped $id (already gone)"
+              done
 
   resolve_deps:
     name: Resolve newest dependencies

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,29 @@
-.PHONY: all build deps cbind clean
+.PHONY: all build deps cbind clean test _test_all testmultiformatexts testintegration testpath \
+        install_pinned pin unpin gen_multicodec format
+
+NIMC     ?= nim
+NIMFLAGS ?=
+V        ?= 0
+
+ifeq ($(V),0)
+VERBOSITY_FLAG = --verbosity:0
+else
+VERBOSITY_FLAG =
+endif
+
+NIM_FLAGS = \
+  --styleCheck:usages --styleCheck:error \
+  $(VERBOSITY_FLAG) \
+  --skipUserCfg \
+  -f \
+  --threads:on \
+  --opt:speed \
+  -d:libp2p_autotls_support \
+  $(NIMFLAGS)
+
+RUNNER_FLAGS = --output-level=VERBOSE --console
+
+TEST_PATH ?=
 
 all: build
 
@@ -13,11 +38,77 @@ deps: nix/deps.nix
 build: deps
 	nix build
 
-# Delegate to cbind/Makefile
 cbind:
 	$(MAKE) -C cbind
 
 clean:
-	$(RM) nimble.lock nix/deps.nix
+	$(RM) nimble.lock nix/deps.nix nimble.paths
 	$(MAKE) -C cbind clean
 
+# Generate nimble.paths so config.nims can include it.
+# nimble injects per-package srcDir paths that --NimblePath alone doesn't provide;
+# this replicates that by reading srcDir from each package's .nimble file.
+nimble.paths: $(wildcard nimbledeps/pkgs2/*/*.nimble) $(wildcard nimbledeps/pkgs/*/*.nimble)
+	@rm -f $@
+	@for pkgdir in nimbledeps/pkgs2 nimbledeps/pkgs; do \
+	  [ -d "$$pkgdir" ] || continue; \
+	  for f in "$$pkgdir"/*/*.nimble; do \
+	    [ -f "$$f" ] || continue; \
+	    pkg=$$(dirname "$$f"); \
+	    src=$$(sed -n 's/^[[:space:]]*srcDir[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$$f" | head -1); \
+	    if [ -n "$$src" ] && [ "$$src" != "." ]; then \
+	      path="$$pkg/$$src"; \
+	    else \
+	      path="$$pkg"; \
+	    fi; \
+	    printf 'switch("path", "%s")\n' "$$path" >> $@; \
+	  done; \
+	done
+
+test: nimble.paths _test_all testmultiformatexts
+
+_test_all: nimble.paths
+	$(NIMC) r $(NIM_FLAGS) \
+	  $(if $(CICOV),--nimcache:nimcache/test_all,) \
+	  tests/test_all.nim -- $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
+
+testmultiformatexts: nimble.paths
+	$(NIMC) r $(NIM_FLAGS) \
+	  $(if $(CICOV),--nimcache:nimcache/test_all_multiformat,) \
+	  -d:libp2p_multicodec_exts=../tests/libp2p/multiformat_exts/multicodec_exts.nim \
+	  -d:libp2p_multiaddress_exts=../tests/libp2p/multiformat_exts/multiaddress_exts.nim \
+	  -d:libp2p_multihash_exts=../tests/libp2p/multiformat_exts/multihash_exts.nim \
+	  -d:libp2p_multibase_exts=../tests/libp2p/multiformat_exts/multibase_exts.nim \
+	  -d:libp2p_contentids_exts=../tests/libp2p/multiformat_exts/contentids_exts.nim \
+	  -d:path=multiformat_exts \
+	  tests/test_all.nim -- $(RUNNER_FLAGS) --xml:tests/results_test_all_multiformat.xml
+
+testintegration: nimble.paths
+	$(NIMC) r $(NIM_FLAGS) \
+	  $(if $(CICOV),--nimcache:nimcache/integration,) \
+	  tests/integration/test_all.nim -- $(RUNNER_FLAGS) --xml:tests/results_integration.xml
+
+testpath: nimble.paths
+ifeq ($(TEST_PATH),)
+	$(error TEST_PATH is required. Usage: make testpath TEST_PATH=quic)
+endif
+	$(NIMC) r $(NIM_FLAGS) \
+	  $(if $(CICOV),--nimcache:nimcache/test_all,) \
+	  -d:path=$(TEST_PATH) \
+	  tests/test_all.nim -- $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
+
+# Tasks that still require nimble
+install_pinned:
+	nimble install_pinned
+
+pin:
+	nimble pin
+
+unpin:
+	nimble unpin
+
+gen_multicodec:
+	nimble gen_multicodec
+
+format:
+	nimble format

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
-.PHONY: all build deps cbind clean test _test_all testmultiformatexts testintegration testpath \
-        install_pinned pin unpin gen_multicodec format
+.PHONY: all build deps cbind clean test _test_all test_multiformat_exts test_integration \
+        install_pinned pin unpin gen_multicodec format clean-nim
+
+NIM_VERSION  ?= 2.2.10
+NPH_VERSION  ?= 0.7.0
 
 NIMC     ?= nim
 NIMFLAGS ?=
@@ -22,6 +25,17 @@ NIM_FLAGS = \
   $(NIMFLAGS)
 
 RUNNER_FLAGS = --output-level=VERBOSE --console
+
+# Allow: make test [path]
+# Captures the optional path argument and synthesises a do-nothing rule for it
+# so Make does not complain about a missing target.
+ifeq ($(firstword $(MAKECMDGOALS)),test)
+  _TEST_PATH_ARG := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  ifneq ($(_TEST_PATH_ARG),)
+    override TEST_PATH := $(_TEST_PATH_ARG)
+    $(eval $(_TEST_PATH_ARG):;@true)
+  endif
+endif
 
 TEST_PATH ?=
 
@@ -65,15 +79,26 @@ nimble.paths: $(wildcard nimbledeps/pkgs2/*/*.nimble) $(wildcard nimbledeps/pkgs
 	  done; \
 	done
 
-test: nimble.paths _test_all testmultiformatexts
+test: nimble.paths
+ifeq ($(TEST_PATH),)
+	$(MAKE) _test_all
+	$(MAKE) test_multiformat_exts
+else
+	$(NIMC) c $(NIM_FLAGS) \
+	  $(if $(CICOV),--nimcache:nimcache/test_all,) \
+	  -d:path=$(TEST_PATH) \
+	  tests/test_all.nim
+	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
+endif
 
 _test_all: nimble.paths
-	$(NIMC) r $(NIM_FLAGS) \
+	$(NIMC) c $(NIM_FLAGS) \
 	  $(if $(CICOV),--nimcache:nimcache/test_all,) \
-	  tests/test_all.nim -- $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
+	  tests/test_all.nim
+	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
 
-testmultiformatexts: nimble.paths
-	$(NIMC) r $(NIM_FLAGS) \
+test_multiformat_exts: nimble.paths
+	$(NIMC) c $(NIM_FLAGS) \
 	  $(if $(CICOV),--nimcache:nimcache/test_all_multiformat,) \
 	  -d:libp2p_multicodec_exts=../tests/libp2p/multiformat_exts/multicodec_exts.nim \
 	  -d:libp2p_multiaddress_exts=../tests/libp2p/multiformat_exts/multiaddress_exts.nim \
@@ -81,23 +106,15 @@ testmultiformatexts: nimble.paths
 	  -d:libp2p_multibase_exts=../tests/libp2p/multiformat_exts/multibase_exts.nim \
 	  -d:libp2p_contentids_exts=../tests/libp2p/multiformat_exts/contentids_exts.nim \
 	  -d:path=multiformat_exts \
-	  tests/test_all.nim -- $(RUNNER_FLAGS) --xml:tests/results_test_all_multiformat.xml
+	  tests/test_all.nim
+	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all_multiformat.xml
 
-testintegration: nimble.paths
-	$(NIMC) r $(NIM_FLAGS) \
+test_integration: nimble.paths
+	$(NIMC) c $(NIM_FLAGS) \
 	  $(if $(CICOV),--nimcache:nimcache/integration,) \
-	  tests/integration/test_all.nim -- $(RUNNER_FLAGS) --xml:tests/results_integration.xml
+	  tests/integration/test_all.nim
+	./tests/integration/test_all $(RUNNER_FLAGS) --xml:tests/results_integration.xml
 
-testpath: nimble.paths
-ifeq ($(TEST_PATH),)
-	$(error TEST_PATH is required. Usage: make testpath TEST_PATH=quic)
-endif
-	$(NIMC) r $(NIM_FLAGS) \
-	  $(if $(CICOV),--nimcache:nimcache/test_all,) \
-	  -d:path=$(TEST_PATH) \
-	  tests/test_all.nim -- $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
-
-# Tasks that still require nimble
 install_pinned:
 	nimble install_pinned
 
@@ -111,4 +128,11 @@ gen_multicodec:
 	nimble gen_multicodec
 
 format:
-	nimble format
+	find . -name '*.nim' -not -path './nimbledeps/*' | xargs nph
+
+clean-nim:
+	rm -rf ~/.nimble/pkgs2 ~/.nimble/pkgcache
+	[ ! -d nimbledeps ] || rm -rf nimbledeps
+	choosenim $(NIM_VERSION)
+	nimble install nimble
+	nimble install nph@$(NPH_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -131,8 +131,5 @@ format:
 	find . -name '*.nim' -not -path './nimbledeps/*' | xargs nph
 
 clean-nim:
-	rm -rf ~/.nimble/pkgs2 ~/.nimble/pkgcache
 	[ ! -d nimbledeps ] || rm -rf nimbledeps
-	choosenim $(NIM_VERSION)
-	nimble install nimble
-	nimble install nph@$(NPH_VERSION)
+	rm nimble.locks nimble.paths 2>/dev/null || true

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -17,70 +17,9 @@ requires "nim >= 2.2.4",
   "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2",
   "https://github.com/status-im/nim-protobuf-serialization#46753f2b90365035bc0f75c6894e160c35880be1"
 
-import hashes, os, sequtils, strutils
+import os, sequtils, strutils
 
-let nimc = getEnv("NIMC", "nim") # Which nim compiler to use
-let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)
-let flags = getEnv("NIMFLAGS", "") # Extra flags for the compiler
-let verbose = getEnv("V", "") notin ["", "0"]
-
-# changes in run configs should be also reflected on flake.nix
-let cfg =
-  " --styleCheck:usages --styleCheck:error" & (if verbose: "" else: " --verbosity:0") &
-  " --skipUserCfg -f" & " --threads:on --opt:speed"
-
-proc runTest(filename: string, moreoptions: string = "") =
-  var compileCmd = nimc & " " & lang & " " & cfg & " " & flags
-  if getEnv("CICOV").len > 0:
-    compileCmd &= " --nimcache:nimcache/" & filename & "-" & $compileCmd.hash
-  compileCmd &= " -d:libp2p_autotls_support"
-  compileCmd &= " " & moreoptions & " "
-
-  var runnerArgs = " --output-level=VERBOSE"
-  runnerArgs &= " --console"
-  runnerArgs &= " --xml:tests/results_" & $hash(filename & $compileCmd) & ".xml"
-
-  # step 1: compile test binary
-  exec compileCmd & " tests/" & filename
-  # step 2: run binary
-  exec "./tests/" & filename.toExe & runnerArgs
-  # step 3: remove binary
-  rmFile "tests/" & filename.toExe
-
-task testmultiformatexts, "Run multiformat extensions tests":
-  let opts =
-    "-d:libp2p_multicodec_exts=../tests/libp2p/multiformat_exts/multicodec_exts.nim " &
-    "-d:libp2p_multiaddress_exts=../tests/libp2p/multiformat_exts/multiaddress_exts.nim " &
-    "-d:libp2p_multihash_exts=../tests/libp2p/multiformat_exts/multihash_exts.nim " &
-    "-d:libp2p_multibase_exts=../tests/libp2p/multiformat_exts/multibase_exts.nim " &
-    "-d:libp2p_contentids_exts=../tests/libp2p/multiformat_exts/contentids_exts.nim " &
-    "-d:path=multiformat_exts"
-  runTest("test_all", opts)
-
-task testintegration, "Runs integration tests":
-  runTest("integration/test_all")
-
-task test, "Runs the test suite":
-  runTest("test_all")
-  testmultiformatextsTask()
-
-task testpath, "Run tests matching a specific path":
-  var testPathArg = ""
-
-  # Extract arguments after task name
-  let params = commandLineParams()
-  let taskIdx = params.find("testpath")
-
-  if taskIdx >= 0 and taskIdx < params.len - 1:
-    testPathArg = params[taskIdx + 1]
-
-  if testPathArg == "":
-    echo "Error: Please provide a test path argument"
-    echo "Usage: nimble testpath <path>"
-    echo "Example: nimble testpath quic"
-    quit(1)
-
-  runTest("test_all", "-d:path=" & testPathArg)
+let nimc = getEnv("NIMC", "nim")
 
 # pin system
 # while nimble lockfile
@@ -88,9 +27,6 @@ task testpath, "Run tests matching a specific path":
 
 const PinFile = ".pinned"
 task pin, "Create a lockfile":
-  # pinner.nim was originally here
-  # but you can't read output from
-  # a command in a nimscript
   exec nimc & " c -r tools/pinner.nim"
 
 task install_pinned, "Reads the lockfile":
@@ -122,6 +58,3 @@ task unpin, "Restore global package use":
 task gen_multicodec,
   "Download the multicodec CSV and regenerate libp2p/multicodec_table.nim":
   exec nimc & " c -r tools/gen_multicodec.nim"
-
-task format, "Format nim code using nph":
-  exec "nph ./. *.nim"

--- a/tests/libp2p/test_name_resolve.nim
+++ b/tests/libp2p/test_name_resolve.nim
@@ -4,7 +4,7 @@
 {.used.}
 
 import std/[sequtils, tables]
-import chronos, chronicles
+import chronos
 import
   ../../libp2p/[
     stream/connection,
@@ -22,7 +22,7 @@ const unixPlatform =
   defined(netbsd) or defined(openbsd) or defined(dragonfly)
 
 when unixPlatform:
-  import std/strutils
+  import std/strutils, chronicles
 
 proc guessOsNameServers(): seq[TransportAddress] {.raises: [].} =
   when unixPlatform:


### PR DESCRIPTION
## Summary

This PR replaces direct `nimble test` invocations in CI workflows with `make test` / `make testintegration`, and adds the corresponding `Makefile` targets that were previously missing. Makefile targets run nim directly, reduce the overall time to run each target. I'm not sure why that is, maybe because nimble needs to be compiled before it runs.

### Changes

- `.github/workflows/ci.yml`
  - Replaced `nimble test` with `make test` in the main test step.

- `.github/workflows/coverage.yml`
  - Replaced `nimble test` with `make test` in the coverage test step.

- `.github/workflows/daily_common.yml`
  - Replaced:
    ```sh
    nimble test -- -d:chronicles_log_level=DEBUG
    ```
    with:
    ```sh
    export NIMFLAGS=...
    make test
    ```
  - Replaced the ad-hoc `nim r` integration test invocation with:
    ```sh
    export NIMFLAGS=...
    make testintegration
    ```
    removing the redundant `nim --version` / `nimble --version` lines.

- `Makefile`
  - Added:
    - `NIMC`
    - `NIMFLAGS`
    - `V`
    - `VERBOSITY_FLAG`
    - `NIM_FLAGS`
    - `RUNNER_FLAGS`
    - `TEST_PATH`
  - Added targets:
    - `test`
    - `_test_all`
    - `testmultiformatexts`
    - `testintegration`
    - `testpath`
  - These targets invoke `nim r` directly with a consistent set of flags.
  - Retained thin wrappers that delegate to `nimble` for tasks that still require it:
    - `install_pinned`
    - `pin`
    - `unpin`
    - `gen_multicodec`
    - `format`
  - Removed an inline comment on the `cbind` target.

## Affected Areas

- Gossipsub
- Transports
- Peer Management / Discovery
- Protocol Logic
- Build / Tooling
  - CI workflows and `Makefile` updated to run tests via `make` instead of `nimble`.
- Other

## Compatibility & Downstream Validation

All public library APIs and encode/decode paths are completely unaffected — this PR only changes how tests are invoked in CI and locally.

Downstream consumers (Nimbus, Waku, Codex) that depend on the library itself will see no change. No downstream validation is needed.

## Impact on Library Users

- No public API, ABI, or behavioral changes.
- This is a build/tooling-only change.

## Risk Assessment

- **Compiler flag parity**
  - The `Makefile`’s `NIM_FLAGS` must stay in sync with any flags previously passed via `nimble test`.
  - If a flag was silently added by `nimble` and is now absent, tests could behave differently.
  - Risk: low — the flag set is now explicit and auditable in one place.

- **`NIMFLAGS` env var propagation**
  - The daily workflow now sets `NIMFLAGS` as an environment variable before calling `make`.
  - The `Makefile` appends `$(NIMFLAGS)` at the end of `NIM_FLAGS`, so extra flags compose correctly.
  - Risk: low — this is the standard `make` override pattern.

- **`-f` (force recompile) flag**
  - `NIM_FLAGS` includes `-f`, which forces full recompilation on every `make test` run.
  - This was likely the existing `nimble` behavior; if it was not, CI build times may increase slightly.
  - Risk: low.

## References
- #1867 