### PR TITLE
test(service-disco): misc component

### DIFF
--- a/tests/libp2p/service_discovery/component/test_advertise_discover.nim
+++ b/tests/libp2p/service_discovery/component/test_advertise_discover.nim
@@ -259,3 +259,35 @@ suite "Service Discovery Component - Advertise Discover":
       .wait(5.seconds)
 
     check registrarNode.countAdsInCache(serviceId) == 0
+
+  asyncTest "auto-advertise on start":
+    # Using ipSimCoefficient = 0.0 to not trigger sybil protection when advertising multiple services
+    # TODO: vacp2p/nim-libp2p#2430 service-disco: missing API for multi-service registration
+    let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0, ipSimCoefficient = 0.0)
+    let registrarNode = setupServiceDiscoveryNode(discoConfig = conf)
+    let discovererNode = setupServiceDiscoveryNode(discoConfig = conf)
+
+    startAndDeferStop(@[registrarNode, discovererNode])
+    await connect(registrarNode, discovererNode)
+
+    let serviceA = makeServiceInfo("service-A")
+    let serviceB = makeServiceInfo("service-B")
+    let serviceAId = serviceA.id.hashServiceId()
+    let serviceBId = serviceB.id.hashServiceId()
+    
+    let advertiserNode = setupServiceDiscoveryNode(
+      discoConfig = conf,
+      bootstrapNodes =
+        @[(registrarNode.switch.peerInfo.peerId, registrarNode.switch.peerInfo.addrs)],
+      services = @[serviceA, serviceB],
+    )
+
+    startAndDeferStop(@[advertiserNode])
+
+    checkUntilTimeout:
+      block:
+        let foundA = await discovererNode.lookup(serviceAId)
+        let foundB = await discovererNode.lookup(serviceBId)
+        foundA.isOk() and foundB.isOk() and
+          foundA.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId) and
+          foundB.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId)

--- a/tests/libp2p/service_discovery/component/test_advertise_discover.nim
+++ b/tests/libp2p/service_discovery/component/test_advertise_discover.nim
@@ -210,9 +210,7 @@ suite "Service Discovery Component - Advertise Discover":
 
     let otherKey = otherNode.switch.peerInfo.peerId.toKey()
     checkUntilTimeout:
-      advertiserNode.rtManager.getTable(serviceId).get().buckets.anyIt(
-        it.peers.anyIt(it.nodeId == otherKey)
-      )
+      advertiserNode.rtManager.getTable(serviceId).get().hasPeer(otherKey)
 
   asyncTest "advertiser retries with the ticket after Wait and gets Confirmed":
     # First REGISTER gets Wait + ticket, advertiser sleeps then retries

--- a/tests/libp2p/service_discovery/component/test_advertise_discover.nim
+++ b/tests/libp2p/service_discovery/component/test_advertise_discover.nim
@@ -47,7 +47,7 @@ suite "Service Discovery Component - Advertise Discover":
     let found = await discovererNode.lookup(serviceId)
     check found.isOk()
     check found.get().len >= 1
-    check found.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId)
+    check found.containsPeer(advertiserNode)
 
   asyncTest "registerInterest seeds per-service table from main routing table":
     let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0)
@@ -108,13 +108,8 @@ suite "Service Discovery Component - Advertise Discover":
     checkUntilTimeout:
       block:
         let found = await discovererNode.lookup(serviceId)
-        if found.isOk():
-          let adverts = found.get()
-          adverts.len == 2 and
-            adverts.anyIt(it.data.peerId == advertiserA.switch.peerInfo.peerId) and
-            adverts.anyIt(it.data.peerId == advertiserB.switch.peerInfo.peerId)
-        else:
-          false
+        found.get().len == 2 and found.containsPeer(advertiserA) and
+          found.containsPeer(advertiserB)
 
   asyncTest "one advertiser provides two services - both discoverable":
     # TODO: vacp2p/nim-libp2p#2430 service-disco: missing API for multi-service registration
@@ -141,9 +136,9 @@ suite "Service Discovery Component - Advertise Discover":
     let foundA = await discovererNode.lookup(svcAId)
     let foundB = await discovererNode.lookup(svcBId)
     check:
-      foundA.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId)
+      foundA.containsPeer(advertiserNode)
       foundA.get().len == 1
-      foundB.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId)
+      foundB.containsPeer(advertiserNode)
       # Regression for vacp2p/nim-libp2p#2431: this lookup previously returned a duplicate.
       foundB.get().len == 1
 
@@ -274,7 +269,7 @@ suite "Service Discovery Component - Advertise Discover":
     let serviceB = makeServiceInfo("service-B")
     let serviceAId = serviceA.id.hashServiceId()
     let serviceBId = serviceB.id.hashServiceId()
-    
+
     let advertiserNode = setupServiceDiscoveryNode(
       discoConfig = conf,
       bootstrapNodes =
@@ -288,6 +283,4 @@ suite "Service Discovery Component - Advertise Discover":
       block:
         let foundA = await discovererNode.lookup(serviceAId)
         let foundB = await discovererNode.lookup(serviceBId)
-        foundA.isOk() and foundB.isOk() and
-          foundA.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId) and
-          foundB.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId)
+        foundA.containsPeer(advertiserNode) and foundB.containsPeer(advertiserNode)

--- a/tests/libp2p/service_discovery/component/test_lookup_get_ads.nim
+++ b/tests/libp2p/service_discovery/component/test_lookup_get_ads.nim
@@ -77,7 +77,7 @@ suite "Service Discovery Component - Lookup Get Ads":
     let found = await discovererNode.lookup(serviceId)
     check found.isOk()
     check found.get().len == 1
-    check found.get()[0].data.peerId == advertiserNode.switch.peerInfo.peerId
+    check found.containsPeer(advertiserNode)
 
   asyncTest "GET_ADS respects F_return limit":
     let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0, fReturn = 2)

--- a/tests/libp2p/service_discovery/component/test_lookup_get_ads.nim
+++ b/tests/libp2p/service_discovery/component/test_lookup_get_ads.nim
@@ -174,3 +174,29 @@ suite "Service Discovery Component - Lookup Get Ads":
     check:
       found.get().len == 1
       found.get()[0].data.peerId == PeerId.init(firstBucketKey).get()
+
+  asyncTest "discoverer learns closer peers from GET_ADS reply":
+    let discovererNode = setupServiceDiscoveryNode()
+    let registrarNode = setupServiceDiscoveryNode()
+    let otherNode = setupServiceDiscoveryNode()
+
+    startAndDeferStop(@[discovererNode, registrarNode, otherNode])
+    await connect(registrarNode, otherNode)
+    await connect(registrarNode, discovererNode)
+
+    let
+      serviceId = "service".hashServiceId()
+      otherKey = otherNode.switch.peerInfo.peerId.toKey()
+
+    check:
+      not discovererNode.rtable.hasPeer(otherKey)
+      discovererNode.rtManager.getTable(serviceId).isNone()
+
+    let found = await discovererNode.lookup(serviceId)
+    check:
+      found.get().len == 0
+
+    let serviceTable = discovererNode.rtManager.getTable(serviceId).get()
+    check:
+      serviceTable.hasPeer(otherKey)
+      discovererNode.rtable.hasPeer(otherKey)

--- a/tests/libp2p/service_discovery/component/test_register.nim
+++ b/tests/libp2p/service_discovery/component/test_register.nim
@@ -4,8 +4,11 @@
 
 import chronos, results
 import
-  ../../../../libp2p/
-    [protocols/service_discovery/advertiser, protocols/service_discovery/types, switch]
+  ../../../../libp2p/[
+    protocols/service_discovery/advertiser,
+    protocols/service_discovery/types,
+    switch,
+  ]
 import ../../../../libp2p/protocols/kademlia/protobuf as kad_protobuf
 import ../../../tools/[lifecycle, unittest]
 import ../utils
@@ -77,3 +80,77 @@ suite "Service Discovery Component - Register":
     )
     check regResp.isOk()
     check regResp.get().status == kad_protobuf.RegistrationStatus.Confirmed
+
+  asyncTest "REGISTER preserves registrar cache seqNo semantics":
+    # Use a non-zero subsecond expiry: the waiting-time formula rounds it down
+    # to zero seconds, while registrar maintenance still has a real interval.
+    let conf = ServiceDiscoveryConfig.new(advertExpiry = 999.millis)
+    let registrarNode = setupServiceDiscoveryNode(discoConfig = conf)
+    let advertiserNode = setupServiceDiscoveryNode(discoConfig = conf)
+
+    startAndDeferStop(@[registrarNode, advertiserNode])
+    await connect(registrarNode, advertiserNode)
+
+    let serviceName = "service"
+    let serviceId = serviceName.hashServiceId()
+    let registrarPeerId = registrarNode.switch.peerInfo.peerId
+    let advertiserKey = advertiserNode.switch.peerInfo.privateKey
+    let addrA = makeMultiAddress("10.0.0.1")
+    let addrB = makeMultiAddress("10.0.0.2")
+    let addrC = makeMultiAddress("10.0.0.3")
+
+    let originalAd =
+      makeAdvertisement(serviceName, advertiserKey, addrs = @[addrA], seqNo = 1)
+    let duplicateSameSeqAd =
+      makeAdvertisement(serviceName, advertiserKey, addrs = @[addrB], seqNo = 1)
+    let newerSeqAd =
+      makeAdvertisement(serviceName, advertiserKey, addrs = @[addrB], seqNo = 2)
+    let staleLowerSeqAd =
+      makeAdvertisement(serviceName, advertiserKey, addrs = @[addrC], seqNo = 1)
+
+    # First REGISTER stores the advertiser's initial seqNo/address pair.
+    var registerResponse = await advertiserNode.sendRegister(
+      registrarPeerId, serviceId, originalAd.encode().get()
+    )
+    check registerResponse.get().status == kad_protobuf.RegistrationStatus.Confirmed
+
+    var cachedAd = registrarNode.getAdsInCache(serviceId)[0]
+    check:
+      cachedAd.data.seqNo == 1
+      cachedAd.data.addresses[0].address == addrA
+
+    # Same peer and same seqNo is a duplicate, even if the payload differs.
+    # The registrar must keep the exact original advertisement.
+    registerResponse = await advertiserNode.sendRegister(
+      registrarPeerId, serviceId, duplicateSameSeqAd.encode().get()
+    )
+    check registerResponse.get().status == kad_protobuf.RegistrationStatus.Confirmed
+
+    cachedAd = registrarNode.getAdsInCache(serviceId)[0]
+    check:
+      cachedAd.envelope.signature.data == originalAd.envelope.signature.data
+      cachedAd.data.seqNo == 1
+      cachedAd.data.addresses[0].address == addrA
+
+    # Same peer with a higher seqNo is newer state, so it replaces the cache.
+    registerResponse = await advertiserNode.sendRegister(
+      registrarPeerId, serviceId, newerSeqAd.encode().get()
+    )
+    check registerResponse.get().status == kad_protobuf.RegistrationStatus.Confirmed
+
+    cachedAd = registrarNode.getAdsInCache(serviceId)[0]
+    check:
+      cachedAd.data.seqNo == 2
+      cachedAd.data.addresses[0].address == addrB
+
+    # Same peer with a lower seqNo is stale and must not replace newer state.
+    registerResponse = await advertiserNode.sendRegister(
+      registrarPeerId, serviceId, staleLowerSeqAd.encode().get()
+    )
+    check registerResponse.get().status == kad_protobuf.RegistrationStatus.Confirmed
+
+    cachedAd = registrarNode.getAdsInCache(serviceId)[0]
+    check:
+      cachedAd.data.seqNo == 2
+      cachedAd.data.addresses[0].address == addrB
+ 

--- a/tests/libp2p/service_discovery/component/test_register.nim
+++ b/tests/libp2p/service_discovery/component/test_register.nim
@@ -4,11 +4,8 @@
 
 import chronos, results
 import
-  ../../../../libp2p/[
-    protocols/service_discovery/advertiser,
-    protocols/service_discovery/types,
-    switch,
-  ]
+  ../../../../libp2p/
+    [protocols/service_discovery/advertiser, protocols/service_discovery/types, switch]
 import ../../../../libp2p/protocols/kademlia/protobuf as kad_protobuf
 import ../../../tools/[lifecycle, unittest]
 import ../utils
@@ -153,4 +150,3 @@ suite "Service Discovery Component - Register":
     check:
       cachedAd.data.seqNo == 2
       cachedAd.data.addresses[0].address == addrB
- 

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -93,6 +93,7 @@ proc setupServiceDiscoveryNode*(
     discoConfig: ServiceDiscoveryConfig = ServiceDiscoveryConfig.new(),
     bootstrapNodes: seq[(PeerId, seq[MultiAddress])] = @[],
     xprPublishing: bool = true,
+    services: seq[ServiceInfo] = @[],
 ): ServiceDiscovery =
   let switch = createSwitch()
   let node = ServiceDiscovery.new(
@@ -100,6 +101,7 @@ proc setupServiceDiscoveryNode*(
     bootstrapNodes = bootstrapNodes,
     config = testKadDHTConfig(),
     rng = rng(),
+    services = services,
     discoConfig = discoConfig,
     xprPublishing = xprPublishing,
   )

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -148,3 +148,10 @@ proc getAdsInCache*(disco: ServiceDiscovery, serviceId: ServiceId): seq[Advertis
 
 proc countAdsInCache*(disco: ServiceDiscovery, serviceId: ServiceId): int =
   disco.getAdsInCache(serviceId).len
+
+proc containsPeer*(
+    response: Result[seq[Advertisement], string], node: ServiceDiscovery
+): bool =
+  response.isOk() and response.get().anyIt(
+    it.data.peerId == node.switch.peerInfo.peerId
+  )

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -126,6 +126,9 @@ proc connect*(disco1, disco2: ServiceDiscovery) {.async.} =
   disco2.switch.peerStore[AddressBook][disco1.switch.peerInfo.peerId] =
     disco1.switch.peerInfo.addrs
 
+proc hasPeer*(rtable: RoutingTable, peerKey: Key): bool =
+  rtable.buckets.anyIt(it.peers.anyIt(it.nodeId == peerKey))
+
 proc populateRoutingTable*(disco: ServiceDiscovery, count: int) =
   for i in 0 ..< count:
     discard disco.rtable.insert(randomPeerId())


### PR DESCRIPTION
# Summary

New tests:
- `auto-advertise on start` confirms a node started with a `services` list advertises all of them automatically.
- `discoverer learns closer peers from GET_ADS reply` checks the lookup path seeds the per-service routing table from peers learned in replies, even when the lookup returns no ads.
- `REGISTER preserves registrar cache seqNo semantics` exercises duplicate / newer / stale seqNo handling.

Refactor:
- New `containsPeer(response, node)` and `hasPeer(rtable, key)` helpers in `tests/libp2p/service_discovery/utils.nim` replace repeated `anyIt(...)` chains across the three component test files.
- `setupServiceDiscoveryNode` gains a `services` parameter so tests can wire up auto-advertising directly.

## Affected Areas

- [x] Tests

## Impact on Library Users

None.

## Risk Assessment

None.