### PR TITLE
fix(peerstore): reset identify stream on cancellation

### DIFF
--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -217,6 +217,7 @@ proc identify*(
   if stream == nil:
     return
 
+  var cancelled = false
   try:
     if (await MultistreamSelect.select(stream, peerStore.identify.codec())):
       let info = await peerStore.identify.identify(stream, stream.peerId)
@@ -231,8 +232,14 @@ proc identify*(
         muxer.setShortAgent(knownAgent)
 
       peerStore.updatePeerInfo(info, stream.observedAddr, Opt.some(dir))
+  except CancelledError as exc:
+    cancelled = true
+    raise exc
   finally:
-    await stream.closeWithEOF()
+    if cancelled:
+      await noCancel stream.reset()
+    else:
+      await noCancel stream.closeWithEOF()
 
 proc getMostObservedProtosAndPorts*(self: PeerStore): seq[MultiAddress] =
   return self.identify.observedAddrManager.getMostObservedProtosAndPorts()


### PR DESCRIPTION
## Summary

Fixes a cancellation hang in `PeerStore.identify`.

When an identify attempt was cancelled, the cleanup path used `closeWithEOF()`. For QUIC, this could wait until the transport timeout if the remote side had not accepted/upgraded the connection yet (60s). This happened in connection limit tests where the remote switch was already at its incoming limit.

The fix resets the identify stream on cancellation, and keeps the normal graceful `closeWithEOF()` path for non-cancelled identify cleanup.

## Affected Areas

- [x] Peer Management / Discovery
Identify cleanup now treats cancellation differently from normal completion.

## Impact on Library Users
Cancelled identify attempts should now finish faster instead of waiting for remote EOF. Normal successful identify behavior is unchanged.

## Risk Assessment
Low risk. The change only affects cleanup after `CancelledError`.
The main behavior change is that cancelled identify streams are reset instead of gracefully closed, which matches the fact that the operation was interrupted.
