### PR TITLE
feat: use BoringSSL for noise crypto primitives

### DIFF
--- a/libp2p/crypto/chacha20poly1305.nim
+++ b/libp2p/crypto/chacha20poly1305.nim
@@ -1,19 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-## This module integrates BearSSL ChaCha20+Poly1305
-##
-## This module uses unmodified parts of code from
-## BearSSL library <https://bearssl.org/>
-## Copyright(C) 2018 Thomas Pornin <pornin@bolet.org>.
-
 # RFC @ https://tools.ietf.org/html/rfc7539
 
 {.push raises: [].}
 
-import bearssl/blockx
+import boringssl
 from stew/assign2 import assign
-from stew/ptrops import baseAddr
+import ../utils/sequninit
 
 const
   ChaChaPolyKeySize = 32
@@ -38,9 +32,27 @@ proc intoChaChaPolyTag*(s: openArray[byte]): ChaChaPolyTag =
   assert s.len == ChaChaPolyTagSize
   assign(result, s)
 
-# bearssl allows us to use optimized versions
-# this is reconciled at runtime
-# we do this in the global scope / module init
+template dataPtr(data: var openArray[byte]): ptr uint8 =
+  if data.len > 0:
+    addr data[0]
+  else:
+    nil
+
+template dataPtr(data: openArray[byte]): ptr uint8 =
+  if data.len > 0:
+    unsafeAddr data[0]
+  else:
+    nil
+
+proc newContext(key: ChaChaPolyKey): ptr EVP_AEAD_CTX =
+  let ctx = EVP_AEAD_CTX_new(
+    EVP_aead_chacha20_poly1305(),
+    unsafeAddr key[0],
+    csize_t(key.len),
+    csize_t(ChaChaPolyTagSize),
+  )
+  doAssert not ctx.isNil, "Could not initialize ChaCha20-Poly1305"
+  ctx
 
 proc encrypt*(
     _: type[ChaChaPoly],
@@ -50,24 +62,31 @@ proc encrypt*(
     data: var openArray[byte],
     aad: openArray[byte],
 ) =
-  let ad =
-    if aad.len > 0:
-      unsafeAddr aad[0]
-    else:
-      nil
+  let ctx = newContext(key)
+  defer:
+    EVP_AEAD_CTX_free(ctx)
 
-  poly1305CtmulRun(
-    unsafeAddr key[0],
+  var
+    outLen: csize_t
+    outBuf = newSeqUninit[byte](data.len + ChaChaPolyTagSize)
+
+  let res = EVP_AEAD_CTX_seal(
+    ctx,
+    addr outBuf[0],
+    addr outLen,
+    csize_t(outBuf.len),
     unsafeAddr nonce[0],
-    baseAddr(data),
-    uint(data.len),
-    ad,
-    uint(aad.len),
-    baseAddr(tag),
-    # cast is required to workaround https://github.com/nim-lang/Nim/issues/13905
-    cast[Chacha20Run](chacha20CtRun), #[encrypt]#
-    1.cint,
+    csize_t(nonce.len),
+    data.dataPtr,
+    csize_t(data.len),
+    aad.dataPtr,
+    csize_t(aad.len),
   )
+  doAssert res == 1 and outLen == csize_t(outBuf.len), "ChaCha20-Poly1305 seal failed"
+
+  if data.len > 0:
+    copyMem(addr data[0], addr outBuf[0], data.len)
+  copyMem(addr tag[0], addr outBuf[data.len], tag.len)
 
 proc decrypt*(
     _: type[ChaChaPoly],
@@ -76,22 +95,35 @@ proc decrypt*(
     tag: var ChaChaPolyTag,
     data: var openArray[byte],
     aad: openArray[byte],
-) =
-  let ad =
-    if aad.len > 0:
-      unsafeAddr aad[0]
-    else:
-      nil
+): bool =
+  let ctx = newContext(key)
+  defer:
+    EVP_AEAD_CTX_free(ctx)
 
-  poly1305CtmulRun(
-    unsafeAddr key[0],
+  var inBuf = newSeqUninit[byte](data.len + ChaChaPolyTagSize)
+  if data.len > 0:
+    copyMem(addr inBuf[0], addr data[0], data.len)
+  copyMem(addr inBuf[data.len], addr tag[0], tag.len)
+
+  var
+    outLen: csize_t
+    outBuf = newSeqUninit[byte](max(data.len, 1))
+
+  let res = EVP_AEAD_CTX_open(
+    ctx,
+    addr outBuf[0],
+    addr outLen,
+    csize_t(data.len),
     unsafeAddr nonce[0],
-    baseAddr(data),
-    uint(data.len),
-    ad,
-    uint(aad.len),
-    baseAddr(tag),
-    # cast is required to workaround https://github.com/nim-lang/Nim/issues/13905
-    cast[Chacha20Run](chacha20CtRun), #[decrypt]#
-    0.cint,
+    csize_t(nonce.len),
+    addr inBuf[0],
+    csize_t(inBuf.len),
+    aad.dataPtr,
+    csize_t(aad.len),
   )
+  if res != 1 or outLen != csize_t(data.len):
+    return false
+
+  if data.len > 0:
+    copyMem(addr data[0], addr outBuf[0], data.len)
+  true

--- a/libp2p/crypto/curve25519.nim
+++ b/libp2p/crypto/curve25519.nim
@@ -1,17 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-## This module integrates BearSSL Cyrve25519 mul and mulgen
-##
-## This module uses unmodified parts of code from
-## BearSSL library <https://bearssl.org/>
-## Copyright(C) 2018 Thomas Pornin <pornin@bolet.org>.
-
 # RFC @ https://tools.ietf.org/html/rfc7748
 
 {.push raises: [].}
 
-import bearssl/ec
+import boringssl
 import results
 from stew/assign2 import assign
 import rng
@@ -32,47 +26,23 @@ proc intoCurve25519Key*(s: openArray[byte]): Curve25519Key =
 proc getBytes*(key: Curve25519Key): seq[byte] =
   @key
 
-proc byteswap(buf: var Curve25519Key) {.inline.} =
-  for i in 0 ..< 16:
-    let x = buf[i]
-    buf[i] = buf[31 - i]
-    buf[31 - i] = x
-
-proc mul*(_: type[Curve25519], point: var Curve25519Key, multiplier: Curve25519Key) =
-  let defaultBrEc = ecGetDefault()
-
-  # multiplier needs to be big-endian
-  var multiplierBs = multiplier
-  multiplierBs.byteswap()
-  let res = defaultBrEc.mul(
-    addr point[0],
-    Curve25519KeySize,
-    addr multiplierBs[0],
-    Curve25519KeySize,
-    EC_curve25519,
-  )
-  assert res == 1
+proc mul*(
+    _: type[Curve25519], point: var Curve25519Key, multiplier: Curve25519Key
+): bool =
+  var shared: Curve25519Key
+  let res = X25519(shared, multiplier, point)
+  if res != 1:
+    return false
+  point = shared
+  true
 
 proc mulgen(_: type[Curve25519], dst: var Curve25519Key, point: Curve25519Key) =
-  let defaultBrEc = ecGetDefault()
-
-  var rpoint = point
-  rpoint.byteswap()
-
-  let size =
-    defaultBrEc.mulgen(addr dst[0], addr rpoint[0], Curve25519KeySize, EC_curve25519)
-
-  assert size == Curve25519KeySize
+  X25519_public_from_private(dst, point)
 
 proc public*(private: Curve25519Key): Curve25519Key =
   Curve25519.mulgen(result, private)
 
 proc random*(_: type[Curve25519Key], rng: Rng): Curve25519Key =
-  var res: Curve25519Key
-  let defaultBrEc = ecGetDefault()
-  let len = ecKeygen(bearSslPrng(rng), defaultBrEc, nil, addr res[0], EC_curve25519)
-  # Per bearssl documentation, the keygen only fails if the curve is
-  # unrecognised -
-  doAssert len == Curve25519KeySize, "Could not generate curve"
-
-  res
+  var key: Curve25519Key
+  rng.generate(key)
+  key

--- a/libp2p/crypto/hkdf.nim
+++ b/libp2p/crypto/hkdf.nim
@@ -6,7 +6,7 @@
 {.push raises: [].}
 
 import nimcrypto
-import bearssl/[kdf, hash]
+import boringssl
 
 type HkdfResult*[len: static int] = array[len, byte]
 
@@ -15,33 +15,31 @@ proc hkdf*[T: sha256, len: static int](
     salt, ikm, info: openArray[byte],
     outputs: var openArray[HkdfResult[len]],
 ) =
-  var ctx: HkdfContext
-  hkdfInit(
-    ctx,
-    addr sha256Vtable,
-    if salt.len > 0:
-      unsafeAddr salt[0]
-    else:
-      nil,
-    csize_t(salt.len),
-  )
-  hkdfInject(
-    ctx,
+  if outputs.len == 0:
+    return
+
+  let totalLen = outputs.len * len
+  if totalLen == 0:
+    return
+
+  let res = HKDF(
+    addr outputs[0][0],
+    csize_t(totalLen),
+    EVP_sha256(),
     if ikm.len > 0:
       unsafeAddr ikm[0]
     else:
       nil,
     csize_t(ikm.len),
+    if salt.len > 0:
+      unsafeAddr salt[0]
+    else:
+      nil,
+    csize_t(salt.len),
+    if info.len > 0:
+      unsafeAddr info[0]
+    else:
+      nil,
+    csize_t(info.len),
   )
-  hkdfFlip(ctx)
-  for i in 0 .. outputs.high:
-    discard hkdfProduce(
-      ctx,
-      if info.len > 0:
-        unsafeAddr info[0]
-      else:
-        nil,
-      csize_t(info.len),
-      addr outputs[i][0],
-      csize_t(outputs[i].len),
-    )
+  doAssert res == 1, "HKDF failed"

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -115,9 +115,12 @@ proc hashProtocol(name: string): MDigest[256] =
   else:
     result = sha256.digest(name)
 
-proc dh(priv: Curve25519Key, pub: Curve25519Key): Curve25519Key =
+proc dh(
+    priv: Curve25519Key, pub: Curve25519Key
+): Curve25519Key {.raises: [NoiseHandshakeError].} =
   result = pub
-  Curve25519.mul(result, priv)
+  if not Curve25519.mul(result, priv):
+    raise (ref NoiseHandshakeError)(msg: "Noise DH failed.")
 
 # Cipherstate
 
@@ -153,17 +156,14 @@ proc decryptWithAd(
     state: var CipherState, ad, data: openArray[byte]
 ): seq[byte] {.raises: [NoiseDecryptTagError, NoiseNonceMaxError].} =
   var
-    tagIn = data.toOpenArray(data.len - ChaChaPolyTag.len, data.high).intoChaChaPolyTag
-    tagOut: ChaChaPolyTag
+    tag = data.toOpenArray(data.len - ChaChaPolyTag.len, data.high).intoChaChaPolyTag
     nonce: ChaChaPolyNonce
   nonce[4 ..< 12] = toBytesLE(state.n)
   result = data[0 .. (data.high - ChaChaPolyTag.len)]
-  ChaChaPoly.decrypt(state.k, nonce, tagOut, result, ad)
-  trace "decryptWithAd",
-    tagIn = tagIn.shortLog, tagOut = tagOut.shortLog, nonce = state.n
-  if tagIn != tagOut:
+  if not ChaChaPoly.decrypt(state.k, nonce, tag, result, ad):
     debug "decryptWithAd failed", data = shortLog(data)
     raise (ref NoiseDecryptTagError)(msg: "decryptWithAd failed tag authentication.")
+  trace "decryptWithAd", tag = tag.shortLog, nonce = state.n
   inc state.n
   if state.n > NonceMax:
     raise (ref NoiseNonceMaxError)(msg: "Noise max nonce value reached")

--- a/tests/libp2p/crypto/test_crypto.nim
+++ b/tests/libp2p/crypto/test_crypto.nim
@@ -505,7 +505,7 @@ suite "Key interface test suite":
     ChaChaPoly.encrypt(key, nonce, ntag, text, aed)
     check text.toHex == cipher.toHex
     check ntag.toHex == tag.toHex
-    ChaChaPoly.decrypt(key, nonce, ntag, text, aed)
+    check ChaChaPoly.decrypt(key, nonce, ntag, text, aed)
     check text.toHex == plain.toHex
     check ntag.toHex == tag.toHex
 
@@ -516,7 +516,7 @@ suite "Key interface test suite":
       noaed: array[0, byte]
     ChaChaPoly.encrypt(key, nonce, btag, smallPlain, noaed)
     ntag = btag
-    ChaChaPoly.decrypt(key, nonce, btag, smallPlain, noaed)
+    check ChaChaPoly.decrypt(key, nonce, btag, smallPlain, noaed)
     check ntag.toHex == btag.toHex
 
     # ensure even a 0 byte array works
@@ -527,7 +527,7 @@ suite "Key interface test suite":
         noaed: array[0, byte]
       ChaChaPoly.encrypt(key, nonce, btag, emptyPlain, noaed)
       ntag = btag
-      ChaChaPoly.decrypt(key, nonce, btag, emptyPlain, noaed)
+      check ChaChaPoly.decrypt(key, nonce, btag, emptyPlain, noaed)
       check ntag.toHex == btag.toHex
 
   test "Curve25519":
@@ -546,7 +546,7 @@ suite "Key interface test suite":
         )
         .intoCurve25519Key()
 
-    Curve25519.mul(bearIn, bearOp)
+    check Curve25519.mul(bearIn, bearOp)
     check bearIn == bearOut
 
     # from https://github.com/golang/crypto/blob/1d94cc7ab1c630336ab82ccb9c9cda72a875c382/curve25519/vectors_test.go#L26
@@ -567,7 +567,7 @@ suite "Key interface test suite":
         0xfb, 0x3e, 0xb, 0x40, 0x74,
       ]
 
-    Curve25519.mul(base, private1)
+    check Curve25519.mul(base, private1)
     check base.toHex == public1Test.toHex
 
     # RFC vectors
@@ -598,9 +598,18 @@ suite "Key interface test suite":
     var
       secret1 = p2Pub
       secret2 = p1Pub
-    Curve25519.mul(secret1, private1)
-    Curve25519.mul(secret2, private2)
+    check Curve25519.mul(secret1, private1)
+    check Curve25519.mul(secret2, private2)
     check secret1.toHex == secret2.toHex
+
+    # BoringSSL rejects low-order public points by returning 0 from X25519.
+    # The wrapper should report failure without modifying the caller's point.
+    let lowOrderPoint = fromHex(
+      "e0eb7a7c3b41b8ae1656e3faf19fc46ada098deb9c32b1fd866205165f49b800"
+    ).intoCurve25519Key
+    var point = lowOrderPoint
+    check Curve25519.mul(point, private1) == false
+    check point == lowOrderPoint
 
   test "HKDF 1":
     let


### PR DESCRIPTION
## Summary
Replaces the BearSSL-backed crypto helpers used by Noise with BoringSSL implementations for ChaCha20-Poly1305, Curve25519/X25519, and HKDF.

The change also propagates BoringSSL failure reporting through the Noise path: AEAD decrypt and Curve25519 multiplication now return failure status, and Noise raises a handshake error when DH fails.

## Affected Areas
- [x] Transports: Noise secure channel crypto and handshake error handling.
- [x] Other: crypto primitives in `libp2p/crypto`.

## Impact on Library Users
Direct callers of `ChaChaPoly.decrypt` and `Curve25519.mul` now need to handle the returned `bool`.

## Risk Assessment
The main risk is behavior drift from switching crypto backends, especially around AEAD authentication failures, empty inputs, HKDF output layout, and X25519 low-order point handling.
