### PR TITLE
chore: pass rng to websock

### DIFF
--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -153,6 +153,12 @@ type WsTransport* = ref object of Transport
 proc secure*(self: WsTransport): bool =
   not (isNil(self.tlsPrivateKey) or isNil(self.tlsCertificate))
 
+proc websockRng(rng: Rng): RandomBytesRng {.raises: [].} =
+  doAssert not rng.isNil, "Rng cannot be nil"
+  proc(dst: var openArray[byte]): bool {.closure, gcsafe, raises: [].} =
+    rng.generate(dst)
+    true
+
 proc notifyAcceptClosed(self: WsTransport) {.raises: [].} =
   if self.acceptResults.isNil:
     return
@@ -341,8 +347,7 @@ method start*(
         except TLSStreamProtocolError as e:
           raise newException(LPError, e.msg, e)
 
-  self.wsserver =
-    WSServer.new(factories = self.factories, rng = bearSslDrbgRef(self.rng))
+  self.wsserver = WSServer.new(factories = self.factories, rng = websockRng(self.rng))
 
   var resolvedAddrs = addrs
   for i, ma in addrs:
@@ -516,7 +521,7 @@ method dial*(
       secure = secure,
       hostName = hostname,
       flags = self.tlsFlags,
-      rng = bearSslDrbgRef(self.rng),
+      rng = websockRng(self.rng),
     )
     return await self.connHandler(transp, secure, Direction.Out)
   except CancelledError as e:


### PR DESCRIPTION
## Summary

Pass the WebSocket transport's libp2p-owned `Rng` to websock through its `RandomBytesRng` closure API.

This removes the direct `bearSslDrbgRef(self.rng)` handoff from WebSocket server and client setup, keeping WebSocket randomness behind libp2p's RNG abstraction as part of the BearSSL-to-BoringSSL migration work.

## Affected Areas

- [x] Transports  
  WebSocket transport RNG wiring for server startup and outbound dialing.

## Impact on Library Users

No public API change. Existing `WsTransport` constructors still take `Rng`; the change is internal to how that RNG is passed to websock.

## Risk Assessment

Low risk. The same `Rng` source is still used, but it now goes through websock's closure-based RNG interface instead of the deprecated BearSSL DRBG overload.
