### PR TITLE
refactor(Switch): Service lifecycle

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -123,7 +123,6 @@ switch("warningAsError", "UnusedImport:on")
 switch("warningAsError", "UseBase:on")
 switch("hintAsError", "ConvFromXtoItselfNotNeeded:on")
 switch("hintAsError", "DuplicateModuleImport:on")
-switch("hintAsError", "XCannotRaiseY:on")
 --styleCheck: usages
 --styleCheck: error
 --mm: refc          # Reference counting (not ORC yet)

--- a/config.nims
+++ b/config.nims
@@ -15,7 +15,6 @@ switch("warningAsError", "UnusedImport:on")
 switch("warningAsError", "UseBase:on")
 switch("hintAsError", "ConvFromXtoItselfNotNeeded:on")
 switch("hintAsError", "DuplicateModuleImport:on")
-# switch("hintAsError", "XCannotRaiseY:on")
 
 --styleCheck:
   usages

--- a/config.nims
+++ b/config.nims
@@ -15,7 +15,7 @@ switch("warningAsError", "UnusedImport:on")
 switch("warningAsError", "UseBase:on")
 switch("hintAsError", "ConvFromXtoItselfNotNeeded:on")
 switch("hintAsError", "DuplicateModuleImport:on")
-switch("hintAsError", "XCannotRaiseY:on")
+# switch("hintAsError", "XCannotRaiseY:on")
 
 --styleCheck:
   usages

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -153,11 +153,11 @@ when defined(libp2p_autotls_support):
         self.config.ipAddress = Opt.some(getPublicIPAddress())
       except ValueError as e:
         raise newException(
-          ServiceSetupError, "Failed to get public IP address. Reason" & $e.msg
+          ServiceSetupError, "Failed to get public IP address. Reason: " & $e.msg
         )
       except OSError as e:
         raise newException(
-          ServiceSetupError, "Failed to get public IP address. Reason" & $e.msg
+          ServiceSetupError, "Failed to get public IP address. Reason: " & $e.msg
         )
 
   method issueCertificate(

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -266,7 +266,7 @@ when defined(libp2p_autotls_support):
       await sleepAsync(self.config.issueRetryTime)
     error "Failed to issue certificate"
 
-  method run*(
+  method start*(
       self: AutotlsService, switch: Switch
   ) {.async: (raises: [CancelledError]).} =
     trace "Starting Autotls management"

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -153,9 +153,10 @@ when defined(libp2p_autotls_support):
         self.config.ipAddress = Opt.some(getPublicIPAddress())
       except ValueError, OSError:
         raise newException(
-          ServiceSetupError, "Failed to get public IP address. Reason: " & getCurrentExceptionMsg()
+          ServiceSetupError,
+          "Failed to get public IP address. Reason: " & getCurrentExceptionMsg(),
         )
-        
+
   method issueCertificate(
       self: AutotlsService
   ): Future[bool] {.

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -151,15 +151,11 @@ when defined(libp2p_autotls_support):
     if self.config.ipAddress.isNone():
       try:
         self.config.ipAddress = Opt.some(getPublicIPAddress())
-      except ValueError as e:
+      except ValueError, OSError:
         raise newException(
-          ServiceSetupError, "Failed to get public IP address. Reason: " & $e.msg
+          ServiceSetupError, "Failed to get public IP address. Reason: " & getCurrentExceptionMsg()
         )
-      except OSError as e:
-        raise newException(
-          ServiceSetupError, "Failed to get public IP address. Reason: " & $e.msg
-        )
-
+        
   method issueCertificate(
       self: AutotlsService
   ): Future[bool] {.

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -146,23 +146,19 @@ when defined(libp2p_autotls_support):
       rng: rng,
     )
 
-  method setup*(
-      self: AutotlsService, switch: Switch
-  ): Future[bool] {.async: (raises: [CancelledError]).} =
+  method setup*(self: AutotlsService, switch: Switch) {.raises: [ServiceSetupError].} =
     trace "Setting up AutotlsService"
-    let hasBeenSetup = await procCall Service(self).setup(switch)
-    if hasBeenSetup:
-      if self.config.ipAddress.isNone():
-        try:
-          self.config.ipAddress = Opt.some(getPublicIPAddress())
-        except ValueError as exc:
-          error "Failed to get public IP address", err = exc.msg
-          return false
-        except OSError as exc:
-          error "Failed to get public IP address", err = exc.msg
-          return false
-      self.managerFut = self.run(switch)
-    return hasBeenSetup
+    if self.config.ipAddress.isNone():
+      try:
+        self.config.ipAddress = Opt.some(getPublicIPAddress())
+      except ValueError as e:
+        raise newException(
+          ServiceSetupError, "Failed to get public IP address. Reason" & $e.msg
+        )
+      except OSError as e:
+        raise newException(
+          ServiceSetupError, "Failed to get public IP address. Reason" & $e.msg
+        )
 
   method issueCertificate(
       self: AutotlsService
@@ -283,28 +279,31 @@ when defined(libp2p_autotls_support):
       error "Could not find a running TcpTransport in switch"
       return
 
-    heartbeat "Certificate Management", self.config.renewCheckTime:
-      if self.cert.isNone():
-        await self.tryIssueCertificate()
+    proc manageCert() {.async: (raises: []).} =
+      try:
+        heartbeat "Certificate Management", self.config.renewCheckTime:
+          if self.cert.isNone():
+            await self.tryIssueCertificate()
 
-      # AutotlsService will renew the cert 1h before it expires
-      let cert = self.cert.valueOr:
-        error "Could not issue certificate"
-        return
-      let waitTime = cert.expiry - Moment.now - self.config.renewBufferTime
-      if waitTime <= self.config.renewBufferTime:
-        await self.tryIssueCertificate()
+          # AutotlsService will renew the cert 1h before it expires
+          let cert = self.cert.valueOr:
+            error "Could not issue certificate"
+            return
+          let waitTime = cert.expiry - Moment.now - self.config.renewBufferTime
+          if waitTime <= self.config.renewBufferTime:
+            await self.tryIssueCertificate()
+      except CancelledError:
+        trace "Autotls management cancelled"
+
+    self.managerFut = manageCert()
 
   method stop*(
       self: AutotlsService, switch: Switch
-  ): Future[bool] {.async: (raises: [CancelledError]).} =
-    let hasBeenStopped = await procCall Service(self).stop(switch)
-    if hasBeenStopped:
-      if not self.acmeClient.isNil():
-        await self.acmeClient.close()
-      if not self.brokerClient.isNil():
-        await self.brokerClient.close()
-      if not self.managerFut.isNil():
-        await self.managerFut.cancelAndWait()
-        self.managerFut = nil
-    return hasBeenStopped
+  ) {.async: (raises: [CancelledError]).} =
+    if not self.acmeClient.isNil():
+      await self.acmeClient.close()
+    if not self.brokerClient.isNil():
+      await self.brokerClient.close()
+    if not self.managerFut.isNil():
+      await self.managerFut.cancelAndWait()
+      self.managerFut = nil

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -463,6 +463,7 @@ proc build*(b: SwitchBuilder): Switch {.raises: [LPError].} =
       PeerStore.new(identify, capacity)
     else:
       PeerStore.new(identify)
+  peerStore.addressPolicy = b.addressPolicy
 
   if b.enableWildcardResolver:
     b.services.add(WildcardAddressResolverService.new())
@@ -479,8 +480,6 @@ proc build*(b: SwitchBuilder): Switch {.raises: [LPError].} =
   if b.identifyPusherEnabled:
     b.services.add(IdentifyPusher.new())
 
-  peerStore.addressPolicy = b.addressPolicy
-
   let switch = newSwitch(
     peerInfo = peerInfo,
     transports = transports,
@@ -492,6 +491,7 @@ proc build*(b: SwitchBuilder): Switch {.raises: [LPError].} =
     services = b.services,
     rng = b.rng,
   )
+  switch.setupServices()
 
   switch.mount(identify)
 

--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -221,6 +221,7 @@ method start*(
 
   if self.enableAddressMapper:
     switch.peerInfo.addressMappers.add(self.addressMapper)
+    await switch.peerInfo.update()
 
   self.scheduleInterval.withValue(interval):
     if self.scheduleHandle.isNil:

--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -210,7 +210,6 @@ method setup*(self: AutonatService, switch: Switch) {.raises: [ServiceSetupError
     ): Future[void] {.async: (raises: [CancelledError]).} =
       discard askPeer(self, switch, peerId)
 
-
 method start*(
     self: AutonatService, switch: Switch
 ) {.async: (raises: [CancelledError]).} =
@@ -219,7 +218,7 @@ method start*(
   switch.connManager.addPeerEventHandler(
     self.newConnectedPeerHandler, PeerEventKind.Joined
   )
-  
+
   if self.enableAddressMapper:
     switch.peerInfo.addressMappers.add(self.addressMapper)
 

--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -210,15 +210,16 @@ method setup*(self: AutonatService, switch: Switch) {.raises: [ServiceSetupError
     ): Future[void] {.async: (raises: [CancelledError]).} =
       discard askPeer(self, switch, peerId)
 
-    switch.connManager.addPeerEventHandler(
-      self.newConnectedPeerHandler, PeerEventKind.Joined
-    )
 
 method start*(
     self: AutonatService, switch: Switch
 ) {.async: (raises: [CancelledError]).} =
   trace "Running AutonatService"
 
+  switch.connManager.addPeerEventHandler(
+    self.newConnectedPeerHandler, PeerEventKind.Joined
+  )
+  
   if self.enableAddressMapper:
     switch.peerInfo.addressMappers.add(self.addressMapper)
 

--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -175,7 +175,7 @@ proc schedule(
     service: AutonatService, switch: Switch, interval: Duration
 ) {.async: (raises: [CancelledError]).} =
   heartbeat "Scheduling AutonatService run", interval:
-    await service.run(switch)
+    await service.askConnectedPeers(switch)
 
 proc addressMapper(
     self: AutonatService, peerStore: PeerStore, listenAddrs: seq[MultiAddress]
@@ -224,7 +224,6 @@ method run*(
   self.scheduleInterval.withValue(interval):
     if self.scheduleHandle.isNil:
       self.scheduleHandle = schedule(self, switch, interval)
-  await askConnectedPeers(self, switch)
 
 method stop*(
     self: AutonatService, switch: Switch

--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -214,13 +214,14 @@ method setup*(self: AutonatService, switch: Switch) {.raises: [ServiceSetupError
       self.newConnectedPeerHandler, PeerEventKind.Joined
     )
 
-  if self.enableAddressMapper:
-    switch.peerInfo.addressMappers.add(self.addressMapper)
-
 method start*(
     self: AutonatService, switch: Switch
 ) {.async: (raises: [CancelledError]).} =
   trace "Running AutonatService"
+
+  if self.enableAddressMapper:
+    switch.peerInfo.addressMappers.add(self.addressMapper)
+
   self.scheduleInterval.withValue(interval):
     if self.scheduleHandle.isNil:
       self.scheduleHandle = schedule(self, switch, interval)

--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -217,7 +217,7 @@ method setup*(self: AutonatService, switch: Switch) {.raises: [ServiceSetupError
   if self.enableAddressMapper:
     switch.peerInfo.addressMappers.add(self.addressMapper)
 
-method run*(
+method start*(
     self: AutonatService, switch: Switch
 ) {.async: (raises: [CancelledError]).} =
   trace "Running AutonatService"

--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -196,58 +196,50 @@ proc addressMapper(
     addrs.add(processedMA)
   return addrs
 
-method setup*(
-    self: AutonatService, switch: Switch
-): Future[bool] {.async: (raises: [CancelledError]).} =
+method setup*(self: AutonatService, switch: Switch) {.raises: [ServiceSetupError].} =
+  info "Setting up AutonatService"
+
   self.addressMapper = proc(
       listenAddrs: seq[MultiAddress]
   ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
     return await addressMapper(self, switch.peerStore, listenAddrs)
 
-  info "Setting up AutonatService"
-  let hasBeenSetup = await procCall Service(self).setup(switch)
-  if hasBeenSetup:
-    if self.askNewConnectedPeers:
-      self.newConnectedPeerHandler = proc(
-          peerId: PeerId, event: PeerEvent
-      ): Future[void] {.async: (raises: [CancelledError]).} =
-        discard askPeer(self, switch, peerId)
+  if self.askNewConnectedPeers:
+    self.newConnectedPeerHandler = proc(
+        peerId: PeerId, event: PeerEvent
+    ): Future[void] {.async: (raises: [CancelledError]).} =
+      discard askPeer(self, switch, peerId)
 
-      switch.connManager.addPeerEventHandler(
-        self.newConnectedPeerHandler, PeerEventKind.Joined
-      )
+    switch.connManager.addPeerEventHandler(
+      self.newConnectedPeerHandler, PeerEventKind.Joined
+    )
 
-    self.scheduleInterval.withValue(interval):
-      self.scheduleHandle = schedule(self, switch, interval)
-
-    if self.enableAddressMapper:
-      switch.peerInfo.addressMappers.add(self.addressMapper)
-
-  return hasBeenSetup
+  if self.enableAddressMapper:
+    switch.peerInfo.addressMappers.add(self.addressMapper)
 
 method run*(
     self: AutonatService, switch: Switch
 ) {.async: (raises: [CancelledError]).} =
   trace "Running AutonatService"
+  self.scheduleInterval.withValue(interval):
+    if self.scheduleHandle.isNil:
+      self.scheduleHandle = schedule(self, switch, interval)
   await askConnectedPeers(self, switch)
 
 method stop*(
     self: AutonatService, switch: Switch
-): Future[bool] {.async: (raises: [CancelledError]).} =
+) {.async: (raises: [CancelledError]).} =
   info "Stopping AutonatService"
-  let hasBeenStopped = await procCall Service(self).stop(switch)
-  if hasBeenStopped:
-    if not isNil(self.scheduleHandle):
-      self.scheduleHandle.cancelSoon()
-      self.scheduleHandle = nil
-    if not isNil(self.newConnectedPeerHandler):
-      switch.connManager.removePeerEventHandler(
-        self.newConnectedPeerHandler, PeerEventKind.Joined
-      )
-    if self.enableAddressMapper:
-      switch.peerInfo.addressMappers.keepItIf(it != self.addressMapper)
-    await switch.peerInfo.update()
-  return hasBeenStopped
+  if not isNil(self.scheduleHandle):
+    self.scheduleHandle.cancelSoon()
+    self.scheduleHandle = nil
+  if not isNil(self.newConnectedPeerHandler):
+    switch.connManager.removePeerEventHandler(
+      self.newConnectedPeerHandler, PeerEventKind.Joined
+    )
+  if self.enableAddressMapper:
+    switch.peerInfo.addressMappers.keepItIf(it != self.addressMapper)
+  await switch.peerInfo.update()
 
 proc statusAndConfidenceHandler*(
     self: AutonatService, statusAndConfidenceHandler: StatusAndConfidenceHandler

--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -202,7 +202,7 @@ proc schedule(
     service: AutonatV2Service, switch: Switch, interval: Duration
 ) {.async: (raises: [CancelledError]).} =
   heartbeat "Scheduling AutonatV2Service run", interval:
-    await service.run(switch)
+    await service.askConnectedPeers(switch)
 
 proc addressMapper(
     self: AutonatV2Service, peerStore: PeerStore, listenAddrs: seq[MultiAddress]
@@ -246,7 +246,6 @@ method run*(
   self.config.scheduleInterval.withValue(interval):
     if self.scheduleHandle.isNil:
       self.scheduleHandle = schedule(self, switch, interval)
-  await askConnectedPeers(self, switch)
 
 method stop*(
     self: AutonatV2Service, switch: Switch

--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -239,7 +239,7 @@ method setup*(self: AutonatV2Service, switch: Switch) {.raises: [ServiceSetupErr
   if self.config.enableAddressMapper:
     switch.peerInfo.addressMappers.add(self.addressMapper)
 
-method run*(
+method start*(
     self: AutonatV2Service, switch: Switch
 ) {.async: (raises: [CancelledError]).} =
   trace "Running AutonatV2Service"

--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -243,6 +243,7 @@ method start*(
 
   if self.config.enableAddressMapper:
     switch.peerInfo.addressMappers.add(self.addressMapper)
+    await switch.peerInfo.update()
 
   self.config.scheduleInterval.withValue(interval):
     if self.scheduleHandle.isNil:

--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -236,13 +236,14 @@ method setup*(self: AutonatV2Service, switch: Switch) {.raises: [ServiceSetupErr
       self.newConnectedPeerHandler, PeerEventKind.Joined
     )
 
-  if self.config.enableAddressMapper:
-    switch.peerInfo.addressMappers.add(self.addressMapper)
-
 method start*(
     self: AutonatV2Service, switch: Switch
 ) {.async: (raises: [CancelledError]).} =
   trace "Running AutonatV2Service"
+
+  if self.config.enableAddressMapper:
+    switch.peerInfo.addressMappers.add(self.addressMapper)
+
   self.config.scheduleInterval.withValue(interval):
     if self.scheduleHandle.isNil:
       self.scheduleHandle = schedule(self, switch, interval)

--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -240,10 +240,10 @@ method start*(
   switch.connManager.addPeerEventHandler(
     self.newConnectedPeerHandler, PeerEventKind.Joined
   )
-  
+
   if self.config.enableAddressMapper:
     switch.peerInfo.addressMappers.add(self.addressMapper)
-  
+
   self.config.scheduleInterval.withValue(interval):
     if self.scheduleHandle.isNil:
       self.scheduleHandle = schedule(self, switch, interval)

--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -218,18 +218,13 @@ proc addressMapper(
       addrs.add(peerStore.guessDialableAddr(listenAddr))
   return addrs
 
-method setup*(
-    self: AutonatV2Service, switch: Switch
-): Future[bool] {.async: (raises: [CancelledError]).} =
+method setup*(self: AutonatV2Service, switch: Switch) {.raises: [ServiceSetupError].} =
+  trace "Setting up AutonatV2Service"
+
   self.addressMapper = proc(
       listenAddrs: seq[MultiAddress]
   ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
     return await addressMapper(self, switch.peerStore, listenAddrs)
-
-  trace "Setting up AutonatV2Service"
-  let hasBeenSetup = await procCall Service(self).setup(switch)
-  if not hasBeenSetup:
-    return hasBeenSetup
 
   if self.config.askNewConnectedPeers:
     self.newConnectedPeerHandler = proc(
@@ -241,27 +236,23 @@ method setup*(
       self.newConnectedPeerHandler, PeerEventKind.Joined
     )
 
-  self.config.scheduleInterval.withValue(interval):
-    self.scheduleHandle = schedule(self, switch, interval)
-
   if self.config.enableAddressMapper:
     switch.peerInfo.addressMappers.add(self.addressMapper)
-
-  return hasBeenSetup
 
 method run*(
     self: AutonatV2Service, switch: Switch
 ) {.async: (raises: [CancelledError]).} =
   trace "Running AutonatV2Service"
+  self.config.scheduleInterval.withValue(interval):
+    if self.scheduleHandle.isNil:
+      self.scheduleHandle = schedule(self, switch, interval)
   await askConnectedPeers(self, switch)
 
 method stop*(
     self: AutonatV2Service, switch: Switch
-): Future[bool] {.async: (raises: [CancelledError]).} =
+) {.async: (raises: [CancelledError]).} =
   trace "Stopping AutonatV2Service"
-  let hasBeenStopped = await procCall Service(self).stop(switch)
-  if not hasBeenStopped:
-    return hasBeenStopped
+
   if not isNil(self.scheduleHandle):
     self.scheduleHandle.cancelSoon()
     self.scheduleHandle = nil
@@ -272,7 +263,6 @@ method stop*(
   if self.config.enableAddressMapper:
     switch.peerInfo.addressMappers.keepItIf(it != self.addressMapper)
   await switch.peerInfo.update()
-  return hasBeenStopped
 
 proc setStatusAndConfidenceHandler*(
     self: AutonatV2Service, statusAndConfidenceHandler: StatusAndConfidenceHandler

--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -232,18 +232,18 @@ method setup*(self: AutonatV2Service, switch: Switch) {.raises: [ServiceSetupErr
     ): Future[void] {.async: (raises: [CancelledError]).} =
       discard askPeer(self, switch, peerId)
 
-    switch.connManager.addPeerEventHandler(
-      self.newConnectedPeerHandler, PeerEventKind.Joined
-    )
-
 method start*(
     self: AutonatV2Service, switch: Switch
 ) {.async: (raises: [CancelledError]).} =
   trace "Running AutonatV2Service"
 
+  switch.connManager.addPeerEventHandler(
+    self.newConnectedPeerHandler, PeerEventKind.Joined
+  )
+  
   if self.config.enableAddressMapper:
     switch.peerInfo.addressMappers.add(self.addressMapper)
-
+  
   self.config.scheduleInterval.withValue(interval):
     if self.scheduleHandle.isNil:
       self.scheduleHandle = schedule(self, switch, interval)

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -624,6 +624,7 @@ method publish*(
   return 0
 
   # Base initPubSub keeps `raises: [InitializationError]` to match overrides.
+
 method initPubSub*(p: PubSub) {.base, raises: [InitializationError].} =
   ## perform pubsub initialization
   p.observers = new(seq[PubSubObserver])

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -623,15 +623,12 @@ method publish*(
 
   return 0
 
-{.push hint[XCannotRaiseY]: off.}
   # Base initPubSub keeps `raises: [InitializationError]` to match overrides.
 method initPubSub*(p: PubSub) {.base, raises: [InitializationError].} =
   ## perform pubsub initialization
   p.observers = new(seq[PubSubObserver])
   if p.msgIdProvider == nil:
     p.msgIdProvider = defaultMsgIdProvider
-
-{.pop.}
 
 method addValidator*(
     p: PubSub, topic: varargs[string], hook: ValidatorHandler

--- a/libp2p/services/autorelayservice.nim
+++ b/libp2p/services/autorelayservice.nim
@@ -126,7 +126,7 @@ proc innerRun(
     else:
       await self.peerAvailable.wait()
 
-method run*(
+method start*(
     self: AutoRelayService, switch: Switch
 ) {.async: (raises: [CancelledError]).} =
   if self.running:

--- a/libp2p/services/autorelayservice.nim
+++ b/libp2p/services/autorelayservice.nim
@@ -129,7 +129,6 @@ method start*(
     self: AutoRelayService, switch: Switch
 ) {.async: (raises: [CancelledError]).} =
   if self.running:
-    trace "Autorelay is already running"
     return
   self.running = true
   switch.peerInfo.addressMappers.add(self.addressMapper)

--- a/libp2p/services/autorelayservice.nim
+++ b/libp2p/services/autorelayservice.nim
@@ -54,35 +54,29 @@ proc reserveAndUpdate(
         self.onReservation(concat(toSeq(self.relayAddresses.values)))
     await sleepAsync chronos.seconds(ttl - 30)
 
-method setup*(
-    self: AutoRelayService, switch: Switch
-): Future[bool] {.async: (raises: [CancelledError]).} =
+method setup*(self: AutoRelayService, switch: Switch) {.raises: [ServiceSetupError].} =
   self.addressMapper = proc(
       listenAddrs: seq[MultiAddress]
   ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
     return await addressMapper(self, listenAddrs)
 
-  let hasBeenSetUp = await procCall Service(self).setup(switch)
-  if hasBeenSetUp:
-    proc handlePeerIdentified(
-        peerId: PeerId, event: PeerEvent
-    ) {.async: (raises: [CancelledError]).} =
-      trace "Peer Identified", peerId
-      if self.relayPeers.len < self.maxNumRelays:
-        self.peerAvailable.fire()
+  proc handlePeerIdentified(
+      peerId: PeerId, event: PeerEvent
+  ) {.async: (raises: [CancelledError]).} =
+    trace "Peer Identified", peerId
+    if self.relayPeers.len < self.maxNumRelays:
+      self.peerAvailable.fire()
 
-    proc handlePeerLeft(
-        peerId: PeerId, event: PeerEvent
-    ) {.async: (raises: [CancelledError]).} =
-      trace "Peer Left", peerId
-      self.relayPeers.withValue(peerId, future):
-        future[].cancelSoon()
+  proc handlePeerLeft(
+      peerId: PeerId, event: PeerEvent
+  ) {.async: (raises: [CancelledError]).} =
+    trace "Peer Left", peerId
+    self.relayPeers.withValue(peerId, future):
+      future[].cancelSoon()
 
-    switch.addPeerEventHandler(handlePeerIdentified, Identified)
-    switch.addPeerEventHandler(handlePeerLeft, Left)
-    switch.peerInfo.addressMappers.add(self.addressMapper)
-    await self.run(switch)
-  return hasBeenSetUp
+  switch.addPeerEventHandler(handlePeerIdentified, Identified)
+  switch.addPeerEventHandler(handlePeerLeft, Left)
+  switch.peerInfo.addressMappers.add(self.addressMapper)
 
 proc manageBackedOff(
     self: AutoRelayService, pid: PeerId
@@ -143,14 +137,11 @@ method run*(
 
 method stop*(
     self: AutoRelayService, switch: Switch
-): Future[bool] {.async: (raises: [CancelledError]).} =
-  let hasBeenStopped = await procCall Service(self).stop(switch)
-  if hasBeenStopped:
-    self.running = false
-    self.runner.cancelSoon()
-    switch.peerInfo.addressMappers.keepItIf(it != self.addressMapper)
-    await switch.peerInfo.update()
-  return hasBeenStopped
+) {.async: (raises: [CancelledError]).} =
+  self.running = false
+  self.runner.cancelSoon()
+  switch.peerInfo.addressMappers.keepItIf(it != self.addressMapper)
+  await switch.peerInfo.update()
 
 proc getAddresses*(self: AutoRelayService): seq[MultiAddress] =
   result = concat(toSeq(self.relayAddresses.values))

--- a/libp2p/services/autorelayservice.nim
+++ b/libp2p/services/autorelayservice.nim
@@ -132,6 +132,7 @@ method start*(
     return
   self.running = true
   switch.peerInfo.addressMappers.add(self.addressMapper)
+  await switch.peerInfo.update()
   self.runner = self.innerRun(switch)
 
 method stop*(

--- a/libp2p/services/autorelayservice.nim
+++ b/libp2p/services/autorelayservice.nim
@@ -76,7 +76,6 @@ method setup*(self: AutoRelayService, switch: Switch) {.raises: [ServiceSetupErr
 
   switch.addPeerEventHandler(handlePeerIdentified, Identified)
   switch.addPeerEventHandler(handlePeerLeft, Left)
-  switch.peerInfo.addressMappers.add(self.addressMapper)
 
 proc manageBackedOff(
     self: AutoRelayService, pid: PeerId
@@ -133,11 +132,14 @@ method start*(
     trace "Autorelay is already running"
     return
   self.running = true
+  switch.peerInfo.addressMappers.add(self.addressMapper)
   self.runner = self.innerRun(switch)
 
 method stop*(
     self: AutoRelayService, switch: Switch
 ) {.async: (raises: [CancelledError]).} =
+  if not self.running:
+    return
   self.running = false
   self.runner.cancelSoon()
   switch.peerInfo.addressMappers.keepItIf(it != self.addressMapper)

--- a/libp2p/services/hpservice.nim
+++ b/libp2p/services/hpservice.nim
@@ -87,52 +87,47 @@ proc newConnectedPeerHandler(
   except CatchableError as err:
     debug "Hole punching failed during dcutr", description = err.msg
 
-method setup*(
-    self: HPService, switch: Switch
-): Future[bool] {.async: (raises: [CancelledError]).} =
-  var hasBeenSetup = await procCall Service(self).setup(switch)
-  hasBeenSetup = hasBeenSetup and await self.autonatService.setup(switch)
+method setup*(self: HPService, switch: Switch) {.raises: [ServiceSetupError].} =
+  self.autonatService.setup(switch)
 
-  if hasBeenSetup:
-    try:
-      let dcutrProto = Dcutr.new(switch)
-      switch.mount(dcutrProto)
-    except LPError as err:
-      error "Failed to mount Dcutr", description = err.msg
-
-    self.newConnectedPeerHandler = proc(
-        peerId: PeerId, event: PeerEvent
-    ) {.async: (raises: [CancelledError]).} =
-      await newConnectedPeerHandler(self, switch, peerId, event)
-
-    switch.connManager.addPeerEventHandler(
-      self.newConnectedPeerHandler, PeerEventKind.Joined
+  try:
+    let dcutrProto = Dcutr.new(switch)
+    switch.mount(dcutrProto)
+  except LPError as e:
+    raise newException(
+      ServiceSetupError, "HPService Failed to mount Dcutr. Reason: " & $e.msg
     )
 
-    self.onNewStatusHandler = proc(
-        networkReachability: NetworkReachability, confidence: Opt[float]
-    ) {.async: (raises: [CancelledError]).} =
-      if networkReachability == NetworkReachability.NotReachable and
-          not self.autoRelayService.isRunning():
-        discard await self.autoRelayService.setup(switch)
-      elif networkReachability == NetworkReachability.Reachable and
-          self.autoRelayService.isRunning():
-        discard await self.autoRelayService.stop(switch)
+  self.newConnectedPeerHandler = proc(
+      peerId: PeerId, event: PeerEvent
+  ) {.async: (raises: [CancelledError]).} =
+    await newConnectedPeerHandler(self, switch, peerId, event)
 
-      # We do it here instead of in the AutonatService because this is useful only when hole punching.
-      for t in switch.transports:
-        t.networkReachability = networkReachability
+  switch.connManager.addPeerEventHandler(
+    self.newConnectedPeerHandler, PeerEventKind.Joined
+  )
 
-    self.autonatService.statusAndConfidenceHandler(self.onNewStatusHandler)
-  return hasBeenSetup
+  self.onNewStatusHandler = proc(
+      networkReachability: NetworkReachability, confidence: Opt[float]
+  ) {.async: (raises: [CancelledError]).} =
+    if networkReachability == NetworkReachability.NotReachable and
+        not self.autoRelayService.isRunning():
+      await self.autoRelayService.run(switch)
+    elif networkReachability == NetworkReachability.Reachable and
+        self.autoRelayService.isRunning():
+      await self.autoRelayService.stop(switch)
+
+    # We do it here instead of in the AutonatService because this is useful only when hole punching.
+    for t in switch.transports:
+      t.networkReachability = networkReachability
+
+  self.autonatService.statusAndConfidenceHandler(self.onNewStatusHandler)
 
 method run*(self: HPService, switch: Switch) {.async: (raises: [CancelledError]).} =
   await self.autonatService.run(switch)
 
-method stop*(
-    self: HPService, switch: Switch
-): Future[bool] {.async: (raises: [CancelledError]).} =
-  discard await self.autonatService.stop(switch)
+method stop*(self: HPService, switch: Switch) {.async: (raises: [CancelledError]).} =
+  await self.autonatService.stop(switch)
   if not isNil(self.newConnectedPeerHandler):
     switch.connManager.removePeerEventHandler(
       self.newConnectedPeerHandler, PeerEventKind.Joined

--- a/libp2p/services/hpservice.nim
+++ b/libp2p/services/hpservice.nim
@@ -113,7 +113,7 @@ method setup*(self: HPService, switch: Switch) {.raises: [ServiceSetupError].} =
   ) {.async: (raises: [CancelledError]).} =
     if networkReachability == NetworkReachability.NotReachable and
         not self.autoRelayService.isRunning():
-      await self.autoRelayService.run(switch)
+      await self.autoRelayService.start(switch)
     elif networkReachability == NetworkReachability.Reachable and
         self.autoRelayService.isRunning():
       await self.autoRelayService.stop(switch)
@@ -124,8 +124,8 @@ method setup*(self: HPService, switch: Switch) {.raises: [ServiceSetupError].} =
 
   self.autonatService.statusAndConfidenceHandler(self.onNewStatusHandler)
 
-method run*(self: HPService, switch: Switch) {.async: (raises: [CancelledError]).} =
-  await self.autonatService.run(switch)
+method start*(self: HPService, switch: Switch) {.async: (raises: [CancelledError]).} =
+  await self.autonatService.start(switch)
 
 method stop*(self: HPService, switch: Switch) {.async: (raises: [CancelledError]).} =
   await self.autonatService.stop(switch)

--- a/libp2p/services/hpservice.nim
+++ b/libp2p/services/hpservice.nim
@@ -89,6 +89,7 @@ proc newConnectedPeerHandler(
 
 method setup*(self: HPService, switch: Switch) {.raises: [ServiceSetupError].} =
   self.autonatService.setup(switch)
+  self.autoRelayService.setup(switch)
 
   try:
     let dcutrProto = Dcutr.new(switch)

--- a/libp2p/services/identify_pusher.nim
+++ b/libp2p/services/identify_pusher.nim
@@ -11,7 +11,8 @@
 ##
 ## - **setup**: Initializes the identify push protocol and mounts it to the switch.
 ## - **run**: Registers event handlers for peer connect/disconnect and enables
-##   automatic broadcasting when peer info changes.
+##   automatic broadcasting when peer info changes. Called by the switch after
+##   it has been fully started.
 ## - **stop**: Cleans up event handlers and cancels any pending broadcasts.
 ##
 ## ### Broadcasting Behavior
@@ -112,13 +113,7 @@ proc broadcast(p: IdentifyPusher) =
       if idx >= 0:
         p.ongoingSend.del(idx)
 
-method setup*(
-    p: IdentifyPusher, switch: Switch
-): Future[bool] {.async: (raises: [CancelledError]).} =
-  var hasBeenSetup = await procCall Service(p).setup(switch)
-  if not hasBeenSetup:
-    return
-
+method setup*(p: IdentifyPusher, switch: Switch) {.raises: [ServiceSetupError].} =
   p.peerStore = switch.peerStore
   p.connManager = switch.connManager
   p.peerInfo = switch.peerInfo
@@ -138,13 +133,10 @@ method setup*(
   try:
     switch.mount(p.identifyPush)
   except LPError as e:
-    trace "could not mount IdentifyPush", msg = e.msg
-    hasBeenSetup = false
-
-  if hasBeenSetup:
-    await p.run(switch)
-
-  return hasBeenSetup
+    raise newException(
+      ServiceSetupError,
+      "IdentifyPusher could not mount IdentifyPush. Reason: " & $e.msg,
+    )
 
 method run*(p: IdentifyPusher, switch: Switch) {.async: (raises: [CancelledError]).} =
   if p.started:
@@ -174,31 +166,25 @@ method run*(p: IdentifyPusher, switch: Switch) {.async: (raises: [CancelledError
   p.connManager.addPeerEventHandler(onIdentified, PeerEventKind.Identified)
   p.connManager.addPeerEventHandler(onLeft, PeerEventKind.Left)
 
-method stop*(
-    p: IdentifyPusher, switch: Switch
-): Future[bool] {.async: (raises: [CancelledError]).} =
-  let hasBeenStopped = await procCall Service(p).stop(switch)
-  if hasBeenStopped:
-    if not p.started:
-      return hasBeenStopped
+method stop*(p: IdentifyPusher, switch: Switch) {.async: (raises: [CancelledError]).} =
+  if not p.started:
+    return
 
-    p.started = false
+  p.started = false
 
-    if not p.onIdentifiedHandler.isNil:
-      p.connManager.removePeerEventHandler(
-        p.onIdentifiedHandler, PeerEventKind.Identified
-      )
-      p.onIdentifiedHandler = nil
-    if not p.onLeftHandler.isNil:
-      p.connManager.removePeerEventHandler(p.onLeftHandler, PeerEventKind.Left)
-      p.onLeftHandler = nil
-    if not p.onPeerInfoUpdated.isNil:
-      p.peerInfo.removeObserver(p.onPeerInfoUpdated)
-      p.onPeerInfoUpdated = nil
+  if not p.onIdentifiedHandler.isNil:
+    p.connManager.removePeerEventHandler(
+      p.onIdentifiedHandler, PeerEventKind.Identified
+    )
+    p.onIdentifiedHandler = nil
+  if not p.onLeftHandler.isNil:
+    p.connManager.removePeerEventHandler(p.onLeftHandler, PeerEventKind.Left)
+    p.onLeftHandler = nil
+  if not p.onPeerInfoUpdated.isNil:
+    p.peerInfo.removeObserver(p.onPeerInfoUpdated)
+    p.onPeerInfoUpdated = nil
 
-    let pending = move(p.ongoingSend)
-    await pending.cancelAndWait()
+  let pending = move(p.ongoingSend)
+  await pending.cancelAndWait()
 
-    p.pushPeers.clear()
-
-  return hasBeenStopped
+  p.pushPeers.clear()

--- a/libp2p/services/identify_pusher.nim
+++ b/libp2p/services/identify_pusher.nim
@@ -10,7 +10,7 @@
 ## ### Lifecycle
 ##
 ## - **setup**: Initializes the identify push protocol and mounts it to the switch.
-## - **run**: Registers event handlers for peer connect/disconnect and enables
+## - **start**: Registers event handlers for peer connect/disconnect and enables
 ##   automatic broadcasting when peer info changes. Called by the switch after
 ##   it has been fully started.
 ## - **stop**: Cleans up event handlers and cancels any pending broadcasts.
@@ -138,7 +138,7 @@ method setup*(p: IdentifyPusher, switch: Switch) {.raises: [ServiceSetupError].}
       "IdentifyPusher could not mount IdentifyPush. Reason: " & $e.msg,
     )
 
-method run*(p: IdentifyPusher, switch: Switch) {.async: (raises: [CancelledError]).} =
+method start*(p: IdentifyPusher, switch: Switch) {.async: (raises: [CancelledError]).} =
   if p.started:
     return
 

--- a/libp2p/services/wildcardresolverservice.nim
+++ b/libp2p/services/wildcardresolverservice.nim
@@ -161,7 +161,7 @@ proc expandWildcardAddresses(
 
 method setup*(
     self: WildcardAddressResolverService, switch: Switch
-): Future[bool] {.async: (raises: [CancelledError]).} =
+) {.raises: [ServiceSetupError].} =
   ## Sets up the `WildcardAddressResolverService`.
   ##
   ## This method adds the address mapper to the peer's list of address mappers.
@@ -172,16 +172,14 @@ method setup*(
   ##
   ## Returns:
   ## - A `Future[bool]` that resolves to `true` if the setup was successful, otherwise `false`.
+  debug "Setting up WildcardAddressResolverService"
+
   self.addressMapper = proc(
       listenAddrs: seq[MultiAddress]
   ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
     return expandWildcardAddresses(self.networkInterfaceProvider, listenAddrs)
 
-  debug "Setting up WildcardAddressResolverService"
-  let hasBeenSetup = await procCall Service(self).setup(switch)
-  if hasBeenSetup:
-    switch.peerInfo.addressMappers.add(self.addressMapper)
-  return hasBeenSetup
+  switch.peerInfo.addressMappers.add(self.addressMapper)
 
 method run*(
     self: WildcardAddressResolverService, switch: Switch
@@ -196,7 +194,7 @@ method run*(
 
 method stop*(
     self: WildcardAddressResolverService, switch: Switch
-): Future[bool] {.async: (raises: [CancelledError]).} =
+) {.async: (raises: [CancelledError]).} =
   ## Stops the WildcardAddressResolverService.
   ##
   ## Handles the shutdown process of the WildcardAddressResolverService for a given switch.
@@ -210,8 +208,6 @@ method stop*(
   ## Returns:
   ## - A future that resolves to `true` if the service was successfully stopped, otherwise `false`.
   debug "Stopping WildcardAddressResolverService"
-  let hasBeenStopped = await procCall Service(self).stop(switch)
-  if hasBeenStopped:
-    switch.peerInfo.addressMappers.keepItIf(it != self.addressMapper)
-    await switch.peerInfo.update()
-  return hasBeenStopped
+
+  switch.peerInfo.addressMappers.keepItIf(it != self.addressMapper)
+  await switch.peerInfo.update()

--- a/libp2p/services/wildcardresolverservice.nim
+++ b/libp2p/services/wildcardresolverservice.nim
@@ -179,8 +179,6 @@ method setup*(
   ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
     return expandWildcardAddresses(self.networkInterfaceProvider, listenAddrs)
 
-  switch.peerInfo.addressMappers.add(self.addressMapper)
-
 method start*(
     self: WildcardAddressResolverService, switch: Switch
 ) {.async: (raises: [CancelledError]).} =
@@ -190,6 +188,7 @@ method start*(
   ## address mappers that are registered with the switch will also be run.
   ##
   trace "Running WildcardAddressResolverService"
+  switch.peerInfo.addressMappers.add(self.addressMapper)
   await switch.peerInfo.update()
 
 method stop*(

--- a/libp2p/services/wildcardresolverservice.nim
+++ b/libp2p/services/wildcardresolverservice.nim
@@ -181,7 +181,7 @@ method setup*(
 
   switch.peerInfo.addressMappers.add(self.addressMapper)
 
-method run*(
+method start*(
     self: WildcardAddressResolverService, switch: Switch
 ) {.async: (raises: [CancelledError]).} =
   ## Runs the WildcardAddressResolverService for a given switch.

--- a/libp2p/services/wildcardresolverservice.nim
+++ b/libp2p/services/wildcardresolverservice.nim
@@ -171,7 +171,7 @@ method setup*(
   ## - `switch`: The switch context in which the service operates.
   ##
   ## Returns:
-  ## - A `Future[bool]` that resolves to `true` if the setup was successful, otherwise `false`.
+  ## - No value. If setup fails, a `ServiceSetupError` is raised.
   debug "Setting up WildcardAddressResolverService"
 
   self.addressMapper = proc(

--- a/libp2p/services/wildcardresolverservice.nim
+++ b/libp2p/services/wildcardresolverservice.nim
@@ -204,9 +204,6 @@ method stop*(
   ## Parameters:
   ## - `self`: The instance of the WildcardAddressResolverService.
   ## - `switch`: The Switch object associated with the service.
-  ##
-  ## Returns:
-  ## - A future that resolves to `true` if the service was successfully stopped, otherwise `false`.
   debug "Stopping WildcardAddressResolverService"
 
   switch.peerInfo.addressMappers.keepItIf(it != self.addressMapper)

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -240,7 +240,7 @@ proc upgradeMonitor(
     trace "Connection upgrade failed", description = e.msg, conn
     libp2p_failed_upgrades_incoming.inc()
   finally:
-    await deadlineFut.cancelAndWait()
+    deadlineFut.cancel()
     if (not upgradeSuccessful) and (not isNil(conn)):
       await conn.close()
     if semAcquired:
@@ -250,26 +250,18 @@ proc upgradeMonitor(
         raiseAssert "semaphore released without acquire"
 
 proc accept(
-    s: Switch, transport: Transport, ready: Option[AsyncEvent] = none(AsyncEvent)
+    s: Switch, transport: Transport,
 ) {.async: (raises: []).} =
   ## switch accept loop, ran for every transport
   ##
   let upgrades = newAsyncSemaphore(ConcurrentUpgrades)
-  var readyOnce = ready
 
   while transport.running:
     var conn: Connection
     try:
       debug "About to accept incoming connection"
       let slot = await s.connManager.getIncomingSlot()
-      # Signal readiness after acquiring the slot but before awaiting
-      # transport.accept(). In chronos, fire() schedules the waiter
-      # callback without suspending here, so the loop continues
-      # synchronously into transport.accept() — on Windows this posts
-      # AcceptEx before switch.start() returns to the caller.
-      if readyOnce.isSome:
-        readyOnce.get().fire()
-        readyOnce = none(AsyncEvent)
+
       conn =
         try:
           await transport.accept()
@@ -298,9 +290,6 @@ proc accept(
       debug "Accepted an incoming connection", conn
       asyncSpawn s.upgradeMonitor(transport, conn, upgrades)
     except CancelledError:
-      if readyOnce.isSome:
-        readyOnce.get().fire()
-        readyOnce = none(AsyncEvent)
       return
     except CatchableError as exc:
       error "Exception in accept loop, exiting", description = exc.msg

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -349,24 +349,12 @@ proc start*(s: Switch) {.async: (raises: [CancelledError, LPError]).} =
 
   debug "starting switch for peer", peerInfo = s.peerInfo
 
-  for service in s.services:
-    await service.start(s)
-
   var startFuts: seq[Future[void]]
   for t in s.transports:
     let addrs = s.peerInfo.listenAddrs.filterIt(t.handles(it))
-
     s.peerInfo.listenAddrs.keepItIf(it notin addrs)
 
-    if addrs.len > 0 or t.running:
-      let fut = t.start(addrs)
-      startFuts.add(fut)
-      if t of TcpTransport:
-        await fut
-        let ready = newAsyncEvent()
-        s.acceptFuts.add(s.accept(t, some(ready)))
-        s.peerInfo.listenAddrs &= t.addrs
-        await ready.wait()
+    startFuts.add(t.start(addrs))
 
   await allFutures(startFuts)
 
@@ -377,16 +365,16 @@ proc start*(s: Switch) {.async: (raises: [CancelledError, LPError]).} =
         LPError, "starting transports failed: " & $fut.error.msg, fut.error
       )
 
-  for t in s.transports: # for each transport
-    if t.addrs.len > 0 or t.running:
-      if t of TcpTransport:
-        continue # already added previously
-      s.acceptFuts.add(s.accept(t))
-      s.peerInfo.listenAddrs &= t.addrs
+  for t in s.transports:
+    s.acceptFuts.add(s.accept(t))
+    s.peerInfo.listenAddrs &= t.addrs
 
   await s.peerInfo.update()
-
   await s.ms.start()
+
+  for service in s.services:
+    await service.start(s)
+
   s.started = true
 
   debug "Started libp2p node", peer = s.peerInfo

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -71,8 +71,10 @@ method setup*(
 ) {.base, gcsafe, raises: [ServiceSetupError].} =
   raiseAssert "[Service.setup] abstract method not implemented!"
 
-method run*(self: Service, switch: Switch) {.base, async: (raises: [CancelledError]).} =
-  raiseAssert "[Service.run] abstract method not implemented!"
+method start*(
+    self: Service, switch: Switch
+) {.base, async: (raises: [CancelledError]).} =
+  raiseAssert "[Service.start] abstract method not implemented!"
 
 method stop*(
     self: Service, switch: Switch
@@ -348,7 +350,7 @@ proc start*(s: Switch) {.async: (raises: [CancelledError, LPError]).} =
   debug "starting switch for peer", peerInfo = s.peerInfo
 
   for service in s.services:
-    await service.run(s)
+    await service.start(s)
 
   var startFuts: seq[Future[void]]
   for t in s.transports:

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -342,18 +342,22 @@ proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
 
 proc start*(s: Switch) {.async: (raises: [CancelledError, LPError]).} =
   ## Start listening on every transport
-
   if s.started:
     warn "Switch has already been started"
     return
 
   debug "starting switch for peer", peerInfo = s.peerInfo
 
+  # start services and transports without await to prevent any
+  # issues when one needs another to start first.
   var startFuts: seq[Future[void]]
+  
+  for service in s.services:
+    startFuts.add(service.start(s))
+ 
   for t in s.transports:
     let addrs = s.peerInfo.listenAddrs.filterIt(t.handles(it))
     s.peerInfo.listenAddrs.keepItIf(it notin addrs)
-
     startFuts.add(t.start(addrs))
 
   await allFutures(startFuts)
@@ -362,7 +366,7 @@ proc start*(s: Switch) {.async: (raises: [CancelledError, LPError]).} =
     if fut.failed:
       await s.stop()
       raise newException(
-        LPError, "starting transports failed: " & $fut.error.msg, fut.error
+        LPError, "starting services and transports failed: " & $fut.error.msg, fut.error
       )
 
   for t in s.transports:
@@ -371,9 +375,6 @@ proc start*(s: Switch) {.async: (raises: [CancelledError, LPError]).} =
 
   await s.peerInfo.update()
   await s.ms.start()
-
-  for service in s.services:
-    await service.start(s)
 
   s.started = true
 

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -249,9 +249,7 @@ proc upgradeMonitor(
       except AsyncSemaphoreError:
         raiseAssert "semaphore released without acquire"
 
-proc accept(
-    s: Switch, transport: Transport,
-) {.async: (raises: []).} =
+proc accept(s: Switch, transport: Transport) {.async: (raises: []).} =
   ## switch accept loop, ran for every transport
   ##
   let upgrades = newAsyncSemaphore(ConcurrentUpgrades)
@@ -340,10 +338,10 @@ proc start*(s: Switch) {.async: (raises: [CancelledError, LPError]).} =
   # start services and transports without await to prevent any
   # issues when one needs another to start first.
   var startFuts: seq[Future[void]]
-  
+
   for service in s.services:
     startFuts.add(service.start(s))
- 
+
   for t in s.transports:
     let addrs = s.peerInfo.listenAddrs.filterIt(t.handles(it))
     s.peerInfo.listenAddrs.keepItIf(it notin addrs)

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -240,7 +240,7 @@ proc upgradeMonitor(
     trace "Connection upgrade failed", description = e.msg, conn
     libp2p_failed_upgrades_incoming.inc()
   finally:
-    deadlineFut.cancel()
+    deadlineFut.cancelSoon()
     if (not upgradeSuccessful) and (not isNil(conn)):
       await conn.close()
     if semAcquired:

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -62,29 +62,22 @@ type
 
   UpgradeError* = object of LPError
 
+  ServiceSetupError* = object of LPError
+
   Service* = ref object of RootObj
-    inUse: bool
 
 method setup*(
     self: Service, switch: Switch
-): Future[bool] {.base, async: (raises: [CancelledError]).} =
-  if self.inUse:
-    warn "service setup has already been called"
-    return false
-  self.inUse = true
-  return true
+) {.base, gcsafe, raises: [ServiceSetupError].} =
+  raiseAssert "[Service.setup] abstract method not implemented!"
 
 method run*(self: Service, switch: Switch) {.base, async: (raises: [CancelledError]).} =
-  doAssert(false, "[Service.run] abstract method not implemented!")
+  raiseAssert "[Service.run] abstract method not implemented!"
 
 method stop*(
     self: Service, switch: Switch
-): Future[bool] {.base, async: (raises: [CancelledError]).} =
-  if not self.inUse:
-    warn "service is already stopped"
-    return false
-  self.inUse = false
-  return true
+) {.base, async: (raises: [CancelledError]).} =
+  raiseAssert "[Service.stop] abstract method not implemented!"
 
 proc addConnEventHandler*(s: Switch, handler: ConnEventHandler, kind: ConnEventKind) =
   ## Adds a ConnEventHandler, which will be triggered when
@@ -185,6 +178,10 @@ proc dial*(
   ## with the specified `proto`
 
   dial(s, peerId, addrs, @[proto])
+
+proc setupServices*(s: Switch) {.raises: [ServiceSetupError].} =
+  for service in s.services:
+    service.setup(s)
 
 proc mount*[T: LPProtocol](
     s: Switch, proto: T, matcher: Matcher = nil
@@ -324,7 +321,7 @@ proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
     debug "Cannot cancel accepts", description = exc.msg
 
   for service in s.services:
-    discard await service.stop(s)
+    await service.stop(s)
 
   # close and cleanup all connections
   await s.connManager.close()
@@ -349,6 +346,10 @@ proc start*(s: Switch) {.async: (raises: [CancelledError, LPError]).} =
     return
 
   debug "starting switch for peer", peerInfo = s.peerInfo
+
+  for service in s.services:
+    await service.run(s)
+
   var startFuts: seq[Future[void]]
   for t in s.transports:
     let addrs = s.peerInfo.listenAddrs.filterIt(t.handles(it))
@@ -364,11 +365,6 @@ proc start*(s: Switch) {.async: (raises: [CancelledError, LPError]).} =
         s.acceptFuts.add(s.accept(t, some(ready)))
         s.peerInfo.listenAddrs &= t.addrs
         await ready.wait()
-
-  # some transports require some services to be running
-  # in order to finish their startup process
-  for service in s.services:
-    discard await service.setup(s)
 
   await allFutures(startFuts)
 

--- a/tests/libp2p/protocols/test_autonat_service.nim
+++ b/tests/libp2p/protocols/test_autonat_service.nim
@@ -273,20 +273,6 @@ suite "Autonat Service":
       switch1.stop(), switch2.stop(), switch3.stop(), switch4.stop()
     )
 
-  asyncTest "Calling setup and stop twice must work":
-    let switch = createSwitch()
-    let autonatService = AutonatService.new(
-      AutonatClientStub.new(expectedDials = 0), rng(), Opt.some(1.seconds)
-    )
-
-    check (await autonatService.setup(switch)) == true
-    check (await autonatService.setup(switch)) == false
-
-    check (await autonatService.stop(switch)) == true
-    check (await autonatService.stop(switch)) == false
-
-    await allFuturesRaising(switch.stop())
-
   asyncTest "Must bypass maxConnectionsPerPeer limit":
     let autonatService = AutonatService.new(
       AutonatClient.new(), rng(), Opt.some(1.seconds), maxQueueSize = 1

--- a/tests/libp2p/protocols/test_autonat_service.nim
+++ b/tests/libp2p/protocols/test_autonat_service.nim
@@ -464,7 +464,7 @@ suite "Autonat Service":
     await switch5.connect(switch1.peerInfo.peerId, switch1.peerInfo.addrs)
     # switch1 is now full, should stick to last observation
     awaiter = newFuture[void]()
-    await autonatService.run(switch1)
+    await autonatService.start(switch1)
 
     await sleepAsync(100.millis)
 

--- a/tests/libp2p/protocols/test_autonat_v2_service.nim
+++ b/tests/libp2p/protocols/test_autonat_v2_service.nim
@@ -299,21 +299,6 @@ suite "AutonatV2 Service":
     await switch.stop()
     await switches.stopAll()
 
-  asyncTest "Calling setup and stop twice must work":
-    let (service, _) = newService(
-      NetworkReachability.NotReachable,
-      config = AutonatV2ServiceConfig.new(scheduleInterval = Opt.some(1.seconds)),
-    )
-
-    let switch = createSwitch()
-    check (await service.setup(switch)) == true
-    check (await service.setup(switch)) == false
-
-    check (await service.stop(switch)) == true
-    check (await service.stop(switch)) == false
-
-    await switch.stop()
-
   asyncTest "Must bypass maxConnectionsPerPeer limit":
     let (service, _) = newService(
       NetworkReachability.Reachable,

--- a/tests/libp2p/protocols/test_autonat_v2_service.nim
+++ b/tests/libp2p/protocols/test_autonat_v2_service.nim
@@ -500,7 +500,7 @@ suite "AutonatV2 Service":
     await switches[3].connect(switch.peerInfo.peerId, switch.peerInfo.addrs)
     # switch1 is now full, should stick to last observation
     awaiter = newFuture[void]()
-    await service.run(switch)
+    await service.start(switch)
 
     await sleepAsync(100.millis)
 

--- a/tests/libp2p/test_switch.nim
+++ b/tests/libp2p/test_switch.nim
@@ -1097,11 +1097,11 @@ suite "Switch":
         .withAddresses(@[tcpAddress, wsAddress, quicAddress])
         .withRng(rng())
         .withMplex()
+        .withTcpTransport()
         .withTransport(
           proc(config: TransportConfig): Transport =
             WsTransport.new(config.upgr, config.rng)
         )
-        .withTcpTransport()
         .withQuicTransport()
         .withNoise()
         .build()


### PR DESCRIPTION
changes:
- return value `bool` from all `Service` method is remove as it was unused (discarded) thus making it unnecessary 
- `Switch` will call `setup()` on all `Service`s right after it is created, this is the time for `Service` to get anything they need form `Switch`
- `setup()` now raises `ServiceSetupError` when service could not be setup
  -  previously errors when setting up service did nothing
- `run()` was renamed to `start()`
- `start()` is called right when `Switch` is started
   - previously it was called from `setup`, this was not okay as switch was not starting at that point
- `stop()` is unchanged 