### PR TITLE
chore(deps): bump nim-websock to >= 0.4.0

### DIFF
--- a/.pinned
+++ b/.pinned
@@ -15,7 +15,7 @@ serialization;https://github.com/status-im/nim-serialization@#f80cfd8657f272a2ab
 stew;https://github.com/status-im/nim-stew@#b66168735d6f3841c5239c3169d3fe5fe98b1257
 testutils;https://github.com/status-im/nim-testutils@#e85cb6ff9c328a6e12441e81ff632ef8b3af62b3
 unittest2;https://github.com/status-im/nim-unittest2@#26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189
-websock;https://github.com/status-im/nim-websock@#02616eccd5c826b83c580fa092e9675da04491c7
+websock;https://github.com/status-im/nim-websock@#387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d
 zlib;https://github.com/status-im/nim-zlib@#e680f269fb01af2c34a2ba879ff281795a5258fe
 bearssl_pkey_decoder;https://github.com/vacp2p/bearssl_pkey_decoder@#d34aa46bf9d0a3ffff810fbd3c4d2fa024eb9368
 jwt;https://github.com/vacp2p/nim-jwt@#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -13,7 +13,7 @@ requires "nim >= 2.2.4",
   "https://github.com/vacp2p/nim-boringssl >= 0.0.4", "chronicles >= 0.11.0",
   "chronos >= 4.2.2", "metrics", "secp256k1", "stew >= 0.4.2", "unittest2", "results",
   "serialization", "lsquic >= 0.4.1",
-  "https://github.com/status-im/nim-websock#02616eccd5c826b83c580fa092e9675da04491c7",
+  "https://github.com/status-im/nim-websock >= 0.4.0",
   "https://github.com/vacp2p/nim-jwt.git#057ec95eb5af0eea9c49bfe9025b3312c95dc5f2",
   "https://github.com/status-im/nim-protobuf-serialization#46753f2b90365035bc0f75c6894e160c35880be1"
 

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -26,8 +26,8 @@
 
   boringssl = pkgs.fetchgit {
     url = "https://github.com/vacp2p/nim-boringssl";
-    rev = "1c91a4a2579123597df43bbdea70cc575957bdea";
-    sha256 = "0vh26cdski46jaaqfxqz8pfzjxxnkr3znvyqdgn5m6q4xkbb1jqz";
+    rev = "03bd48b54bc2bdc12d8c1bd9c95a32951f2c5962";
+    sha256 = "0idisahaqbl88lccsdngpvaliah6dj3gnm76k83jnjv1gjnih2dj";
     fetchSubmodules = true;
   };
 
@@ -40,8 +40,8 @@
 
   stew = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-stew";
-    rev = "b66168735d6f3841c5239c3169d3fe5fe98b1257";
-    sha256 = "10n71vfa6klzd9dmal96jy0hiqk04gaj8wc9g91z6fclryf0yq92";
+    rev = "4382b18f04b3c43c8409bfcd6b62063773b2bbaa";
+    sha256 = "0mx9g5m636h3sk5pllcpylk51brf7lx91izx3gc23k3ih3hrxyk2";
     fetchSubmodules = true;
   };
 
@@ -54,15 +54,15 @@
 
   serialization = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-serialization";
-    rev = "f80cfd8657f272a2abd063d070b77f2a74f704cd";
-    sha256 = "0yc0wha180xnyffr13gnqy303bm6ghgyrgw5h353zscmll2qbm4c";
+    rev = "b0f2fa32960ea532a184394b0f27be37bd80248b";
+    sha256 = "0wip1fjx7ka39ck1g1xvmyarzq1p5dlngpqil6zff8k8z5skiz27";
     fetchSubmodules = true;
   };
 
   json_serialization = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-json-serialization";
-    rev = "a6dcf03e04e179127a5fcb7e495d19a821d56c17";
-    sha256 = "0nn1kllp5khsmy4a412w425pycdsn1x7gfhjl9wmlvvsvjvkw7rm";
+    rev = "c343b0e243d9e17e2c40f3a8a24340f7c4a71d44";
+    sha256 = "0i8sq51nqj8lshf6bfixaz9a7sq0ahsbvq3chkxdvv4khsqvam91";
     fetchSubmodules = true;
   };
 
@@ -110,8 +110,8 @@
 
   zlib = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-zlib";
-    rev = "e680f269fb01af2c34a2ba879ff281795a5258fe";
-    sha256 = "1xw9f1gjsgqihdg7kdkbaq1wankgnx2vn9l3ihc6nqk2jzv5bvk5";
+    rev = "c9e64574438e69f3dd9b64da048f9fffc89e2809";
+    sha256 = "1yj9d3z96pyad0dnb1a1cbl4rwgrzqmbjk8wc7ynh4sbh7nwxh4q";
     fetchSubmodules = true;
   };
 
@@ -159,8 +159,8 @@
 
   websock = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-websock";
-    rev = "42c37b4172519566db016810eccfce8a02cc1cdf";
-    sha256 = "1l5laqyvfbldiii1vrp1crx56lvbdn1xm5hbnl3mcihbn18lzvxg";
+    rev = "387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d";
+    sha256 = "1v0m3x96fbp9jdzsys6mbxxc2xw3k3dqiv7wksfla89gc6z8w377";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
## Summary
- Bumps the `status-im/nim-websock` pin used by `.pinned` and Nix dependency metadata.
- Changes the Nimble dependency from a commit-pinned URL to `https://github.com/status-im/nim-websock >= 0.4.0`.
- Refreshes Nix dependency revisions and hashes associated with the dependency set.

## Affected Areas
- [x] Build / Tooling
  - Dependency metadata in `.pinned`, `libp2p.nimble`, and `nix/deps.nix`.
- [x] Other
  - `nim-websock` dependency pin and Nimble requirement.

## Impact on Library Users
Projects resolving dependencies through Nimble can now use `nim-websock >= 0.4.0` instead of the previous commit-pinned dependency. No nim-libp2p source APIs are changed in this diff.

## Risk Assessment
Low code-change risk because this PR only updates dependency metadata. The main risk is dependency resolution or build behavior changing due to the newer `nim-websock` requirement and refreshed Nix dependency revisions.
