### PR TITLE
test(service-disco): client mode + one register component

### DIFF
--- a/tests/libp2p/service_discovery/component/test_advertise_discover.nim
+++ b/tests/libp2p/service_discovery/component/test_advertise_discover.nim
@@ -137,15 +137,14 @@ suite "Service Discovery Component - Advertise Discover":
     checkUntilTimeout:
       registrarNode.countAdsInCache(svcAId) == 1
       registrarNode.countAdsInCache(svcBId) == 1
-
-    let foundA = await discovererNode.lookup(svcAId)
-    let foundB = await discovererNode.lookup(svcBId)
-    check:
-      foundA.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId)
-      foundA.get().len == 1
-      foundB.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId)
-      # Regression for vacp2p/nim-libp2p#2431: this lookup previously returned a duplicate.
-      foundB.get().len == 1
+      block:
+        let foundA = await discovererNode.lookup(svcAId)
+        let foundB = await discovererNode.lookup(svcBId)
+        foundA.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId) and
+          foundA.get().len == 1 and
+          foundB.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId) and
+          foundB.get().len == 1
+          # Regression for vacp2p/nim-libp2p#2431: this lookup previously returned a duplicate.
 
   asyncTest "lookup dedups byte-identical adverts but keeps same (peerId, seqNo) variants":
     let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0)

--- a/tests/libp2p/service_discovery/component/test_client_mode.nim
+++ b/tests/libp2p/service_discovery/component/test_client_mode.nim
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+{.used.}
+
+import chronos, results, std/[sequtils, tables]
+import
+  ../../../../libp2p/[
+    peerinfo,
+    protocols/service_discovery,
+    protocols/service_discovery/advertiser,
+    protocols/service_discovery/types,
+    switch,
+  ]
+import ../../../tools/[lifecycle, unittest]
+import ../utils
+
+suite "Service Discovery Component - Client Mode":
+  teardown:
+    checkTrackers()
+
+  asyncTest "client-mode node does not advertise the service-discovery codec":
+    # Client mode is consumer-only, it doesn't serve REGISTER.
+    let clientNode = setupServiceDiscoveryNode(client = true)
+    let serverNode = setupServiceDiscoveryNode()
+    startAndDeferStop(@[clientNode, serverNode])
+    await connect(serverNode, clientNode)
+
+    check:
+      ExtendedServiceDiscoveryCodec in serverNode.switch.peerInfo.protocols
+      ExtendedServiceDiscoveryCodec notin clientNode.switch.peerInfo.protocols
+
+    let serviceName = "service"
+    let serviceId = serviceName.hashServiceId()
+    let ad = makeAdvertisement(serviceName).encode().get()
+    let response =
+      await serverNode.sendRegister(clientNode.switch.peerInfo.peerId, serviceId, ad)
+    check:
+      response.isErr
+      clientNode.registrar.cache.len == 0
+
+  asyncTest "client-mode node returns no ads when targeted by lookup":
+    let clientNode = setupServiceDiscoveryNode(client = true)
+    let discovererNode = setupServiceDiscoveryNode()
+    startAndDeferStop(@[clientNode, discovererNode])
+    await connect(discovererNode, clientNode)
+
+    check ExtendedServiceDiscoveryCodec notin clientNode.switch.peerInfo.protocols
+
+    let serviceName = "service"
+    let serviceId = serviceName.hashServiceId()
+    # Seed the client's cache so lookup would find the ad if the client were serving GET_ADS.
+    clientNode.registrar.cache[serviceId] = @[makeAdvertisement(serviceName)]
+
+    let found = await discovererNode.lookup(serviceId)
+    check:
+      found.get().len == 0
+
+  asyncTest "client-mode node successfully completes lookup against server-mode registrars":
+    let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0)
+    let clientDiscoverer = setupServiceDiscoveryNode(discoConfig = conf, client = true)
+    let serverRegistrar = setupServiceDiscoveryNode(discoConfig = conf)
+    let serverAdvertiser = setupServiceDiscoveryNode(discoConfig = conf)
+    startAndDeferStop(@[clientDiscoverer, serverRegistrar, serverAdvertiser])
+
+    await connect(clientDiscoverer, serverRegistrar)
+    await connect(serverAdvertiser, serverRegistrar)
+
+    let service = makeServiceInfo("service")
+    let serviceId = service.id.hashServiceId()
+
+    serverAdvertiser.addProvidedService(service)
+
+    checkUntilTimeout:
+      serverRegistrar.countAdsInCache(serviceId) == 1
+
+    let found = await clientDiscoverer.lookup(serviceId)
+    check:
+      found.get().anyIt(it.data.peerId == serverAdvertiser.switch.peerInfo.peerId)

--- a/tests/libp2p/service_discovery/component/test_register.nim
+++ b/tests/libp2p/service_discovery/component/test_register.nim
@@ -92,3 +92,32 @@ suite "Service Discovery Component - Register":
     )
     check regResp.isOk()
     check regResp.get().status == kad_protobuf.RegistrationStatus.Confirmed
+
+  asyncTest "back-to-back REGISTERs return identical waits":
+    # Anti-grinding: tMod + tWaitFor (eligibility moment) must never move earlier across retries.
+    let registrarNode = setupServiceDiscoveryNode()
+    let advertiserNode = setupServiceDiscoveryNode()
+    startAndDeferStop(@[registrarNode, advertiserNode])
+    await connect(registrarNode, advertiserNode)
+
+    let serviceName = "service"
+    let serviceId = serviceName.hashServiceId()
+    let adBytes = makeAdvertisement(
+        serviceName, advertiserNode.switch.peerInfo.privateKey
+      )
+      .encode()
+      .get()
+    let registrarPeerId = registrarNode.switch.peerInfo.peerId
+
+    proc requestTicket(): Future[Ticket] {.async.} =
+      let response: RegistrationResponse =
+        (await advertiserNode.sendRegister(registrarPeerId, serviceId, adBytes)).get()
+      check response.status == kad_protobuf.RegistrationStatus.Wait
+      check response.ticket.isSome()
+      return response.ticket.get()
+
+    let first = await requestTicket()
+    let second = await requestTicket()
+    check:
+      second.tWaitFor == first.tWaitFor
+      second.tMod >= first.tMod

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -93,6 +93,7 @@ proc setupServiceDiscoveryNode*(
     discoConfig: ServiceDiscoveryConfig = ServiceDiscoveryConfig.new(),
     bootstrapNodes: seq[(PeerId, seq[MultiAddress])] = @[],
     xprPublishing: bool = true,
+    client: bool = false,
 ): ServiceDiscovery =
   let switch = createSwitch()
   let node = ServiceDiscovery.new(
@@ -100,10 +101,12 @@ proc setupServiceDiscoveryNode*(
     bootstrapNodes = bootstrapNodes,
     config = testKadDHTConfig(),
     rng = rng(),
+    client = client,
     discoConfig = discoConfig,
     xprPublishing = xprPublishing,
   )
-  switch.mount(node)
+  if not client:
+    switch.mount(node)
   node
 
 proc setupServiceDiscoveryNodes*(


### PR DESCRIPTION
## Summary

Adds component coverage for client-mode behavior and REGISTER retry handling.

This PR verifies that client-mode service discovery nodes do not advertise or serve the service-discovery codec, while still being able to perform lookups against server-mode registrars. It also adds a back-to-back REGISTER test that checks retry waits stay stable and `tMod` does not move backwards.

The test helper now supports constructing client-mode service discovery nodes without mounting the inbound protocol handler.

## Affected Areas

- [x] Tests  

## Impact on Library Users

None.

## Risk Assessment

None.

## Additional Notes

New tests:
- client-mode nodes do not advertise the service-discovery codec
- client-mode nodes do not serve cached ads to inbound lookups
- client-mode nodes can still look up ads from server-mode registrars
- back-to-back REGISTER requests preserve retry wait behavior