### PR TITLE
fix(service-disco): fix misplaced log line

### DIFF
--- a/libp2p/protocols/service_discovery/advertiser.nim
+++ b/libp2p/protocols/service_discovery/advertiser.nim
@@ -96,9 +96,9 @@ proc advertiseToRegistrar*(
 
   var currentTicket = ticket
 
-  while true:
-    debug "registering advert", serviceId, registrar
+  debug "registering advert", serviceId, registrar
 
+  while true:
     let response = (
       await disco.sendRegister(registrar, serviceId, advertBuff, currentTicket)
     ).valueOr:


### PR DESCRIPTION
Fix a log line that was producing confusing double expected output.