### PR TITLE
chore: better names for streams and connections

### DIFF
--- a/cbind/examples/cbindings.c
+++ b/cbind/examples/cbindings.c
@@ -54,8 +54,8 @@ static void peerstore_entry_handler(int callerRet,
                                     const char *msg, size_t len,
                                     void *userData);
 
-static void connection_handler(int callerRet, libp2p_stream_t *conn,
-                               const char *msg, size_t len, void *userData);
+static void stream_handler(int callerRet, libp2p_stream_t *stream,
+                           const char *msg, size_t len, void *userData);
 static void create_cid_handler(int callerRet, const char *msg, size_t len,
                                void *userData);
 static void read_handler(int callerRet, const uint8_t *data, size_t dataLen,
@@ -156,8 +156,7 @@ int main(int argc, char **argv) {
   libp2p_connected_peers(ctx1, Direction_In, peers_handler, NULL);
   waitForCallback();
 
-  libp2p_dial(ctx1, pInfo2.peerId, "/ipfs/ping/1.0.0", connection_handler,
-              NULL);
+  libp2p_dial(ctx1, pInfo2.peerId, "/ipfs/ping/1.0.0", stream_handler, NULL);
   waitForCallback();
 
   uint8_t ping_payload[32] = {0};
@@ -497,14 +496,14 @@ static void get_providers_handler(int callerRet,
   signal_callback_executed();
 }
 
-static void connection_handler(int callerRet, libp2p_stream_t *conn,
-                               const char *msg, size_t len, void *userData) {
+static void stream_handler(int callerRet, libp2p_stream_t *stream,
+                           const char *msg, size_t len, void *userData) {
   if (callerRet != RET_OK) {
     printf("Error(%d): %.*s\n", callerRet, (int)len, msg != NULL ? msg : "");
     exit(1);
   }
 
-  ping_stream = conn;
+  ping_stream = stream;
 
   signal_callback_executed();
 }

--- a/cbind/examples/echo.c
+++ b/cbind/examples/echo.c
@@ -36,8 +36,8 @@ static void event_handler(int callerRet, const char *msg, size_t len,
                           void *userData);
 static void peerinfo_handler(int callerRet, const Libp2pPeerInfo *info,
                              const char *msg, size_t len, void *userData);
-static void connection_handler(int callerRet, libp2p_stream_t *conn,
-                               const char *msg, size_t len, void *userData);
+static void stream_handler(int callerRet, libp2p_stream_t *stream,
+                           const char *msg, size_t len, void *userData);
 static void client_read_handler(int callerRet, const uint8_t *data,
                                 size_t dataLen, const char *msg, size_t len,
                                 void *userData);
@@ -110,7 +110,7 @@ int main(void) {
                  serverInfo.addrCount, 0, event_handler, NULL);
   waitForCallback();
 
-  libp2p_dial(client, serverInfo.peerId, ECHO_PROTO, connection_handler, NULL);
+  libp2p_dial(client, serverInfo.peerId, ECHO_PROTO, stream_handler, NULL);
   waitForCallback();
   if (client_stream == NULL) {
     printf("Error: dial did not return a stream\n");
@@ -223,8 +223,8 @@ static void peerinfo_handler(int callerRet, const Libp2pPeerInfo *info,
   signal_callback_executed();
 }
 
-static void connection_handler(int callerRet, libp2p_stream_t *conn,
-                               const char *msg, size_t len, void *userData) {
+static void stream_handler(int callerRet, libp2p_stream_t *stream,
+                           const char *msg, size_t len, void *userData) {
   (void)userData;
   if (callerRet != RET_OK) {
     printf("Dial error(%d): %.*s\n", callerRet, (int)len,
@@ -232,7 +232,7 @@ static void connection_handler(int callerRet, libp2p_stream_t *conn,
     exit(1);
   }
 
-  client_stream = conn;
+  client_stream = stream;
   signal_callback_executed();
 }
 

--- a/cbind/ffi_types.nim
+++ b/cbind/ffi_types.nim
@@ -98,11 +98,11 @@ type RandomRecordsCallback* = proc(
 ) {.cdecl, gcsafe, raises: [].}
 
 type Libp2pStream* = object
-  conn*: pointer
+  stream*: pointer
 
-type ConnectionCallback* = proc(
+type StreamCallback* = proc(
   callerRet: cint,
-  conn: ptr Libp2pStream,
+  stream: ptr Libp2pStream,
   msg: ptr cchar,
   len: csize_t,
   userData: pointer,

--- a/cbind/libp2p.h
+++ b/cbind/libp2p.h
@@ -252,10 +252,10 @@ typedef void (*PeersCallback)(int callerRet, const char **peerIds,
                               size_t peerIdsLen, const char *msg, size_t len,
                               void *userData);
 
-// ConnectionCallback returns a stream handle that must be released with
+// StreamCallback returns a stream handle that must be released with
 // libp2p_stream_release when no longer needed.
-typedef void (*ConnectionCallback)(int callerRet, libp2p_stream_t *conn,
-                                   const char *msg, size_t len, void *userData);
+typedef void (*StreamCallback)(int callerRet, libp2p_stream_t *stream,
+                               const char *msg, size_t len, void *userData);
 
 // Protocol handlers run on the libp2p worker thread. They must not block while
 // waiting for libp2p callbacks. Use the asynchronous libp2p_stream_* APIs and
@@ -347,7 +347,7 @@ int libp2p_start(libp2p_ctx_t *ctx, Libp2pCallback callback, void *userData);
 
 int libp2p_stop(libp2p_ctx_t *ctx, Libp2pCallback callback, void *userData);
 
-// === Connection APIs ===
+// === Peer Connection APIs ===
 
 int libp2p_connect(libp2p_ctx_t *ctx, const char *peerId,
                    const char **multiaddrs, size_t multiaddrsLen,
@@ -367,7 +367,7 @@ int libp2p_connected_peers(libp2p_ctx_t *ctx, Direction dir,
 // === Stream APIs ===
 
 int libp2p_dial(libp2p_ctx_t *ctx, const char *peerId, const char *proto,
-                ConnectionCallback callback, void *userData);
+                StreamCallback callback, void *userData);
 
 // Mounts a custom protocol handler. The handler receives incoming streams for
 // proto and must eventually call libp2p_stream_release on each stream.
@@ -376,34 +376,34 @@ int libp2p_mount_protocol(libp2p_ctx_t *ctx, const char *proto,
                           Libp2pCallback callback, void *userData);
 
 // Read callbacks receive a buffer that is freed immediately after the callback.
-int libp2p_stream_readExactly(libp2p_ctx_t *ctx, libp2p_stream_t *conn,
+int libp2p_stream_readExactly(libp2p_ctx_t *ctx, libp2p_stream_t *stream,
                               size_t dataLen, Libp2pBufferCallback callback,
                               void *userData);
 
-int libp2p_stream_readLp(libp2p_ctx_t *ctx, libp2p_stream_t *conn,
+int libp2p_stream_readLp(libp2p_ctx_t *ctx, libp2p_stream_t *stream,
                          int64_t maxSize, Libp2pBufferCallback callback,
                          void *userData);
 
 // Write calls copy the input buffer before enqueueing; data can be freed after
 // the function returns.
-int libp2p_stream_write(libp2p_ctx_t *ctx, libp2p_stream_t *conn,
+int libp2p_stream_write(libp2p_ctx_t *ctx, libp2p_stream_t *stream,
                         const uint8_t *data, size_t dataLen,
                         Libp2pCallback callback, void *userData);
 
-int libp2p_stream_writeLp(libp2p_ctx_t *ctx, libp2p_stream_t *conn,
+int libp2p_stream_writeLp(libp2p_ctx_t *ctx, libp2p_stream_t *stream,
                           const uint8_t *data, size_t dataLen,
                           Libp2pCallback callback, void *userData);
 
-int libp2p_stream_close(libp2p_ctx_t *ctx, libp2p_stream_t *conn,
+int libp2p_stream_close(libp2p_ctx_t *ctx, libp2p_stream_t *stream,
                         Libp2pCallback callback, void *userData);
 
 // Closes the stream and then sends EOF to the remote side.
-int libp2p_stream_closeWithEOF(libp2p_ctx_t *ctx, libp2p_stream_t *conn,
+int libp2p_stream_closeWithEOF(libp2p_ctx_t *ctx, libp2p_stream_t *stream,
                                Libp2pCallback callback, void *userData);
 
-// Releases the local stream handle. After this, conn must not be used again.
+// Releases the local stream handle. After this, stream must not be used again.
 // You usually call close/closeWithEOF first, then release.
-int libp2p_stream_release(libp2p_ctx_t *ctx, libp2p_stream_t *conn,
+int libp2p_stream_release(libp2p_ctx_t *ctx, libp2p_stream_t *stream,
                           Libp2pCallback callback, void *userData);
 
 // === Pubsub APIs ===
@@ -512,7 +512,7 @@ int libp2p_public_key(libp2p_ctx_t *ctx, Libp2pBufferCallback callback,
 // from libp2p_circuit_relay_reserve with "/p2p-circuit" appended by the caller.
 int libp2p_dial_circuit_relay(libp2p_ctx_t *ctx, const char *dstPeerId,
                               const char *multiaddr, const char *proto,
-                              ConnectionCallback callback, void *userData);
+                              StreamCallback callback, void *userData);
 
 // Reserves a relay slot on relayPeerId, requires circuit_relay_client=1.
 // The callback receives relay addresses (without /p2p-circuit suffix).

--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -64,19 +64,19 @@ template failWithBufferMsg(
   callback(RET_ERR.cint, nil, 0, msgPtr, msgLen, userData)
   return RET_ERR.cint
 
-template failIfConnNil(
-    conn: ptr Libp2pStream, callback: Libp2pCallback, userData: pointer, msg: string
+template failIfStreamNil(
+    stream: ptr Libp2pStream, callback: Libp2pCallback, userData: pointer, msg: string
 ) =
-  if conn.isNil():
+  if stream.isNil():
     failWithMsg(callback, userData, msg)
 
-template failIfConnNil(
-    conn: ptr Libp2pStream,
+template failIfStreamNil(
+    stream: ptr Libp2pStream,
     callback: Libp2pBufferCallback,
     userData: pointer,
     msg: string,
 ) =
-  if conn.isNil():
+  if stream.isNil():
     failWithBufferMsg(callback, userData, msg)
 
 template failIfDataMissing(
@@ -444,7 +444,7 @@ proc libp2p_dial(
     ctx: ptr LibP2PContext,
     peerId: cstring,
     proto: cstring,
-    callback: ConnectionCallback,
+    callback: ffi_types.StreamCallback,
     userData: pointer,
 ): cint {.dynlib, exportc, cdecl.} =
   initializeLibrary()
@@ -515,7 +515,7 @@ proc libp2p_public_key(
 
 proc libp2p_stream_readExactly(
     ctx: ptr LibP2PContext,
-    conn: ptr Libp2pStream,
+    stream: ptr Libp2pStream,
     dataLen: csize_t,
     callback: Libp2pBufferCallback,
     userData: pointer,
@@ -523,13 +523,13 @@ proc libp2p_stream_readExactly(
   initializeLibrary()
   checkLibParams(ctx, callback, userData)
 
-  failIfConnNil(conn, callback, userData, "connection is not set 1")
+  failIfStreamNil(stream, callback, userData, "stream is not set")
 
   libp2p_thread.sendRequestToLibP2PThread(
     ctx,
     RequestType.STREAM,
     StreamRequest.createShared(
-      StreamMsgType.READEXACTLY, conn = conn, readLen = dataLen
+      StreamMsgType.READEXACTLY, stream = stream, readLen = dataLen
     ),
     callback,
     CallbackKind.READ,
@@ -543,7 +543,7 @@ proc libp2p_stream_readExactly(
 
 proc libp2p_stream_readLp(
     ctx: ptr LibP2PContext,
-    conn: ptr Libp2pStream,
+    stream: ptr Libp2pStream,
     maxSize: int64,
     callback: Libp2pBufferCallback,
     userData: pointer,
@@ -551,12 +551,12 @@ proc libp2p_stream_readLp(
   initializeLibrary()
   checkLibParams(ctx, callback, userData)
 
-  failIfConnNil(conn, callback, userData, "connection is not set")
+  failIfStreamNil(stream, callback, userData, "stream is not set")
 
   libp2p_thread.sendRequestToLibP2PThread(
     ctx,
     RequestType.STREAM,
-    StreamRequest.createShared(StreamMsgType.READLP, conn = conn, maxSize = maxSize),
+    StreamRequest.createShared(StreamMsgType.READLP, stream = stream, maxSize = maxSize),
     callback,
     CallbackKind.READ,
     userData,
@@ -569,7 +569,7 @@ proc libp2p_stream_readLp(
 
 proc libp2p_stream_write(
     ctx: ptr LibP2PContext,
-    conn: ptr Libp2pStream,
+    stream: ptr Libp2pStream,
     data: ptr byte,
     dataLen: csize_t,
     callback: Libp2pCallback,
@@ -578,7 +578,7 @@ proc libp2p_stream_write(
   initializeLibrary()
   checkLibParams(ctx, callback, userData)
 
-  failIfConnNil(conn, callback, userData, "connection is not set")
+  failIfStreamNil(stream, callback, userData, "stream is not set")
 
   failIfDataMissing(data, dataLen, callback, userData)
 
@@ -586,7 +586,7 @@ proc libp2p_stream_write(
     ctx,
     RequestType.STREAM,
     StreamRequest.createShared(
-      StreamMsgType.WRITE, conn = conn, data = data, dataLen = dataLen
+      StreamMsgType.WRITE, stream = stream, data = data, dataLen = dataLen
     ),
     callback,
     userData,
@@ -599,7 +599,7 @@ proc libp2p_stream_write(
 
 proc libp2p_stream_writeLp(
     ctx: ptr LibP2PContext,
-    conn: ptr Libp2pStream,
+    stream: ptr Libp2pStream,
     data: ptr byte,
     dataLen: csize_t,
     callback: Libp2pCallback,
@@ -608,7 +608,7 @@ proc libp2p_stream_writeLp(
   initializeLibrary()
   checkLibParams(ctx, callback, userData)
 
-  failIfConnNil(conn, callback, userData, "connection is not set")
+  failIfStreamNil(stream, callback, userData, "stream is not set")
 
   failIfDataMissing(data, dataLen, callback, userData)
 
@@ -616,7 +616,7 @@ proc libp2p_stream_writeLp(
     ctx,
     RequestType.STREAM,
     StreamRequest.createShared(
-      StreamMsgType.WRITELP, conn = conn, data = data, dataLen = dataLen
+      StreamMsgType.WRITELP, stream = stream, data = data, dataLen = dataLen
     ),
     callback,
     userData,
@@ -627,19 +627,19 @@ proc libp2p_stream_writeLp(
 
 proc libp2p_stream_close(
     ctx: ptr LibP2PContext,
-    conn: ptr Libp2pStream,
+    stream: ptr Libp2pStream,
     callback: Libp2pCallback,
     userData: pointer,
 ): cint {.dynlib, exportc, cdecl.} =
   initializeLibrary()
   checkLibParams(ctx, callback, userData)
 
-  failIfConnNil(conn, callback, userData, "connection is not set")
+  failIfStreamNil(stream, callback, userData, "stream is not set")
 
   libp2p_thread.sendRequestToLibP2PThread(
     ctx,
     RequestType.STREAM,
-    StreamRequest.createShared(StreamMsgType.CLOSE, conn = conn),
+    StreamRequest.createShared(StreamMsgType.CLOSE, stream = stream),
     callback,
     userData,
   ).isOkOr:
@@ -649,19 +649,19 @@ proc libp2p_stream_close(
 
 proc libp2p_stream_closeWithEOF(
     ctx: ptr LibP2PContext,
-    conn: ptr Libp2pStream,
+    stream: ptr Libp2pStream,
     callback: Libp2pCallback,
     userData: pointer,
 ): cint {.dynlib, exportc, cdecl.} =
   initializeLibrary()
   checkLibParams(ctx, callback, userData)
 
-  failIfConnNil(conn, callback, userData, "connection is not set")
+  failIfStreamNil(stream, callback, userData, "stream is not set")
 
   libp2p_thread.sendRequestToLibP2PThread(
     ctx,
     RequestType.STREAM,
-    StreamRequest.createShared(StreamMsgType.CLOSE_WITH_EOF, conn = conn),
+    StreamRequest.createShared(StreamMsgType.CLOSE_WITH_EOF, stream = stream),
     callback,
     userData,
   ).isOkOr:
@@ -671,19 +671,19 @@ proc libp2p_stream_closeWithEOF(
 
 proc libp2p_stream_release(
     ctx: ptr LibP2PContext,
-    conn: ptr Libp2pStream,
+    stream: ptr Libp2pStream,
     callback: Libp2pCallback,
     userData: pointer,
 ): cint {.dynlib, exportc, cdecl.} =
   initializeLibrary()
   checkLibParams(ctx, callback, userData)
 
-  failIfConnNil(conn, callback, userData, "connection is not set")
+  failIfStreamNil(stream, callback, userData, "stream is not set")
 
   libp2p_thread.sendRequestToLibP2PThread(
     ctx,
     RequestType.STREAM,
-    StreamRequest.createShared(StreamMsgType.RELEASE, conn = conn),
+    StreamRequest.createShared(StreamMsgType.RELEASE, stream = stream),
     callback,
     userData,
   ).isOkOr:
@@ -1195,7 +1195,7 @@ proc libp2p_dial_circuit_relay(
     peerId: cstring,
     multiaddr: cstring,
     proto: cstring,
-    callback: ConnectionCallback,
+    callback: ffi_types.StreamCallback,
     userData: pointer,
 ): cint {.dynlib, exportc, cdecl.} =
   initializeLibrary()

--- a/cbind/libp2p_thread/inter_thread_communication/libp2p_thread_request.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/libp2p_thread_request.nim
@@ -37,7 +37,7 @@ type CallbackKind* {.pure.} = enum
   GET_PROVIDERS
   RANDOM_RECORDS
   CONNECTED_PEERS
-  CONNECTION
+  STREAM
   READ
   RESERVATION
 
@@ -414,22 +414,22 @@ proc processKademlia(
   else:
     handleRes(await kadReq.process(kad), request)
 
-proc handleConnectionRes(
+proc handleStreamRes(
     res: Result[ptr Libp2pStream, string], request: ptr LibP2PThreadRequest
 ) =
   defer:
     deallocShared(request)
 
-  let cb = cast[ConnectionCallback](request[].callback)
+  let cb = cast[ffi_types.StreamCallback](request[].callback)
 
-  let conn = res.valueOr:
+  let stream = res.valueOr:
     foreignThreadGc:
       let msg = $error
       cb(RET_ERR.cint, nil, msg[0].addr, cast[csize_t](len(msg)), request[].userData)
     return
 
   foreignThreadGc:
-    cb(RET_OK.cint, conn, nil, 0, request[].userData)
+    cb(RET_OK.cint, stream, nil, 0, request[].userData)
 
 proc processStream(
     request: ptr LibP2PThreadRequest, libp2p: ptr LibP2P
@@ -437,9 +437,9 @@ proc processStream(
   let req = cast[ptr StreamRequest](request[].reqContent)
   case req[].operation
   of StreamMsgType.DIAL:
-    handleConnectionRes(await req.processDial(libp2p), request)
+    handleStreamRes(await req.processDial(libp2p), request)
   of StreamMsgType.DIAL_CIRCUIT_RELAY:
-    handleConnectionRes(await req.processDialCircuitRelay(libp2p), request)
+    handleStreamRes(await req.processDialCircuitRelay(libp2p), request)
   of StreamMsgType.CLOSE, StreamMsgType.CLOSE_WITH_EOF:
     handleRes(await req.processClose(libp2p), request)
   of StreamMsgType.RELEASE:

--- a/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_lifecycle_requests.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_lifecycle_requests.nim
@@ -307,7 +307,7 @@ proc createLibp2p(appCallbacks: AppCallbacks, config: Libp2pConfig): LibP2P =
     kad: Opt.none(KadDHT),
     relayClient: relayClientOpt,
     topicHandlers: initTable[PubsubTopicPair, TopicHandlerEntry](),
-    connections: initTable[ptr Libp2pStream, Connection](),
+    streams: initTable[ptr Libp2pStream, Stream](),
     streamReleaseWaiters:
       initTable[ptr Libp2pStream, Future[void].Raising([CancelledError])](),
     customProtocols: initTable[string, LPProtocol](),

--- a/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_protocol_requests.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_protocol_requests.nim
@@ -61,18 +61,18 @@ proc processMount*(
     protocolUserData = self[].protocolUserData
 
   proc handle(
-      conn: Connection, selectedProto: string
+      stream: Stream, selectedProto: string
   ) {.async: (raises: [CancelledError]).} =
-    let stream = cast[ptr Libp2pStream](createShared(Libp2pStream, 1))
-    stream[].conn = cast[pointer](conn)
+    let streamHandle = cast[ptr Libp2pStream](createShared(Libp2pStream, 1))
+    streamHandle[].stream = cast[pointer](stream)
     # The C handler is callback-based and returns before read/write callbacks
     # finish. Waiting here prevents multistream from closing the incoming stream
     # until C explicitly releases its stream handle.
     let releaseWaiter =
       Future[void].Raising([CancelledError]).init("cbind custom protocol release")
 
-    libp2p[].connections[stream] = conn
-    libp2p[].streamReleaseWaiters[stream] = releaseWaiter
+    libp2p[].streams[streamHandle] = stream
+    libp2p[].streamReleaseWaiters[streamHandle] = releaseWaiter
 
     try:
       foreignThreadGc:
@@ -82,17 +82,21 @@ proc processMount*(
           else:
             cast[ptr cchar](nil)
         handler(
-          ctx, stream, protoPtr, cast[csize_t](selectedProto.len), protocolUserData
+          ctx,
+          streamHandle,
+          protoPtr,
+          cast[csize_t](selectedProto.len),
+          protocolUserData,
         )
 
       await releaseWaiter
     finally:
-      if libp2p[].streamReleaseWaiters.hasKey(stream):
-        libp2p[].streamReleaseWaiters.del(stream)
+      if libp2p[].streamReleaseWaiters.hasKey(streamHandle):
+        libp2p[].streamReleaseWaiters.del(streamHandle)
 
-      if libp2p[].connections.hasKey(stream):
-        libp2p[].connections.del(stream)
-        deallocShared(stream)
+      if libp2p[].streams.hasKey(streamHandle):
+        libp2p[].streams.del(streamHandle)
+        deallocShared(streamHandle)
 
   let mountedProtocol = LPProtocol.new(codecs = @[proto], handler = handle)
   await mountedProtocol.start()

--- a/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_stream_requests.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_stream_requests.nim
@@ -22,7 +22,7 @@ type StreamRequest* = object
   peerId: cstring
   multiaddr: cstring
   proto: cstring
-  connHandle: ptr Libp2pStream
+  streamHandle: ptr Libp2pStream
   data: SharedSeq[byte] ## Only used for WRITE/WRITELP
   readLen: csize_t ## Only used for READEXACTLY
   maxSize: int64 ## Only used for READLP
@@ -33,7 +33,7 @@ proc createShared*(
     peerId: cstring = "",
     multiaddr: cstring = "",
     proto: cstring = "",
-    conn: ptr Libp2pStream = nil,
+    stream: ptr Libp2pStream = nil,
     data: ptr byte = nil,
     dataLen: csize_t = 0,
     readLen: csize_t = 0,
@@ -44,7 +44,7 @@ proc createShared*(
   ret[].peerId = peerId.alloc()
   ret[].multiaddr = multiaddr.alloc()
   ret[].proto = proto.alloc()
-  ret[].connHandle = conn
+  ret[].streamHandle = stream
   ret[].data = allocSharedSeqFromCArray(data, dataLen.int)
   ret[].readLen = readLen
   ret[].maxSize = maxSize
@@ -65,15 +65,15 @@ proc processDial*(
 
   let peerId = PeerId.init($self[].peerId).valueOr:
     return err($error)
-  let conn =
+  let stream =
     try:
       await libp2p.switch.dial(peerId, $self[].proto)
     except DialFailedError as exc:
       return err(exc.msg)
 
   let handle = cast[ptr Libp2pStream](createShared(Libp2pStream, 1))
-  handle[].conn = cast[pointer](conn)
-  libp2p[].connections[handle] = conn
+  handle[].stream = cast[pointer](stream)
+  libp2p[].streams[handle] = stream
 
   return ok(handle)
 
@@ -88,15 +88,15 @@ proc processDialCircuitRelay*(
   let relayCircuitAddr = MultiAddress.init($self[].multiaddr).valueOr:
     return err($error)
 
-  let conn =
+  let stream =
     try:
       await libp2p.switch.dial(dstPeerId, @[relayCircuitAddr], $self[].proto)
     except DialFailedError as exc:
       return err(exc.msg)
 
   let handle = cast[ptr Libp2pStream](createShared(Libp2pStream, 1))
-  handle[].conn = cast[pointer](conn)
-  libp2p[].connections[handle] = conn
+  handle[].stream = cast[pointer](stream)
+  libp2p[].streams[handle] = stream
   return ok(handle)
 
 proc processClose*(
@@ -105,19 +105,19 @@ proc processClose*(
   defer:
     destroyShared(self)
 
-  let handle = self[].connHandle
+  let handle = self[].streamHandle
   if handle.isNil():
-    return err("invalid connection handle")
+    return err("invalid stream handle")
 
-  let conn = libp2p[].connections.getOrDefault(handle, nil)
-  if conn.isNil():
-    return err("unknown connection handle")
+  let stream = libp2p[].streams.getOrDefault(handle, nil)
+  if stream.isNil():
+    return err("unknown stream handle")
 
   case self.operation
   of CLOSE:
-    await conn.close()
+    await stream.close()
   of CLOSE_WITH_EOF:
-    await conn.closeWithEOF()
+    await stream.closeWithEOF()
   else:
     raiseAssert "unsupported operation"
 
@@ -129,12 +129,12 @@ proc processRelease*(
   defer:
     destroyShared(self)
 
-  let handle = self[].connHandle
+  let handle = self[].streamHandle
   if handle.isNil():
-    return err("invalid connection handle")
+    return err("invalid stream handle")
 
-  if not libp2p[].connections.hasKey(handle):
-    return err("unknown connection handle")
+  if not libp2p[].streams.hasKey(handle):
+    return err("unknown stream handle")
 
   # For incoming custom-protocol streams, release completes the Nim protocol
   # handler that has been waiting for C to finish its callback chain.
@@ -148,7 +148,7 @@ proc processRelease*(
     if not releaseWaiter.finished:
       releaseWaiter.complete()
 
-  libp2p[].connections.del(handle)
+  libp2p[].streams.del(handle)
   deallocShared(handle)
 
   return ok()
@@ -159,20 +159,20 @@ proc processWrite*(
   defer:
     destroyShared(self)
 
-  let handle = self[].connHandle
+  let handle = self[].streamHandle
   if handle.isNil():
-    return err("invalid connection handle")
+    return err("invalid stream handle")
 
-  let conn = libp2p[].connections.getOrDefault(handle, nil)
-  if conn.isNil():
-    return err("unknown connection handle")
+  let stream = libp2p[].streams.getOrDefault(handle, nil)
+  if stream.isNil():
+    return err("unknown stream handle")
 
   try:
     case self.operation
     of WRITE:
-      await conn.write(self[].data.toSeq())
+      await stream.write(self[].data.toSeq())
     of WRITELP:
-      await conn.writeLp(self[].data.toSeq())
+      await stream.writeLp(self[].data.toSeq())
     else:
       raiseAssert "unsupported operation in processWrite"
   except LPStreamError as exc:
@@ -186,13 +186,13 @@ proc processRead*(
   defer:
     destroyShared(self)
 
-  let handle = self[].connHandle
+  let handle = self[].streamHandle
   if handle.isNil():
-    return err("invalid connection handle")
+    return err("invalid stream handle")
 
-  let conn = libp2p[].connections.getOrDefault(handle, nil)
-  if conn.isNil():
-    return err("unknown connection handle")
+  let stream = libp2p[].streams.getOrDefault(handle, nil)
+  if stream.isNil():
+    return err("unknown stream handle")
 
   try:
     case self.operation
@@ -203,12 +203,12 @@ proc processRead*(
       if expected == 0:
         return ok(allocReadResponse(@[]))
       var buf = newSeqUninit[byte](expected)
-      await conn.readExactly(addr buf[0], expected)
+      await stream.readExactly(addr buf[0], expected)
       return ok(allocReadResponse(buf))
     of READLP:
       if self[].maxSize > int64(int.high) or self[].maxSize < int64(int.low):
         return err("maxSize out of range")
-      let data = await conn.readLp(int(self[].maxSize))
+      let data = await stream.readLp(int(self[].maxSize))
       return ok(allocReadResponse(data))
     else:
       raiseAssert "unsupported operation in processRead"

--- a/cbind/libp2p_thread/libp2p_thread.nim
+++ b/cbind/libp2p_thread/libp2p_thread.nim
@@ -254,12 +254,12 @@ proc sendRequestToLibP2PThread*(
     ctx: ptr LibP2PContext,
     reqType: RequestType,
     reqContent: pointer,
-    callback: ConnectionCallback,
+    callback: ffi_types.StreamCallback,
     userData: pointer,
 ): Result[void, string] =
-  ## Sends a request to the LibP2P thread for connection callbacks
+  ## Sends a request to the LibP2P thread for stream callbacks
   sendRequest(
-    ctx, reqType, reqContent, userData, CallbackKind.CONNECTION, cast[pointer](callback)
+    ctx, reqType, reqContent, userData, CallbackKind.STREAM, cast[pointer](callback)
   )
 
 proc sendRequestToLibP2PThread*(

--- a/cbind/types.nim
+++ b/cbind/types.nim
@@ -29,6 +29,6 @@ type LibP2P* = ref object
   kad*: Opt[KadDHT]
   relayClient*: Opt[RelayClient]
   topicHandlers*: Table[PubsubTopicPair, TopicHandlerEntry]
-  connections*: Table[ptr Libp2pStream, Connection]
+  streams*: Table[ptr Libp2pStream, Stream]
   streamReleaseWaiters*: Table[ptr Libp2pStream, Future[void].Raising([CancelledError])]
   customProtocols*: Table[string, LPProtocol]

--- a/examples/circuitrelay.nim
+++ b/examples/circuitrelay.nim
@@ -28,17 +28,17 @@ proc main() {.async.} =
   var proto = new LPProtocol
   proto.codec = customProtoCodec
   proto.handler = proc(
-      conn: Connection, proto: string
+      stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     try:
-      var msg = string.fromBytes(await conn.readLp(1024))
+      var msg = string.fromBytes(await stream.readLp(1024))
       echo "1 - Dst Received: ", msg
       assert "test1" == msg
-      await conn.writeLp("test2")
-      msg = string.fromBytes(await conn.readLp(1024))
+      await stream.writeLp("test2")
+      msg = string.fromBytes(await stream.readLp(1024))
       echo "2 - Dst Received: ", msg
       assert "test3" == msg
-      await conn.writeLp("test4")
+      await stream.writeLp("test4")
     except LPStreamError as exc:
       echo "exception in handler", exc.msg
 
@@ -75,14 +75,14 @@ proc main() {.async.} =
   let rsvp = await clDst.reserve(swRel.peerInfo.peerId, swRel.peerInfo.addrs)
 
   # Src dial Dst using the relay
-  let conn = await swSrc.dial(swDst.peerInfo.peerId, @[addrs], customProtoCodec)
+  let stream = await swSrc.dial(swDst.peerInfo.peerId, @[addrs], customProtoCodec)
 
-  await conn.writeLp("test1")
-  var msg = string.fromBytes(await conn.readLp(1024))
+  await stream.writeLp("test1")
+  var msg = string.fromBytes(await stream.readLp(1024))
   echo "1 - Src Received: ", msg
   assert "test2" == msg
-  await conn.writeLp("test3")
-  msg = string.fromBytes(await conn.readLp(1024))
+  await stream.writeLp("test3")
+  msg = string.fromBytes(await stream.readLp(1024))
   echo "2 - Src Received: ", msg
   assert "test4" == msg
 

--- a/examples/directchat.nim
+++ b/examples/directchat.nim
@@ -17,7 +17,7 @@ const Help = """
 type Chat = ref object
   switch: Switch # a single entry point for dialing and listening to peer
   stdinReader: StreamTransport # transport streams between read & write file descriptor
-  conn: Connection # connection to the other peer
+  stream: Stream # stream to the other peer
   connected: bool # if the node is connected to another peer
 
 ##
@@ -42,10 +42,10 @@ type ChatProto = ref object of LPProtocol
 proc new(T: typedesc[ChatProto], c: Chat): T =
   let chatproto = T()
 
-  # create handler for incoming connection
-  proc handle(stream: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+  # create handler for incoming stream
+  proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
     try:
-      if c.connected and not c.conn.closed:
+      if c.connected and not c.stream.closed:
         c.writeStdout "a chat session is already in progress - refusing incoming peer!"
       else:
         await c.handlePeer(stream)
@@ -63,24 +63,24 @@ proc new(T: typedesc[ChatProto], c: Chat): T =
 # Chat application
 ##
 proc handlePeer(
-    c: Chat, conn: Connection
+    c: Chat, stream: Stream
 ) {.async: (raises: [CancelledError, IOError]).} =
   # Handle a peer (incoming or outgoing)
   try:
-    c.conn = conn
+    c.stream = stream
     c.connected = true
-    c.writeStdout $conn.peerId & " connected"
+    c.writeStdout $stream.peerId & " connected"
 
     # Read loop
     while true:
       let
-        strData = await conn.readLp(1024)
+        strData = await stream.readLp(1024)
         str = string.fromBytes(strData)
-      c.writeStdout $conn.peerId & ": " & $str
+      c.writeStdout $stream.peerId & ": " & $str
   except LPStreamError:
     defer:
-      c.writeStdout $conn.peerId & " disconnected"
-    await c.conn.close()
+      c.writeStdout $stream.peerId & " disconnected"
+    await c.stream.close()
     c.connected = false
 
 proc dialPeer(c: Chat, address: string) {.async.} =
@@ -113,8 +113,8 @@ proc readLoop(c: Chat) {.async.} =
 
     if line.startsWith("/disconnect"):
       c.writeStdout "Ending current session"
-      if c.connected and c.conn.closed.not:
-        await c.conn.close()
+      if c.connected and c.stream.closed.not:
+        await c.stream.close()
       c.connected = false
     elif line.startsWith("/connect"):
       c.writeStdout "enter address of remote peer"
@@ -122,8 +122,8 @@ proc readLoop(c: Chat) {.async.} =
       if address.len > 0:
         await c.dialPeer(address)
     elif line.startsWith("/exit"):
-      if c.connected and c.conn.closed.not:
-        await c.conn.close()
+      if c.connected and c.stream.closed.not:
+        await c.stream.close()
         c.connected = false
 
       await c.switch.stop()
@@ -131,7 +131,7 @@ proc readLoop(c: Chat) {.async.} =
       return
     else:
       if c.connected:
-        await c.conn.writeLp(line)
+        await c.stream.writeLp(line)
       else:
         if line.startsWith("/") and "p2p" in line:
           await c.dialPeer(line)

--- a/examples/helloworld.nim
+++ b/examples/helloworld.nim
@@ -12,16 +12,16 @@ const TestCodec = "/test/proto/1.0.0" # custom protocol string identifier
 type TestProto = ref object of LPProtocol # declare a custom protocol
 
 proc new(T: typedesc[TestProto]): T =
-  # every incoming connections will be in handled in this closure
-  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+  # every incoming stream will be handled in this closure
+  proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
     try:
-      echo "Got from remote - ", string.fromBytes(await conn.readLp(1024))
-      await conn.writeLp("Roger p2p!")
+      echo "Got from remote - ", string.fromBytes(await stream.readLp(1024))
+      await stream.writeLp("Roger p2p!")
     except LPStreamError as exc:
       echo "exception in handler", exc.msg
     finally:
-      # We must close the connections ourselves when we're done with it
-      await conn.close()
+      # We must close the stream ourselves when we're done with it
+      await stream.close()
 
   return T.new(codecs = @[TestCodec], handler = handle)
 
@@ -81,17 +81,18 @@ proc main() {.async.} =
   # use the second node to dial the first node
   # using the first node peerid and address
   # and specify our custom protocol codec
-  let conn =
+  let stream =
     await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, TestCodec)
 
-  # conn is now a fully setup connection, we talk directly to the node1 custom protocol handler
-  await conn.writeLp("Hello p2p!") # writeLp send a length prefixed buffer over the wire
+  # stream is now fully set up; we talk directly to the node1 custom protocol handler
+  await stream.writeLp("Hello p2p!")
+    # writeLp send a length prefixed buffer over the wire
 
   # readLp reads length prefixed bytes and returns a buffer without the prefix
-  echo "Remote responded with - ", string.fromBytes(await conn.readLp(1024))
+  echo "Remote responded with - ", string.fromBytes(await stream.readLp(1024))
 
-  # We must close the connection ourselves when we're done with it
-  await conn.close()
+  # We must close the stream ourselves when we're done with it
+  await stream.close()
 
   await allFutures(switch1.stop(), switch2.stop())
     # close connections and shutdown all transports

--- a/examples/tutorial_1_connect.nim
+++ b/examples/tutorial_1_connect.nim
@@ -84,14 +84,14 @@ proc main() {.async.} =
   ## We can find out which port was attributed, and the resulting local addresses, by using `switch1.peerInfo.addrs`.
   ##
   ## We'll **dial** the first switch from the second one, by specifying its **Peer ID**, its **MultiAddress** and the **`Ping` protocol codec**:
-  let conn =
+  let stream =
     await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, PingCodec)
-  ## We now have a `Ping` connection setup between the second and the first switch, we can use it to actually ping the node:
+  ## We now have a `Ping` stream setup between the second and the first switch, we can use it to actually ping the node:
   # ping the other node and echo the ping duration
-  echo "ping: ", await pingProtocol.ping(conn)
+  echo "ping: ", await pingProtocol.ping(stream)
 
-  # We must close the connection ourselves when we're done with it
-  await conn.close()
+  # We must close the stream ourselves when we're done with it
+  await stream.close()
   ## And that's it! Just a little bit of cleanup: shutting down the switches, waiting for them to stop, and we'll call our `main` procedure:
   await allFutures(switch1.stop(), switch2.stop())
     # close connections and shutdown all transports

--- a/examples/tutorial_2_customproto.nim
+++ b/examples/tutorial_2_customproto.nim
@@ -25,25 +25,25 @@ type TestProto = ref object of LPProtocol
 ## Let's start with the server part:
 
 proc new(T: typedesc[TestProto]): T =
-  # every incoming connections will in be handled in this closure
-  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
-    # Read up to 1024 bytes from this connection, and transform them into
+  # every incoming stream will be handled in this closure
+  proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
+    # Read up to 1024 bytes from this stream, and transform them into
     # a string
     try:
-      echo "Got from remote - ", string.fromBytes(await conn.readLp(1024))
+      echo "Got from remote - ", string.fromBytes(await stream.readLp(1024))
     except LPStreamError as exc:
       echo "exception in handler", exc.msg
     finally:
-      await conn.close()
+      await stream.close()
 
   return T.new(codecs = @[TestCodec], handler = handle)
 
 ## This is a constructor for our `TestProto`, that will specify our `codecs` and a `handler`, which will be called for each incoming peer asking for this protocol.
-## In our handle, we simply read a message from the connection and `echo` it.
+## In our handle, we simply read a message from the stream and `echo` it.
 ##
 ## We can now create our client part:
-proc hello(p: TestProto, conn: Connection) {.async.} =
-  await conn.writeLp("Hello p2p!")
+proc hello(p: TestProto, stream: Stream) {.async.} =
+  await stream.writeLp("Hello p2p!")
 
 proc createSwitch(rng: Rng): Switch {.raises: [LPError].} =
   return SwitchBuilder
@@ -55,7 +55,7 @@ proc createSwitch(rng: Rng): Switch {.raises: [LPError].} =
     .withNoise()
     .build()
 
-## Again, pretty straightforward, we just send a message on the connection.
+## Again, pretty straightforward, we just send a message on the stream.
 ##
 ## We can now create our main procedure:
 proc main() {.async.} =
@@ -70,13 +70,13 @@ proc main() {.async.} =
   await switch1.start()
   await switch2.start()
 
-  let conn =
+  let stream =
     await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, TestCodec)
 
-  await testProto.hello(conn)
+  await testProto.hello(stream)
 
-  # We must close the connection ourselves when we're done with it
-  await conn.close()
+  # We must close the stream ourselves when we're done with it
+  await stream.close()
 
   await allFutures(switch1.stop(), switch2.stop())
     # close connections and shutdown all transports

--- a/examples/tutorial_3_protobuf.nim
+++ b/examples/tutorial_3_protobuf.nim
@@ -110,23 +110,23 @@ type
 
 proc new(_: typedesc[MetricProto], cb: MetricCallback): MetricProto =
   var res: MetricProto
-  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+  proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
     try:
       let
         metrics = await res.metricGetter()
         asProtobuf = metrics.encode()
-      await conn.writeLp(asProtobuf.buffer)
+      await stream.writeLp(asProtobuf.buffer)
     except LPStreamError as exc:
       echo "exception in handler", exc.msg
     finally:
-      await conn.close()
+      await stream.close()
 
   res = MetricProto.new(@["/metric-getter/1.0.0"], handle)
   res.metricGetter = cb
   return res
 
-proc fetch(p: MetricProto, conn: Connection): Future[MetricList] {.async.} =
-  let protobuf = await conn.readLp(2048)
+proc fetch(p: MetricProto, stream: Stream): Future[MetricList] {.async.} =
+  let protobuf = await stream.readLp(2048)
   # tryGet will raise an exception if the Result contains an error.
   # It's useful to bridge between exception-world and result-world
   return MetricList.decode(protobuf).tryGet()
@@ -164,11 +164,11 @@ proc main() {.async.} =
   await switch2.start()
 
   let
-    conn = await switch2.dial(
+    stream = await switch2.dial(
       switch1.peerInfo.peerId, switch1.peerInfo.addrs, metricProto2.codecs
     )
-    metrics = await metricProto2.fetch(conn)
-  await conn.close()
+    metrics = await metricProto2.fetch(stream)
+  await stream.close()
 
   for metric in metrics.metrics:
     echo metric.name, " = ", metric.value

--- a/interop/gossipsub/src/runner.nim
+++ b/interop/gossipsub/src/runner.nim
@@ -21,7 +21,7 @@ logScope:
 type ScriptRunner* = ref object
   nodeId*: int
   node*: GossipSub
-  logStream*: Stream
+  logStream*: streams.Stream
   resolveAddr*: proc(nodeId: int): MultiAddress {.gcsafe, raises: [CatchableError].}
   startTime: Moment
   messages*: Table[string, InteropPartialMessage]
@@ -100,7 +100,7 @@ proc makePartialMessageConfig(runner: ScriptRunner): PartialMessageExtensionConf
 
 proc newScriptRunner*(
     nodeId: int,
-    logStream: Stream,
+    logStream: streams.Stream,
     listenAddr: MultiAddress,
     gossipSubParams: GossipSubParams = GossipSubParams.init(),
     resolveAddr: proc(nodeId: int): MultiAddress {.gcsafe, raises: [CatchableError].} =

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -152,7 +152,7 @@ proc withMplex*(
 ): SwitchBuilder =
   ## | Uses `Mplex <https://docs.libp2p.io/concepts/stream-multiplexing/#mplex>`_ as a multiplexer
   ## | `Timeout` is the duration after which a inactive connection will be closed
-  proc newMuxer(conn: Connection): Muxer =
+  proc newMuxer(conn: RawConn): Muxer =
     Mplex.new(conn, inTimeout, outTimeout, maxChannCount)
 
   assert b.muxers.countIt(it.codec == MplexCodec) == 0, "Mplex build multiple times"
@@ -166,7 +166,7 @@ proc withYamux*(
     inTimeout: Duration = 5.minutes,
     outTimeout: Duration = 5.minutes,
 ): SwitchBuilder =
-  proc newMuxer(conn: Connection): Muxer =
+  proc newMuxer(conn: RawConn): Muxer =
     Yamux.new(
       conn,
       maxChannCount = maxChannCount,

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -515,7 +515,7 @@ proc release*(cs: ConnectionSlot) =
   except AsyncSemaphoreError:
     raiseAssert "semaphore released without acquire"
 
-proc trackConnection*(cs: ConnectionSlot, conn: Connection) =
+proc trackConnection*(cs: ConnectionSlot, conn: RawConn) =
   proc semaphoreMonitor() {.async: (raises: [CancelledError]).} =
     try:
       await conn.join()
@@ -531,7 +531,7 @@ proc trackMuxer*(cs: ConnectionSlot, mux: Muxer) =
 
 proc getStream*(
     c: ConnManager, muxer: Muxer
-): Future[Connection] {.async: (raises: [LPStreamError, MuxerError, CancelledError]).} =
+): Future[MuxedStream] {.async: (raises: [LPStreamError, MuxerError, CancelledError]).} =
   ## get a muxed stream for the passed muxer
   if not muxer.isNil:
     return await muxer.newStream()
@@ -539,14 +539,14 @@ proc getStream*(
 
 proc getStream*(
     c: ConnManager, peerId: PeerId
-): Future[Connection] {.async: (raises: [LPStreamError, MuxerError, CancelledError]).} =
+): Future[MuxedStream] {.async: (raises: [LPStreamError, MuxerError, CancelledError]).} =
   ## get a muxed stream for the passed peer from any connection
 
   return await c.getStream(c.selectMuxer(peerId))
 
 proc getStream*(
     c: ConnManager, peerId: PeerId, dir: Direction
-): Future[Connection] {.async: (raises: [LPStreamError, MuxerError, CancelledError]).} =
+): Future[MuxedStream] {.async: (raises: [LPStreamError, MuxerError, CancelledError]).} =
   ## get a muxed stream for the passed peer from a connection with `dir`
 
   return await c.getStream(c.selectMuxer(peerId, dir))

--- a/libp2p/dial.nim
+++ b/libp2p/dial.nim
@@ -36,7 +36,7 @@ method connect*(
 
 method dial*(
     self: Dial, peerId: PeerId, protos: seq[string]
-): Future[Connection] {.base, async: (raises: [DialFailedError, CancelledError]).} =
+): Future[Stream] {.base, async: (raises: [DialFailedError, CancelledError]).} =
   ## create a protocol stream over an
   ## existing connection
   ##
@@ -65,7 +65,7 @@ method dial*(
     addrs: seq[MultiAddress],
     protos: seq[string],
     forceDial = false,
-): Future[Connection] {.base, async: (raises: [DialFailedError, CancelledError]).} =
+): Future[Stream] {.base, async: (raises: [DialFailedError, CancelledError]).} =
   ## create a protocol stream and establish
   ## a connection if one doesn't exist already
   ##
@@ -76,8 +76,8 @@ method addTransport*(self: Dial, transport: Transport) {.base.} =
   doAssert(false, "[Dial.addTransport] abstract method not implemented!")
 
 method negotiateStream*(
-    self: Dial, conn: Connection, protos: seq[string]
-): Future[Connection] {.base, async: (raises: [CatchableError]).} =
+    self: Dial, stream: Stream, protos: seq[string]
+): Future[Stream] {.base, async: (raises: [CatchableError]).} =
   doAssert(false, "[Dial.negotiateStream] abstract method not implemented!")
 
 method tryDial*(

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -284,17 +284,17 @@ method connect*(
     (await self.internalConnect(Opt.none(PeerId), @[address], false)).connection.peerId
 
 method negotiateStream*(
-    self: Dialer, conn: Stream, protos: seq[string]
+    self: Dialer, stream: Stream, protos: seq[string]
 ): Future[Stream] {.async: (raises: [CatchableError]).} =
-  trace "Negotiating stream", conn, protos
-  let selected = await MultistreamSelect.select(conn, protos)
+  trace "Negotiating stream", stream, protos
+  let selected = await MultistreamSelect.select(stream, protos)
   if not protos.contains(selected):
-    await conn.closeWithEOF()
+    await stream.closeWithEOF()
     raise newException(
       DialFailedError,
       "Unable to select sub-protocol. Selected: " & $selected & ". Available: " & $protos,
     )
-  return conn
+  return stream
 
 method tryDial*(
     self: Dialer, peerId: PeerId, addrs: seq[MultiAddress]

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -284,8 +284,8 @@ method connect*(
     (await self.internalConnect(Opt.none(PeerId), @[address], false)).connection.peerId
 
 method negotiateStream*(
-    self: Dialer, conn: Connection, protos: seq[string]
-): Future[Connection] {.async: (raises: [CatchableError]).} =
+    self: Dialer, conn: Stream, protos: seq[string]
+): Future[Stream] {.async: (raises: [CatchableError]).} =
   trace "Negotiating stream", conn, protos
   let selected = await MultistreamSelect.select(conn, protos)
   if not protos.contains(selected):
@@ -318,7 +318,7 @@ method tryDial*(
 
 method dial*(
     self: Dialer, peerId: PeerId, protos: seq[string]
-): Future[Connection] {.async: (raises: [DialFailedError, CancelledError]).} =
+): Future[Stream] {.async: (raises: [DialFailedError, CancelledError]).} =
   ## create a protocol stream over an
   ## existing connection
   ##
@@ -346,14 +346,14 @@ method dial*(
     addrs: seq[MultiAddress],
     protos: seq[string],
     forceDial = false,
-): Future[Connection] {.async: (raises: [DialFailedError, CancelledError]).} =
+): Future[Stream] {.async: (raises: [DialFailedError, CancelledError]).} =
   ## create a protocol stream and establish
   ## a connection if one doesn't exist already
   ##
 
   var
     conn: Muxer
-    stream: Connection
+    stream: Stream
 
   proc cleanup() {.async: (raises: []).} =
     if not (isNil(stream)):

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -42,7 +42,7 @@ template validateSuffix(str: string): untyped =
     raise (ref MultiStreamError)(msg: "MultistreamSelect failed, malformed message")
 
 proc select*(
-    _: MultistreamSelect | type MultistreamSelect, conn: Connection, proto: seq[string]
+    _: MultistreamSelect | type MultistreamSelect, conn: Stream, proto: seq[string]
 ): Future[string] {.async: (raises: [CancelledError, LPStreamError, MultiStreamError]).} =
   trace "initiating handshake", conn, codec = Codec
   ## select a remote protocol
@@ -89,7 +89,7 @@ proc select*(
       return ""
 
 proc select*(
-    _: MultistreamSelect | type MultistreamSelect, conn: Connection, proto: string
+    _: MultistreamSelect | type MultistreamSelect, conn: Stream, proto: string
 ): Future[bool] {.async: (raises: [CancelledError, LPStreamError, MultiStreamError]).} =
   if proto.len > 0:
     (await MultistreamSelect.select(conn, @[proto])) == proto
@@ -97,14 +97,14 @@ proc select*(
     (await MultistreamSelect.select(conn, @[])) == Codec
 
 proc select*(
-    m: MultistreamSelect, conn: Connection
+    m: MultistreamSelect, conn: Stream
 ): Future[bool] {.
     async: (raises: [CancelledError, LPStreamError, MultiStreamError], raw: true)
 .} =
   m.select(conn, "")
 
 proc list*(
-    m: MultistreamSelect, conn: Connection
+    m: MultistreamSelect, conn: Stream
 ): Future[seq[string]] {.
     async: (raises: [CancelledError, LPStreamError, MultiStreamError])
 .} =
@@ -124,7 +124,7 @@ proc list*(
 
 proc handle*(
     _: type MultistreamSelect,
-    conn: Connection,
+    conn: Stream,
     protos: seq[string],
     matchers = newSeq[Matcher](),
     active: bool = false,
@@ -170,7 +170,7 @@ proc handle*(
       await conn.writeLp(Na)
 
 proc handle*(
-    m: MultistreamSelect, conn: Connection, active: bool = false
+    m: MultistreamSelect, conn: Stream, active: bool = false
 ) {.async: (raises: [CancelledError]).} =
   trace "Starting multistream handler", conn, handshaked = active
   var
@@ -230,8 +230,7 @@ proc addHandler*[E](
     m: MultistreamSelect,
     codec: string,
     handler:
-      LPProtoHandler |
-      proc(conn: Connection, proto: string): InternalRaisesFuture[void, E],
+      LPProtoHandler | proc(conn: Stream, proto: string): InternalRaisesFuture[void, E],
     matcher: Matcher = nil,
 ) =
   ## helper to allow registering pure handlers

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -42,46 +42,46 @@ template validateSuffix(str: string): untyped =
     raise (ref MultiStreamError)(msg: "MultistreamSelect failed, malformed message")
 
 proc select*(
-    _: MultistreamSelect | type MultistreamSelect, conn: Stream, proto: seq[string]
+    _: MultistreamSelect | type MultistreamSelect, stream: Stream, proto: seq[string]
 ): Future[string] {.async: (raises: [CancelledError, LPStreamError, MultiStreamError]).} =
-  trace "initiating handshake", conn, codec = Codec
+  trace "initiating handshake", stream, codec = Codec
   ## select a remote protocol
-  await conn.writeLp(Codec & "\n") # write handshake
+  await stream.writeLp(Codec & "\n") # write handshake
   if proto.len() > 0:
-    trace "selecting proto", conn, proto = proto[0]
-    await conn.writeLp((proto[0] & "\n")) # select proto
+    trace "selecting proto", stream, proto = proto[0]
+    await stream.writeLp((proto[0] & "\n")) # select proto
 
-  var s = string.fromBytes((await conn.readLp(MsgSize))) # read ms header
+  var s = string.fromBytes((await stream.readLp(MsgSize))) # read ms header
   validateSuffix(s)
 
   if s != Codec:
-    notice "handshake failed", conn, codec = s
+    notice "handshake failed", stream, codec = s
     raise (ref MultiStreamError)(msg: "MultistreamSelect handshake failed")
   else:
-    trace "multistream handshake success", conn
+    trace "multistream handshake success", stream
 
   if proto.len() == 0: # no protocols, must be a handshake call
     return Codec
   else:
-    s = string.fromBytes(await conn.readLp(MsgSize)) # read the first proto
+    s = string.fromBytes(await stream.readLp(MsgSize)) # read the first proto
     validateSuffix(s)
-    trace "reading first requested proto", conn, s, proto
+    trace "reading first requested proto", stream, s, proto
     if s == proto[0]:
-      trace "successfully selected ", conn, proto = proto[0]
-      conn.protocol = proto[0]
+      trace "successfully selected ", stream, proto = proto[0]
+      stream.protocol = proto[0]
       return proto[0]
     elif proto.len > 1:
       # Try to negotiate alternatives
       let protos = proto[1 ..< proto.len()]
-      trace "selecting one of several protos", conn, protos = protos
+      trace "selecting one of several protos", stream, protos = protos
       for p in protos:
-        trace "selecting proto", conn, proto = p
-        await conn.writeLp((p & "\n")) # select proto
-        s = string.fromBytes(await conn.readLp(MsgSize)) # read the first proto
+        trace "selecting proto", stream, proto = p
+        await stream.writeLp((p & "\n")) # select proto
+        s = string.fromBytes(await stream.readLp(MsgSize)) # read the first proto
         validateSuffix(s)
         if s == p:
-          trace "selected protocol", conn, protocol = s
-          conn.protocol = s
+          trace "selected protocol", stream, protocol = s
+          stream.protocol = s
           return s
       return ""
     else:
@@ -89,33 +89,33 @@ proc select*(
       return ""
 
 proc select*(
-    _: MultistreamSelect | type MultistreamSelect, conn: Stream, proto: string
+    _: MultistreamSelect | type MultistreamSelect, stream: Stream, proto: string
 ): Future[bool] {.async: (raises: [CancelledError, LPStreamError, MultiStreamError]).} =
   if proto.len > 0:
-    (await MultistreamSelect.select(conn, @[proto])) == proto
+    (await MultistreamSelect.select(stream, @[proto])) == proto
   else:
-    (await MultistreamSelect.select(conn, @[])) == Codec
+    (await MultistreamSelect.select(stream, @[])) == Codec
 
 proc select*(
-    m: MultistreamSelect, conn: Stream
+    m: MultistreamSelect, stream: Stream
 ): Future[bool] {.
     async: (raises: [CancelledError, LPStreamError, MultiStreamError], raw: true)
 .} =
-  m.select(conn, "")
+  m.select(stream, "")
 
 proc list*(
-    m: MultistreamSelect, conn: Stream
+    m: MultistreamSelect, stream: Stream
 ): Future[seq[string]] {.
     async: (raises: [CancelledError, LPStreamError, MultiStreamError])
 .} =
   ## list remote protos requests on connection
-  if not await m.select(conn):
+  if not await m.select(stream):
     return
 
-  await conn.writeLp(Ls) # send ls
+  await stream.writeLp(Ls) # send ls
 
   var list = newSeq[string]()
-  let ms = string.fromBytes(await conn.readLp(MsgSize))
+  let ms = string.fromBytes(await stream.readLp(MsgSize))
   for s in ms.split("\n"):
     if s.len() > 0:
       list.add(s)
@@ -124,55 +124,55 @@ proc list*(
 
 proc handle*(
     _: type MultistreamSelect,
-    conn: Stream,
+    stream: Stream,
     protos: seq[string],
     matchers = newSeq[Matcher](),
     active: bool = false,
 ): Future[string] {.async: (raises: [CancelledError, LPStreamError, MultiStreamError]).} =
-  trace "Starting multistream negotiation", conn, handshaked = active
+  trace "Starting multistream negotiation", stream, handshaked = active
   var handshaked = active
-  while not conn.atEof:
-    var ms = string.fromBytes(await conn.readLp(MsgSize))
+  while not stream.atEof:
+    var ms = string.fromBytes(await stream.readLp(MsgSize))
     validateSuffix(ms)
 
     if not handshaked and ms != Codec:
-      debug "expected handshake message", conn, instead = ms
+      debug "expected handshake message", stream, instead = ms
       raise (ref MultiStreamError)(
         msg: "MultistreamSelect handling failed, invalid first message"
       )
 
-    trace "handle: got request", conn, ms
+    trace "handle: got request", stream, ms
     if ms.len() <= 0:
-      trace "handle: invalid proto", conn
-      await conn.writeLp(Na)
+      trace "handle: invalid proto", stream
+      await stream.writeLp(Na)
 
     case ms
     of "ls":
-      trace "handle: listing protos", conn
+      trace "handle: listing protos", stream
       #TODO this doens't seem to follow spec, each protocol
       # should be length prefixed. Not very important
       # since LS is getting deprecated
-      await conn.writeLp(protos.join("\n") & "\n")
+      await stream.writeLp(protos.join("\n") & "\n")
     of Codec:
       if not handshaked:
-        await conn.writeLp(Codec & "\n")
+        await stream.writeLp(Codec & "\n")
         handshaked = true
       else:
-        trace "handle: sending `na` for duplicate handshake while handshaked", conn
-        await conn.writeLp(Na)
+        trace "handle: sending `na` for duplicate handshake while handshaked", stream
+        await stream.writeLp(Na)
     elif ms in protos or matchers.anyIt(it(ms)):
-      trace "found handler", conn, protocol = ms
-      await conn.writeLp(ms & "\n")
-      conn.protocol = ms
+      trace "found handler", stream, protocol = ms
+      await stream.writeLp(ms & "\n")
+      stream.protocol = ms
       return ms
     else:
-      trace "no handlers", conn, protocol = ms
-      await conn.writeLp(Na)
+      trace "no handlers", stream, protocol = ms
+      await stream.writeLp(Na)
 
 proc handle*(
-    m: MultistreamSelect, conn: Stream, active: bool = false
+    m: MultistreamSelect, stream: Stream, active: bool = false
 ) {.async: (raises: [CancelledError]).} =
-  trace "Starting multistream handler", conn, handshaked = active
+  trace "Starting multistream handler", stream, handshaked = active
   var
     protos: seq[string]
     matchers: seq[Matcher]
@@ -183,34 +183,34 @@ proc handle*(
       protos.add(proto)
 
   try:
-    let ms = await MultistreamSelect.handle(conn, protos, matchers, active)
+    let ms = await MultistreamSelect.handle(stream, protos, matchers, active)
     for h in m.handlers:
       if (h.match != nil and h.match(ms)) or h.protos.contains(ms):
-        trace "found handler", conn, protocol = ms
+        trace "found handler", stream, protocol = ms
 
         var protocolHolder = h
         let maxIncomingStreams = protocolHolder.protocol.maxIncomingStreams
-        if protocolHolder.openedStreams.getOrDefault(conn.peerId) >= maxIncomingStreams:
+        if protocolHolder.openedStreams.getOrDefault(stream.peerId) >= maxIncomingStreams:
           debug "Max streams for protocol reached, blocking new stream",
-            conn, protocol = ms, maxIncomingStreams
+            stream, protocol = ms, maxIncomingStreams
           return
-        protocolHolder.openedStreams.inc(conn.peerId)
+        protocolHolder.openedStreams.inc(stream.peerId)
         try:
-          await protocolHolder.protocol.handler(conn, ms)
+          await protocolHolder.protocol.handler(stream, ms)
         finally:
-          protocolHolder.openedStreams.inc(conn.peerId, -1)
-          if protocolHolder.openedStreams[conn.peerId] == 0:
-            protocolHolder.openedStreams.del(conn.peerId)
+          protocolHolder.openedStreams.inc(stream.peerId, -1)
+          if protocolHolder.openedStreams[stream.peerId] == 0:
+            protocolHolder.openedStreams.del(stream.peerId)
         return
-    debug "no handlers", conn, ms
+    debug "no handlers", stream, ms
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    trace "Exception in multistream", conn, description = exc.msg
+    trace "Exception in multistream", stream, description = exc.msg
   finally:
-    await conn.close()
+    await stream.close()
 
-  trace "Stopped multistream handler", conn
+  trace "Stopped multistream handler", stream
 
 proc addHandler*(
     m: MultistreamSelect,
@@ -230,7 +230,9 @@ proc addHandler*[E](
     m: MultistreamSelect,
     codec: string,
     handler:
-      LPProtoHandler | proc(conn: Stream, proto: string): InternalRaisesFuture[void, E],
+      LPProtoHandler | proc(
+        stream: Stream, proto: string
+      ): InternalRaisesFuture[void, E],
     matcher: Matcher = nil,
 ) =
   ## helper to allow registering pure handlers

--- a/libp2p/muxer_store.nim
+++ b/libp2p/muxer_store.nim
@@ -4,7 +4,7 @@
 import std/[tables, sequtils]
 from peerinfo import PeerId
 from muxers/muxer import Muxer
-from stream/connection import Connection, Direction
+from stream/connection import Direction
 
 type MuxerStore* = ref object
   muxed: Table[PeerId, seq[Muxer]]

--- a/libp2p/muxers/mplex/coder.nim
+++ b/libp2p/muxers/mplex/coder.nim
@@ -30,7 +30,7 @@ proc newInvalidMplexMsgType*(): ref InvalidMplexMsgType =
   newException(InvalidMplexMsgType, "invalid message type")
 
 proc readMsg*(
-    conn: Connection
+    conn: RawConn
 ): Future[Msg] {.async: (raises: [CancelledError, LPStreamError, MuxerError]).} =
   let header = await conn.readVarint()
   trace "read header varint", varint = header, conn
@@ -45,7 +45,7 @@ proc readMsg*(
   return (header shr 3, MessageType(msgType), data)
 
 proc writeMsg*(
-    conn: Connection, id: uint64, msgType: MessageType, data: seq[byte] = @[]
+    conn: RawConn, id: uint64, msgType: MessageType, data: seq[byte] = @[]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   var
     left = data.len
@@ -76,6 +76,6 @@ proc writeMsg*(
   conn.write(buf.buffer)
 
 proc writeMsg*(
-    conn: Connection, id: uint64, msgType: MessageType, data: string
+    conn: RawConn, id: uint64, msgType: MessageType, data: string
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   conn.writeMsg(id, msgType, data.toBytes())

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -44,7 +44,7 @@ const
 type LPChannel* = ref object of BufferStream
   id*: uint64 # channel id
   name*: string # name of the channel (for debugging)
-  conn*: Connection # wrapped connection used to for writing
+  conn*: RawConn # wrapped connection used to for writing
   initiator*: bool # initiated remotely or locally flag
   isOpen*: bool # has channel been opened
   closedLocal*: bool # has channel been closed locally
@@ -291,7 +291,7 @@ method getWrapped*(s: LPChannel): Connection =
 proc init*(
     L: type LPChannel,
     id: uint64,
-    conn: Connection,
+    conn: RawConn,
     initiator: bool,
     name: string = "",
     timeout: Duration = DefaultChanTimeout,

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -190,7 +190,7 @@ method handle*(m: Mplex) {.async: (raises: []).} =
 
 proc new*(
     M: type Mplex,
-    conn: Connection,
+    conn: RawConn,
     inTimeout: Duration = DefaultChanTimeout,
     outTimeout: Duration = DefaultChanTimeout,
     maxChannCount: int = MaxChannelCount,
@@ -205,7 +205,7 @@ proc new*(
 
 method newStream*(
     m: Mplex, name: string = "", lazy: bool = false
-): Future[Connection] {.async: (raises: [CancelledError, LPStreamError, MuxerError]).} =
+): Future[MuxedStream] {.async: (raises: [CancelledError, LPStreamError, MuxerError]).} =
   let channel = m.newStreamInternal(timeout = m.inChannTimeout)
 
   if not lazy:
@@ -241,7 +241,7 @@ method close*(m: Mplex) {.async: (raises: []).} =
 
   trace "Closed mplex", m
 
-method getStreams*(m: Mplex): seq[Connection] {.gcsafe.} =
+method getStreams*(m: Mplex): seq[MuxedStream] {.gcsafe.} =
   for c in m.channels[false].values:
     result.add(c)
   for c in m.channels[true].values:

--- a/libp2p/muxers/muxer.nim
+++ b/libp2p/muxers/muxer.nim
@@ -15,16 +15,16 @@ type
   MuxerError* = object of LPError
   TooManyChannels* = object of MuxerError
 
-  StreamHandler* = proc(conn: Connection): Future[void] {.async: (raises: []).}
+  StreamHandler* = proc(stream: MuxedStream): Future[void] {.async: (raises: []).}
   MuxerHandler* = proc(muxer: Muxer): Future[void] {.async: (raises: []).}
 
   Muxer* = ref object of RootObj
     streamHandler*: StreamHandler
     handler*: Future[void].Raising([])
-    connection*: Connection
+    connection*: RawConn
 
   # user provider proc that returns a constructed Muxer
-  MuxerConstructor* = proc(conn: Connection): Muxer {.gcsafe, closure, raises: [].}
+  MuxerConstructor* = proc(conn: RawConn): Muxer {.gcsafe, closure, raises: [].}
 
   # this wraps a creator proc that knows how to make muxers
   MuxerProvider* = object
@@ -43,7 +43,7 @@ chronicles.formatIt(Muxer):
 # muxer interface
 method newStream*(
     m: Muxer, name: string = "", lazy: bool = false
-): Future[Connection] {.
+): Future[MuxedStream] {.
     base, async: (raises: [CancelledError, LPStreamError, MuxerError], raw: true)
 .} =
   raiseAssert("[Muxer.newStream] abstract method not implemented!")
@@ -65,5 +65,5 @@ proc new*(
   let muxerProvider = T(newMuxer: creator, codec: codec)
   muxerProvider
 
-method getStreams*(m: Muxer): seq[Connection] {.base, gcsafe.} =
+method getStreams*(m: Muxer): seq[MuxedStream] {.base, gcsafe.} =
   raiseAssert("[Muxer.getStreams] abstract method not implemented!")

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -140,7 +140,7 @@ type
     sendWindow: int
     maxRecvWindow: int
     maxSendQueueSize: int
-    conn: Connection
+    conn: RawConn
     isSrc: bool
     opened: bool
     isSending: bool

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -672,13 +672,13 @@ method handle*(m: Yamux) {.async: (raises: []).} =
     await m.close()
   trace "Stopped yamux handler"
 
-method getStreams*(m: Yamux): seq[Connection] {.gcsafe.} =
+method getStreams*(m: Yamux): seq[MuxedStream] {.gcsafe.} =
   for c in m.channels.values:
     result.add(c)
 
 method newStream*(
     m: Yamux, name: string = "", lazy: bool = false
-): Future[Connection] {.async: (raises: [CancelledError, LPStreamError, MuxerError]).} =
+): Future[MuxedStream] {.async: (raises: [CancelledError, LPStreamError, MuxerError]).} =
   if m.channels.len > m.maxChannCount - 1:
     raise newException(TooManyChannels, "max allowed channel count exceeded")
   let stream = m.createStream(m.currentId, true, m.windowSize, m.maxSendQueueSize)
@@ -689,7 +689,7 @@ method newStream*(
 
 proc new*(
     T: type[Yamux],
-    conn: Connection,
+    conn: RawConn,
     maxChannCount: int = MaxChannelCount,
     windowSize: int = YamuxDefaultWindowSize,
     maxSendQueueSize: int = MaxSendQueueSize,

--- a/libp2p/protocols/connectivity/autonat/client.nim
+++ b/libp2p/protocols/connectivity/autonat/client.nim
@@ -14,12 +14,12 @@ logScope:
 type AutonatClient* = ref object of RootObj
 
 proc sendDial(
-    conn: Connection, pid: PeerId, addrs: seq[MultiAddress]
+    stream: Stream, pid: PeerId, addrs: seq[MultiAddress]
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
   let pb = AutonatDial(
     peerInfo: Opt.some(AutonatPeerInfo(id: Opt.some(pid), addrs: addrs))
   ).encode()
-  await conn.writeLp(pb.buffer)
+  await stream.writeLp(pb.buffer)
 
 method dialMe*(
     self: AutonatClient,
@@ -39,7 +39,7 @@ method dialMe*(
             return res
     raise newException(AutonatError, "Unexpected response")
 
-  let conn =
+  let stream =
     try:
       if addrs.len == 0:
         await switch.dial(pid, @[AutonatCodec])
@@ -57,7 +57,7 @@ method dialMe*(
       incomingConnection.error of AlreadyExpectingConnectionError:
     raise newException(AutonatError, incomingConnection.error.msg)
   defer:
-    await conn.close()
+    await stream.close()
     incomingConnection.cancelSoon()
       # Safer to always try to cancel cause we aren't sure if the peer dialled us or not
     if incomingConnection.completed():
@@ -69,7 +69,7 @@ method dialMe*(
 
   try:
     trace "sending Dial", addrs = switch.peerInfo.addrs
-    await conn.sendDial(switch.peerInfo.peerId, switch.peerInfo.addrs)
+    await stream.sendDial(switch.peerInfo.peerId, switch.peerInfo.addrs)
   except CancelledError as e:
     raise e
   except CatchableError as e:
@@ -77,7 +77,7 @@ method dialMe*(
 
   var respBytes: seq[byte]
   try:
-    respBytes = await conn.readLp(1024)
+    respBytes = await stream.readLp(1024)
   except CancelledError as e:
     raise e
   except CatchableError as e:

--- a/libp2p/protocols/connectivity/autonat/server.nim
+++ b/libp2p/protocols/connectivity/autonat/server.nim
@@ -27,7 +27,7 @@ type Autonat* = ref object of LPProtocol
   dialTimeout: Duration
 
 proc sendResponseError(
-    conn: Connection, status: ResponseStatus, text: string = ""
+    stream: Stream, status: ResponseStatus, text: string = ""
 ) {.async: (raises: [CancelledError]).} =
   let pb = AutonatDialResponse(
     status: status,
@@ -39,54 +39,54 @@ proc sendResponseError(
     ma: Opt.none(MultiAddress),
   ).encode()
   try:
-    await conn.writeLp(pb.buffer)
+    await stream.writeLp(pb.buffer)
   except LPStreamError as exc:
-    trace "autonat failed to send response error", description = exc.msg, conn
+    trace "autonat failed to send response error", description = exc.msg, stream
 
 proc sendResponseOk(
-    conn: Connection, ma: MultiAddress
+    stream: Stream, ma: MultiAddress
 ) {.async: (raises: [CancelledError]).} =
   let pb = AutonatDialResponse(
     status: ResponseStatus.Ok, text: Opt.some("Ok"), ma: Opt.some(ma)
   ).encode()
   try:
-    await conn.writeLp(pb.buffer)
+    await stream.writeLp(pb.buffer)
   except LPStreamError as exc:
-    trace "autonat failed to send response ok", description = exc.msg, conn
+    trace "autonat failed to send response ok", description = exc.msg, stream
 
 proc tryDial(
-    autonat: Autonat, conn: Connection, addrs: seq[MultiAddress]
+    autonat: Autonat, stream: Stream, addrs: seq[MultiAddress]
 ) {.async: (raises: [DialFailedError, CancelledError]).} =
   await autonat.sem.acquire()
   var futs: seq[Future[Opt[MultiAddress]].Raising([DialFailedError, CancelledError])]
   try:
     # This is to bypass the per peer max connections limit
     let outgoingConnection =
-      autonat.switch.connManager.expectConnection(conn.peerId, Out)
+      autonat.switch.connManager.expectConnection(stream.peerId, Out)
     if outgoingConnection.failed() and
         outgoingConnection.error of AlreadyExpectingConnectionError:
-      await conn.sendResponseError(DialRefused, outgoingConnection.error.msg)
+      await stream.sendResponseError(DialRefused, outgoingConnection.error.msg)
       return
     # Safer to always try to cancel cause we aren't sure if the connection was established
     defer:
       outgoingConnection.cancelSoon()
 
     # tryDial is to bypass the global max connections limit
-    futs = addrs.mapIt(autonat.switch.dialer.tryDial(conn.peerId, @[it]))
+    futs = addrs.mapIt(autonat.switch.dialer.tryDial(stream.peerId, @[it]))
     let fut = await anyCompleted(futs).wait(autonat.dialTimeout)
     let ma = await fut
     ma.withValue(maddr):
-      await conn.sendResponseOk(maddr)
+      await stream.sendResponseOk(maddr)
     else:
-      await conn.sendResponseError(DialError, "Missing observed address")
+      await stream.sendResponseError(DialError, "Missing observed address")
   except CancelledError as exc:
     raise exc
   except AllFuturesFailedError as exc:
     debug "All dial attempts failed", addrs, description = exc.msg
-    await conn.sendResponseError(DialError, "All dial attempts failed")
+    await stream.sendResponseError(DialError, "All dial attempts failed")
   except AsyncTimeoutError as exc:
     debug "Dial timeout", addrs, description = exc.msg
-    await conn.sendResponseError(DialError, "Dial timeout")
+    await stream.sendResponseError(DialError, "Dial timeout")
   finally:
     try:
       autonat.sem.release()
@@ -94,27 +94,28 @@ proc tryDial(
       raiseAssert "semaphore released without acquire"
     futs.cancelSoon()
 
-proc handleDial(autonat: Autonat, conn: Connection, msg: AutonatMsg): Future[void] =
+proc handleDial(autonat: Autonat, stream: Stream, msg: AutonatMsg): Future[void] =
   let dial = msg.dial.valueOr:
-    return conn.sendResponseError(BadRequest, "Missing Dial")
+    return stream.sendResponseError(BadRequest, "Missing Dial")
   let peerInfo = dial.peerInfo.valueOr:
-    return conn.sendResponseError(BadRequest, "Missing Peer Info")
+    return stream.sendResponseError(BadRequest, "Missing Peer Info")
   peerInfo.id.withValue(id):
-    if id != conn.peerId:
-      return conn.sendResponseError(BadRequest, "PeerId mismatch")
+    if id != stream.peerId:
+      return stream.sendResponseError(BadRequest, "PeerId mismatch")
 
-  let observedAddr = conn.observedAddr.valueOr:
-    return conn.sendResponseError(BadRequest, "Missing observed address")
+  let observedAddr = stream.observedAddr.valueOr:
+    return stream.sendResponseError(BadRequest, "Missing observed address")
 
   var isRelayed = observedAddr.contains(multiCodec("p2p-circuit")).valueOr:
-    return conn.sendResponseError(DialRefused, "Invalid observed address")
+    return stream.sendResponseError(DialRefused, "Invalid observed address")
   if isRelayed:
-    return
-      conn.sendResponseError(DialRefused, "Refused to dial a relayed observed address")
+    return stream.sendResponseError(
+      DialRefused, "Refused to dial a relayed observed address"
+    )
   let hostIp = observedAddr[0].valueOr:
-    return conn.sendResponseError(InternalError, "Wrong observed address")
+    return stream.sendResponseError(InternalError, "Wrong observed address")
   if not IP.match(hostIp):
-    return conn.sendResponseError(InternalError, "Expected an IP address")
+    return stream.sendResponseError(InternalError, "Expected an IP address")
   var addrs = initHashSet[MultiAddress]()
   addrs.incl(observedAddr)
   trace "addrs received", addrs = peerInfo.addrs
@@ -141,10 +142,10 @@ proc handleDial(autonat: Autonat, conn: Connection, msg: AutonatMsg): Future[voi
       break
 
   if len(addrs) == 0:
-    return conn.sendResponseError(DialRefused, "No dialable address")
+    return stream.sendResponseError(DialRefused, "No dialable address")
   let addrsSeq = toSeq(addrs)
   trace "trying to dial", addrs = addrsSeq
-  return autonat.tryDial(conn, addrsSeq)
+  return autonat.tryDial(stream, addrsSeq)
 
 proc new*(
     T: typedesc[Autonat], switch: Switch, semSize: int = 1, dialTimeout = 15.seconds
@@ -152,22 +153,22 @@ proc new*(
   let autonat =
     T(switch: switch, sem: newAsyncSemaphore(semSize), dialTimeout: dialTimeout)
   proc handleStream(
-      conn: Connection, proto: string
+      stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     try:
-      let msg = AutonatMsg.decode(await conn.readLp(1024)).valueOr:
+      let msg = AutonatMsg.decode(await stream.readLp(1024)).valueOr:
         raise newException(AutonatError, "Received malformed message")
       if msg.msgType != MsgType.Dial:
         raise newException(AutonatError, "Message type should be dial")
-      await autonat.handleDial(conn, msg)
+      await autonat.handleDial(stream, msg)
     except CancelledError as exc:
       trace "cancelled autonat handler"
       raise exc
     except CatchableError as exc:
-      debug "exception in autonat handler", description = exc.msg, conn
+      debug "exception in autonat handler", description = exc.msg, stream
     finally:
-      trace "exiting autonat handler", conn
-      await conn.close()
+      trace "exiting autonat handler", stream
+      await stream.close()
 
   autonat.handler = handleStream
   autonat.codec = AutonatCodec

--- a/libp2p/protocols/connectivity/autonatv2/client.nim
+++ b/libp2p/protocols/connectivity/autonatv2/client.nim
@@ -30,16 +30,16 @@ type AutonatV2Client* = ref object of LPProtocol
   expectedNonces: Table[Nonce, Opt[MultiAddress]]
 
 proc handleDialBack(
-    self: AutonatV2Client, conn: Connection, dialBack: DialBack
+    self: AutonatV2Client, stream: Stream, dialBack: DialBack
 ) {.async: (raises: [CancelledError, AutonatV2Error, LPStreamError]).} =
   debug "Handling DialBack",
-    conn = conn, localAddr = conn.localAddr, observedAddr = conn.observedAddr
+    stream = stream, localAddr = stream.localAddr, observedAddr = stream.observedAddr
 
   if not self.expectedNonces.hasKey(dialBack.nonce):
     error "Not expecting this nonce", nonce = dialBack.nonce
     return
 
-  conn.localAddr.withValue(localAddr):
+  stream.localAddr.withValue(localAddr):
     debug "Setting expectedNonces",
       nonce = dialBack.nonce, localAddr = Opt.some(localAddr)
     self.expectedNonces[dialBack.nonce] = Opt.some(localAddr)
@@ -48,7 +48,7 @@ proc handleDialBack(
     return
 
   trace "Sending DialBackResponse"
-  await conn.writeLp(DialBackResponse(status: DialBackStatus.Ok).encode().buffer)
+  await stream.writeLp(DialBackResponse(status: DialBackStatus.Ok).encode().buffer)
 
 proc new*(
     T: typedesc[AutonatV2Client],
@@ -59,22 +59,24 @@ proc new*(
 
   # handler for DialBack messages
   proc handleStream(
-      conn: Connection, proto: string
+      stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     try:
-      let dialBack = DialBack.decode(initProtoBuffer(await conn.readLp(DialBackLpSize))).valueOr:
+      let dialBack = DialBack.decode(
+        initProtoBuffer(await stream.readLp(DialBackLpSize))
+      ).valueOr:
         trace "Unable to decode DialBack"
         return
-      if not await client.handleDialBack(conn, dialBack).withTimeout(
+      if not await client.handleDialBack(stream, dialBack).withTimeout(
         client.dialBackTimeout
       ):
         trace "Sending DialBackResponse timed out"
     except CancelledError as exc:
       raise exc
     except LPStreamRemoteClosedError as exc:
-      debug "Connection closed by peer", description = exc.msg, peer = conn.peerId
+      debug "Stream closed by peer", description = exc.msg, peer = stream.peerId
     except LPStreamError as exc:
-      debug "Connection closed by peer", description = exc.msg, peer = conn.peerId
+      debug "Stream closed by peer", description = exc.msg, peer = stream.peerId
 
   client.handler = handleStream
   client.codec = $AutonatV2Codec.DialBack
@@ -84,7 +86,7 @@ proc setup*(self: AutonatV2Client, switch: Switch) =
   self.dialer = switch.dialer
 
 proc handleDialDataRequest*(
-    conn: Connection, req: DialDataRequest
+    stream: Stream, req: DialDataRequest
 ): Future[DialResponse] {.
     async: (raises: [CancelledError, AutonatV2Error, LPStreamError])
 .} =
@@ -104,11 +106,11 @@ proc handleDialDataRequest*(
   let messagesToSend =
     (req.numBytes + MaxDialDataResponsePayload - 1) div MaxDialDataResponsePayload
   for i in 0 ..< messagesToSend:
-    await conn.writeLp(msg.encode().buffer)
+    await stream.writeLp(msg.encode().buffer)
     debug "Sending DialDataResponse", i = i, messagesToSend = messagesToSend
 
   # get DialResponse
-  msg = AutonatV2Msg.decode(initProtoBuffer(await conn.readLp(AutonatV2MsgLpSize))).valueOr:
+  msg = AutonatV2Msg.decode(initProtoBuffer(await stream.readLp(AutonatV2MsgLpSize))).valueOr:
     raise newException(AutonatV2Error, "Unable to decode AutonatV2Msg")
 
   debug "Received message", msgType = msg.msgType
@@ -152,19 +154,19 @@ method sendDialRequest*(
 
   var dialResp: DialResponse
   try:
-    let conn = await self.dialer.dial(pid, @[$AutonatV2Codec.DialRequest])
+    let stream = await self.dialer.dial(pid, @[$AutonatV2Codec.DialRequest])
     defer:
-      await conn.close()
+      await stream.close()
 
     # send dialRequest
-    await conn.writeLp(
+    await stream.writeLp(
       AutonatV2Msg(
         msgType: MsgType.DialRequest,
         dialReq: DialRequest(addrs: testAddrs, nonce: nonce),
       ).encode().buffer
     )
     let msg = AutonatV2Msg.decode(
-      initProtoBuffer(await conn.readLp(AutonatV2MsgLpSize))
+      initProtoBuffer(await stream.readLp(AutonatV2MsgLpSize))
     ).valueOr:
       raise newException(AutonatV2Error, "Unable to decode AutonatV2Msg")
 
@@ -173,7 +175,7 @@ method sendDialRequest*(
       of MsgType.DialResponse:
         msg.dialResp
       of MsgType.DialDataRequest:
-        await conn.handleDialDataRequest(msg.dialDataReq)
+        await stream.handleDialDataRequest(msg.dialDataReq)
       else:
         raise newException(
           AutonatV2Error,

--- a/libp2p/protocols/connectivity/autonatv2/mock.nim
+++ b/libp2p/protocols/connectivity/autonatv2/mock.nim
@@ -22,14 +22,14 @@ proc new*(
 ): T =
   let autonatV2 = T(config: config)
   proc handleStream(
-      conn: Connection, proto: string
+      stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     defer:
-      await conn.close()
+      await stream.close()
 
     try:
       let msg = AutonatV2Msg.decode(
-        initProtoBuffer(await conn.readLp(AutonatV2MsgLpSize))
+        initProtoBuffer(await stream.readLp(AutonatV2MsgLpSize))
       ).valueOr:
         return
       if msg.msgType != MsgType.DialRequest:
@@ -39,7 +39,7 @@ proc new*(
 
     try:
       # return mocked message
-      await conn.writeLp(autonatV2.response.buffer)
+      await stream.writeLp(autonatV2.response.buffer)
     except CancelledError as exc:
       raise exc
     except LPStreamRemoteClosedError:

--- a/libp2p/protocols/connectivity/autonatv2/mockserver.nim
+++ b/libp2p/protocols/connectivity/autonatv2/mockserver.nim
@@ -22,14 +22,14 @@ proc new*(
 ): T =
   let autonatV2 = T(config: config)
   proc handleStream(
-      conn: Connection, proto: string
+      stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     defer:
-      await conn.close()
+      await stream.close()
 
     try:
       let msg = AutonatV2Msg.decode(
-        initProtoBuffer(await conn.readLp(AutonatV2MsgLpSize))
+        initProtoBuffer(await stream.readLp(AutonatV2MsgLpSize))
       ).valueOr:
         return
       if msg.msgType != MsgType.DialRequest:
@@ -39,7 +39,7 @@ proc new*(
 
     try:
       # return mocked message
-      await conn.writeLp(autonatV2.response.buffer)
+      await stream.writeLp(autonatV2.response.buffer)
     except CancelledError as exc:
       raise exc
     except LPStreamRemoteClosedError:

--- a/libp2p/protocols/connectivity/autonatv2/server.nim
+++ b/libp2p/protocols/connectivity/autonatv2/server.nim
@@ -48,12 +48,12 @@ proc new*(
   )
 
 proc sendDialResponse(
-    conn: Connection,
+    stream: Stream,
     status: ResponseStatus,
     addrIdx: Opt[AddrIdx] = Opt.none(AddrIdx),
     dialStatus: Opt[DialStatus] = Opt.none(DialStatus),
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
-  await conn.writeLp(
+  await stream.writeLp(
     AutonatV2Msg(
       msgType: MsgType.DialResponse,
       dialResp: DialResponse(status: status, addrIdx: addrIdx, dialStatus: dialStatus),
@@ -61,41 +61,41 @@ proc sendDialResponse(
   )
 
 proc findObservedIPAddr*(
-    conn: Connection, req: DialRequest
+    stream: Stream, req: DialRequest
 ): Future[Opt[MultiAddress]] {.async: (raises: [CancelledError, LPStreamError]).} =
-  let observedAddr = conn.observedAddr.valueOr:
-    await conn.sendDialResponse(ResponseStatus.EInternalError)
+  let observedAddr = stream.observedAddr.valueOr:
+    await stream.sendDialResponse(ResponseStatus.EInternalError)
     return Opt.none(MultiAddress)
 
   let isRelayed = observedAddr.contains(multiCodec("p2p-circuit")).valueOr:
     error "Invalid observed address"
-    await conn.sendDialResponse(ResponseStatus.EDialRefused)
+    await stream.sendDialResponse(ResponseStatus.EDialRefused)
     return Opt.none(MultiAddress)
 
   if isRelayed:
     error "Invalid observed address: relayed address"
-    await conn.sendDialResponse(ResponseStatus.EDialRefused)
+    await stream.sendDialResponse(ResponseStatus.EDialRefused)
     return Opt.none(MultiAddress)
 
   let hostIp = observedAddr[0].valueOr:
     error "Invalid observed address"
-    await conn.sendDialResponse(ResponseStatus.EInternalError)
+    await stream.sendDialResponse(ResponseStatus.EInternalError)
     return Opt.none(MultiAddress)
 
   return Opt.some(hostIp)
 
 proc dialBack(
-    conn: Connection, nonce: Nonce
+    stream: Stream, nonce: Nonce
 ): Future[DialStatus] {.
     async: (raises: [CancelledError, DialFailedError, LPStreamError])
 .} =
   try:
     # send dial back
-    await conn.writeLp(DialBack(nonce: nonce).encode().buffer)
+    await stream.writeLp(DialBack(nonce: nonce).encode().buffer)
 
     # receive DialBackResponse
     discard DialBackResponse.decode(
-      initProtoBuffer(await conn.readLp(AutonatV2MsgLpSize))
+      initProtoBuffer(await stream.readLp(AutonatV2MsgLpSize))
     ).valueOr:
       trace "DialBack failed, could not decode DialBackResponse"
       return DialStatus.EDialBackError
@@ -110,13 +110,13 @@ proc dialBack(
   return DialStatus.Ok
 
 proc handleDialDataResponses(
-    self: AutonatV2, conn: Connection
+    self: AutonatV2, stream: Stream
 ) {.async: (raises: [CancelledError, AutonatV2Error, LPStreamError]).} =
   var dataReceived: uint64 = 0
 
   while dataReceived < self.config.dialDataSize:
     let msg = AutonatV2Msg.decode(
-      initProtoBuffer(await conn.readLp(DialDataResponseLpSize))
+      initProtoBuffer(await stream.readLp(DialDataResponseLpSize))
     ).valueOr:
       raise newException(AutonatV2Error, "Received malformed message")
     debug "Received message", msgType = $msg.msgType
@@ -129,10 +129,10 @@ proc handleDialDataResponses(
       dataReceived = resp.data.len.uint64, totalDataReceived = dataReceived
 
 proc amplificationAttackPrevention(
-    self: AutonatV2, conn: Connection, addrIdx: AddrIdx
+    self: AutonatV2, stream: Stream, addrIdx: AddrIdx
 ): Future[bool] {.async: (raises: [CancelledError, LPStreamError]).} =
   # send DialDataRequest
-  await conn.writeLp(
+  await stream.writeLp(
     AutonatV2Msg(
       msgType: MsgType.DialDataRequest,
       dialDataReq: DialDataRequest(addrIdx: addrIdx, numBytes: self.config.dialDataSize),
@@ -141,7 +141,7 @@ proc amplificationAttackPrevention(
 
   # recieve DialDataResponses until we're satisfied
   try:
-    await self.handleDialDataResponses(conn)
+    await self.handleDialDataResponses(stream)
   except AutonatV2Error as exc:
     error "Amplification attack prevention failed", description = exc.msg
     return false
@@ -168,13 +168,13 @@ proc canDial(self: AutonatV2, addrs: MultiAddress): bool =
 
 proc forceNewConnection(
     self: AutonatV2, pid: PeerId, addrs: seq[MultiAddress]
-): Future[Opt[(Muxer, Connection)]] {.async: (raises: [CancelledError]).} =
+): Future[Opt[(Muxer, Stream)]] {.async: (raises: [CancelledError]).} =
   ## Bypasses connManager to force a new connection to ``pid``
   ## instead of reusing a preexistent one
   try:
     let mux = await self.switch.dialer.dialAndUpgrade(Opt.some(pid), addrs)
     if mux.isNil():
-      return Opt.none((Muxer, Connection))
+      return Opt.none((Muxer, Stream))
     return Opt.some(
       (
         mux,
@@ -186,42 +186,41 @@ proc forceNewConnection(
   except CancelledError as exc:
     raise exc
   except CatchableError:
-    return Opt.none((Muxer, Connection))
+    return Opt.none((Muxer, Stream))
 
 proc chooseDialAddr(
     self: AutonatV2, pid: PeerId, addrs: seq[MultiAddress]
-): Future[(Opt[(Muxer, Connection)], Opt[AddrIdx])] {.
-    async: (raises: [CancelledError])
-.} =
+): Future[(Opt[(Muxer, Stream)], Opt[AddrIdx])] {.async: (raises: [CancelledError]).} =
   for i, ma in addrs:
     if self.canDial(ma):
       debug "Trying to dial", chosenAddrs = ma, addrIdx = i
-      let (mux, conn) =
+      let (mux, stream) =
         try:
           (await (self.forceNewConnection(pid, @[ma]).wait(self.config.dialTimeout))).valueOr:
-            return (Opt.none((Muxer, Connection)), Opt.none(AddrIdx))
+            return (Opt.none((Muxer, Stream)), Opt.none(AddrIdx))
         except AsyncTimeoutError:
           trace "Dial timed out"
-          return (Opt.none((Muxer, Connection)), Opt.some(i.AddrIdx))
-      return (Opt.some((mux, conn)), Opt.some(i.AddrIdx))
-  return (Opt.none((Muxer, Connection)), Opt.none(AddrIdx))
+          return (Opt.none((Muxer, Stream)), Opt.some(i.AddrIdx))
+      return (Opt.some((mux, stream)), Opt.some(i.AddrIdx))
+  return (Opt.none((Muxer, Stream)), Opt.none(AddrIdx))
 
 proc handleDialRequest(
-    self: AutonatV2, conn: Connection, req: DialRequest
+    self: AutonatV2, stream: Stream, req: DialRequest
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
-  let observedIPAddr = (await conn.findObservedIPAddr(req)).valueOr:
+  let observedIPAddr = (await stream.findObservedIPAddr(req)).valueOr:
     trace "Could not find observed IP address"
-    await conn.sendDialResponse(ResponseStatus.ERequestRejected)
+    await stream.sendDialResponse(ResponseStatus.ERequestRejected)
     return
 
-  let (dialBackConnOpt, addrIdxOpt) = await self.chooseDialAddr(conn.peerId, req.addrs)
+  let (dialBackConnOpt, addrIdxOpt) =
+    await self.chooseDialAddr(stream.peerId, req.addrs)
   let addrIdx = addrIdxOpt.valueOr:
     trace "No dialable addresses found"
-    await conn.sendDialResponse(ResponseStatus.EDialRefused)
+    await stream.sendDialResponse(ResponseStatus.EDialRefused)
     return
   let (dialBackMux, dialBackConn) = dialBackConnOpt.valueOr:
     trace "Dial failed"
-    await conn.sendDialResponse(
+    await stream.sendDialResponse(
       ResponseStatus.Ok,
       addrIdx = Opt.some(addrIdx),
       dialStatus = Opt.some(DialStatus.EDialError),
@@ -237,12 +236,12 @@ proc handleDialRequest(
     debug "Starting amplification attack prevention",
       observedIPAddr = observedIPAddr, testAddr = req.addrs[addrIdx]
     # send DialDataRequest and wait until dataReceived is enough
-    if not await self.amplificationAttackPrevention(conn, addrIdx).withTimeout(
+    if not await self.amplificationAttackPrevention(stream, addrIdx).withTimeout(
       self.config.amplificationAttackTimeout
     ):
       debug "Amplification attack prevention timeout",
-        timeout = self.config.amplificationAttackTimeout, peer = conn.peerId
-      await conn.sendDialResponse(ResponseStatus.EDialRefused)
+        timeout = self.config.amplificationAttackTimeout, peer = stream.peerId
+      await stream.sendDialResponse(ResponseStatus.EDialRefused)
       return
 
   debug "Sending DialBack",
@@ -251,19 +250,19 @@ proc handleDialRequest(
   try:
     let dialStatus =
       await dialBackConn.dialBack(req.nonce).wait(self.config.dialTimeout)
-    await conn.sendDialResponse(
+    await stream.sendDialResponse(
       ResponseStatus.Ok, addrIdx = Opt.some(addrIdx), dialStatus = Opt.some(dialStatus)
     )
   except DialFailedError as exc:
     debug "DialBack failed", description = exc.msg
-    await conn.sendDialResponse(
+    await stream.sendDialResponse(
       ResponseStatus.Ok,
       addrIdx = Opt.some(addrIdx),
       dialStatus = Opt.some(DialStatus.EDialBackError),
     )
   except AsyncTimeoutError:
     debug "DialBack timeout", timeout = self.config.dialTimeout
-    await conn.sendDialResponse(
+    await stream.sendDialResponse(
       ResponseStatus.Ok,
       addrIdx = Opt.some(addrIdx),
       dialStatus = Opt.some(DialStatus.EDialBackError),
@@ -277,14 +276,14 @@ proc new*(
   # Self instead of T to avoid clashing with withValue[T]'s type param under --lineDir:on
   let autonatV2 = Self(switch: switch, config: config)
   proc handleStream(
-      conn: Connection, proto: string
+      stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     defer:
-      await conn.close()
+      await stream.close()
 
     let msg =
       try:
-        AutonatV2Msg.decode(initProtoBuffer(await conn.readLp(AutonatV2MsgLpSize))).valueOr:
+        AutonatV2Msg.decode(initProtoBuffer(await stream.readLp(AutonatV2MsgLpSize))).valueOr:
           trace "Unable to decode AutonatV2Msg"
           return
       except LPStreamError as exc:
@@ -297,11 +296,11 @@ proc new*(
       return
 
     try:
-      await autonatV2.handleDialRequest(conn, msg.dialReq)
+      await autonatV2.handleDialRequest(stream, msg.dialReq)
     except CancelledError as exc:
       raise exc
     except LPStreamRemoteClosedError as exc:
-      debug "Connection closed by peer", description = exc.msg, peer = conn.peerId
+      debug "Stream closed by peer", description = exc.msg, peer = stream.peerId
     except LPStreamError as exc:
       debug "Stream Error", description = exc.msg
 

--- a/libp2p/protocols/connectivity/dcutr/client.nim
+++ b/libp2p/protocols/connectivity/dcutr/client.nim
@@ -34,7 +34,7 @@ proc startSync*(
 
   var
     peerDialableAddrs: seq[MultiAddress]
-    stream: Connection
+    stream: Stream
   try:
     var ourDialableAddrs = getHolePunchableAddrs(addrs)
     if ourDialableAddrs.len == 0:

--- a/libp2p/protocols/connectivity/dcutr/core.nim
+++ b/libp2p/protocols/connectivity/dcutr/core.nim
@@ -45,10 +45,10 @@ proc decode*(_: typedesc[DcutrMsg], buf: seq[byte]): DcutrMsg {.raises: [DcutrEr
   return dcutrMsg
 
 proc send*(
-    conn: Connection, msgType: MsgType, addrs: seq[MultiAddress]
+    stream: Stream, msgType: MsgType, addrs: seq[MultiAddress]
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
   let pb = DcutrMsg(msgType: msgType, addrs: addrs).encode()
-  await conn.writeLp(pb.buffer)
+  await stream.writeLp(pb.buffer)
 
 proc getHolePunchableAddrs*(
     addrs: seq[MultiAddress]

--- a/libp2p/protocols/connectivity/dcutr/server.nim
+++ b/libp2p/protocols/connectivity/dcutr/server.nim
@@ -25,7 +25,7 @@ proc new*(
     maxDialableAddrs = 8,
 ): T =
   proc handleStream(
-      stream: Connection, proto: string
+      stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     var peerDialableAddrs: seq[MultiAddress]
     try:

--- a/libp2p/protocols/connectivity/relay/client.nim
+++ b/libp2p/protocols/connectivity/relay/client.nim
@@ -27,7 +27,7 @@ type
   RelayV1DialError* = object of RelayDialError
   RelayV2DialError* = object of RelayDialError
   RelayClientAddConn* = proc(
-    conn: Connection, duration: uint32, data: uint64
+    conn: RawConn, duration: uint32, data: uint64
   ): Future[void] {.gcsafe, async: (raises: [CancelledError]).}
   RelayClient* = ref object of Relay
     onNewConnection*: RelayClientAddConn
@@ -41,25 +41,25 @@ type
     limitData*: uint64 # bytes
 
 proc sendStopError(
-    conn: Connection, code: StatusV2
+    stream: Stream, code: StatusV2
 ) {.async: (raises: [CancelledError]).} =
   trace "send stop status", status = $code & " (" & $ord(code) & ")"
   try:
     let msg = StopMessage(msgType: StopMessageType.Status, status: Opt.some(code))
-    await conn.writeLp(encode(msg).buffer)
+    await stream.writeLp(encode(msg).buffer)
   except CancelledError as e:
     raise e
   except LPStreamError as e:
     trace "failed to send stop status", description = e.msg
 
 proc handleRelayedConnect(
-    cl: RelayClient, conn: Connection, msg: StopMessage
+    cl: RelayClient, stream: Stream, msg: StopMessage
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
   let
     # TODO: check the go version to see in which way this could fail
     # it's unclear in the spec
     src = msg.peer.valueOr:
-      await sendStopError(conn, MalformedMessage)
+      await sendStopError(stream, MalformedMessage)
       return
     limitDuration = msg.limit.duration
     limitData = msg.limit.data
@@ -69,29 +69,29 @@ proc handleRelayedConnect(
   trace "incoming relay connection", src
 
   if cl.onNewConnection == nil:
-    await sendStopError(conn, StatusV2.ConnectionFailed)
-    await conn.close()
+    await sendStopError(stream, StatusV2.ConnectionFailed)
+    await stream.close()
     return
-  await conn.writeLp(pb.buffer)
+  await stream.writeLp(pb.buffer)
   # This sound redundant but the callback could, in theory, be set to nil during
-  # conn.writeLp so it's safer to double check
+  # stream.writeLp so it's safer to double check
   if cl.onNewConnection != nil:
-    await cl.onNewConnection(conn, limitDuration, limitData)
+    await cl.onNewConnection(stream, limitDuration, limitData)
   else:
-    await conn.close()
+    await stream.close()
 
 proc reserve*(
     cl: RelayClient, peerId: PeerId, addrs: seq[MultiAddress] = @[]
 ): Future[Rsvp] {.async: (raises: [ReservationError, DialFailedError, CancelledError]).} =
-  let conn = await cl.switch.dial(peerId, addrs, RelayV2HopCodec)
+  let stream = await cl.switch.dial(peerId, addrs, RelayV2HopCodec)
   defer:
-    await conn.close()
+    await stream.close()
   let
     pb = encode(HopMessage(msgType: HopMessageType.Reserve))
     msg =
       try:
-        await conn.writeLp(pb.buffer)
-        HopMessage.decode(await conn.readLp(RelayClientMsgSize)).tryGet()
+        await stream.writeLp(pb.buffer)
+        HopMessage.decode(await stream.readLp(RelayClientMsgSize)).tryGet()
       except CancelledError as exc:
         raise exc
       except CatchableError as exc:
@@ -122,8 +122,8 @@ proc reserve*(
   result.limitData = msg.limit.data
 
 proc dialPeerV1*(
-    cl: RelayClient, conn: Connection, dstPeerId: PeerId, dstAddrs: seq[MultiAddress]
-): Future[Connection] {.async: (raises: [CancelledError, RelayV1DialError]).} =
+    cl: RelayClient, stream: Stream, dstPeerId: PeerId, dstAddrs: seq[MultiAddress]
+): Future[RawConn] {.async: (raises: [CancelledError, RelayV1DialError]).} =
   var
     msg = RelayMessage(
       msgType: Opt.some(RelayType.Hop),
@@ -137,7 +137,7 @@ proc dialPeerV1*(
   trace "Dial peer", msgSend = msg
 
   try:
-    await conn.writeLp(pb.buffer)
+    await stream.writeLp(pb.buffer)
   except CancelledError as exc:
     raise exc
   except LPStreamError as exc:
@@ -146,12 +146,12 @@ proc dialPeerV1*(
 
   let msgRcvFromRelayOpt =
     try:
-      RelayMessage.decode(await conn.readLp(RelayClientMsgSize))
+      RelayMessage.decode(await stream.readLp(RelayClientMsgSize))
     except CancelledError as exc:
       raise exc
     except LPStreamError as exc:
       trace "error reading stop response", description = exc.msg
-      await sendStatus(conn, StatusV1.HopCantOpenDstStream)
+      await sendStatus(stream, StatusV1.HopCantOpenDstStream)
       raise
         newException(RelayV1DialError, "error reading stop response: " & exc.msg, exc)
 
@@ -167,25 +167,25 @@ proc dialPeerV1*(
         RelayV1DialError, "Hop can't open destination stream: status failed"
       )
   except RelayV1DialError as exc:
-    await sendStatus(conn, StatusV1.HopCantOpenDstStream)
+    await sendStatus(stream, StatusV1.HopCantOpenDstStream)
     raise newException(
       RelayV1DialError,
       "Hop can't open destination stream after sendStatus: " & exc.msg,
       exc,
     )
   except ValueError as exc:
-    await sendStatus(conn, StatusV1.HopCantOpenDstStream)
+    await sendStatus(stream, StatusV1.HopCantOpenDstStream)
     raise newException(
       RelayV1DialError, "Exception reading msg in dialPeerV1: " & exc.msg, exc
     )
-  result = conn
+  result = stream
 
 proc dialPeerV2*(
     cl: RelayClient,
-    conn: RelayConnection,
+    relayConn: RelayConnection,
     dstPeerId: PeerId,
     dstAddrs: seq[MultiAddress],
-): Future[Connection] {.async: (raises: [RelayV2DialError, CancelledError]).} =
+): Future[RawConn] {.async: (raises: [RelayV2DialError, CancelledError]).} =
   let
     p = Peer(peerId: dstPeerId, addrs: dstAddrs)
     pb = encode(HopMessage(msgType: HopMessageType.Connect, peer: Opt.some(p)))
@@ -194,8 +194,8 @@ proc dialPeerV2*(
 
   let msgRcvFromRelay =
     try:
-      await conn.writeLp(pb.buffer)
-      HopMessage.decode(await conn.readLp(RelayClientMsgSize)).tryGet()
+      await relayConn.writeLp(pb.buffer)
+      HopMessage.decode(await relayConn.readLp(RelayClientMsgSize)).tryGet()
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
@@ -208,81 +208,81 @@ proc dialPeerV2*(
   if msgRcvFromRelay.status.get(UnexpectedMessage) != Ok:
     trace "Relay stop failed", description = msgRcvFromRelay.status
     raise newException(RelayV2DialError, "Relay stop failure")
-  conn.limitDuration = msgRcvFromRelay.limit.duration
-  conn.limitData = msgRcvFromRelay.limit.data
-  return conn
+  relayConn.limitDuration = msgRcvFromRelay.limit.duration
+  relayConn.limitData = msgRcvFromRelay.limit.data
+  return relayConn
 
 proc handleStopStreamV2(
-    cl: RelayClient, conn: Connection
+    cl: RelayClient, stream: Stream
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
-  let msg = StopMessage.decode(await conn.readLp(RelayClientMsgSize)).valueOr:
-    await sendHopStatus(conn, MalformedMessage)
+  let msg = StopMessage.decode(await stream.readLp(RelayClientMsgSize)).valueOr:
+    await sendHopStatus(stream, MalformedMessage)
     return
   trace "client circuit relay v2 handle stream", msg
 
   if msg.msgType == StopMessageType.Connect:
-    await cl.handleRelayedConnect(conn, msg)
+    await cl.handleRelayedConnect(stream, msg)
   else:
     trace "Unexpected client / relayv2 handshake", msgType = msg.msgType
-    await sendStopError(conn, MalformedMessage)
+    await sendStopError(stream, MalformedMessage)
 
 proc handleStop(
-    cl: RelayClient, conn: Connection, msg: RelayMessage
+    cl: RelayClient, stream: Stream, msg: RelayMessage
 ) {.async: (raises: [CancelledError]).} =
   let src = msg.srcPeer.valueOr:
-    await sendStatus(conn, StatusV1.StopSrcMultiaddrInvalid)
+    await sendStatus(stream, StatusV1.StopSrcMultiaddrInvalid)
     return
 
   let dst = msg.dstPeer.valueOr:
-    await sendStatus(conn, StatusV1.StopDstMultiaddrInvalid)
+    await sendStatus(stream, StatusV1.StopDstMultiaddrInvalid)
     return
 
   if dst.peerId != cl.switch.peerInfo.peerId:
-    await sendStatus(conn, StatusV1.StopDstMultiaddrInvalid)
+    await sendStatus(stream, StatusV1.StopDstMultiaddrInvalid)
     return
 
-  trace "get a relay connection", src, conn
+  trace "get a relay connection", src, stream
 
   if cl.onNewConnection == nil:
-    await sendStatus(conn, StatusV1.StopRelayRefused)
-    await conn.close()
+    await sendStatus(stream, StatusV1.StopRelayRefused)
+    await stream.close()
     return
-  await sendStatus(conn, StatusV1.Success)
+  await sendStatus(stream, StatusV1.Success)
   # This sound redundant but the callback could, in theory, be set to nil during
   # sendStatus(Success) so it's safer to double check
   if cl.onNewConnection != nil:
-    await cl.onNewConnection(conn, 0, 0)
+    await cl.onNewConnection(stream, 0, 0)
   else:
-    await conn.close()
+    await stream.close()
 
 proc handleStreamV1(
-    cl: RelayClient, conn: Connection
+    cl: RelayClient, stream: Stream
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
-  let msg = RelayMessage.decode(await conn.readLp(RelayClientMsgSize)).valueOr:
-    await sendStatus(conn, StatusV1.MalformedMessage)
+  let msg = RelayMessage.decode(await stream.readLp(RelayClientMsgSize)).valueOr:
+    await sendStatus(stream, StatusV1.MalformedMessage)
     return
   trace "client circuit relay v1 handle stream", msg
 
   let typ = msg.msgType.valueOr:
     trace "Message type not set"
-    await sendStatus(conn, StatusV1.MalformedMessage)
+    await sendStatus(stream, StatusV1.MalformedMessage)
     return
   case typ
   of RelayType.Hop:
     if cl.canHop:
-      await cl.handleHop(conn, msg)
+      await cl.handleHop(stream, msg)
     else:
-      await sendStatus(conn, StatusV1.HopCantSpeakRelay)
+      await sendStatus(stream, StatusV1.HopCantSpeakRelay)
   of RelayType.Stop:
-    await cl.handleStop(conn, msg)
+    await cl.handleStop(stream, msg)
   of RelayType.CanHop:
     if cl.canHop:
-      await sendStatus(conn, StatusV1.Success)
+      await sendStatus(stream, StatusV1.Success)
     else:
-      await sendStatus(conn, StatusV1.HopCantSpeakRelay)
+      await sendStatus(stream, StatusV1.HopCantSpeakRelay)
   else:
     trace "Unexpected relay handshake", msgType = msg.msgType
-    await sendStatus(conn, StatusV1.MalformedMessage)
+    await sendStatus(stream, StatusV1.MalformedMessage)
 
 proc new*(
     T: typedesc[RelayClient],
@@ -307,24 +307,24 @@ proc new*(
     isCircuitRelayV1: circuitRelayV1,
   )
   proc handleStream(
-      conn: Connection, proto: string
+      stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     try:
       case proto
       of RelayV1Codec:
-        await cl.handleStreamV1(conn)
+        await cl.handleStreamV1(stream)
       of RelayV2StopCodec:
-        await cl.handleStopStreamV2(conn)
+        await cl.handleStopStreamV2(stream)
       of RelayV2HopCodec:
-        await cl.handleHopStreamV2(conn)
+        await cl.handleHopStreamV2(stream)
     except CancelledError as exc:
       trace "cancelled client handler"
       raise exc
     except CatchableError as exc:
-      trace "exception in client handler", description = exc.msg, conn
+      trace "exception in client handler", description = exc.msg, stream
     finally:
-      trace "exiting client handler", conn
-      await conn.close()
+      trace "exiting client handler", stream
+      await stream.close()
 
   cl.handler = handleStream
   cl.codecs =

--- a/libp2p/protocols/connectivity/relay/rconn.nim
+++ b/libp2p/protocols/connectivity/relay/rconn.nim
@@ -8,7 +8,7 @@ import chronos
 import ../../../stream/connection
 
 type RelayConnection* = ref object of Connection
-  conn*: Connection
+  stream*: Stream
   limitDuration*: uint32
   limitData*: uint64
   dataSent*: uint64
@@ -17,7 +17,7 @@ method readOnce*(
     self: RelayConnection, pbytes: pointer, nbytes: int
 ): Future[int] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   self.activity = true
-  self.conn.readOnce(pbytes, nbytes)
+  self.stream.readOnce(pbytes, nbytes)
 
 method write*(
     self: RelayConnection, msg: seq[byte]
@@ -27,34 +27,34 @@ method write*(
     await self.close()
     return
   self.activity = true
-  await self.conn.write(msg)
+  await self.stream.write(msg)
 
 method closeImpl*(self: RelayConnection): Future[void] {.async: (raises: []).} =
-  await self.conn.close()
+  await self.stream.close()
   await procCall Connection(self).closeImpl()
 
 method resetImpl*(self: RelayConnection): Future[void] {.async: (raises: []).} =
-  await self.conn.reset()
+  await self.stream.reset()
   await procCall Connection(self).closeImpl()
 
 method getWrapped*(self: RelayConnection): Connection =
-  self.conn
+  self.stream
 
 proc new*(
     T: typedesc[RelayConnection],
-    conn: Connection,
+    stream: Stream,
     limitDuration: uint32,
     limitData: uint64,
 ): T =
-  let rc = T(conn: conn, limitDuration: limitDuration, limitData: limitData)
-  rc.dir = conn.dir
+  let rc = T(stream: stream, limitDuration: limitDuration, limitData: limitData)
+  rc.dir = stream.dir
   rc.initStream()
   if limitDuration > 0:
     proc checkDurationConnection() {.async: (raises: []).} =
       try:
-        await noCancel conn.join().wait(limitDuration.seconds())
+        await noCancel stream.join().wait(limitDuration.seconds())
       except AsyncTimeoutError:
-        await conn.close()
+        await stream.close()
 
     asyncSpawn checkDurationConnection()
   return rc

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -98,8 +98,8 @@ proc createReserveResponse(
     )
   return ok(msg)
 
-proc isRelayed*(conn: Connection): bool =
-  var wrappedConn = conn
+proc isRelayed*(stream: Stream): bool =
+  var wrappedConn = stream
   while not isNil(wrappedConn):
     if wrappedConn of RelayConnection:
       return true
@@ -107,44 +107,44 @@ proc isRelayed*(conn: Connection): bool =
   return false
 
 proc handleReserve(
-    r: Relay, conn: Connection
+    r: Relay, stream: Stream
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
-  if conn.isRelayed():
-    trace "reservation attempt over relay connection", pid = conn.peerId
-    await sendHopStatus(conn, PermissionDenied)
+  if stream.isRelayed():
+    trace "reservation attempt over relay connection", pid = stream.peerId
+    await sendHopStatus(stream, PermissionDenied)
     return
 
-  if r.peerCount[conn.peerId] + r.rsvp.len() >= r.maxCircuit:
-    trace "Too many reservations", pid = conn.peerId
-    await sendHopStatus(conn, ReservationRefused)
+  if r.peerCount[stream.peerId] + r.rsvp.len() >= r.maxCircuit:
+    trace "Too many reservations", pid = stream.peerId
+    await sendHopStatus(stream, ReservationRefused)
     return
-  trace "reserving relay slot for", pid = conn.peerId
+  trace "reserving relay slot for", pid = stream.peerId
   let
-    pid = conn.peerId
+    pid = stream.peerId
     expire = now().utc + r.reservationTTL
     msg = r.createReserveResponse(pid, expire).valueOr:
       trace "error signing the voucher", pid
       return
 
   r.rsvp[pid] = expire
-  await conn.writeLp(encode(msg).buffer)
+  await stream.writeLp(encode(msg).buffer)
 
 proc handleConnect(
-    r: Relay, connSrc: Connection, msg: HopMessage
+    r: Relay, srcStream: Stream, msg: HopMessage
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
-  if connSrc.isRelayed():
+  if srcStream.isRelayed():
     trace "connection attempt over relay connection"
-    await sendHopStatus(connSrc, PermissionDenied)
+    await sendHopStatus(srcStream, PermissionDenied)
     return
   let
     msgPeer = msg.peer.valueOr:
-      await sendHopStatus(connSrc, MalformedMessage)
+      await sendHopStatus(srcStream, MalformedMessage)
       return
-    src = connSrc.peerId
+    src = srcStream.peerId
     dst = msgPeer.peerId
   if dst notin r.rsvp:
     trace "refusing connection, no reservation", src, dst
-    await sendHopStatus(connSrc, NoReservation)
+    await sendHopStatus(srcStream, NoReservation)
     return
 
   r.peerCount.inc(src)
@@ -156,20 +156,20 @@ proc handleConnect(
   if r.peerCount[src] > r.maxCircuitPerPeer or r.peerCount[dst] > r.maxCircuitPerPeer:
     trace "too many connections",
       src = r.peerCount[src], dst = r.peerCount[dst], max = r.maxCircuitPerPeer
-    await sendHopStatus(connSrc, ResourceLimitExceeded)
+    await sendHopStatus(srcStream, ResourceLimitExceeded)
     return
 
-  let connDst =
+  let dstStream =
     try:
       await r.switch.dial(dst, RelayV2StopCodec)
     except CancelledError as exc:
       raise exc
     except DialFailedError as exc:
       trace "error opening relay stream", dst, description = exc.msg
-      await sendHopStatus(connSrc, ConnectionFailed)
+      await sendHopStatus(srcStream, ConnectionFailed)
       return
   defer:
-    await connDst.close()
+    await dstStream.close()
 
   proc sendStopMsg() {.async: (raises: [SendStopError, CancelledError, LPStreamError]).} =
     let stopMsg = StopMessage(
@@ -177,15 +177,15 @@ proc handleConnect(
       peer: Opt.some(Peer(peerId: src, addrs: @[])),
       limit: r.limit,
     )
-    await connDst.writeLp(encode(stopMsg).buffer)
-    let msg = StopMessage.decode(await connDst.readLp(r.msgSize)).valueOr:
+    await dstStream.writeLp(encode(stopMsg).buffer)
+    let msg = StopMessage.decode(await dstStream.readLp(r.msgSize)).valueOr:
       raise newException(SendStopError, "Malformed message")
     if msg.msgType != StopMessageType.Status:
       raise
         newException(SendStopError, "Unexpected stop response, not a status message")
     if msg.status.get(UnexpectedMessage) != Ok:
       raise newException(SendStopError, "Relay stop failure")
-    await connSrc.writeLp(
+    await srcStream.writeLp(
       encode(HopMessage(msgType: HopMessageType.Status, status: Opt.some(Ok))).buffer
     )
 
@@ -195,38 +195,38 @@ proc handleConnect(
     raise exc
   except CatchableError as exc:
     trace "error sending stop message", description = exc.msg
-    await sendHopStatus(connSrc, ConnectionFailed)
+    await sendHopStatus(srcStream, ConnectionFailed)
     return
 
   trace "relaying connection", src, dst
   let
-    rconnSrc = RelayConnection.new(connSrc, r.limit.duration, r.limit.data)
-    rconnDst = RelayConnection.new(connDst, r.limit.duration, r.limit.data)
+    srcRelayConn = RelayConnection.new(srcStream, r.limit.duration, r.limit.data)
+    dstRelayConn = RelayConnection.new(dstStream, r.limit.duration, r.limit.data)
   defer:
-    await rconnSrc.close()
-    await rconnDst.close()
-  await bridge(rconnSrc, rconnDst)
+    await srcRelayConn.close()
+    await dstRelayConn.close()
+  await bridge(srcRelayConn, dstRelayConn)
 
 proc handleHopStreamV2*(
-    r: Relay, conn: Connection
+    r: Relay, stream: Stream
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
-  let msg = HopMessage.decode(await conn.readLp(r.msgSize)).valueOr:
-    await sendHopStatus(conn, MalformedMessage)
+  let msg = HopMessage.decode(await stream.readLp(r.msgSize)).valueOr:
+    await sendHopStatus(stream, MalformedMessage)
     return
   trace "relayv2 handle stream", hopMsg = msg
   case msg.msgType
   of HopMessageType.Reserve:
-    await r.handleReserve(conn)
+    await r.handleReserve(stream)
   of HopMessageType.Connect:
-    await r.handleConnect(conn, msg)
+    await r.handleConnect(stream, msg)
   else:
     trace "Unexpected relayv2 handshake", msgType = msg.msgType
-    await sendHopStatus(conn, MalformedMessage)
+    await sendHopStatus(stream, MalformedMessage)
 
 # Relay V1
 
 proc handleHop*(
-    r: Relay, connSrc: Connection, msg: RelayMessage
+    r: Relay, srcStream: Stream, msg: RelayMessage
 ) {.async: (raises: [CancelledError]).} =
   r.streamCount.inc()
   defer:
@@ -234,14 +234,14 @@ proc handleHop*(
   if r.streamCount + r.rsvp.len() >= r.maxCircuit:
     trace "refusing connection; too many active circuit",
       streamCount = r.streamCount, rsvp = r.rsvp.len()
-    await sendStatus(connSrc, StatusV1.HopCantSpeakRelay)
+    await sendStatus(srcStream, StatusV1.HopCantSpeakRelay)
     return
 
   var src, dst: RelayPeer
   proc checkMsg(): Result[RelayMessage, StatusV1] =
     src = msg.srcPeer.valueOr:
       return err(StatusV1.HopSrcMultiaddrInvalid)
-    if src.peerId != connSrc.peerId:
+    if src.peerId != srcStream.peerId:
       return err(StatusV1.HopSrcMultiaddrInvalid)
     dst = msg.dstPeer.valueOr:
       return err(StatusV1.HopDstMultiaddrInvalid)
@@ -254,13 +254,13 @@ proc handleHop*(
 
   let check = checkMsg()
   if check.isErr:
-    await sendStatus(connSrc, check.error())
+    await sendStatus(srcStream, check.error())
     return
 
   if r.peerCount[src.peerId] >= r.maxCircuitPerPeer or
       r.peerCount[dst.peerId] >= r.maxCircuitPerPeer:
     trace "refusing connection; too many connection from src or to dst", src, dst
-    await sendStatus(connSrc, StatusV1.HopCantSpeakRelay)
+    await sendStatus(srcStream, StatusV1.HopCantSpeakRelay)
     return
   r.peerCount.inc(src.peerId)
   r.peerCount.inc(dst.peerId)
@@ -268,17 +268,17 @@ proc handleHop*(
     r.peerCount.inc(src.peerId, -1)
     r.peerCount.inc(dst.peerId, -1)
 
-  let connDst =
+  let dstStream =
     try:
       await r.switch.dial(dst.peerId, RelayV1Codec)
     except CancelledError as exc:
       raise exc
     except DialFailedError as exc:
       trace "error opening relay stream", dst, description = exc.msg
-      await sendStatus(connSrc, StatusV1.HopCantDialDst)
+      await sendStatus(srcStream, StatusV1.HopCantDialDst)
       return
   defer:
-    await connDst.close()
+    await dstStream.close()
 
   let msgToSend = RelayMessage(
     msgType: Opt.some(RelayType.Stop), srcPeer: Opt.some(src), dstPeer: Opt.some(dst)
@@ -286,53 +286,53 @@ proc handleHop*(
 
   let msgRcvFromDstOpt =
     try:
-      await connDst.writeLp(encode(msgToSend).buffer)
-      RelayMessage.decode(await connDst.readLp(r.msgSize))
+      await dstStream.writeLp(encode(msgToSend).buffer)
+      RelayMessage.decode(await dstStream.readLp(r.msgSize))
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
       trace "error writing stop handshake or reading stop response",
         description = exc.msg
-      await sendStatus(connSrc, StatusV1.HopCantOpenDstStream)
+      await sendStatus(srcStream, StatusV1.HopCantOpenDstStream)
       return
 
   let msgRcvFromDst = msgRcvFromDstOpt.valueOr:
     trace "error reading stop response", response = msgRcvFromDstOpt
-    await sendStatus(connSrc, StatusV1.HopCantOpenDstStream)
+    await sendStatus(srcStream, StatusV1.HopCantOpenDstStream)
     return
 
   if msgRcvFromDst.msgType.get(RelayType.Stop) != RelayType.Status or
       msgRcvFromDst.status.get(StatusV1.StopRelayRefused) != StatusV1.Success:
     trace "unexcepted relay stop response", msgRcvFromDst
-    await sendStatus(connSrc, StatusV1.HopCantOpenDstStream)
+    await sendStatus(srcStream, StatusV1.HopCantOpenDstStream)
     return
 
-  await sendStatus(connSrc, StatusV1.Success)
+  await sendStatus(srcStream, StatusV1.Success)
   trace "relaying connection", src, dst
-  await bridge(connSrc, connDst)
+  await bridge(srcStream, dstStream)
 
 proc handleStreamV1(
-    r: Relay, conn: Connection
+    r: Relay, stream: Stream
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
-  let msg = RelayMessage.decode(await conn.readLp(r.msgSize)).valueOr:
-    await sendStatus(conn, StatusV1.MalformedMessage)
+  let msg = RelayMessage.decode(await stream.readLp(r.msgSize)).valueOr:
+    await sendStatus(stream, StatusV1.MalformedMessage)
     return
   trace "relay handle stream", msg
 
   let typ = msg.msgType.valueOr:
     trace "Message type not set"
-    await sendStatus(conn, StatusV1.MalformedMessage)
+    await sendStatus(stream, StatusV1.MalformedMessage)
     return
   case typ
   of RelayType.Hop:
-    await r.handleHop(conn, msg)
+    await r.handleHop(stream, msg)
   of RelayType.Stop:
-    await sendStatus(conn, StatusV1.StopRelayRefused)
+    await sendStatus(stream, StatusV1.StopRelayRefused)
   of RelayType.CanHop:
-    await sendStatus(conn, StatusV1.Success)
+    await sendStatus(stream, StatusV1.Success)
   else:
     trace "Unexpected relay handshake", msgType = msg.msgType
-    await sendStatus(conn, StatusV1.MalformedMessage)
+    await sendStatus(stream, StatusV1.MalformedMessage)
 
 proc setup*(r: Relay, switch: Switch) =
   r.switch = switch
@@ -364,22 +364,22 @@ proc new*(
   )
 
   proc handleStream(
-      conn: Connection, proto: string
+      stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     try:
       case proto
       of RelayV2HopCodec:
-        await r.handleHopStreamV2(conn)
+        await r.handleHopStreamV2(stream)
       of RelayV1Codec:
-        await r.handleStreamV1(conn)
+        await r.handleStreamV1(stream)
     except CancelledError as exc:
       trace "cancelled relayv2 handler"
       raise exc
     except CatchableError as exc:
-      debug "exception in relayv2 handler", description = exc.msg, conn
+      debug "exception in relayv2 handler", description = exc.msg, stream
     finally:
-      trace "exiting relayv2 handler", conn
-      await conn.close()
+      trace "exiting relayv2 handler", stream
+      await stream.close()
 
   r.codecs =
     if r.isCircuitRelayV1:

--- a/libp2p/protocols/connectivity/relay/rtransport.nim
+++ b/libp2p/protocols/connectivity/relay/rtransport.nim
@@ -31,7 +31,7 @@ method start*(
     return
 
   self.client.onNewConnection = proc(
-      conn: Connection, duration: uint32 = 0, data: uint64 = 0
+      conn: RawConn, duration: uint32 = 0, data: uint64 = 0
   ) {.async: (raises: [CancelledError]).} =
     await self.queue.addLast(RelayConnection.new(conn, duration, data))
     await conn.join()
@@ -131,6 +131,6 @@ proc new*(Self: typedesc[RelayTransport], cl: RelayClient, upgrader: Upgrade): S
   # Self instead of T to avoid clashing with withValue[T]'s type param under --lineDir:on
   let self = Self(client: cl, upgrader: upgrader)
   self.running = true
-  self.queue = newAsyncQueue[Connection](0)
+  self.queue = newAsyncQueue[RawConn](0)
   procCall Transport(self).initialize()
   self

--- a/libp2p/protocols/connectivity/relay/rtransport.nim
+++ b/libp2p/protocols/connectivity/relay/rtransport.nim
@@ -20,7 +20,7 @@ logScope:
 
 type RelayTransport* = ref object of Transport
   client*: RelayClient
-  queue: AsyncQueue[Connection]
+  queue: AsyncQueue[RawConn]
   selfRunning: bool
 
 method start*(
@@ -51,12 +51,12 @@ method stop*(self: RelayTransport) {.async: (raises: []).} =
 
 method accept*(
     self: RelayTransport
-): Future[Connection] {.async: (raises: [transport.TransportError, CancelledError]).} =
+): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =
   result = await self.queue.popFirst()
 
 proc dial*(
     self: RelayTransport, ma: MultiAddress
-): Future[Connection] {.async: (raises: [RelayDialError, CancelledError]).} =
+): Future[RawConn] {.async: (raises: [RelayDialError, CancelledError]).} =
   var
     relayAddrs: MultiAddress
     relayPeerId: PeerId
@@ -107,7 +107,7 @@ method dial*(
     hostname: string,
     ma: MultiAddress,
     peerId: Opt[PeerId] = Opt.none(PeerId),
-): Future[Connection] {.async: (raises: [transport.TransportError, CancelledError]).} =
+): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =
   peerId.withValue(pid):
     try:
       let address = MultiAddress.init($ma & "/p2p/" & $pid).tryGet()

--- a/libp2p/protocols/connectivity/relay/utils.nim
+++ b/libp2p/protocols/connectivity/relay/utils.nim
@@ -14,53 +14,51 @@ const
   RelayV2HopCodec* = "/libp2p/circuit/relay/0.2.0/hop"
   RelayV2StopCodec* = "/libp2p/circuit/relay/0.2.0/stop"
 
-proc sendStatus*(
-    conn: Connection, code: StatusV1
-) {.async: (raises: [CancelledError]).} =
+proc sendStatus*(stream: Stream, code: StatusV1) {.async: (raises: [CancelledError]).} =
   trace "send relay/v1 status", status = $code & "(" & $ord(code) & ")"
   try:
     let
       msg = RelayMessage(msgType: Opt.some(RelayType.Status), status: Opt.some(code))
       pb = encode(msg)
-    await conn.writeLp(pb.buffer)
+    await stream.writeLp(pb.buffer)
   except CancelledError as e:
     raise e
   except LPStreamError as e:
     trace "error sending relay status", description = e.msg
 
 proc sendHopStatus*(
-    conn: Connection, code: StatusV2
+    stream: Stream, code: StatusV2
 ) {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   trace "send hop relay/v2 status", status = $code & "(" & $ord(code) & ")"
   let
     msg = HopMessage(msgType: HopMessageType.Status, status: Opt.some(code))
     pb = encode(msg)
-  conn.writeLp(pb.buffer)
+  stream.writeLp(pb.buffer)
 
 proc sendStopStatus*(
-    conn: Connection, code: StatusV2
+    stream: Stream, code: StatusV2
 ) {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   trace "send stop relay/v2 status", status = $code & " (" & $ord(code) & ")"
   let
     msg = StopMessage(msgType: StopMessageType.Status, status: Opt.some(code))
     pb = encode(msg)
-  conn.writeLp(pb.buffer)
+  stream.writeLp(pb.buffer)
 
 proc bridge*(
-    connSrc: Connection, connDst: Connection
+    srcStream: Stream, dstStream: Stream
 ) {.async: (raises: [CancelledError]).} =
   const bufferSize = 4096
   var
     bufSrcToDst: array[bufferSize, byte]
     bufDstToSrc: array[bufferSize, byte]
-    futSrc = connSrc.readOnce(addr bufSrcToDst[0], bufSrcToDst.len)
-    futDst = connDst.readOnce(addr bufDstToSrc[0], bufDstToSrc.len)
+    futSrc = srcStream.readOnce(addr bufSrcToDst[0], bufSrcToDst.len)
+    futDst = dstStream.readOnce(addr bufDstToSrc[0], bufDstToSrc.len)
     bytesSentFromSrcToDst = 0
     bytesSentFromDstToSrc = 0
     bufRead: int
 
   try:
-    while not connSrc.closed() and not connDst.closed():
+    while not srcStream.closed() and not dstStream.closed():
       try: # https://github.com/status-im/nim-chronos/issues/516
         discard await race(futSrc, futDst)
       except ValueError as e:
@@ -69,23 +67,23 @@ proc bridge*(
         bufRead = await futSrc
         if bufRead > 0:
           bytesSentFromSrcToDst.inc(bufRead)
-          await connDst.write(@bufSrcToDst[0 ..< bufRead])
+          await dstStream.write(@bufSrcToDst[0 ..< bufRead])
           zeroMem(addr bufSrcToDst[0], bufSrcToDst.len)
-        futSrc = connSrc.readOnce(addr bufSrcToDst[0], bufSrcToDst.len)
+        futSrc = srcStream.readOnce(addr bufSrcToDst[0], bufSrcToDst.len)
       if futDst.finished():
         bufRead = await futDst
         if bufRead > 0:
           bytesSentFromDstToSrc += bufRead
-          await connSrc.write(bufDstToSrc[0 ..< bufRead])
+          await srcStream.write(bufDstToSrc[0 ..< bufRead])
           zeroMem(addr bufDstToSrc[0], bufDstToSrc.len)
-        futDst = connDst.readOnce(addr bufDstToSrc[0], bufDstToSrc.len)
+        futDst = dstStream.readOnce(addr bufDstToSrc[0], bufDstToSrc.len)
   except CancelledError as exc:
     raise exc
   except LPStreamError as exc:
-    if connSrc.closed() or connSrc.atEof():
-      trace "relay src closed connection", src = connSrc.peerId
-    if connDst.closed() or connDst.atEof():
-      trace "relay dst closed connection", dst = connDst.peerId
+    if srcStream.closed() or srcStream.atEof():
+      trace "relay src closed connection", src = srcStream.peerId
+    if dstStream.closed() or dstStream.atEof():
+      trace "relay dst closed connection", dst = dstStream.peerId
     trace "relay error", description = exc.msg
   trace "end relaying", bytesSentFromSrcToDst, bytesSentFromDstToSrc
   await futSrc.cancelAndWait()

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -141,41 +141,41 @@ proc new*(
   identify
 
 method init*(p: Identify) =
-  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+  proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
     try:
-      trace "handling identify request", conn
-      let pb = encodeMsg(p.peerInfo, conn.observedAddr, p.sendSignedPeerRecord)
-      await conn.writeLp(pb.buffer)
-      debug "identify: info sent", conn, info = p.peerInfo
+      trace "handling identify request", stream
+      let pb = encodeMsg(p.peerInfo, stream.observedAddr, p.sendSignedPeerRecord)
+      await stream.writeLp(pb.buffer)
+      debug "identify: info sent", stream, info = p.peerInfo
     except CancelledError as exc:
       trace "cancelled identify handler"
       raise exc
     except CatchableError as exc:
-      trace "exception in identify handler", description = exc.msg, conn
+      trace "exception in identify handler", description = exc.msg, stream
     finally:
-      trace "exiting identify handler", conn
-      await conn.closeWithEOF()
+      trace "exiting identify handler", stream
+      await stream.closeWithEOF()
 
   p.handler = handle
   p.codec = IdentifyCodec
 
 proc identify*(
-    self: Identify, conn: Connection, remotePeerId: PeerId
+    self: Identify, stream: Stream, remotePeerId: PeerId
 ): Future[IdentifyInfo] {.
     async: (
       raises:
         [IdentityInvalidMsgError, IdentityNoMatchError, LPStreamError, CancelledError]
     )
 .} =
-  trace "initiating identify", conn
-  var message = await conn.readLp(maxMsgSize)
+  trace "initiating identify", stream
+  var message = await stream.readLp(maxMsgSize)
   if len(message) == 0:
-    trace "identify: Empty message received!", conn
+    trace "identify: Empty message received!", stream
     raise newException(IdentityInvalidMsgError, "Empty message received!")
 
   var info = decodeMsg(message).valueOr:
     raise newException(IdentityInvalidMsgError, "Incorrect message received!")
-  debug "identify: info received", conn, info
+  debug "identify: info received", stream, info
   let
     pubkey = info.pubkey.valueOr:
       raise newException(IdentityInvalidMsgError, "No pubkey in identify")
@@ -205,41 +205,41 @@ proc new*(T: typedesc[IdentifyPush], handler: IdentifyPushHandler = nil): T =
   identifypush
 
 proc init*(p: IdentifyPush) =
-  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
-    trace "handling identify push", conn
+  proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
+    trace "handling identify push", stream
     try:
-      var message = await conn.readLp(maxMsgSize)
+      var message = await stream.readLp(maxMsgSize)
 
       var identInfo = decodeMsg(message).valueOr:
         raise newException(IdentityInvalidMsgError, "Incorrect message received!")
-      debug "identify push: info received", conn, identInfo
+      debug "identify push: info received", stream, identInfo
 
       identInfo.pubkey.withValue(pubkey):
         let receivedPeerId = PeerId.init(pubkey).tryGet()
-        if receivedPeerId != conn.peerId:
+        if receivedPeerId != stream.peerId:
           raise newException(IdentityNoMatchError, "Peer ids don't match")
         identInfo.peerId = receivedPeerId
       else:
-        identInfo.peerId = conn.peerId
+        identInfo.peerId = stream.peerId
 
-      trace "triggering peer event", peerInfo = conn.peerId
+      trace "triggering peer event", peerInfo = stream.peerId
       if not isNil(p.identifyHandler):
-        await p.identifyHandler(conn.peerId, identInfo)
+        await p.identifyHandler(stream.peerId, identInfo)
     except CancelledError as exc:
       trace "cancelled identify push handler"
       raise exc
     except CatchableError as exc:
-      info "exception in identify push handler", description = exc.msg, conn
+      info "exception in identify push handler", description = exc.msg, stream
     finally:
-      trace "exiting identify push handler", conn
-      await conn.closeWithEOF()
+      trace "exiting identify push handler", stream
+      await stream.closeWithEOF()
 
   p.handler = handle
   p.codec = IdentifyPushCodec
 
 proc push*(
-    p: IdentifyPush, peerInfo: PeerInfo, conn: Connection
+    p: IdentifyPush, peerInfo: PeerInfo, stream: Stream
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
   ## Send new `peerInfo`s to a connection
-  let pb = encodeMsg(peerInfo, conn.observedAddr, true)
-  await conn.writeLp(pb.buffer)
+  let pb = encodeMsg(peerInfo, stream.observedAddr, true)
+  await stream.writeLp(pb.buffer)

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -82,18 +82,18 @@ proc new*(
     return kad
 
   kad.handler = proc(
-      conn: Connection, proto: string
+      stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     defer:
-      await conn.close()
-    while not conn.atEof:
+      await stream.close()
+    while not stream.atEof:
       let buf =
         try:
-          await conn.readLp(MaxMsgSize)
+          await stream.readLp(MaxMsgSize)
         except LPStreamEOFError:
           return
         except LPStreamError as exc:
-          debug "Read error when handling kademlia RPC", conn = conn, err = exc.msg
+          debug "Read error when handling kademlia RPC", stream = stream, err = exc.msg
           return
       let msg = Message.decode(buf).valueOr:
         debug "Failed to decode message", err = error
@@ -104,17 +104,17 @@ proc new*(
 
       case msg.msgType
       of MessageType.findNode:
-        await kad.handleFindNode(conn, msg)
+        await kad.handleFindNode(stream, msg)
       of MessageType.putValue:
-        await kad.handlePutValue(conn, msg)
+        await kad.handlePutValue(stream, msg)
       of MessageType.getValue:
-        await kad.handleGetValue(conn, msg)
+        await kad.handleGetValue(stream, msg)
       of MessageType.addProvider:
-        await kad.handleAddProvider(conn, msg)
+        await kad.handleAddProvider(stream, msg)
       of MessageType.getProviders:
-        await kad.handleGetProviders(conn, msg)
+        await kad.handleGetProviders(stream, msg)
       of MessageType.ping:
-        await kad.handlePing(conn, msg)
+        await kad.handlePing(stream, msg)
       of MessageType.register:
         trace "Unsupported message REGISTER"
         continue

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -128,13 +128,13 @@ proc dispatchFindNode*(
     addrs: Opt[seq[MultiAddress]] = Opt.none(seq[MultiAddress]),
 ): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
   let addrs = addrs.valueOr(kad.switch.peerStore[AddressBook][peer])
-  let connRes = catch:
+  let streamRes = catch:
     await kad.switch.dial(peer, addrs, kad.codec)
-  if connRes.isErr:
-    return err(connRes.error.msg)
-  let conn = connRes.value()
+  if streamRes.isErr:
+    return err(streamRes.error.msg)
+  let stream = streamRes.value()
   defer:
-    await conn.close()
+    await stream.close()
 
   let msg = Message(msgType: MessageType.findNode, key: target)
   let encoded = msg.encode(kad.config.hideConnectionStatus)
@@ -148,8 +148,8 @@ proc dispatchFindNode*(
   var ioRes: Result[void, ref CatchableError]
   kad_message_duration_ms.time(labelValues = [$MessageType.findNode]):
     ioRes = catch:
-      await conn.writeLp(encoded.buffer)
-      replyBuf = await conn.readLp(MaxMsgSize)
+      await stream.writeLp(encoded.buffer)
+      replyBuf = await stream.readLp(MaxMsgSize)
   if ioRes.isErr:
     return err(ioRes.error.msg)
 
@@ -319,7 +319,7 @@ proc findClosestPeers*(kad: KadDHT, target: Key): seq[Peer] =
   return kad.switch.toPeers(closestPeerKeys)
 
 method handleFindNode*(
-    kad: KadDHT, conn: Connection, msg: Message
+    kad: KadDHT, stream: Stream, msg: Message
 ) {.base, async: (raises: [CancelledError]).} =
   let target = msg.key
 
@@ -330,10 +330,11 @@ method handleFindNode*(
     encoded.buffer.len.int64, labelValues = [$MessageType.findNode]
   )
   try:
-    await conn.writeLp(encoded.buffer)
+    await stream.writeLp(encoded.buffer)
   except LPStreamError as exc:
-    debug "Write error when writing kad find-node RPC reply", conn = conn, err = exc.msg
+    debug "Write error when writing kad find-node RPC reply",
+      stream = stream, err = exc.msg
     return
 
   # Peer is useful. adding to rtable
-  discard kad.rtable.insert(conn.peerId)
+  discard kad.rtable.insert(stream.peerId)

--- a/libp2p/protocols/kademlia/get.nim
+++ b/libp2p/protocols/kademlia/get.nim
@@ -14,13 +14,13 @@ logScope:
 proc dispatchGetVal*(
     kad: KadDHT, peer: PeerId, key: Key
 ): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
-  let connRes = catch:
+  let streamRes = catch:
     await kad.switch.dial(peer, kad.switch.peerStore[AddressBook][peer], kad.codec)
-  if connRes.isErr:
-    return err(connRes.error.msg)
-  let conn = connRes.value()
+  if streamRes.isErr:
+    return err(streamRes.error.msg)
+  let stream = streamRes.value()
   defer:
-    await conn.close()
+    await stream.close()
 
   let msg = Message(msgType: MessageType.getValue, key: key)
   let encoded = msg.encode(kad.config.hideConnectionStatus)
@@ -34,8 +34,8 @@ proc dispatchGetVal*(
   var ioRes: Result[void, ref CatchableError]
   kad_message_duration_ms.time(labelValues = [$MessageType.getValue]):
     ioRes = catch:
-      await conn.writeLp(encoded.buffer)
-      replyBuf = await conn.readLp(MaxMsgSize)
+      await stream.writeLp(encoded.buffer)
+      replyBuf = await stream.readLp(MaxMsgSize)
   if ioRes.isErr:
     return err(ioRes.error.msg)
 
@@ -49,8 +49,8 @@ proc dispatchGetVal*(
   if reply.closerPeers.len > 0:
     kad_responses_with_closer_peers.inc(labelValues = [$MessageType.getValue])
 
-  conn.observedAddr.withValue(observedAddr):
-    kad.updatePeers(@[PeerInfo(peerId: conn.peerId, addrs: @[observedAddr])])
+  stream.observedAddr.withValue(observedAddr):
+    kad.updatePeers(@[PeerInfo(peerId: stream.peerId, addrs: @[observedAddr])])
 
   return ok(reply)
 
@@ -149,7 +149,7 @@ proc getValue*(
   ok(best)
 
 method handleGetValue*(
-    kad: KadDHT, conn: Connection, msg: Message
+    kad: KadDHT, stream: Stream, msg: Message
 ) {.base, async: (raises: [CancelledError]).} =
   let key = msg.key
 
@@ -171,9 +171,9 @@ method handleGetValue*(
       encoded.buffer.len.int64, labelValues = [$MessageType.getValue]
     )
     try:
-      await conn.writeLp(encoded.buffer)
+      await stream.writeLp(encoded.buffer)
     except LPStreamError as exc:
-      debug "Failed to send get-value RPC reply", conn = conn, err = exc.msg
+      debug "Failed to send get-value RPC reply", stream = stream, err = exc.msg
     return
 
   let response = Message(
@@ -193,7 +193,7 @@ method handleGetValue*(
     encoded.buffer.len.int64, labelValues = [$MessageType.getValue]
   )
   try:
-    await conn.writeLp(encoded.buffer)
+    await stream.writeLp(encoded.buffer)
   except LPStreamError as exc:
-    debug "Failed to send get-value RPC reply", conn = conn, err = exc.msg
+    debug "Failed to send get-value RPC reply", stream = stream, err = exc.msg
     return

--- a/libp2p/protocols/kademlia/ping.nim
+++ b/libp2p/protocols/kademlia/ping.nim
@@ -11,9 +11,9 @@ proc ping*(
 ): Future[bool] {.
     async: (raises: [CancelledError, DialFailedError, ValueError, LPStreamError])
 .} =
-  let conn = await kad.switch.dial(peerId, addrs, kad.codec)
+  let stream = await kad.switch.dial(peerId, addrs, kad.codec)
   defer:
-    await conn.close()
+    await stream.close()
 
   let request = Message(msgType: MessageType.ping)
   let encoded = request.encode(kad.config.hideConnectionStatus)
@@ -25,8 +25,8 @@ proc ping*(
 
   var replyBuf: seq[byte]
   kad_message_duration_ms.time(labelValues = [$MessageType.ping]):
-    await conn.writeLp(encoded.buffer)
-    replyBuf = await conn.readLp(MaxMsgSize)
+    await stream.writeLp(encoded.buffer)
+    replyBuf = await stream.readLp(MaxMsgSize)
 
   kad_message_bytes_received.inc(replyBuf.len.int64, labelValues = [$MessageType.ping])
 
@@ -36,14 +36,14 @@ proc ping*(
   return reply == request
 
 proc handlePing*(
-    kad: KadDHT, conn: Connection, msg: Message
+    kad: KadDHT, stream: Stream, msg: Message
 ) {.async: (raises: [CancelledError]).} =
   let encoded = msg.encode(kad.config.hideConnectionStatus)
   kad_message_bytes_sent.inc(
     encoded.buffer.len.int64, labelValues = [$MessageType.ping]
   )
   try:
-    await conn.writeLp(encoded.buffer)
+    await stream.writeLp(encoded.buffer)
   except LPStreamError as exc:
-    debug "Failed to send ping reply", conn = conn, err = exc.msg
+    debug "Failed to send ping reply", stream = stream, err = exc.msg
     return

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -111,13 +111,13 @@ proc dispatchAddProvider(
     replyTimeout: Duration,
     providerRejection: bool,
 ): Future[Result[AddProviderStatus, string]] {.async: (raises: [CancelledError]).} =
-  let connRes = catch:
+  let streamRes = catch:
     await switch.dial(peer, switch.peerStore[AddressBook][peer], codec)
-  if connRes.isErr:
-    return err(connRes.error.msg)
-  let conn = connRes.value()
+  if streamRes.isErr:
+    return err(streamRes.error.msg)
+  let stream = streamRes.value()
   defer:
-    await conn.close()
+    await stream.close()
 
   let msg = Message(
     msgType: MessageType.addProvider,
@@ -130,14 +130,14 @@ proc dispatchAddProvider(
     encoded.buffer.len.int64, labelValues = [$MessageType.addProvider]
   )
   let writeRes = catch:
-    await conn.writeLp(encoded.buffer)
+    await stream.writeLp(encoded.buffer)
   if writeRes.isErr:
     return err(writeRes.error.msg)
 
   if not providerRejection:
     return ok(AddProviderStatus.accepted)
 
-  let readFut = conn.readLp(MaxMsgSize)
+  let readFut = stream.readLp(MaxMsgSize)
   if not (await readFut.withTimeout(replyTimeout)):
     return ok(AddProviderStatus.accepted)
   let readRes = catch:
@@ -237,27 +237,28 @@ proc manageExpiredProviders*(kad: KadDHT) {.async: (raises: [CancelledError]).} 
       kad.providerManager.removeProviderRecord(expired)
 
 proc sendAddProviderResponse(
-    conn: Connection, kad: KadDHT, status: AddProviderStatus
+    stream: Stream, kad: KadDHT, status: AddProviderStatus
 ) {.async: (raises: [CancelledError]).} =
   let response =
     Message(msgType: MessageType.addProvider, providerStatus: Opt.some(status))
   try:
-    await conn.writeLp(response.encode(kad.config.hideConnectionStatus).buffer)
+    await stream.writeLp(response.encode(kad.config.hideConnectionStatus).buffer)
   except LPStreamError as exc:
     debug "Failed to send add-provider response",
-      conn = conn, err = exc.msg, status = status
+      stream = stream, err = exc.msg, status = status
 
 method handleAddProvider*(
-    kad: KadDHT, conn: Connection, msg: Message
+    kad: KadDHT, stream: Stream, msg: Message
 ) {.base, async: (raises: [CancelledError]).} =
   if not MultiHash.validate(msg.key):
-    error "Received key is an invalid Multihash", msg = msg, conn = conn, key = msg.key
+    error "Received key is an invalid Multihash",
+      msg = msg, stream = stream, key = msg.key
     if kad.config.providerRejection:
-      await conn.sendAddProviderResponse(kad, AddProviderStatus.rejected)
+      await stream.sendAddProviderResponse(kad, AddProviderStatus.rejected)
     return
 
   # filter out infos that do not match sender's
-  let peerBytes = conn.peerId.getBytes()
+  let peerBytes = stream.peerId.getBytes()
   let validPeers =
     msg.providerPeers.filterIt(it.id == peerBytes and PeerId.init(it.id).isOk())
 
@@ -271,7 +272,7 @@ method handleAddProvider*(
         kad_provider_rejections_sent.inc()
         debug "ADD_PROVIDER rejected: per-key limit reached",
           key = msg.key, limit = limit
-        await conn.sendAddProviderResponse(kad, AddProviderStatus.rejected)
+        await stream.sendAddProviderResponse(kad, AddProviderStatus.rejected)
         return
 
   for peer in validPeers:
@@ -287,18 +288,18 @@ method handleAddProvider*(
   if kad.config.providerRejection:
     let status =
       if validPeers.len > 0: AddProviderStatus.accepted else: AddProviderStatus.rejected
-    await conn.sendAddProviderResponse(kad, status)
+    await stream.sendAddProviderResponse(kad, status)
 
 proc dispatchGetProviders*(
     kad: KadDHT, peer: PeerId, key: Key
 ): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
-  let connRes = catch:
+  let streamRes = catch:
     await kad.switch.dial(peer, kad.switch.peerStore[AddressBook][peer], kad.codec)
-  if connRes.isErr:
-    return err(connRes.error.msg)
-  let conn = connRes.value()
+  if streamRes.isErr:
+    return err(streamRes.error.msg)
+  let stream = streamRes.value()
   defer:
-    await conn.close()
+    await stream.close()
   let msg = Message(msgType: MessageType.getProviders, key: key)
   let encoded = msg.encode(kad.config.hideConnectionStatus)
 
@@ -311,8 +312,8 @@ proc dispatchGetProviders*(
   var ioRes: Result[void, ref CatchableError]
   kad_message_duration_ms.time(labelValues = [$MessageType.getProviders]):
     ioRes = catch:
-      await conn.writeLp(encoded.buffer)
-      replyBuf = await conn.readLp(MaxMsgSize)
+      await stream.writeLp(encoded.buffer)
+      replyBuf = await stream.readLp(MaxMsgSize)
   if ioRes.isErr:
     return err(ioRes.error.msg)
 
@@ -328,8 +329,8 @@ proc dispatchGetProviders*(
 
   debug "Received reply for GetProviders", peer = peer, reply = reply
 
-  conn.observedAddr.withValue(observedAddr):
-    kad.updatePeers(@[PeerInfo(peerId: conn.peerId, addrs: @[observedAddr])])
+  stream.observedAddr.withValue(observedAddr):
+    kad.updatePeers(@[PeerInfo(peerId: stream.peerId, addrs: @[observedAddr])])
 
   return ok(reply)
 
@@ -366,7 +367,7 @@ proc getProviders*(
   return allProviders
 
 proc handleGetProviders*(
-    kad: KadDHT, conn: Connection, msg: Message
+    kad: KadDHT, stream: Stream, msg: Message
 ) {.async: (raises: [CancelledError]).} =
   var providers =
     kad.providerManager.knownKeys.getOrDefault(msg.key, initHashSet[Provider]())
@@ -386,6 +387,6 @@ proc handleGetProviders*(
     encoded.buffer.len.int64, labelValues = [$MessageType.getProviders]
   )
   try:
-    await conn.writeLp(encoded.buffer)
+    await stream.writeLp(encoded.buffer)
   except LPStreamError as exc:
-    debug "Failed to send get-providers RPC reply", conn = conn, err = exc.msg
+    debug "Failed to send get-providers RPC reply", stream = stream, err = exc.msg

--- a/libp2p/protocols/kademlia/put.nim
+++ b/libp2p/protocols/kademlia/put.nim
@@ -50,13 +50,13 @@ proc manageExpiredRecords*(kad: KadDHT) {.async: (raises: [CancelledError]).} =
 proc dispatchPutVal*(
     switch: Switch, peer: PeerId, key: Key, value: seq[byte], codec: string
 ): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
-  let connRes = catch:
+  let streamRes = catch:
     await switch.dial(peer, switch.peerStore[AddressBook][peer], codec)
-  if connRes.isErr:
-    return err(connRes.error.msg)
-  let conn = connRes.value()
+  if streamRes.isErr:
+    return err(streamRes.error.msg)
+  let stream = streamRes.value()
   defer:
-    await conn.close()
+    await stream.close()
   let msg = Message(
     msgType: MessageType.putValue,
     key: key,
@@ -73,8 +73,8 @@ proc dispatchPutVal*(
   var ioRes: Result[void, ref CatchableError]
   kad_message_duration_ms.time(labelValues = [$MessageType.putValue]):
     ioRes = catch:
-      await conn.writeLp(encoded.buffer)
-      replyBuf = await conn.readLp(MaxMsgSize)
+      await stream.writeLp(encoded.buffer)
+      replyBuf = await stream.readLp(MaxMsgSize)
   if ioRes.isErr:
     return err(ioRes.error.msg)
 
@@ -85,11 +85,11 @@ proc dispatchPutVal*(
   let reply = Message.decode(replyBuf).valueOr:
     return err("PutValue reply decode fail")
 
-  debug "Got PutValue reply", msg = msg, reply = reply, conn = conn
+  debug "Got PutValue reply", msg = msg, reply = reply, stream = stream
 
   if reply != msg:
     error "Unexpected change between msg and reply: ",
-      msg = msg, reply = reply, conn = conn
+      msg = msg, reply = reply, stream = stream
 
   return ok()
 
@@ -115,18 +115,18 @@ proc putValue*(
   ok()
 
 proc handlePutValue*(
-    kad: KadDHT, conn: Connection, msg: Message
+    kad: KadDHT, stream: Stream, msg: Message
 ) {.async: (raises: [CancelledError]).} =
   let record = msg.record.valueOr:
-    error "No record in message buffer", msg = msg, conn = conn
+    error "No record in message buffer", msg = msg, stream = stream
     return
 
   if record.key != msg.key:
-    error "Record key is different than Message key", msg = msg, conn = conn
+    error "Record key is different than Message key", msg = msg, stream = stream
     return
 
   let value = record.value.valueOr:
-    error "No value in record", msg = msg, conn = conn
+    error "No value in record", msg = msg, stream = stream
     return
 
   let entryRecord = EntryRecord(value: value, time: Timestamp.now())
@@ -148,7 +148,7 @@ proc handlePutValue*(
     encoded.buffer.len.int64, labelValues = [$MessageType.putValue]
   )
   try:
-    await conn.writeLp(encoded.buffer)
+    await stream.writeLp(encoded.buffer)
   except LPStreamError as exc:
-    debug "Failed to send find-node RPC reply", conn = conn, err = exc.msg
+    debug "Failed to send find-node RPC reply", stream = stream, err = exc.msg
     return

--- a/libp2p/protocols/perf/client.nim
+++ b/libp2p/protocols/perf/client.nim
@@ -26,9 +26,9 @@ proc currentStats*(p: PerfClient): Stats =
   return p.stats
 
 proc perf*(
-    p: PerfClient, conn: Connection, sizeToWrite: uint64 = 0, sizeToRead: uint64 = 0
+    p: PerfClient, stream: Stream, sizeToWrite: uint64 = 0, sizeToRead: uint64 = 0
 ): Future[Duration] {.async: (raises: [CancelledError, LPStreamError]).} =
-  trace "starting performance benchmark", conn, sizeToWrite, sizeToRead
+  trace "starting performance benchmark", stream, sizeToWrite, sizeToRead
 
   p.stats = Stats()
 
@@ -39,10 +39,10 @@ proc perf*(
 
     let start = Moment.now()
 
-    await conn.write(toSeq(toBytesBE(sizeToRead)))
+    await stream.write(toSeq(toBytesBE(sizeToRead)))
     while size > 0:
       let toWrite = min(size, PerfSize)
-      await conn.write(buf[0 ..< toWrite])
+      await stream.write(buf[0 ..< toWrite])
       size -= toWrite.uint
 
       # set stats using copy value to avoid race condition
@@ -52,13 +52,13 @@ proc perf*(
       p.stats = statsCopy
 
     # Close write side of the stream (half-close) to signal EOF to server
-    await conn.closeWrite()
+    await stream.closeWrite()
 
     size = sizeToRead
 
     while size > 0:
       let toRead = min(size, PerfSize)
-      await conn.readExactly(addr buf[0], toRead.int)
+      await stream.readExactly(addr buf[0], toRead.int)
       size = size - toRead.uint
 
       # set stats using copy value to avoid race condition
@@ -68,7 +68,7 @@ proc perf*(
       p.stats = statsCopy
 
     # Close the connection after reading
-    await conn.close()
+    await stream.close()
   except CancelledError as e:
     raise e
   except LPStreamError as e:

--- a/libp2p/protocols/perf/server.nim
+++ b/libp2p/protocols/perf/server.nim
@@ -19,18 +19,18 @@ type Perf* = ref object of LPProtocol
 proc new*(T: typedesc[Perf]): T =
   var p = T()
 
-  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+  proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
     try:
-      trace "Received benchmark performance check", conn
+      trace "Received benchmark performance check", stream
 
       var uploadSizeBuffer: array[8, byte]
-      await conn.readExactly(addr uploadSizeBuffer[0], 8)
+      await stream.readExactly(addr uploadSizeBuffer[0], 8)
       var uploadSize = uint64.fromBytesBE(uploadSizeBuffer)
 
       var readBuffer: array[PerfSize, byte]
-      while not conn.atEof:
+      while not stream.atEof:
         try:
-          let readBytes = await conn.readOnce(addr readBuffer[0], PerfSize)
+          let readBytes = await stream.readOnce(addr readBuffer[0], PerfSize)
           if readBytes == 0:
             break
         except LPStreamEOFError:
@@ -39,15 +39,15 @@ proc new*(T: typedesc[Perf]): T =
       var writeBuffer: array[PerfSize, byte]
       while uploadSize > 0:
         let toWrite = min(uploadSize, PerfSize)
-        await conn.write(writeBuffer[0 ..< toWrite])
+        await stream.write(writeBuffer[0 ..< toWrite])
         uploadSize -= toWrite
     except CancelledError as exc:
       trace "cancelled perf handler"
       raise exc
     except CatchableError as exc:
-      trace "exception in perf handler", description = exc.msg, conn
+      trace "exception in perf handler", description = exc.msg, stream
     finally:
-      await conn.close()
+      await stream.close()
 
   p.handler = handle
   p.codec = PerfCodec

--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -40,32 +40,32 @@ proc new*(T: typedesc[Ping], handler: PingHandler = nil, rng: Rng): T =
   ping
 
 method init*(p: Ping) =
-  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+  proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
     try:
-      trace "handling ping", conn
+      trace "handling ping", stream
       var buf: array[PingSize, byte]
-      await conn.readExactly(addr buf[0], PingSize)
-      trace "echoing ping", conn, pingData = @buf
-      await conn.write(@buf)
+      await stream.readExactly(addr buf[0], PingSize)
+      trace "echoing ping", stream, pingData = @buf
+      await stream.write(@buf)
       if not isNil(p.pingHandler):
-        await p.pingHandler(conn.peerId)
+        await p.pingHandler(stream.peerId)
     except CancelledError as exc:
       trace "cancelled ping handler"
       raise exc
     except CatchableError as exc:
-      trace "exception in ping handler", description = exc.msg, conn
+      trace "exception in ping handler", description = exc.msg, stream
 
   p.handler = handle
   p.codec = PingCodec
 
 proc ping*(
-    p: Ping, conn: Connection
+    p: Ping, stream: Stream
 ): Future[Duration] {.
     async: (raises: [CancelledError, LPStreamError, WrongPingAckError])
 .} =
-  ## Sends ping to `conn`, returns the delay
+  ## Sends ping to `stream`, returns the delay
 
-  trace "initiating ping", conn
+  trace "initiating ping", stream
 
   var
     randomBuf: array[PingSize, byte]
@@ -75,18 +75,18 @@ proc ping*(
 
   let startTime = Moment.now()
 
-  trace "sending ping", conn
-  await conn.write(@randomBuf)
+  trace "sending ping", stream
+  await stream.write(@randomBuf)
 
-  await conn.readExactly(addr resultBuf[0], PingSize)
+  await stream.readExactly(addr resultBuf[0], PingSize)
 
   let responseDur = Moment.now() - startTime
 
-  trace "got ping response", conn, responseDur
+  trace "got ping response", stream, responseDur
 
   for i in 0 ..< randomBuf.len:
     if randomBuf[i] != resultBuf[i]:
       raise newException(WrongPingAckError, "Incorrect ping data from peer!")
 
-  trace "valid ping response", conn
+  trace "valid ping response", stream
   return responseDur

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -12,7 +12,7 @@ export results
 const DefaultMaxIncomingStreams* = 10
 
 type
-  LPProtoHandler* = proc(conn: Connection, proto: string): Future[void] {.
+  LPProtoHandler* = proc(stream: Stream, proto: string): Future[void] {.
     async: (raises: [CancelledError])
   .}
 
@@ -51,8 +51,8 @@ func `codec=`*(p: LPProtocol, codec: string) =
 template `handler`*(p: LPProtocol): LPProtoHandler =
   p.handlerImpl
 
-template `handler`*(p: LPProtocol, conn: Connection, proto: string): Future[void] =
-  p.handlerImpl(conn, proto)
+template `handler`*(p: LPProtocol, stream: Stream, proto: string): Future[void] =
+  p.handlerImpl(stream, proto)
 
 func `handler=`*(p: LPProtocol, handler: LPProtoHandler) =
   p.handlerImpl = handler

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -171,15 +171,15 @@ method rpcHandler*(
   f.updateMetrics(rpcMsg)
 
 method init*(f: FloodSub) =
-  proc handler(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+  proc handler(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
     ## main protocol handler that gets triggered on every
     ## connection for a protocol string
     ## e.g. ``/floodsub/1.0.0``, etc...
     ##
     try:
-      await f.handleConn(conn, proto)
+      await f.handleConn(stream, proto)
     except CancelledError as exc:
-      trace "floodsub handler cancelled", conn
+      trace "floodsub handler cancelled", stream
       raise exc
 
   f.handler = handler

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -235,15 +235,15 @@ proc validateParameters*(parameters: TopicParams): Result[void, cstring] =
     ok()
 
 method init*(g: GossipSub) =
-  proc handler(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+  proc handler(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
     ## main protocol handler that gets triggered on every
     ## connection for a protocol string
     ## e.g. ``/floodsub/1.0.0``, etc...
     ##
     try:
-      await g.handleConn(conn, proto)
+      await g.handleConn(stream, proto)
     except CancelledError as exc:
-      trace "gossipsub handler cancelled", conn
+      trace "gossipsub handler cancelled", stream
       raise exc
 
   g.handler = handler
@@ -755,15 +755,15 @@ method onTopicSubscription*(g: GossipSub, topic: string, subscribed: bool) =
     # Send unsubscribe (in reverse order to sub/graft)
     procCall PubSub(g).onTopicSubscription(topic, subscribed)
 
-proc makePeersForPublishUsingCustomConn(
+proc makePeersForPublishUsingCustomStream(
     g: GossipSub, topic: string
 ): HashSet[PubSubPeer] =
-  assert g.customConnCallbacks.isSome,
-    "GossipSub misconfiguration: useCustomConn was true, but no customConnCallbacks provided"
+  assert g.customStreamCallbacks.isSome,
+    "GossipSub misconfiguration: useCustomStream was true, but no customStreamCallbacks provided"
 
-  trace "Selecting peers via custom connection callback"
+  trace "Selecting peers via custom stream callback"
 
-  return g.customConnCallbacks.get().customPeerSelectionCB(
+  return g.customStreamCallbacks.get().customPeerSelectionCB(
       g.gossipsub.getOrDefault(topic),
       g.subscribedDirectPeers.getOrDefault(topic),
       g.mesh.getOrDefault(topic),
@@ -847,8 +847,8 @@ method publish*(
   let pubParams = publishParams.get(PublishParams())
 
   var peers =
-    if pubParams.useCustomConn:
-      g.makePeersForPublishUsingCustomConn(topic)
+    if pubParams.useCustomStream:
+      g.makePeersForPublishUsingCustomStream(topic)
     else:
       g.makePeersForPublishDefault(topic, data.len)
 
@@ -907,7 +907,7 @@ method publish*(
     peers,
     RPCMsg.withMessages(msg),
     MessagePriority.Medium,
-    useCustomConn = pubParams.useCustomConn,
+    useCustomStream = pubParams.useCustomStream,
   )
 
   libp2p_pubsub_messages_published.inc(

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -146,9 +146,9 @@ type
     ## This callback can be used to reject topic we're not interested in
 
   PublishParams* = object
-    ## Used to indicate whether a message will be broadcasted using a custom connection
-    ## defined when instantiating Pubsub, or if it will use the normal connection
-    useCustomConn*: bool
+    ## Used to indicate whether a message will be broadcasted using a custom stream
+    ## defined when instantiating Pubsub, or if it will use the normal send stream
+    useCustomStream*: bool
 
     ## Can be used to avoid having the node reply to IWANT messages when initially 
     ## broadcasting a message, it's only after relaying its own message that the
@@ -199,7 +199,7 @@ type
     rng*: Rng
 
     knownTopics*: HashSet[string]
-    customConnCallbacks*: Opt[CustomConnectionCallbacks]
+    customStreamCallbacks*: Opt[CustomStreamCallbacks]
 
 proc topicLabel*(p: PubSub, topic: string): string {.inline.} =
   ## returns value to be used for `topic` labels.
@@ -221,7 +221,7 @@ proc send*(
     peer: PubSubPeer,
     msg: RPCMsg,
     priority: MessagePriority,
-    useCustomConn: bool = false,
+    useCustomStream: bool = false,
 ) {.raises: [].} =
   ## This procedure attempts to send a `msg` (of type `RPCMsg`) to the specified remote peer in the PubSub network.
   ##
@@ -234,14 +234,14 @@ proc send*(
   ##   and sent only after all high priority messages have been sent.
 
   trace "sending pubsub message to peer", peer, rpcMsg = shortLog(msg)
-  peer.send(msg, p.anonymize, priority, useCustomConn)
+  peer.send(msg, p.anonymize, priority, useCustomStream)
 
 proc broadcast*(
     p: PubSub,
     sendPeers: auto, # Iteratble[PubSubPeer]
     msg: RPCMsg,
     priority: MessagePriority,
-    useCustomConn: bool = false,
+    useCustomStream: bool = false,
 ) {.raises: [].} =
   ## This procedure attempts to send a `msg` (of type `RPCMsg`) to a specified group of peers in the PubSub network.
   ##
@@ -289,12 +289,12 @@ proc broadcast*(
 
   if anyIt(sendPeers, it.hasObservers):
     for peer in sendPeers:
-      p.send(peer, msg, priority, useCustomConn)
+      p.send(peer, msg, priority, useCustomStream)
   else:
     # Fast path that only encodes message once
     let encoded = encodeRpcMsg(msg, p.anonymize)
     for peer in sendPeers:
-      asyncSpawn peer.sendEncoded(encoded, priority, useCustomConn)
+      asyncSpawn peer.sendEncoded(encoded, priority, useCustomStream)
 
 proc sendSubs*(
     p: PubSub, peer: PubSubPeer, subTopics: openArray[string], subscribe: bool
@@ -356,7 +356,7 @@ method onNewPeer(p: PubSub, peer: PubSubPeer) {.base, gcsafe.} =
 method onPubSubPeerEvent*(
     p: PubSub, peer: PubSubPeer, event: PubSubPeerEvent
 ) {.base, gcsafe.} =
-  # Peer event is raised for the send connection in particular
+  # Peer event is raised for the send stream in particular
   case event.kind
   of PubSubPeerEventKind.StreamOpened:
     if p.topics.len > 0:
@@ -380,13 +380,13 @@ method getOrCreatePeer*(
     else:
       protosToDial
 
-  proc getConn(): Future[Connection] {.
-      async: (raises: [CancelledError, GetConnDialError])
+  proc getStream(): Future[Stream] {.
+      async: (raises: [CancelledError, GetStreamDialError])
   .} =
     try:
       return await p.switch.dial(peerId, protos)
     except DialFailedError as e:
-      raise (ref GetConnDialError)(parent: e, msg: e.msg)
+      raise (ref GetStreamDialError)(parent: e, msg: e.msg)
 
   proc onEvent(peer: PubSubPeer, event: PubSubPeerEvent) {.gcsafe.} =
     p.onPubSubPeerEvent(peer, event)
@@ -394,11 +394,11 @@ method getOrCreatePeer*(
   # create new pubsub peer
   let pubSubPeer = PubSubPeer.new(
     peerId,
-    getConn,
+    getStream,
     onEvent,
     protoNegotiated,
     p.maxMessageSize,
-    customConnCallbacks = p.customConnCallbacks,
+    customStreamCallbacks = p.customStreamCallbacks,
   )
   debug "created new pubsub peer", peerId
 
@@ -451,7 +451,7 @@ template handleSelfPublishing*(p: PubSub, topic: string, data: seq[byte]) =
     await handleData(p, topic, data)
 
 method handleConn*(
-    p: PubSub, conn: Connection, proto: string
+    p: PubSub, stream: Stream, proto: string
 ) {.base, async: (raises: [CancelledError]).} =
   ## handle incoming connections
   ##
@@ -471,23 +471,23 @@ method handleConn*(
       await p.rpcHandler(peer, data)
     except PeerMessageDecodeError as e:
       trace "failed to decode message in peerHandler",
-        description = e.msg, conn, peer = peer
+        description = e.msg, stream, peer = peer
       # loop continues and invalid messages are swallowed
     except PeerRateLimitError as e:
       trace "peer rate limit exceeded in peerHandler",
-        description = e.msg, conn, peer = peer
+        description = e.msg, stream, peer = peer
       # loop needs to stop. we are doing this by closing connection
-      await conn.closeWithEOF()
+      await stream.closeWithEOF()
 
-  let peer = p.getOrCreatePeer(conn.peerId, @[], proto)
+  let peer = p.getOrCreatePeer(stream.peerId, @[], proto)
 
   try:
     peer.handler = peerHandler
-    await peer.runHandleLoop(conn)
+    await peer.runHandleLoop(stream)
   except CancelledError as exc:
     raise exc
   finally:
-    await conn.closeWithEOF()
+    await stream.closeWithEOF()
 
 method subscribePeer*(p: PubSub, peer: PeerId) {.base, gcsafe.} =
   ## subscribe to remote peer to receive/send pubsub
@@ -524,10 +524,10 @@ method onTopicSubscription*(
 
   # Notify others that we are no longer interested in the topic
   for _, peer in p.peers:
-    # If we don't have a sendConn yet, we will
-    # send the full sub list when we get the sendConn,
+    # If we don't have a sendStream yet, we will
+    # send the full sub list when we get the sendStream,
     # so no need to send it here
-    if peer.hasSendConn:
+    if peer.hasSendStream:
       p.sendSubs(peer, [topic], subscribed)
 
   if subscribed:
@@ -702,8 +702,7 @@ proc init*[PubParams: object | bool](
     maxMessageSize: int = 1024 * 1024,
     rng: Rng,
     parameters: PubParams = false,
-    customConnCallbacks: Opt[CustomConnectionCallbacks] =
-      Opt.none(CustomConnectionCallbacks),
+    customStreamCallbacks: Opt[CustomStreamCallbacks] = Opt.none(CustomStreamCallbacks),
 ): P {.raises: [InitializationError].} =
   let pubsub =
     when PubParams is bool:
@@ -719,7 +718,7 @@ proc init*[PubParams: object | bool](
         maxMessageSize: maxMessageSize,
         rng: rng,
         topicsHigh: int.high,
-        customConnCallbacks: customConnCallbacks,
+        customStreamCallbacks: customStreamCallbacks,
       )
     else:
       P(
@@ -735,7 +734,7 @@ proc init*[PubParams: object | bool](
         maxMessageSize: maxMessageSize,
         rng: rng,
         topicsHigh: int.high,
-        customConnCallbacks: customConnCallbacks,
+        customStreamCallbacks: customStreamCallbacks,
       )
 
   proc peerEventHandler(

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -75,7 +75,7 @@ const
 type
   PeerRateLimitError* = object of CatchableError
 
-  GetConnDialError* = object of CatchableError
+  GetStreamDialError* = object of CatchableError
 
   PubSubObserver* = ref object
     onRecv*: proc(peer: PubSubPeer, msgs: var RPCMsg) {.gcsafe, raises: [].}
@@ -110,9 +110,9 @@ type
   PubSubPeerEvent* = object
     kind*: PubSubPeerEventKind
 
-  GetConn* =
-    proc(): Future[Connection] {.async: (raises: [CancelledError, GetConnDialError]).}
-  DropConn* = proc(peer: PubSubPeer) {.gcsafe, raises: [].}
+  GetStream* =
+    proc(): Future[Stream] {.async: (raises: [CancelledError, GetStreamDialError]).}
+  DropStream* = proc(peer: PubSubPeer) {.gcsafe, raises: [].}
     # have to pass peer as it's unknown during init
   OnEvent* = proc(peer: PubSubPeer, event: PubSubPeerEvent) {.gcsafe, raises: [].}
 
@@ -120,7 +120,7 @@ type
     # Messages sent as medium/low priority are queued and sent on a
     # separate routine.
     data: seq[byte]
-    useCustomConn: bool
+    useCustomStream: bool
 
   RpcMessageQueue* = ref object
     # Tracks async tasks for sending high-priority peer-published messages.
@@ -134,9 +134,9 @@ type
     # Task for processing non-priority message queue.
     sendNonHighPriorityTask: Future[void]
 
-  CustomConnCreationProc* = proc(
+  CustomStreamCreationProc* = proc(
     destAddr: Opt[MultiAddress], destPeerId: PeerId, codec: string
-  ): Connection {.gcsafe, raises: [].}
+  ): Stream {.gcsafe, raises: [].}
 
   CustomPeerSelectionProc* = proc(
     allPeers: HashSet[PubSubPeer],
@@ -145,15 +145,15 @@ type
     fanoutPeers: HashSet[PubSubPeer],
   ): HashSet[PubSubPeer] {.gcsafe, raises: [].}
 
-  CustomConnectionCallbacks* = object
-    customConnCreationCB*: CustomConnCreationProc
+  CustomStreamCallbacks* = object
+    customStreamCreationCB*: CustomStreamCreationProc
     customPeerSelectionCB*: CustomPeerSelectionProc
 
   PubSubPeer* = ref object of RootObj
-    getConn*: GetConn # callback to establish a new send connection
+    getStream*: GetStream # callback to establish a new send stream
     onEvent*: OnEvent # Connectivity updates for peer
     codec*: string # the protocol that this peer joined from
-    sendConn*: Connection # cached send connection
+    sendStream*: Stream # cached send stream
     connectedFut: Future[void]
     address*: Opt[MultiAddress]
     peerId*: PeerId
@@ -176,7 +176,7 @@ type
     maxMediumPriorityQueueLen*: int
     maxLowPriorityQueueLen*: int
     disconnected: bool
-    customConnCallbacks*: Opt[CustomConnectionCallbacks]
+    customStreamCallbacks*: Opt[CustomStreamCallbacks]
 
   RPCHandler* = proc(peer: PubSubPeer, data: sink seq[byte]): Future[void] {.
     async: (raises: [CancelledError])
@@ -184,12 +184,12 @@ type
 
 when defined(libp2p_agents_metrics):
   func shortAgent*(p: PubSubPeer): string =
-    if p.sendConn.isNil or p.sendConn.getWrapped().isNil:
+    if p.sendStream.isNil or p.sendStream.getWrapped().isNil:
       "unknown"
     else:
-      #TODO the sendConn is setup before identify,
+      #TODO the sendStream is setup before identify,
       #so we have to read the parents short agent..
-      p.sendConn.getWrapped().shortAgent
+      p.sendStream.getWrapped().shortAgent
 
 proc getAgent*(peer: PubSubPeer): string =
   return
@@ -216,7 +216,7 @@ chronicles.formatIt(PubSubPeer):
   shortLog(it)
 
 proc connected*(p: PubSubPeer): bool =
-  not p.sendConn.isNil and not (p.sendConn.closed or p.sendConn.atEof)
+  not p.sendStream.isNil and not (p.sendStream.closed or p.sendStream.atEof)
 
 proc hasObservers*(p: PubSubPeer): bool =
   p.observers != nil and anyIt(p.observers[], it != nil)
@@ -226,7 +226,10 @@ func outbound*(p: PubSubPeer): bool =
   # in order to give priotity to connections we make
   # https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#outbound-mesh-quotas
   # This behaviour is presrcibed to counter sybil attacks and ensures that a coordinated inbound attack can never fully take over the mesh
-  if not p.sendConn.isNil and p.sendConn.transportDir == Direction.Out: true else: false
+  if not p.sendStream.isNil and p.sendStream.transportDir == Direction.Out:
+    true
+  else:
+    false
 
 func determineQueueAction*(
     priority: MessagePriority,
@@ -296,37 +299,37 @@ proc sendObservers(p: PubSubPeer, msg: var RPCMsg) =
           obs.onSend(p, msg)
 
 proc runHandleLoop*(
-    p: PubSubPeer, conn: Connection
+    p: PubSubPeer, stream: Stream
 ) {.async: (raises: [CancelledError]).} =
-  debug "starting pubsub read loop", conn, peer = p, closed = conn.closed
+  debug "starting pubsub read loop", stream, peer = p, closed = stream.closed
   defer:
-    debug "exiting pubsub read loop", conn, peer = p, closed = conn.closed
+    debug "exiting pubsub read loop", stream, peer = p, closed = stream.closed
 
-  while not conn.atEof:
-    trace "waiting for data", conn, peer = p, closed = conn.closed
+  while not stream.atEof:
+    trace "waiting for data", stream, peer = p, closed = stream.closed
 
     let data =
       try:
-        await conn.readLp(p.maxMessageSize)
+        await stream.readLp(p.maxMessageSize)
       except LPStreamEOFError:
         return
       except LPStreamError as e:
         debug "Exception occurred reading message PubSubPeer.handle",
-          conn, peer = p, closed = conn.closed, description = e.msg
+          stream, peer = p, closed = stream.closed, description = e.msg
         return
 
     trace "read data from peer",
-      conn, peer = p, closed = conn.closed, data = data.shortLog
+      stream, peer = p, closed = stream.closed, data = data.shortLog
 
     await p.handler(p, data)
 
-proc closeSendConn(
+proc closeSendStream(
     p: PubSubPeer, event: PubSubPeerEventKind
 ) {.async: (raises: [CancelledError]).} =
-  if p.sendConn != nil:
-    trace "Removing send connection", p, conn = p.sendConn
-    await p.sendConn.close()
-    p.sendConn = nil
+  if p.sendStream != nil:
+    trace "Removing send stream", p, stream = p.sendStream
+    await p.sendStream.close()
+    p.sendStream = nil
 
   if not p.connectedFut.finished:
     p.connectedFut.complete()
@@ -340,49 +343,49 @@ proc closeSendConn(
 
 proc connectOnce(
     p: PubSubPeer
-): Future[void] {.async: (raises: [CancelledError, GetConnDialError]).} =
+): Future[void] {.async: (raises: [CancelledError, GetStreamDialError]).} =
   try:
     if p.connectedFut.finished:
       p.connectedFut = newFuture[void]()
-    let newConn =
+    let newStream =
       try:
-        await p.getConn().wait(5.seconds)
+        await p.getStream().wait(5.seconds)
       except AsyncTimeoutError:
-        raise newException(GetConnDialError, "establishing connection timed out")
+        raise newException(GetStreamDialError, "establishing stream timed out")
 
     # When the send channel goes up, subscriptions need to be sent to the
     # remote peer - if we had multiple channels up and one goes down, all
     # stop working so we make an effort to only keep a single channel alive
 
-    trace "Get new send connection", p, newConn
+    trace "Get new send stream", p, newStream
 
     # Careful to race conditions here.
     # Topic subscription relies on either connectedFut
     # to be completed, or onEvent to be called later
-    p.sendConn = newConn
+    p.sendStream = newStream
     p.address =
-      if p.sendConn.observedAddr.isSome:
-        Opt.some(p.sendConn.observedAddr.get)
+      if p.sendStream.observedAddr.isSome:
+        Opt.some(p.sendStream.observedAddr.get)
       else:
         Opt.none(MultiAddress)
 
     if p.codec == "":
-      # if codec was not know, it can be retrieved from newly established connection
-      p.codec = newConn.protocol
+      # if codec was not know, it can be retrieved from newly established stream
+      p.codec = newStream.protocol
 
     p.connectedFut.complete()
     if p.onEvent != nil:
       p.onEvent(p, PubSubPeerEvent(kind: PubSubPeerEventKind.StreamOpened))
 
-    await p.runHandleLoop(newConn)
+    await p.runHandleLoop(newStream)
   finally:
-    await p.closeSendConn(PubSubPeerEventKind.StreamClosed)
+    await p.closeSendStream(PubSubPeerEventKind.StreamClosed)
 
 proc connectImpl(p: PubSubPeer) {.async: (raises: []).} =
   try:
-    # Keep trying to establish a connection while it's possible to do so - the
-    # send connection might get disconnected due to a timeout or an unrelated
-    # issue so we try to get a new on
+    # Keep trying to establish a stream while it's possible to do so - the
+    # send stream might get disconnected due to a timeout or an unrelated
+    # issue so we try to get a new one
     while true:
       if p.disconnected:
         if not p.connectedFut.finished:
@@ -390,9 +393,9 @@ proc connectImpl(p: PubSubPeer) {.async: (raises: []).} =
         return
       await connectOnce(p)
   except CancelledError as exc:
-    debug "Could not establish send connection", description = exc.msg
-  except GetConnDialError as exc:
-    debug "Could not establish send connection", description = exc.msg
+    debug "Could not establish send stream", description = exc.msg
+  except GetStreamDialError as exc:
+    debug "Could not establish send stream", description = exc.msg
 
 proc connect*(p: PubSubPeer) =
   if p.connected:
@@ -400,8 +403,8 @@ proc connect*(p: PubSubPeer) =
 
   asyncSpawn connectImpl(p)
 
-proc hasSendConn*(p: PubSubPeer): bool =
-  p.sendConn != nil
+proc hasSendStream*(p: PubSubPeer): bool =
+  p.sendStream != nil
 
 template sendMetrics(msg: RPCMsg): untyped =
   when defined(libp2p_expensive_metrics):
@@ -427,65 +430,65 @@ proc clearSendPriorityQueue(p: PubSubPeer) =
     )
 
 proc sendMsgContinue(
-    conn: Connection, msgFut: Future[void].Raising([CancelledError, LPStreamError])
+    stream: Stream, msgFut: Future[void].Raising([CancelledError, LPStreamError])
 ) {.async: (raises: [CancelledError]).} =
   # Continuation for a pending transport write from below
   try:
     await msgFut
-    trace "sent pubsub message to remote", conn
+    trace "sent pubsub message to remote", stream
   except CancelledError as exc:
-    trace "sendMsgContinue cancelled", conn, description = exc.msg
+    trace "sendMsgContinue cancelled", stream, description = exc.msg
     raise exc
   except LPStreamError as exc:
-    trace "Unexpected exception in sendMsgContinue", conn, description = exc.msg
-    # Next time sendConn is used, it will be have its close flag set and thus
+    trace "Unexpected exception in sendMsgContinue", stream, description = exc.msg
+    # Next time sendStream is used, it will be have its close flag set and thus
     # will be recycled
-    await conn.close() # This will clean up the send connection
+    await stream.close() # This will clean up the send stream
 
 proc sendMsgSlow(p: PubSubPeer, msg: seq[byte]) {.async: (raises: [CancelledError]).} =
-  # Slow path where msg is held in memory while send connection is being set up.
-  if p.sendConn == nil:
-    # Wait for a send conn to be setup. `connectOnce` will
-    # complete this even if the sendConn setup failed
+  # Slow path where msg is held in memory while send stream is being set up.
+  if p.sendStream == nil:
+    # Wait for a send stream to be setup. `connectOnce` will
+    # complete this even if the sendStream setup failed
     discard await race(p.connectedFut)
 
-  var conn = p.sendConn
-  if conn == nil or conn.closed():
-    debug "No send connection", p, encoded = shortLog(msg)
+  var stream = p.sendStream
+  if stream == nil or stream.closed():
+    debug "No send stream", p, encoded = shortLog(msg)
     return
 
-  trace "sending encoded msg to peer", conn, encoded = shortLog(msg)
-  await sendMsgContinue(conn, conn.writeLp(msg))
+  trace "sending encoded msg to peer", stream, encoded = shortLog(msg)
+  await sendMsgContinue(stream, stream.writeLp(msg))
 
 proc sendMsg(
-    p: PubSubPeer, msg: seq[byte], useCustomConn: bool = false
+    p: PubSubPeer, msg: seq[byte], useCustomStream: bool = false
 ): Future[void] {.async: (raises: [CancelledError]).} =
   ## Starts a transport write and returns its lifecycle future for internal
   ## queue accounting. Do not await this from receive-handler paths.
-  type ConnectionType = enum
+  type StreamType = enum
     ctCustom
     ctSend
     ctSlow
 
   var slowPath = false
-  let (conn, connType) =
-    if useCustomConn and p.customConnCallbacks.isSome:
+  let (stream, streamType) =
+    if useCustomStream and p.customStreamCallbacks.isSome:
       let address = p.address
       (
-        p.customConnCallbacks.get().customConnCreationCB(address, p.peerId, p.codec),
+        p.customStreamCallbacks.get().customStreamCreationCB(address, p.peerId, p.codec),
         ctCustom,
       )
-    elif p.sendConn != nil and not p.sendConn.closed():
-      (p.sendConn, ctSend)
+    elif p.sendStream != nil and not p.sendStream.closed():
+      (p.sendStream, ctSend)
     else:
       slowPath = true
       (nil, ctSlow)
 
   if not slowPath:
     trace "sending encoded msg to peer",
-      conntype = $connType, conn = conn, encoded = shortLog(msg)
-    let f = conn.writeLp(msg)
-    await sendMsgContinue(conn, f)
+      streamType = $streamType, stream = stream, encoded = shortLog(msg)
+    let f = stream.writeLp(msg)
+    await sendMsgContinue(stream, f)
   else:
     trace "sending encoded msg to peer via slow path"
     await sendMsgSlow(p, msg)
@@ -495,14 +498,14 @@ proc disconnectPeer(p: PubSubPeer): Future[void] =
     p.disconnected = true
     when defined(pubsubpeer_queue_metrics):
       libp2p_pubsub_disconnects_over_high_priority_queue_limit.inc()
-    return p.closeSendConn(PubSubPeerEventKind.DisconnectionRequested)
+    return p.closeSendStream(PubSubPeerEventKind.DisconnectionRequested)
 
   return newFutureCompleted[void]()
 
 proc sendHighPriorityMessage(
-    p: PubSubPeer, msg: seq[byte], useCustomConn: bool
+    p: PubSubPeer, msg: seq[byte], useCustomStream: bool
 ): Future[void] =
-  let f = p.sendMsg(msg, useCustomConn)
+  let f = p.sendMsg(msg, useCustomStream)
   if not f.finished:
     p.rpcmessagequeue.sendPriorityQueue.addLast(f)
     when defined(pubsubpeer_queue_metrics):
@@ -510,9 +513,9 @@ proc sendHighPriorityMessage(
   return newFutureCompleted[void]()
 
 proc enqueueNonHighPriorityMessage(
-    p: PubSubPeer, msg: seq[byte], useCustomConn: bool, priority: MessagePriority
+    p: PubSubPeer, msg: seq[byte], useCustomStream: bool, priority: MessagePriority
 ): Future[void] =
-  let queuedMsg = QueuedMessage(data: msg, useCustomConn: useCustomConn)
+  let queuedMsg = QueuedMessage(data: msg, useCustomStream: useCustomStream)
   case priority
   of MessagePriority.Medium:
     p.rpcmessagequeue.mediumPriorityQueue.addLast(queuedMsg)
@@ -549,7 +552,7 @@ proc sendEncoded*(
     p: PubSubPeer,
     msg: seq[byte],
     priority: MessagePriority,
-    useCustomConn: bool = false,
+    useCustomStream: bool = false,
 ): Future[void] =
   ## Asynchronously sends an encoded message to a specified `PubSubPeer` according to its priority.
   ##
@@ -560,7 +563,7 @@ proc sendEncoded*(
   ##   - `High` or any priority when all queues are empty: sent immediately
   ##   - `Medium`: queued in `mediumPriorityQueue`. Dropped when full.
   ##   - `Low`: queued in `lowPriorityQueue`. Dropped when full.
-  ## - `useCustomConn`: boolean used to indicate if a custom connection is going to 
+  ## - `useCustomStream`: boolean used to indicate if a custom stream is going to
   ##   be used for sending this message
   ## Low and medium priority messages are queued and sent only after all high
   ## priority messages have been sent.
@@ -584,12 +587,12 @@ proc sendEncoded*(
     case action.priority
     of High:
       if action.send:
-        p.sendHighPriorityMessage(msg, useCustomConn)
+        p.sendHighPriorityMessage(msg, useCustomStream)
       else:
         p.disconnectPeer()
     of Medium, Low:
       if action.send:
-        p.enqueueNonHighPriorityMessage(msg, useCustomConn, action.priority)
+        p.enqueueNonHighPriorityMessage(msg, useCustomStream, action.priority)
       else:
         p.dropNonHighPriorityMessage(action.slowPeerPenaltyDelta, action.priority)
 
@@ -631,7 +634,7 @@ proc send*(
     msg: RPCMsg,
     anonymize: bool,
     priority: MessagePriority,
-    useCustomConn: bool = false,
+    useCustomStream: bool = false,
 ) {.raises: [].} =
   ## Asynchronously sends an `RPCMsg` to a specified `PubSubPeer` with an option for anonymization.
   ##
@@ -665,11 +668,11 @@ proc send*(
 
   if encoded.len > maxEncodedMsgSize and msg.messages.len > 1:
     for encodedSplitMsg in splitRPCMsg(p, msg, maxEncodedMsgSize, anonymize):
-      asyncSpawn p.sendEncoded(encodedSplitMsg, priority, useCustomConn)
+      asyncSpawn p.sendEncoded(encodedSplitMsg, priority, useCustomStream)
   else:
     # If the message size is within limits, send it as is
     trace "sending msg to peer", peer = p, rpcMsg = shortLog(msg)
-    asyncSpawn p.sendEncoded(encoded, priority, useCustomConn)
+    asyncSpawn p.sendEncoded(encoded, priority, useCustomStream)
 
 proc canAskIWant*(p: PubSubPeer, msgId: MessageId): bool =
   for sentIHave in p.sentIHaves.mitems():
@@ -712,7 +715,7 @@ proc sendNonHighPriorityTask(p: PubSubPeer) {.async: (raises: [CancelledError]).
       else:
         libp2p_gossipsub_low_priority_queue_size.dec(labelValues = [$p.peerId])
 
-    await p.sendMsg(msg.data, msg.useCustomConn)
+    await p.sendMsg(msg.data, msg.useCustomStream)
 
 proc startSendNonHighPriorityTask(p: PubSubPeer) =
   debug "starting sendNonHighPriorityTask", p
@@ -748,7 +751,7 @@ proc new(T: typedesc[RpcMessageQueue]): T =
 proc new*(
     T: typedesc[PubSubPeer],
     peerId: PeerId,
-    getConn: GetConn,
+    getStream: GetStream,
     onEvent: OnEvent,
     codec: string,
     maxMessageSize: int,
@@ -756,11 +759,10 @@ proc new*(
     maxMediumPriorityQueueLen: int = DefaultMaxMediumPriorityQueueLen,
     maxLowPriorityQueueLen: int = DefaultMaxLowPriorityQueueLen,
     overheadRateLimitOpt: Opt[TokenBucket] = Opt.none(TokenBucket),
-    customConnCallbacks: Opt[CustomConnectionCallbacks] =
-      Opt.none(CustomConnectionCallbacks),
+    customStreamCallbacks: Opt[CustomStreamCallbacks] = Opt.none(CustomStreamCallbacks),
 ): T =
   let response = T(
-    getConn: getConn,
+    getStream: getStream,
     onEvent: onEvent,
     codec: codec,
     peerId: peerId,
@@ -771,7 +773,7 @@ proc new*(
     maxHighPriorityQueueLen: maxHighPriorityQueueLen,
     maxMediumPriorityQueueLen: maxMediumPriorityQueueLen,
     maxLowPriorityQueueLen: maxLowPriorityQueueLen,
-    customConnCallbacks: customConnCallbacks,
+    customStreamCallbacks: customStreamCallbacks,
   )
   response.sentIHaves.addFirst(default(HashSet[MessageId]))
   response.iDontWants.addFirst(default(HashSet[SaltedId]))

--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -118,7 +118,7 @@ proc checkPeerRecord*(
   return ok()
 
 proc sendRegisterResponse*(
-    conn: Connection, ttl: uint64
+    stream: Stream, ttl: uint64
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
   let msg = encode(
     Message(
@@ -126,10 +126,10 @@ proc sendRegisterResponse*(
       registerResponse: Opt.some(RegisterResponse(status: Ok, ttl: Opt.some(ttl))),
     )
   )
-  await conn.writeLp(msg)
+  await stream.writeLp(msg)
 
 proc sendRegisterResponseError*(
-    conn: Connection, status: ResponseStatus, text: string = ""
+    stream: Stream, status: ResponseStatus, text: string = ""
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
   let msg = encode(
     Message(
@@ -137,10 +137,10 @@ proc sendRegisterResponseError*(
       registerResponse: Opt.some(RegisterResponse(status: status, text: Opt.some(text))),
     )
   )
-  await conn.writeLp(msg)
+  await stream.writeLp(msg)
 
 proc sendDiscoverResponse*(
-    conn: Connection, s: seq[Register], cookie: Cookie
+    stream: Stream, s: seq[Register], cookie: Cookie
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
   let msg = encode(
     Message(
@@ -150,10 +150,10 @@ proc sendDiscoverResponse*(
       ),
     )
   )
-  await conn.writeLp(msg)
+  await stream.writeLp(msg)
 
 proc sendDiscoverResponseError*(
-    conn: Connection, status: ResponseStatus, text: string = ""
+    stream: Stream, status: ResponseStatus, text: string = ""
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
   let msg = encode(
     Message(
@@ -161,7 +161,7 @@ proc sendDiscoverResponseError*(
       discoverResponse: Opt.some(DiscoverResponse(status: status, text: Opt.some(text))),
     )
   )
-  await conn.writeLp(msg)
+  await stream.writeLp(msg)
 
 proc countRegister*[E](rdv: GenericRendezVous[E], peerId: PeerId): int =
   for data in rdv.registered:
@@ -196,44 +196,44 @@ proc save*[E](
     raiseAssert "Should have key: " & e.msg
 
 proc register*[E](
-    rdv: GenericRendezVous[E], conn: Connection, r: Register, peerRecord: E
+    rdv: GenericRendezVous[E], stream: Stream, r: Register, peerRecord: E
 ): Future[void] =
-  trace "Received Register", peerId = conn.peerId, ns = r.ns
+  trace "Received Register", peerId = stream.peerId, ns = r.ns
   libp2p_rendezvous_register.inc()
   if r.ns.len < MinimumNamespaceLen or r.ns.len > MaximumNamespaceLen:
-    return conn.sendRegisterResponseError(InvalidNamespace)
+    return stream.sendRegisterResponseError(InvalidNamespace)
   let ttl = r.ttl.get(rdv.config.minTTL)
   if ttl < rdv.config.minTTL or ttl > rdv.config.maxTTL:
-    return conn.sendRegisterResponseError(InvalidTTL)
-  let pr = rdv.peerRecordValidator(peerRecord, r.signedPeerRecord, conn.peerId)
+    return stream.sendRegisterResponseError(InvalidTTL)
+  let pr = rdv.peerRecordValidator(peerRecord, r.signedPeerRecord, stream.peerId)
   if pr.isErr():
-    return conn.sendRegisterResponseError(InvalidSignedPeerRecord, pr.error())
-  if rdv.countRegister(conn.peerId) >= RegistrationLimitPerPeer:
-    return conn.sendRegisterResponseError(NotAuthorized, "Registration limit reached")
+    return stream.sendRegisterResponseError(InvalidSignedPeerRecord, pr.error())
+  if rdv.countRegister(stream.peerId) >= RegistrationLimitPerPeer:
+    return stream.sendRegisterResponseError(NotAuthorized, "Registration limit reached")
 
-  rdv.save(r.ns, conn.peerId, r)
+  rdv.save(r.ns, stream.peerId, r)
   libp2p_rendezvous_registered.inc()
   libp2p_rendezvous_namespaces.set(int64(rdv.namespaces.len))
-  conn.sendRegisterResponse(ttl)
+  stream.sendRegisterResponse(ttl)
 
-proc unregister*[E](rdv: GenericRendezVous[E], conn: Connection, u: Unregister) =
-  trace "Received Unregister", peerId = conn.peerId, ns = u.ns
+proc unregister*[E](rdv: GenericRendezVous[E], stream: Stream, u: Unregister) =
+  trace "Received Unregister", peerId = stream.peerId, ns = u.ns
   let nsSalted = u.ns & rdv.salt
   try:
     for index in rdv.namespaces[nsSalted]:
-      if rdv.registered[index].peerId == conn.peerId:
+      if rdv.registered[index].peerId == stream.peerId:
         rdv.registered[index].expiration = rdv.expiredDT
         libp2p_rendezvous_registered.dec()
   except exceptions.KeyError:
     return
 
 proc discover*[E](
-    rdv: GenericRendezVous[E], conn: Connection, d: Discover
+    rdv: GenericRendezVous[E], stream: Stream, d: Discover
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
-  trace "Received Discover", peerId = conn.peerId, ns = d.ns
+  trace "Received Discover", peerId = stream.peerId, ns = d.ns
   libp2p_rendezvous_discover.inc()
   if d.ns.isSome() and d.ns.get().len > MaximumNamespaceLen:
-    await conn.sendDiscoverResponseError(InvalidNamespace)
+    await stream.sendDiscoverResponseError(InvalidNamespace)
     return
   var limit = min(DiscoverLimit, d.limit.get(DiscoverLimit))
   var cookie =
@@ -241,7 +241,7 @@ proc discover*[E](
       try:
         Cookie.decode(d.cookie.tryGet()).tryGet()
       except CatchableError:
-        await conn.sendDiscoverResponseError(InvalidCookie)
+        await stream.sendDiscoverResponseError(InvalidCookie)
         return
     else:
       # Start from the current lowest index (inclusive)
@@ -260,12 +260,12 @@ proc discover*[E](
       try:
         rdv.namespaces[d.ns.get() & rdv.salt]
       except exceptions.KeyError:
-        await conn.sendDiscoverResponseError(InvalidNamespace)
+        await stream.sendDiscoverResponseError(InvalidNamespace)
         return
     else:
       toSeq(max(cookie.offset.int, rdv.registered.offset) .. rdv.registered.high())
   if namespaces.len() == 0:
-    await conn.sendDiscoverResponse(@[], Cookie())
+    await stream.sendDiscoverResponse(@[], Cookie())
     return
   var nextOffset = cookie.offset
   let n = Moment.now()
@@ -281,19 +281,19 @@ proc discover*[E](
     reg.data.ttl = Opt.some((reg.expiration - Moment.now()).seconds.uint64)
     s.add(reg.data)
   rdv.rng.shuffle(s)
-  await conn.sendDiscoverResponse(s, Cookie(offset: nextOffset, ns: d.ns))
+  await stream.sendDiscoverResponse(s, Cookie(offset: nextOffset, ns: d.ns))
 
 proc advertisePeer[E](
     rdv: GenericRendezVous[E], peer: PeerId, msg: seq[byte]
 ) {.async: (raises: [CancelledError]).} =
   proc advertiseWrap() {.async: (raises: []).} =
     try:
-      let conn = await rdv.switch.dial(peer, rdv.codec)
+      let stream = await rdv.switch.dial(peer, rdv.codec)
       defer:
-        await conn.close()
-      await conn.writeLp(msg)
+        await stream.close()
+      await stream.writeLp(msg)
       let
-        buf = await conn.readLp(4096)
+        buf = await stream.readLp(4096)
         msgRecv = Message.decode(buf).tryGet()
       if msgRecv.msgType != MessageType.RegisterResponse:
         trace "Unexpected register response", peer, msgType = msgRecv.msgType
@@ -385,9 +385,9 @@ proc requestPeer[E](
 ): Future[seq[Register]] {.
     async: (raises: [CancelledError, DialFailedError, LPStreamError])
 .} =
-  let conn = await rdv.switch.dial(peer, rdv.codec)
+  let stream = await rdv.switch.dial(peer, rdv.codec)
   defer:
-    await conn.close()
+    await stream.close()
 
   var d = Discover(ns: ns, limit: Opt.some(limit))
   d.cookie =
@@ -398,11 +398,11 @@ proc requestPeer[E](
         Opt.none(seq[byte])
     else:
       Opt.none(seq[byte])
-  await conn.writeLp(
+  await stream.writeLp(
     encode(Message(msgType: MessageType.Discover, discover: Opt.some(d)))
   )
   let
-    buf = await conn.readLp(MaximumMessageLen)
+    buf = await stream.readLp(MaximumMessageLen)
     msgRcv = Message.decode(buf).valueOr:
       debug "Message undecodable"
       return @[]
@@ -503,10 +503,10 @@ proc unsubscribe*[E](
 
   proc unsubscribePeer(peerId: PeerId) {.async: (raises: []).} =
     try:
-      let conn = await rdv.switch.dial(peerId, RendezVousCodec)
+      let stream = await rdv.switch.dial(peerId, RendezVousCodec)
       defer:
-        await conn.close()
-      await conn.writeLp(msg)
+        await stream.close()
+      await stream.writeLp(msg)
     except CatchableError as exc:
       trace "exception while unsubscribing", description = exc.msg
 
@@ -552,23 +552,23 @@ proc new*(
   logScope:
     topics = "libp2p discovery rendezvous"
   proc handleStream(
-      conn: Connection, proto: string
+      stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     try:
       let
-        buf = await conn.readLp(4096)
+        buf = await stream.readLp(4096)
         msg = Message.decode(buf).tryGet()
       case msg.msgType
       of MessageType.Register:
         await rdv.register(
-          conn, msg.register.tryGet(), rdv.switch.peerInfo.signedPeerRecord.data
+          stream, msg.register.tryGet(), rdv.switch.peerInfo.signedPeerRecord.data
         )
       of MessageType.RegisterResponse:
         trace "Got an unexpected Register Response", response = msg.registerResponse
       of MessageType.Unregister:
-        rdv.unregister(conn, msg.unregister.tryGet())
+        rdv.unregister(stream, msg.unregister.tryGet())
       of MessageType.Discover:
-        await rdv.discover(conn, msg.discover.tryGet())
+        await rdv.discover(stream, msg.discover.tryGet())
       of MessageType.DiscoverResponse:
         trace "Got an unexpected Discover Response", response = msg.discoverResponse
     except CancelledError as exc:
@@ -577,7 +577,7 @@ proc new*(
     except CatchableError as exc:
       trace "exception in rendezvous handler", description = exc.msg
     finally:
-      await conn.close()
+      await stream.close()
 
   info "Rendezvous protocol initialized"
   rdv.handler = handleStream

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -299,7 +299,7 @@ template read_s(): untyped =
   rsLen
 
 proc readFrame(
-    sconn: Connection
+    sconn: RawConn
 ): Future[seq[byte]] {.async: (raises: [CancelledError, LPStreamError]).} =
   var besize {.noinit.}: array[2, byte]
   await sconn.readExactly(addr besize[0], besize.len)
@@ -313,11 +313,11 @@ proc readFrame(
   return buffer
 
 proc receiveHSMessage(
-    sconn: Connection
+    sconn: RawConn
 ): Future[seq[byte]] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   readFrame(sconn)
 
-template sendHSMessage(sconn: Connection, parts: varargs[seq[byte]]): untyped =
+template sendHSMessage(sconn: RawConn, parts: varargs[seq[byte]]): untyped =
   # sends message (message frame) using multiple seq[byte] that 
   # concatenated represent entire mesage.
 
@@ -333,7 +333,7 @@ template sendHSMessage(sconn: Connection, parts: varargs[seq[byte]]): untyped =
     await sconn.write(p)
 
 proc handshakeXXOutbound(
-    p: Noise, conn: Connection, p2pSecret: seq[byte]
+    p: Noise, conn: RawConn, p2pSecret: seq[byte]
 ): Future[HandshakeResult] {.async: (raises: [CancelledError, LPStreamError]).} =
   const initiator = true
   var hs = HandshakeState.init()
@@ -373,7 +373,7 @@ proc handshakeXXOutbound(
     burnMem(hs)
 
 proc handshakeXXInbound(
-    p: Noise, conn: Connection, p2pSecret: seq[byte]
+    p: Noise, conn: RawConn, p2pSecret: seq[byte]
 ): Future[HandshakeResult] {.async: (raises: [CancelledError, LPStreamError]).} =
   const initiator = false
 
@@ -489,7 +489,7 @@ method write*(
   sconn.stream.write(cipherFrames)
 
 method handshake*(
-    p: Noise, conn: Connection, initiator: bool, peerId: Opt[PeerId]
+    p: Noise, conn: RawConn, initiator: bool, peerId: Opt[PeerId]
 ): Future[SecureConn] {.async: (raises: [CancelledError, LPStreamError]).} =
   trace "Starting Noise handshake", conn, initiator
 

--- a/libp2p/protocols/secure/plaintext.nim
+++ b/libp2p/protocols/secure/plaintext.nim
@@ -11,7 +11,7 @@ const PlainTextCodec* = "/plaintext/1.0.0"
 type PlainText* = ref object of Secure
 
 method init(p: PlainText) {.gcsafe.} =
-  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+  proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
     ## plain text doesn't do anything
     discard
 

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -25,7 +25,7 @@ type
   Secure* = ref object of LPProtocol # base type for secure managers
 
   SecureConn* = ref object of Connection
-    stream*: Connection
+    stream*: RawConn
     buf: ZeroQueue
 
 func shortLog*(conn: SecureConn): auto =
@@ -42,7 +42,7 @@ chronicles.formatIt(SecureConn):
 
 proc new*(
     T: type SecureConn,
-    conn: Connection,
+    conn: RawConn,
     peerId: PeerId,
     observedAddr: Opt[MultiAddress],
     localAddr: Opt[MultiAddress],
@@ -90,15 +90,15 @@ method getWrapped*(s: SecureConn): Connection =
   s.stream
 
 method handshake*(
-    s: Secure, conn: Connection, initiator: bool, peerId: Opt[PeerId]
+    s: Secure, conn: RawConn, initiator: bool, peerId: Opt[PeerId]
 ): Future[SecureConn] {.
     async: (raises: [CancelledError, LPStreamError], raw: true), base
 .} =
   raiseAssert("[Secure.handshake] abstract method not implemented!")
 
 proc handleConn(
-    s: Secure, conn: Connection, initiator: bool, peerId: Opt[PeerId]
-): Future[Connection] {.async: (raises: [CancelledError, LPStreamError]).} =
+    s: Secure, conn: RawConn, initiator: bool, peerId: Opt[PeerId]
+): Future[SecureConn] {.async: (raises: [CancelledError, LPStreamError]).} =
   var sconn = await s.handshake(conn, initiator, peerId)
   # mark connection bottom level transport direction
   # this is the safest place to do this
@@ -145,26 +145,26 @@ proc handleConn(
 method init*(s: Secure) =
   procCall LPProtocol(s).init()
 
-  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
-    trace "handling connection upgrade", proto, conn
+  proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
+    trace "handling connection upgrade", proto, stream
     try:
       # We don't need the result but we
       # definitely need to await the handshake
-      discard await s.handleConn(conn, false, Opt.none(PeerId))
-      trace "connection secured", conn
+      discard await s.handleConn(stream, false, Opt.none(PeerId))
+      trace "connection secured", stream
     except CancelledError as exc:
-      warn "securing connection canceled", conn
+      warn "securing connection canceled", stream
       raise exc
     except LPStreamError as exc:
-      warn "securing connection failed", description = exc.msg, conn
+      warn "securing connection failed", description = exc.msg, stream
     finally:
-      await conn.close()
+      await stream.close()
 
   s.handler = handle
 
 method secure*(
-    s: Secure, conn: Connection, peerId: Opt[PeerId]
-): Future[Connection] {.
+    s: Secure, conn: RawConn, peerId: Opt[PeerId]
+): Future[SecureConn] {.
     async: (raises: [CancelledError, LPStreamError], raw: true), base
 .} =
   s.handleConn(conn, conn.dir == Direction.Out, peerId)

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -94,19 +94,19 @@ proc new*(
     return disco
 
   disco.handler = proc(
-      conn: Connection, proto: string
+      stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     defer:
-      await conn.close()
-    while not conn.atEof:
+      await stream.close()
+    while not stream.atEof:
       let buf =
         try:
-          await conn.readLp(MaxMsgSize)
+          await stream.readLp(MaxMsgSize)
         except LPStreamEOFError:
           return
         except LPStreamError as exc:
           debug "Read error when handling service-discovery RPC",
-            conn = conn, err = exc.msg
+            stream = stream, err = exc.msg
           return
       let msg = Message.decode(buf).valueOr:
         debug "Failed to decode message", err = error
@@ -114,19 +114,19 @@ proc new*(
 
       case msg.msgType
       of MessageType.findNode:
-        await disco.handleFindNode(conn, msg)
+        await disco.handleFindNode(stream, msg)
       of MessageType.putValue:
-        await disco.handlePutValue(conn, msg)
+        await disco.handlePutValue(stream, msg)
       of MessageType.getValue:
-        await disco.handleGetValue(conn, msg)
+        await disco.handleGetValue(stream, msg)
       of MessageType.addProvider:
-        await disco.handleAddProvider(conn, msg)
+        await disco.handleAddProvider(stream, msg)
       of MessageType.getProviders:
-        await disco.handleGetProviders(conn, msg)
+        await disco.handleGetProviders(stream, msg)
       of MessageType.ping:
-        await disco.handlePing(conn, msg)
+        await disco.handlePing(stream, msg)
       else:
-        await disco.handleMessage(conn, msg)
+        await disco.handleMessage(stream, msg)
 
   return disco
 

--- a/libp2p/protocols/service_discovery/connection.nim
+++ b/libp2p/protocols/service_discovery/connection.nim
@@ -19,10 +19,10 @@ proc send*(
 
   let connRes = catch:
     await disco.switch.dial(peerId, addrs, disco.codec)
-  let conn = connRes.valueOr:
+  let stream = connRes.valueOr:
     return err("dialing peer failed: " & error.msg)
   defer:
-    await conn.close()
+    await stream.close()
 
   let encodedMsg = msg.encode().buffer
 
@@ -33,9 +33,9 @@ proc send*(
   var readRes: Result[seq[byte], ref CatchableError]
   cd_message_duration_ms.time(labelValues = [$msg.msgType]):
     writeRes = catch:
-      await conn.writeLp(encodedMsg)
+      await stream.writeLp(encodedMsg)
     readRes = catch:
-      await conn.readLp(MaxMsgSize)
+      await stream.readLp(MaxMsgSize)
 
   if writeRes.isErr:
     return err("connection writing failed: " & writeRes.error.msg)
@@ -51,7 +51,7 @@ proc send*(
   return ok(reply)
 
 proc handleMessage*(
-    disco: ServiceDiscovery, conn: Connection, msg: Message
+    disco: ServiceDiscovery, stream: Stream, msg: Message
 ) {.async: (raises: [CancelledError]).} =
   cd_messages_received.inc(labelValues = [$msg.msgType])
 
@@ -67,6 +67,6 @@ proc handleMessage*(
   cd_message_bytes_sent.inc(bytes.len.float64, labelValues = [$msg.msgType])
 
   let writeRes = catch:
-    await conn.writeLp(bytes)
+    await stream.writeLp(bytes)
   if writeRes.isErr:
     error "failed to send message response", error = writeRes.error.msg

--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -270,7 +270,7 @@ proc processRetryTicket*(
   return t_wait
 
 proc sendRegisterResponse*(
-    conn: Connection,
+    stream: Stream,
     status: RegistrationStatus,
     closerPeers: seq[Peer],
     ticket: Opt[Ticket] = Opt.none(Ticket),
@@ -284,7 +284,7 @@ proc sendRegisterResponse*(
   )
   let bytes = msg.encode().buffer
   let writeRes = catch:
-    await conn.writeLp(bytes)
+    await stream.writeLp(bytes)
   if writeRes.isErr:
     error "failed to send register response", err = writeRes.error.msg
 

--- a/libp2p/services/hpservice.nim
+++ b/libp2p/services/hpservice.nim
@@ -53,7 +53,7 @@ proc tryStartingDirectConn(
       continue
   return false
 
-proc closeRelayConn(relayedConn: Connection) {.async: (raises: [CancelledError]).} =
+proc closeRelayConn(relayedConn: RawConn) {.async: (raises: [CancelledError]).} =
   await sleepAsync(2000.milliseconds) # grace period before closing relayed connection
   await relayedConn.close()
 

--- a/libp2p/services/identify_pusher.nim
+++ b/libp2p/services/identify_pusher.nim
@@ -72,7 +72,7 @@ proc sendOne(p: IdentifyPusher, peerId: PeerId) {.async: (raises: [CancelledErro
   let muxer = p.connManager.selectMuxer(peerId)
   if muxer.isNil:
     return
-  var stream: Connection
+  var stream: Stream
   try:
     stream = await muxer.newStream()
     if stream.isNil:

--- a/libp2p/stream/connection.nim
+++ b/libp2p/stream/connection.nim
@@ -33,6 +33,12 @@ type
     when defined(libp2p_agents_metrics):
       shortAgent*: string
 
+  ## Semantic aliases for stream endpoints at different stages of the stack.
+  ## These are aliases, not distinct types.
+  Stream* = Connection
+  RawConn* = Stream
+  MuxedStream* = Stream
+
 proc timeoutMonitor(s: Connection) {.async: (raises: []).}
 
 method closeWrite*(s: Connection): Future[void] {.base, async: (raises: []).} =

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -148,14 +148,14 @@ method connect*(
 
 method dial*(
     s: Switch, peerId: PeerId, protos: seq[string]
-): Future[Connection] {.async: (raises: [DialFailedError, CancelledError], raw: true).} =
+): Future[Stream] {.async: (raises: [DialFailedError, CancelledError], raw: true).} =
   ## Open a stream to a connected peer with the specified `protos`
 
   s.dialer.dial(peerId, protos)
 
 proc dial*(
     s: Switch, peerId: PeerId, proto: string
-): Future[Connection] {.async: (raises: [DialFailedError, CancelledError], raw: true).} =
+): Future[Stream] {.async: (raises: [DialFailedError, CancelledError], raw: true).} =
   ## Open a stream to a connected peer with the specified `proto`
 
   dial(s, peerId, @[proto])
@@ -166,7 +166,7 @@ method dial*(
     addrs: seq[MultiAddress],
     protos: seq[string],
     forceDial = false,
-): Future[Connection] {.async: (raises: [DialFailedError, CancelledError], raw: true).} =
+): Future[Stream] {.async: (raises: [DialFailedError, CancelledError], raw: true).} =
   ## Connected to a peer and open a stream
   ## with the specified `protos`
 
@@ -174,7 +174,7 @@ method dial*(
 
 proc dial*(
     s: Switch, peerId: PeerId, addrs: seq[MultiAddress], proto: string
-): Future[Connection] {.async: (raises: [DialFailedError, CancelledError], raw: true).} =
+): Future[Stream] {.async: (raises: [DialFailedError, CancelledError], raw: true).} =
   ## Connected to a peer and open a stream
   ## with the specified `proto`
 
@@ -199,7 +199,7 @@ proc mount*[T: LPProtocol](
   s.peerInfo.notifyObservers()
 
 proc upgrader(
-    switch: Switch, trans: Transport, conn: Connection
+    switch: Switch, trans: Transport, conn: RawConn
 ) {.async: (raises: [CancelledError, UpgradeError]).} =
   try:
     let muxed = await trans.upgrade(conn, Opt.none(PeerId))
@@ -215,7 +215,7 @@ proc upgrader(
     raise newException(UpgradeError, "catchable error upgrader: " & e.msg, e)
 
 proc upgradeMonitor(
-    switch: Switch, trans: Transport, conn: Connection, upgrades: AsyncSemaphore
+    switch: Switch, trans: Transport, conn: RawConn, upgrades: AsyncSemaphore
 ) {.async: (raises: []).} =
   var semAcquired = false
   var upgradeSuccessful = false
@@ -250,7 +250,7 @@ proc accept(s: Switch, transport: Transport) {.async: (raises: []).} =
   let upgrades = newAsyncSemaphore(ConcurrentUpgrades)
 
   while transport.running:
-    var conn: Connection
+    var conn: RawConn
     try:
       debug "About to accept incoming connection"
       let slot = await s.connManager.getIncomingSlot()

--- a/libp2p/transports/memorymanager.nim
+++ b/libp2p/transports/memorymanager.nim
@@ -15,7 +15,7 @@ type
 
 type MemoryListener* = object
   address: string
-  accept: Future[Connection]
+  accept: Future[RawConn]
   onListenerEnd: proc(address: string) {.closure, gcsafe, raises: [].}
 
 proc init(
@@ -24,7 +24,7 @@ proc init(
     onListenerEnd: proc(address: string) {.closure, gcsafe, raises: [].},
 ): MemoryListener =
   return MemoryListener(
-    accept: newFuture[Connection]("MemoryListener.accept"),
+    accept: newFuture[RawConn]("MemoryListener.accept"),
     address: address,
     onListenerEnd: onListenerEnd,
   )
@@ -34,23 +34,23 @@ proc close*(self: MemoryListener) =
     self.accept.fail(newException(MemoryTransportAcceptStopped, "Listener closed"))
     self.onListenerEnd(self.address)
 
-proc accept*(self: MemoryListener): Future[Connection] {.gcsafe, raises: [].} =
+proc accept*(self: MemoryListener): Future[RawConn] {.gcsafe, raises: [].} =
   return self.accept
 
-proc dial*(self: MemoryListener): Future[Connection] {.gcsafe, raises: [].} =
+proc dial*(self: MemoryListener): Future[RawConn] {.gcsafe, raises: [].} =
   let (connA, connB) = bridgedConnections()
 
   self.onListenerEnd(self.address)
   self.accept.complete(connA)
 
-  let dFut = newFuture[Connection]("MemoryListener.dial")
+  let dFut = newFuture[RawConn]("MemoryListener.dial")
   dFut.complete(connB)
 
   return dFut
 
 type memoryConnManager = ref object
   listeners: Table[string, MemoryListener]
-  connections: Table[string, Connection]
+  connections: Table[string, RawConn]
   lock: Lock
 
 proc init(_: type[memoryConnManager]): memoryConnManager =

--- a/libp2p/transports/memorytransport.nim
+++ b/libp2p/transports/memorytransport.nim
@@ -23,7 +23,7 @@ logScope:
 
 type MemoryTransport* = ref object of Transport
   rng: Rng
-  connections: seq[Connection]
+  connections: seq[RawConn]
   listener: Opt[MemoryListener]
 
 proc new*(T: typedesc[MemoryTransport], upgrade: Upgrade = Upgrade(), rng: Rng): T =
@@ -72,7 +72,7 @@ method stop*(self: MemoryTransport) {.async: (raises: []).} =
 
 method accept*(
     self: MemoryTransport
-): Future[Connection] {.async: (raises: [transport.TransportError, CancelledError]).} =
+): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =
   if not self.running:
     raise newException(MemoryTransportError, "Transport closed, no more connections!")
 
@@ -97,7 +97,7 @@ method dial*(
     hostname: string,
     ma: MultiAddress,
     peerId: Opt[PeerId] = Opt.none(PeerId),
-): Future[Connection] {.async: (raises: [transport.TransportError, CancelledError]).} =
+): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =
   try:
     let listener = getInstance().dial($ma)
     let conn = await listener.dial()
@@ -112,7 +112,7 @@ method dial*(
 
 proc dial*(
     self: MemoryTransport, ma: MultiAddress, peerId: Opt[PeerId] = Opt.none(PeerId)
-): Future[Connection] {.gcsafe.} =
+): Future[RawConn] {.gcsafe.} =
   self.dial("", ma)
 
 method handles*(self: MemoryTransport, ma: MultiAddress): bool {.gcsafe, raises: [].} =

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -525,22 +525,22 @@ method upgrade*(
     self: QuicTransport, conn: RawConn, peerId: Opt[PeerId]
 ): Future[Muxer] {.async: (raises: [CancelledError, LPError]).} =
   let muxer = QuicMuxer.new(conn, peerId)
-  muxer.streamHandler = proc(conn: MuxedStream) {.async: (raises: []).} =
+  muxer.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
     trace "Starting stream handler"
     try:
       let quicUpgrader = QuicUpgrade(self.upgrader)
       quicUpgrader.connManager.withValue(connManager):
-        let ready = await connManager.waitForPeerReady(conn.peerId)
+        let ready = await connManager.waitForPeerReady(stream.peerId)
         if not ready:
-          debug "Timed out waiting for peer ready before handling stream", conn
+          debug "Timed out waiting for peer ready before handling stream", stream
           return
-      await self.upgrader.ms.handle(conn) # handle incoming connection
+      await self.upgrader.ms.handle(stream) # handle incoming stream
     except CancelledError:
       return
     except CatchableError as exc:
-      trace "exception in stream handler", conn, msg = exc.msg
+      trace "exception in stream handler", stream, msg = exc.msg
     finally:
-      await conn.closeWithEOF()
-      trace "Stream handler done", conn
+      await stream.closeWithEOF()
+      trace "Stream handler done", stream
   muxer.handleFut = muxer.handle()
   return muxer

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -28,13 +28,14 @@ logScope:
 type
   P2PConnection = connection.Connection
   QuicConnection = lsquic.Connection
+  LsquicStream = lsquic.Stream
   QuicTransportError* = object of transport.TransportError
   QuicTransportDialError* = object of transport.TransportDialError
   QuicTransportAcceptStopped* = object of QuicTransportError
 
   QuicStream* = ref object of P2PConnection
     session: QuicSession
-    stream: Stream
+    stream: LsquicStream
 
   QuicSession* = ref object of P2PConnection
     connection: QuicConnection
@@ -51,7 +52,7 @@ initializeLsquic()
 
 proc new(
     _: type QuicStream,
-    stream: Stream,
+    stream: LsquicStream,
     dir: Direction,
     session: QuicSession,
     oaddr: Opt[MultiAddress],
@@ -170,7 +171,7 @@ proc getStream(
   if session.closed:
     raise newException(ConnectionClosedError, "session is closed")
 
-  var stream: Stream
+  var stream: LsquicStream
   case direction
   of Direction.In:
     stream = await session.connection.incomingStream()
@@ -218,16 +219,14 @@ when defined(libp2p_agents_metrics):
 
 method newStream*(
     m: QuicMuxer, name: string = "", lazy: bool = false
-): Future[P2PConnection] {.
-    async: (raises: [CancelledError, LPStreamError, MuxerError])
-.} =
+): Future[MuxedStream] {.async: (raises: [CancelledError, LPStreamError, MuxerError]).} =
   try:
     return await m.session.getStream(Direction.Out)
   except ConnectionError as e:
     raise newException(MuxerError, "error in newStream: " & e.msg, e)
 
-method getStreams*(m: QuicMuxer): seq[connection.Connection] {.gcsafe.} =
-  var streams = newSeqOfCap[connection.Connection](m.session.streams.len)
+method getStreams*(m: QuicMuxer): seq[MuxedStream] {.gcsafe.} =
+  var streams = newSeqOfCap[MuxedStream](m.session.streams.len)
   for s in m.session.streams:
     streams.add(s)
   return streams
@@ -446,9 +445,7 @@ proc wrapConnection(
 
 method accept*(
     self: QuicTransport
-): Future[connection.Connection] {.
-    async: (raises: [transport.TransportError, CancelledError])
-.} =
+): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =
   if not self.running:
     # stop accept only when transport is stopped (not when error occurs)
     raise newException(QuicTransportAcceptStopped, "Quic transport stopped")
@@ -493,9 +490,7 @@ method dial*(
     hostname: string,
     address: MultiAddress,
     peerId: Opt[PeerId] = Opt.none(PeerId),
-): Future[connection.Connection] {.
-    async: (raises: [transport.TransportError, CancelledError])
-.} =
+): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =
   let taAddress =
     try:
       initTAddress(address).tryGet
@@ -527,10 +522,10 @@ method dial*(
     raise newException(QuicTransportDialError, "error in quic dial:" & e.msg, e)
 
 method upgrade*(
-    self: QuicTransport, conn: P2PConnection, peerId: Opt[PeerId]
+    self: QuicTransport, conn: RawConn, peerId: Opt[PeerId]
 ): Future[Muxer] {.async: (raises: [CancelledError, LPError]).} =
   let muxer = QuicMuxer.new(conn, peerId)
-  muxer.streamHandler = proc(conn: P2PConnection) {.async: (raises: []).} =
+  muxer.streamHandler = proc(conn: MuxedStream) {.async: (raises: []).} =
     trace "Starting stream handler"
     try:
       let quicUpgrader = QuicUpgrade(self.upgrader)

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -44,7 +44,7 @@ proc connHandler*(
     observedAddr: Opt[MultiAddress],
     localAddr: Opt[MultiAddress],
     dir: Direction,
-): Connection =
+): RawConn =
   trace "Handling tcp connection",
     address = $observedAddr,
     dir = $dir,
@@ -197,7 +197,7 @@ method stop*(self: TcpTransport): Future[void] {.async: (raises: []).} =
 
 method accept*(
     self: TcpTransport
-): Future[Connection] {.async: (raises: [transport.TransportError, CancelledError]).} =
+): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =
   ## accept a new TCP connection, returning nil on non-fatal errors
   ##
   ## Raises an exception when the transport is broken and cannot be used for
@@ -280,7 +280,7 @@ method dial*(
     hostname: string,
     address: MultiAddress,
     peerId: Opt[PeerId] = Opt.none(PeerId),
-): Future[Connection] {.async: (raises: [transport.TransportError, CancelledError]).} =
+): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =
   ## dial a peer
   if self.stopping:
     raise newTransportClosedError()

--- a/libp2p/transports/tortransport.nim
+++ b/libp2p/transports/tortransport.nim
@@ -221,7 +221,7 @@ method dial*(
     hostname: string,
     address: MultiAddress,
     peerId: Opt[PeerId] = Opt.none(PeerId),
-): Future[Connection] {.async: (raises: [transport.TransportError, CancelledError]).} =
+): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =
   ## dial a peer
   ##
   if not handlesDial(address):
@@ -271,7 +271,7 @@ method start*(
 
 method accept*(
     self: TorTransport
-): Future[Connection] {.async: (raises: [transport.TransportError, CancelledError]).} =
+): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =
   ## accept a new Tor connection
   ##
   let conn = await self.tcpTransport.accept()

--- a/libp2p/transports/transport.nim
+++ b/libp2p/transports/transport.nim
@@ -64,9 +64,7 @@ method stop*(self: Transport) {.base, async: (raises: []).} =
 
 method accept*(
     self: Transport
-): Future[Connection] {.
-    gcsafe, base, async: (raises: [TransportError, CancelledError])
-.} =
+): Future[RawConn] {.gcsafe, base, async: (raises: [TransportError, CancelledError]).} =
   ## accept incoming connections
   ##
 
@@ -77,9 +75,7 @@ method dial*(
     hostname: string,
     address: MultiAddress,
     peerId: Opt[PeerId] = Opt.none(PeerId),
-): Future[Connection] {.
-    base, gcsafe, async: (raises: [TransportError, CancelledError])
-.} =
+): Future[RawConn] {.base, gcsafe, async: (raises: [TransportError, CancelledError]).} =
   ## dial a peer
   ##
 
@@ -87,11 +83,11 @@ method dial*(
 
 proc dial*(
     self: Transport, address: MultiAddress, peerId: Opt[PeerId] = Opt.none(PeerId)
-): Future[Connection] {.gcsafe.} =
+): Future[RawConn] {.gcsafe.} =
   self.dial("", address)
 
 method upgrade*(
-    self: Transport, conn: Connection, peerId: Opt[PeerId]
+    self: Transport, conn: RawConn, peerId: Opt[PeerId]
 ): Future[Muxer] {.base, async: (raises: [CancelledError, LPError], raw: true).} =
   ## base upgrade method that the transport uses to perform
   ## transport specific upgrades

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -137,7 +137,7 @@ type WsTransport* = ref object of Transport
   connections: array[Direction, seq[WsStream]]
   acceptLoop: Future[void]
   handshakeFuts: seq[Future[void]]
-  acceptResults: AsyncQueue[Connection]
+  acceptResults: AsyncQueue[RawConn]
   acceptSem: AsyncSemaphore
 
   tlsPrivateKey*: TLSPrivateKey
@@ -176,7 +176,7 @@ proc closeHttpStream(stream: AsyncStream) {.async: (raises: []).} =
 
 proc connHandler(
   self: WsTransport, stream: WSSession, secure: bool, dir: Direction
-): Future[Connection] {.async: (raises: [CatchableError]).}
+): Future[RawConn] {.async: (raises: [CatchableError]).}
 
 proc wsHandshakeWorker(
     self: WsTransport, server: HttpServer, stream: AsyncStream
@@ -187,7 +187,7 @@ proc wsHandshakeWorker(
 
   try:
     let conn = await (
-      proc(): Future[Connection] {.async: (raises: [CatchableError]).} =
+      proc(): Future[RawConn] {.async: (raises: [CatchableError]).} =
         let req = await readHttpRequest(stream, server.headersTimeout)
         let wstransp = await self.wsserver.handleRequest(req)
         return await self.connHandler(wstransp, server.secure, Direction.In)
@@ -437,7 +437,7 @@ method stop*(self: WsTransport) {.async: (raises: []).} =
 
 proc connHandler(
     self: WsTransport, stream: WSSession, secure: bool, dir: Direction
-): Future[Connection] {.async: (raises: [CatchableError]).} =
+): Future[RawConn] {.async: (raises: [CatchableError]).} =
   ## Returning CatchableError is fine because we later handle different exceptions.
 
   let (observedAddr, localAddr) =
@@ -474,7 +474,7 @@ proc connHandler(
 
 method accept*(
     self: WsTransport
-): Future[Connection] {.async: (raises: [transport.TransportError, CancelledError]).} =
+): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =
   trace "WsTransport accept"
 
   # wstransport can only start accepting connections after autotls is done
@@ -498,7 +498,7 @@ method dial*(
     hostname: string,
     address: MultiAddress,
     peerId: Opt[PeerId] = Opt.none(PeerId),
-): Future[Connection] {.async: (raises: [transport.TransportError, CancelledError]).} =
+): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =
   ## dial a peer
   ##
 

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -389,7 +389,7 @@ method start*(
       MultiAddress.init(httpserver.localAddress()).tryGet() & codec.tryGet()
 
   self.acceptSem = newAsyncSemaphore(self.concurrentAccepts)
-  self.acceptResults = newAsyncQueue[Connection](self.concurrentAccepts)
+  self.acceptResults = newAsyncQueue[RawConn](self.concurrentAccepts)
   self.handshakeFuts = @[]
 
   await procCall Transport(self).start(resolvedAddrs)

--- a/libp2p/upgrademngrs/muxedupgrade.nim
+++ b/libp2p/upgrademngrs/muxedupgrade.nim
@@ -29,31 +29,31 @@ func getMuxerByCodec(self: MuxedUpgrade, muxerName: string): Opt[MuxerProvider] 
   Opt.none(MuxerProvider)
 
 proc mux(
-    self: MuxedUpgrade, conn: Stream
+    self: MuxedUpgrade, secureConn: SecureConn
 ): Future[Opt[Muxer]] {.
     async: (raises: [CancelledError, LPStreamError, MultiStreamError])
 .} =
-  ## mux connection
-  trace "Muxing connection", conn
+  ## mux secure connection
+  trace "Muxing connection", secureConn
   if self.muxers.len == 0:
-    warn "no muxers registered, skipping upgrade flow", conn
+    warn "no muxers registered, skipping upgrade flow", secureConn
     return Opt.none(Muxer)
 
   let
     muxerName =
-      case conn.dir
+      case secureConn.dir
       of Direction.Out:
-        await self.ms.select(conn, self.muxers.mapIt(it.codec))
+        await self.ms.select(secureConn, self.muxers.mapIt(it.codec))
       of Direction.In:
-        await MultistreamSelect.handle(conn, self.muxers.mapIt(it.codec))
+        await MultistreamSelect.handle(secureConn, self.muxers.mapIt(it.codec))
     muxerProvider = self.getMuxerByCodec(muxerName).valueOr:
-      debug "no muxer available, early exit", conn, muxerName
+      debug "no muxer available, early exit", secureConn, muxerName
       return Opt.none(Muxer)
 
-  trace "Found a muxer", conn, muxerName
+  trace "Found a muxer", secureConn, muxerName
 
   # create new muxer for connection
-  let muxer = muxerProvider.newMuxer(conn)
+  let muxer = muxerProvider.newMuxer(secureConn)
 
   # install stream handler
   muxer.streamHandler = self.streamHandler
@@ -94,20 +94,20 @@ proc new*(
   let upgrader =
     T(muxers: muxers, secureManagers: @secureManagers, ms: ms, connManager: connManager)
 
-  upgrader.streamHandler = proc(conn: MuxedStream) {.async: (raises: []).} =
-    trace "Starting stream handler", conn
+  upgrader.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
+    trace "Starting stream handler", stream
     try:
       upgrader.connManager.withValue(connManager):
-        let ready = await connManager.waitForPeerReady(conn.peerId)
+        let ready = await connManager.waitForPeerReady(stream.peerId)
         if not ready:
-          debug "Timed out waiting for peer ready before handling stream", conn
+          debug "Timed out waiting for peer ready before handling stream", stream
           return
-      await upgrader.ms.handle(conn) # handle incoming connection
+      await upgrader.ms.handle(stream) # handle incoming stream
     except CancelledError:
       return
     finally:
-      await conn.closeWithEOF()
-    trace "Stream handler done", conn
+      await stream.closeWithEOF()
+    trace "Stream handler done", stream
 
   return upgrader
 

--- a/libp2p/upgrademngrs/muxedupgrade.nim
+++ b/libp2p/upgrademngrs/muxedupgrade.nim
@@ -29,7 +29,7 @@ func getMuxerByCodec(self: MuxedUpgrade, muxerName: string): Opt[MuxerProvider] 
   Opt.none(MuxerProvider)
 
 proc mux(
-    self: MuxedUpgrade, conn: Connection
+    self: MuxedUpgrade, conn: Stream
 ): Future[Opt[Muxer]] {.
     async: (raises: [CancelledError, LPStreamError, MultiStreamError])
 .} =
@@ -61,7 +61,7 @@ proc mux(
   Opt.some(muxer)
 
 method upgrade*(
-    self: MuxedUpgrade, conn: Connection, peerId: Opt[PeerId]
+    self: MuxedUpgrade, conn: RawConn, peerId: Opt[PeerId]
 ): Future[Muxer] {.async: (raises: [CancelledError, LPError]).} =
   trace "Upgrading connection", conn, direction = conn.dir
 
@@ -94,7 +94,7 @@ proc new*(
   let upgrader =
     T(muxers: muxers, secureManagers: @secureManagers, ms: ms, connManager: connManager)
 
-  upgrader.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
+  upgrader.streamHandler = proc(conn: MuxedStream) {.async: (raises: []).} =
     trace "Starting stream handler", conn
     try:
       upgrader.connManager.withValue(connManager):

--- a/libp2p/upgrademngrs/upgrade.nim
+++ b/libp2p/upgrademngrs/upgrade.nim
@@ -43,7 +43,7 @@ method upgrade*(
 
 proc secure*(
     self: Upgrade, conn: RawConn, peerId: Opt[PeerId]
-): Future[Stream] {.async: (raises: [CancelledError, LPError]).} =
+): Future[SecureConn] {.async: (raises: [CancelledError, LPError]).} =
   if self.secureManagers.len <= 0:
     raise (ref UpgradeFailedError)(msg: "No secure managers registered!")
 

--- a/libp2p/upgrademngrs/upgrade.nim
+++ b/libp2p/upgrademngrs/upgrade.nim
@@ -37,13 +37,13 @@ type
     secureManagers*: seq[Secure]
 
 method upgrade*(
-    self: Upgrade, conn: Connection, peerId: Opt[PeerId]
+    self: Upgrade, conn: RawConn, peerId: Opt[PeerId]
 ): Future[Muxer] {.async: (raises: [CancelledError, LPError], raw: true), base.} =
   raiseAssert("[Upgrade.upgrade] abstract method not implemented!")
 
 proc secure*(
-    self: Upgrade, conn: Connection, peerId: Opt[PeerId]
-): Future[Connection] {.async: (raises: [CancelledError, LPError]).} =
+    self: Upgrade, conn: RawConn, peerId: Opt[PeerId]
+): Future[Stream] {.async: (raises: [CancelledError, LPError]).} =
   if self.secureManagers.len <= 0:
     raise (ref UpgradeFailedError)(msg: "No secure managers registered!")
 

--- a/tests/libp2p/discovery/test_rendezvous.nim
+++ b/tests/libp2p/discovery/test_rendezvous.nim
@@ -76,21 +76,21 @@ proc new*(
   logScope:
     topics = "libp2p discovery rendezvous"
   proc handleStream(
-      conn: Connection, proto: string
+      stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     try:
       let
-        buf = await conn.readLp(4096)
+        buf = await stream.readLp(4096)
         msg = Message.decode(buf).tryGet()
       case msg.msgType
       of MessageType.Register:
-        await rdv.register(conn, msg.register.tryGet(), pr)
+        await rdv.register(stream, msg.register.tryGet(), pr)
       of MessageType.RegisterResponse:
         trace "Got an unexpected Register Response", response = msg.registerResponse
       of MessageType.Unregister:
-        rdv.unregister(conn, msg.unregister.tryGet())
+        rdv.unregister(stream, msg.unregister.tryGet())
       of MessageType.Discover:
-        await rdv.discover(conn, msg.discover.tryGet())
+        await rdv.discover(stream, msg.discover.tryGet())
       of MessageType.DiscoverResponse:
         trace "Got an unexpected Discover Response", response = msg.discoverResponse
     except CancelledError as exc:
@@ -99,7 +99,7 @@ proc new*(
     except CatchableError as exc:
       trace "exception in rendezvous handler", description = exc.msg
     finally:
-      await conn.close()
+      await stream.close()
 
   rdv.handler = handleStream
   rdv.codec = "/cust-rendezvous/1.0.0"

--- a/tests/libp2p/kademlia/mock_kademlia.nim
+++ b/tests/libp2p/kademlia/mock_kademlia.nim
@@ -30,28 +30,28 @@ method findNode*(
   return kad.rtable.findClosestPeerIds(target, kad.config.replication)
 
 method handleGetValue*(
-    kad: MockKadDHT, conn: Connection, msg: Message
+    kad: MockKadDHT, stream: Stream, msg: Message
 ) {.async: (raises: [CancelledError]).} =
   let response = kad.getValueResponse.valueOr:
-    await procCall handleGetValue(KadDHT(kad), conn, msg)
+    await procCall handleGetValue(KadDHT(kad), stream, msg)
     return
 
   try:
-    await conn.writeLp(response.encode().buffer)
+    await stream.writeLp(response.encode().buffer)
   except LPStreamError as exc:
-    debug "Failed to send malicious get-value response", conn = conn, err = exc.msg
+    debug "Failed to send malicious get-value response", stream = stream, err = exc.msg
 
 method handleAddProvider*(
-    kad: MockKadDHT, conn: Connection, msg: Message
+    kad: MockKadDHT, stream: Stream, msg: Message
 ) {.async: (raises: [CancelledError]).} =
   await procCall handleAddProvider(
-    KadDHT(kad), conn, kad.handleAddProviderMessage.valueOr(msg)
+    KadDHT(kad), stream, kad.handleAddProviderMessage.valueOr(msg)
   )
 
 method handleFindNode*(
-    kad: MockKadDHT, conn: Connection, msg: Message
+    kad: MockKadDHT, stream: Stream, msg: Message
 ) {.async: (raises: [CancelledError]).} =
   kad.handleFindNodeCalls.inc()
   if kad.handleFindNodeDelay > ZeroDuration:
     await sleepAsync(kad.handleFindNodeDelay)
-  await procCall handleFindNode(KadDHT(kad), conn, msg)
+  await procCall handleFindNode(KadDHT(kad), stream, msg)

--- a/tests/libp2p/kademlia/utils.nim
+++ b/tests/libp2p/kademlia/utils.nim
@@ -227,25 +227,25 @@ proc addRandomPeers*(
 proc sendAddProviderAndGetStatus*(
     sender: KadDHT, receiver: KadDHT, key: Key
 ): Future[Result[AddProviderStatus, string]] {.async: (raises: [CancelledError]).} =
-  let connRes = catch:
+  let streamRes = catch:
     await sender.switch.dial(
       receiver.switch.peerInfo.peerId, receiver.switch.peerInfo.addrs, sender.codec
     )
-  if connRes.isErr:
-    return err(connRes.error.msg)
-  let conn = connRes.value()
+  if streamRes.isErr:
+    return err(streamRes.error.msg)
+  let stream = streamRes.value()
   defer:
-    await conn.close()
+    await stream.close()
   let msg = Message(
     msgType: MessageType.addProvider,
     key: key,
     providerPeers: @[sender.switch.peerInfo.toPeer()],
   )
   let writeRes = catch:
-    await conn.writeLp(msg.encode(sender.config.hideConnectionStatus).buffer)
+    await stream.writeLp(msg.encode(sender.config.hideConnectionStatus).buffer)
   if writeRes.isErr:
     return err(writeRes.error.msg)
-  let readFut = conn.readLp(MaxMsgSize)
+  let readFut = stream.readLp(MaxMsgSize)
   if not (await readFut.withTimeout(sender.config.timeout)):
     return ok(AddProviderStatus.accepted)
   let readRes = catch:

--- a/tests/libp2p/muxers/test_mplex.nim
+++ b/tests/libp2p/muxers/test_mplex.nim
@@ -379,7 +379,7 @@ suite "Mplex":
       proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
-        mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+        mplexListen.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
           try:
             let msg = await stream.readLp(1024)
             check string.fromBytes(msg) == "HELLO"
@@ -417,7 +417,7 @@ suite "Mplex":
       proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
-        mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+        mplexListen.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
           try:
             let msg = await stream.readLp(1024)
             check string.fromBytes(msg) == "HELLO"
@@ -463,7 +463,9 @@ suite "Mplex":
         try:
           let conn = await transport1.accept()
           let mplexListen = Mplex.new(conn)
-          mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+          mplexListen.streamHandler = proc(
+              stream: MuxedStream
+          ) {.async: (raises: []).} =
             try:
               let msg = await stream.readLp(MaxMsgSize)
               check msg == bigseq
@@ -510,7 +512,7 @@ suite "Mplex":
       proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
-        mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+        mplexListen.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
           try:
             await stream.writeLp("Hello from stream!")
           except CancelledError, LPStreamError:
@@ -549,7 +551,7 @@ suite "Mplex":
         var count = 1
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
-        mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+        mplexListen.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
           try:
             let msg = await stream.readLp(1024)
             try:
@@ -597,7 +599,7 @@ suite "Mplex":
         var count = 1
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
-        mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+        mplexListen.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
           try:
             let msg = await stream.readLp(1024)
             try:
@@ -641,12 +643,12 @@ suite "Mplex":
       let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
 
       let transport1 = TcpTransport.new(upgrade = Upgrade())
-      var listenStreams: seq[Connection]
+      var listenStreams: seq[MuxedStream]
       proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
 
-        mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+        mplexListen.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
           listenStreams.add(stream)
           try:
             discard await stream.readLp(1024)
@@ -690,11 +692,11 @@ suite "Mplex":
 
       var count = 0
       var done = newFuture[void]()
-      var listenStreams: seq[Connection]
+      var listenStreams: seq[MuxedStream]
       proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
-        mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+        mplexListen.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
           listenStreams.add(stream)
           count.inc()
           if count == 10:
@@ -747,7 +749,7 @@ suite "Mplex":
       proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
-        mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+        mplexListen.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
           await stream.reset()
 
         await mplexListen.handle()
@@ -781,11 +783,11 @@ suite "Mplex":
       let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
       let transport1 = TcpTransport.new(upgrade = Upgrade())
 
-      var listenStreams: seq[Connection]
+      var listenStreams: seq[MuxedStream]
       proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
-        mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+        mplexListen.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
           listenStreams.add(stream)
           await noCancel stream.join()
 
@@ -820,11 +822,11 @@ suite "Mplex":
       let transport1 = TcpTransport.new(upgrade = Upgrade())
 
       var mplexListen: Mplex
-      var listenStreams: seq[Connection]
+      var listenStreams: seq[MuxedStream]
       proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         mplexListen = Mplex.new(conn)
-        mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+        mplexListen.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
           listenStreams.add(stream)
           await noCancel stream.join()
 
@@ -862,11 +864,11 @@ suite "Mplex":
       let transport1 = TcpTransport.new(upgrade = Upgrade())
 
       var mplexHandle: Future[void]
-      var listenStreams: seq[Connection]
+      var listenStreams: seq[MuxedStream]
       proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
-        mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+        mplexListen.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
           listenStreams.add(stream)
           await noCancel stream.join()
 
@@ -903,11 +905,11 @@ suite "Mplex":
       let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
       let transport1 = TcpTransport.new(upgrade = Upgrade())
 
-      var listenStreams: seq[Connection]
+      var listenStreams: seq[MuxedStream]
       proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
-        mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+        mplexListen.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
           listenStreams.add(stream)
           await noCancel stream.join()
 
@@ -944,12 +946,12 @@ suite "Mplex":
       let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
       let transport1 = TcpTransport.new(upgrade = Upgrade())
 
-      var listenConn: Connection
-      var listenStreams: seq[Connection]
+      var listenConn: MuxedStream
+      var listenStreams: seq[MuxedStream]
       proc acceptHandler() {.async.} =
         listenConn = await transport1.accept()
         let mplexListen = Mplex.new(listenConn)
-        mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+        mplexListen.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
           listenStreams.add(stream)
           await noCancel stream.join()
 
@@ -994,7 +996,9 @@ suite "Mplex":
         proc acceptHandler() {.async.} =
           let conn = await transport1.accept()
           let mplexListen = Mplex.new(conn)
-          mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+          mplexListen.streamHandler = proc(
+              stream: MuxedStream
+          ) {.async: (raises: []).} =
             try:
               let msg = await stream.readLp(MsgSize)
               check msg.len == MsgSize
@@ -1065,7 +1069,9 @@ suite "Mplex":
         proc acceptHandler() {.async.} =
           let conn = await transport1.accept()
           let mplexListen = Mplex.new(conn)
-          mplexListen.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+          mplexListen.streamHandler = proc(
+              stream: MuxedStream
+          ) {.async: (raises: []).} =
             try:
               let msg = await stream.readLp(MsgSize)
               check msg.len == MsgSize

--- a/tests/libp2p/muxers/test_yamux.nim
+++ b/tests/libp2p/muxers/test_yamux.nim
@@ -50,14 +50,14 @@ suite "Yamux":
     asyncTest "Roundtrip of small messages":
       mSetup()
 
-      yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
+      yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
         try:
-          check (await conn.readLp(100)) == fromHex("1234")
-          await conn.writeLp(fromHex("5678"))
+          check (await stream.readLp(100)) == fromHex("1234")
+          await stream.writeLp(fromHex("5678"))
         except CancelledError, LPStreamError:
           return
         finally:
-          await conn.close()
+          await stream.close()
 
       let streamA = await yamuxa.newStream()
       check streamA == yamuxa.getStreams()[0]
@@ -72,16 +72,16 @@ suite "Yamux":
         readerBlocker = newBlockerFut()
         handlerBlocker = newBlockerFut()
       var numberOfRead = 0
-      yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
+      yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
         await readerBlocker
         try:
           var buffer: array[25600, byte]
-          while (await conn.readOnce(addr buffer[0], 25600)) > 0:
+          while (await stream.readOnce(addr buffer[0], 25600)) > 0:
             numberOfRead.inc()
         except CancelledError, LPStreamError:
           return
         finally:
-          await conn.close()
+          await stream.close()
         handlerBlocker.complete()
 
       let streamA = await yamuxa.newStream()
@@ -98,15 +98,15 @@ suite "Yamux":
     asyncTest "Basic exhaustion blocking":
       mSetup()
       let readerBlocker = newBlockerFut()
-      yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
+      yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
         await readerBlocker
         try:
           var buffer: array[160000, byte]
-          discard await conn.readOnce(addr buffer[0], 160000)
+          discard await stream.readOnce(addr buffer[0], 160000)
         except CancelledError, LPStreamError:
           return
         finally:
-          await conn.close()
+          await stream.close()
 
       let streamA = await yamuxa.newStream()
       check streamA == yamuxa.getStreams()[0]
@@ -126,15 +126,15 @@ suite "Yamux":
     asyncTest "Exhaustion doesn't block other channels":
       mSetup()
       let readerBlocker = newBlockerFut()
-      yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
+      yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
         await readerBlocker
         try:
           var buffer: array[160000, byte]
-          discard await conn.readOnce(addr buffer[0], 160000)
+          discard await stream.readOnce(addr buffer[0], 160000)
         except CancelledError, LPStreamError:
           return
         finally:
-          await conn.close()
+          await stream.close()
 
       let streamA = await yamuxa.newStream()
       check streamA == yamuxa.getStreams()[0]
@@ -146,14 +146,14 @@ suite "Yamux":
 
       # Now that the secondWriter is stuck, create a second stream
       # and exchange some data
-      yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
+      yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
         try:
-          check (await conn.readLp(100)) == fromHex("1234")
-          await conn.writeLp(fromHex("5678"))
+          check (await stream.readLp(100)) == fromHex("1234")
+          await stream.writeLp(fromHex("5678"))
         except CancelledError, LPStreamError:
           return
         finally:
-          await conn.close()
+          await stream.close()
 
       let streamB = await yamuxa.newStream()
       await streamB.writeLp(fromHex("1234"))
@@ -172,17 +172,17 @@ suite "Yamux":
       let writerBlocker = newBlockerFut()
       var numberOfRead = 0
       const newWindow = 20
-      yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
-        YamuxChannel(conn).setMaxRecvWindow(newWindow)
+      yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
+        YamuxChannel(stream).setMaxRecvWindow(newWindow)
         try:
           var buffer: array[256000, byte]
-          while (await conn.readOnce(addr buffer[0], 256000)) > 0:
+          while (await stream.readOnce(addr buffer[0], 256000)) > 0:
             numberOfRead.inc()
           writerBlocker.complete()
         except CancelledError, LPStreamError:
           return
         finally:
-          await conn.close()
+          await stream.close()
 
       let streamA = await yamuxa.newStream()
       check streamA == yamuxa.getStreams()[0]
@@ -201,16 +201,16 @@ suite "Yamux":
     asyncTest "Saturate until reset":
       mSetup()
       let writerBlocker = newBlockerFut()
-      yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
+      yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
         await writerBlocker
         try:
           var buffer: array[256, byte]
           check:
-            (await conn.readOnce(addr buffer[0], 256)) == 0
+            (await stream.readOnce(addr buffer[0], 256)) == 0
         except CancelledError, LPStreamError:
           return
         finally:
-          await conn.close()
+          await stream.close()
 
       let streamA = await yamuxa.newStream()
       check streamA == yamuxa.getStreams()[0]
@@ -228,15 +228,15 @@ suite "Yamux":
     asyncTest "Increase window size":
       mSetup(512000)
       let readerBlocker = newBlockerFut()
-      yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
+      yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
         await readerBlocker
         try:
           var buffer: array[260000, byte]
-          discard await conn.readOnce(addr buffer[0], 260000)
+          discard await stream.readOnce(addr buffer[0], 260000)
         except CancelledError, LPStreamError:
           return
         finally:
-          await conn.close()
+          await stream.close()
 
       let streamA = await yamuxa.newStream()
       check streamA == yamuxa.getStreams()[0]
@@ -257,18 +257,18 @@ suite "Yamux":
       mSetup(64000)
       let readerBlocker1 = newBlockerFut()
       let readerBlocker2 = newBlockerFut()
-      yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
+      yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
         try:
           await readerBlocker1
           var buffer: array[256000, byte]
           # For the first roundtrip, the send window size is assumed to be 256k
-          discard await conn.readOnce(addr buffer[0], 256000)
+          discard await stream.readOnce(addr buffer[0], 256000)
           await readerBlocker2
-          discard await conn.readOnce(addr buffer[0], 40000)
+          discard await stream.readOnce(addr buffer[0], 40000)
         except CancelledError, LPStreamError:
           return
         finally:
-          await conn.close()
+          await stream.close()
 
       let streamA = await yamuxa.newStream()
       check streamA == yamuxa.getStreams()[0]
@@ -298,15 +298,15 @@ suite "Yamux":
       let blocker = newBlockerFut()
       let connBlocker = newBlockerFut()
 
-      yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
+      yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
         try:
-          check (await conn.readLp(100)) == fromHex("1234")
-          await conn.writeLp(fromHex("5678"))
+          check (await stream.readLp(100)) == fromHex("1234")
+          await stream.writeLp(fromHex("5678"))
           await blocker
-          check conn.isClosed
+          check stream.isClosed
           connBlocker.complete()
         except CancelledError, LPStreamError:
-          await conn.close()
+          await stream.close()
 
       let streamA = await yamuxa.newStream()
       check streamA == yamuxa.getStreams()[0]
@@ -324,15 +324,15 @@ suite "Yamux":
       let blocker = newBlockerFut()
       let connBlocker = newBlockerFut()
 
-      yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
+      yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
         try:
-          check (await conn.readLp(100)) == fromHex("1234")
-          await conn.writeLp(fromHex("5678"))
+          check (await stream.readLp(100)) == fromHex("1234")
+          await stream.writeLp(fromHex("5678"))
           await blocker
-          check conn.isClosed
+          check stream.isClosed
           connBlocker.complete()
         except CancelledError, LPStreamError:
-          await conn.close()
+          await stream.close()
 
       let streamA = await yamuxa.newStream()
       check streamA == yamuxa.getStreams()[0]
@@ -349,17 +349,17 @@ suite "Yamux":
     asyncTest "Local & Remote close":
       mSetup()
 
-      yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
+      yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
         try:
-          check (await conn.readLp(100)) == fromHex("1234")
+          check (await stream.readLp(100)) == fromHex("1234")
         except CancelledError, LPStreamError:
           return
         finally:
-          await conn.close()
+          await stream.close()
         expect LPStreamClosedError:
-          await conn.writeLp(fromHex("102030"))
+          await stream.writeLp(fromHex("102030"))
         try:
-          check (await conn.readLp(100)) == fromHex("5678")
+          check (await stream.readLp(100)) == fromHex("5678")
         except CancelledError, LPStreamError:
           return
 
@@ -376,17 +376,17 @@ suite "Yamux":
       mSetup()
       let blocker = newBlockerFut()
 
-      yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
+      yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
         await blocker
         try:
           expect LPStreamResetError:
-            discard await conn.readLp(100)
+            discard await stream.readLp(100)
           expect LPStreamResetError:
-            await conn.writeLp(fromHex("1234"))
+            await stream.writeLp(fromHex("1234"))
         except CancelledError, LPStreamError:
           return
         finally:
-          await conn.close()
+          await stream.close()
 
       let streamA = await yamuxa.newStream()
       check streamA == yamuxa.getStreams()[0]
@@ -402,8 +402,8 @@ suite "Yamux":
     asyncTest "Connection.reset aborts the initiator stream":
       mSetup()
 
-      yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
-        await conn.reset()
+      yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
+        await stream.reset()
 
       let streamA = await yamuxa.newStream()
       check streamA == yamuxa.getStreams()[0]
@@ -418,16 +418,16 @@ suite "Yamux":
     asyncTest "Peer must be able to read from stream after closing it for writing":
       mSetup()
 
-      yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
+      yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
         try:
-          check (await conn.readLp(100)) == fromHex("1234")
+          check (await stream.readLp(100)) == fromHex("1234")
         except CancelledError, LPStreamError:
           return
         try:
-          await conn.writeLp(fromHex("5678"))
+          await stream.writeLp(fromHex("5678"))
         except CancelledError, LPStreamError:
           return
-        await conn.close()
+        await stream.close()
 
       let streamA = await yamuxa.newStream()
       check streamA == yamuxa.getStreams()[0]
@@ -467,9 +467,9 @@ suite "Yamux":
       asyncTest "Syn opens stream and sends Ack - " & $testCase:
         mSetup(startHandlera = false)
 
-        yamuxb.streamHandler = proc(conn: Connection) {.async: (raises: []).} =
+        yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
           try:
-            await conn.close()
+            await stream.close()
           except CancelledError, LPStreamError:
             return
 

--- a/tests/libp2p/protocols/test_autonat.nim
+++ b/tests/libp2p/protocols/test_autonat.nim
@@ -34,11 +34,11 @@ proc makeSwitch(): Switch =
 proc makeAutonatServicePrivate(): Switch =
   var autonatProtocol = new LPProtocol
   autonatProtocol.handler = proc(
-      conn: Connection, proto: string
+      stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     try:
-      discard await conn.readLp(1024)
-      await conn.writeLp(
+      discard await stream.readLp(1024)
+      await stream.writeLp(
         AutonatDialResponse(
           status: DialError, text: Opt.some("dial failed"), ma: Opt.none(MultiAddress)
         ).encode().buffer
@@ -46,7 +46,7 @@ proc makeAutonatServicePrivate(): Switch =
     except LPStreamError:
       raiseAssert "Unexpected LPStreamError in autonat private service handler"
     finally:
-      await conn.close()
+      await stream.close()
   autonatProtocol.codec = AutonatCodec
   result = makeSwitch()
   result.mount(autonatProtocol)
@@ -95,7 +95,7 @@ suite "Autonat":
     await doesNothingListener.start(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
 
     await src.connect(dst.peerInfo.peerId, dst.peerInfo.addrs)
-    let conn = await src.dial(dst.peerInfo.peerId, @[AutonatCodec])
+    let stream = await src.dial(dst.peerInfo.peerId, @[AutonatCodec])
     let buffer = AutonatDial(
       peerInfo: Opt.some(
         AutonatPeerInfo(
@@ -105,8 +105,8 @@ suite "Autonat":
         )
       )
     ).encode().buffer
-    await conn.writeLp(buffer)
-    let response = AutonatMsg.decode(await conn.readLp(1024)).get().response.get()
+    await stream.writeLp(buffer)
+    let response = AutonatMsg.decode(await stream.readLp(1024)).get().response.get()
     check:
       response.status == DialError
       response.text.get() == "Dial timeout"

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -43,7 +43,7 @@ suite "Identify":
       transport2 {.threadvar.}: Transport
       msListen {.threadvar.}: MultistreamSelect
       msDial {.threadvar.}: MultistreamSelect
-      conn {.threadvar.}: Connection
+      conn {.threadvar.}: RawConn
 
     asyncSetup:
       ma = @[
@@ -118,7 +118,7 @@ suite "Identify":
       msListen.addHandler(IdentifyCodec, identifyProto1)
 
       proc acceptHandler() {.async: (raises: [CancelledError]).} =
-        var conn: Connection
+        var conn: RawConn
         try:
           conn = await transport1.accept()
           await msListen.handle(conn)
@@ -161,7 +161,7 @@ suite "Identify":
       switch2 {.threadvar.}: Switch
       identifyPush1 {.threadvar.}: IdentifyPush
       identifyPush2 {.threadvar.}: IdentifyPush
-      conn {.threadvar.}: Connection
+      stream {.threadvar.}: Stream
 
     asyncSetup:
       let ma = @[
@@ -192,7 +192,7 @@ suite "Identify":
       await switch1.start()
       await switch2.start()
 
-      conn = await switch2.dial(
+      stream = await switch2.dial(
         switch1.peerInfo.peerId, switch1.peerInfo.addrs, IdentifyPushCodec
       )
 
@@ -232,7 +232,7 @@ suite "Identify":
           switch1.peerInfo.signedPeerRecord.envelope
 
     proc closeAll() {.async.} =
-      await conn.close()
+      await stream.close()
 
       await switch1.stop()
       await switch2.stop()
@@ -246,7 +246,7 @@ suite "Identify":
         switch1.peerStore[ProtoBook][switch2.peerInfo.peerId] !=
           switch2.peerInfo.protocols
 
-      await identifyPush2.push(switch2.peerInfo, conn)
+      await identifyPush2.push(switch2.peerInfo, stream)
 
       checkUntilTimeout:
         switch1.peerStore[ProtoBook][switch2.peerInfo.peerId] ==
@@ -268,7 +268,7 @@ suite "Identify":
       let oldPeerId = switch2.peerInfo.peerId
       switch2.peerInfo = PeerInfo.new(PrivateKey.random(rng()).get())
 
-      await identifyPush2.push(switch2.peerInfo, conn)
+      await identifyPush2.push(switch2.peerInfo, stream)
 
       # We have no way to know when the message will is received
       # because it will fail validation inside push identify itself

--- a/tests/libp2p/protocols/test_noise.nim
+++ b/tests/libp2p/protocols/test_noise.nim
@@ -35,15 +35,15 @@ type TestProto = ref object of LPProtocol
 {.push raises: [].}
 
 method init(p: TestProto) {.gcsafe.} =
-  proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+  proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
     try:
-      let msg = string.fromBytes(await conn.readLp(1024))
+      let msg = string.fromBytes(await stream.readLp(1024))
       check "Hello!" == msg
-      await conn.writeLp("Hello!")
+      await stream.writeLp("Hello!")
     except LPStreamError:
       raiseAssert "LPStreamError while handling connection"
     finally:
-      await conn.close()
+      await stream.close()
 
   p.codec = TestCodec
   p.handler = handle
@@ -55,7 +55,7 @@ proc makeSwitch(ma: MultiAddress, outgoing: bool, plaintext: bool = false): Swit
     privateKey = PrivateKey.random(ECDSA, rng()).get()
     peerInfo = PeerInfo.new(privateKey, @[ma])
 
-  proc createMplex(conn: Connection): Muxer =
+  proc createMplex(conn: RawConn): Muxer =
     Mplex.new(conn)
 
   let
@@ -140,7 +140,7 @@ suite "Noise":
     asyncSpawn transport1.start(server)
 
     proc acceptHandler() {.async.} =
-      var conn: Connection
+      var conn: RawConn
       expect LPStreamError:
         conn = await transport1.accept()
         discard await serverNoise.secure(conn, Opt.none(PeerId))
@@ -155,7 +155,7 @@ suite "Noise":
       )
       conn = await transport2.dial(transport1.addrs[0])
 
-    var sconn: Connection = nil
+    var sconn: SecureConn = nil
     expect NoiseDecryptTagError:
       sconn = await clientNoise.secure(conn, Opt.some(conn.peerId))
 

--- a/tests/libp2p/protocols/test_ping.nim
+++ b/tests/libp2p/protocols/test_ping.nim
@@ -30,7 +30,7 @@ suite "Ping":
     transport2 {.threadvar.}: Transport
     msListen {.threadvar.}: MultistreamSelect
     msDial {.threadvar.}: MultistreamSelect
-    conn {.threadvar.}: Connection
+    stream {.threadvar.}: Stream
     pingReceivedCount {.threadvar.}: int
 
   asyncSetup:
@@ -51,7 +51,7 @@ suite "Ping":
     pingReceivedCount = 0
 
   asyncTeardown:
-    await conn.close()
+    await stream.close()
     await acceptFut
     await transport1.stop()
     await serverFut
@@ -66,10 +66,10 @@ suite "Ping":
       await msListen.handle(c)
 
     acceptFut = acceptHandler()
-    conn = await transport2.dial(transport1.addrs[0])
+    stream = await transport2.dial(transport1.addrs[0])
 
-    discard await msDial.select(conn, PingCodec)
-    let time = await pingProto2.ping(conn)
+    discard await msDial.select(stream, PingCodec)
+    let time = await pingProto2.ping(stream)
 
     check not time.isZero()
 
@@ -82,23 +82,23 @@ suite "Ping":
       discard await pingProto1.ping(c)
 
     acceptFut = acceptHandler()
-    conn = await transport2.dial(transport1.addrs[0])
+    stream = await transport2.dial(transport1.addrs[0])
 
-    await msDial.handle(conn)
+    await msDial.handle(stream)
     check pingReceivedCount == 1
 
   asyncTest "bad ping data ack":
     type FakePing = ref object of LPProtocol
     let fakePingProto = FakePing()
     proc fakeHandle(
-        conn: Connection, proto: string
+        stream: Stream, proto: string
     ) {.async: (raises: [CancelledError]).} =
       try:
         var
           buf: array[32, byte]
           fakebuf: array[32, byte]
-        await conn.readExactly(addr buf[0], 32)
-        await conn.write(@fakebuf)
+        await stream.readExactly(addr buf[0], 32)
+        await stream.write(@fakebuf)
       except LPStreamError:
         raiseAssert "LPStreamError while handling connection"
 
@@ -112,9 +112,9 @@ suite "Ping":
       await msListen.handle(c)
 
     acceptFut = acceptHandler()
-    conn = await transport2.dial(transport1.addrs[0])
+    stream = await transport2.dial(transport1.addrs[0])
 
-    discard await msDial.select(conn, PingCodec)
+    discard await msDial.select(stream, PingCodec)
 
     expect WrongPingAckError:
-      discard await pingProto2.ping(conn)
+      discard await pingProto2.ping(stream)

--- a/tests/libp2p/protocols/test_relay_v1.nim
+++ b/tests/libp2p/protocols/test_relay_v1.nim
@@ -42,7 +42,7 @@ suite "Circuit Relay":
     clSrc {.threadvar.}: RelayClient
     clDst {.threadvar.}: RelayClient
     r {.threadvar.}: Relay
-    conn {.threadvar.}: Connection
+    stream {.threadvar.}: Stream
     msg {.threadvar.}: ProtoBuffer
     rcv {.threadvar.}: Opt[RelayMessage]
 
@@ -74,17 +74,17 @@ suite "Circuit Relay":
       m.dstPeer == dst
 
   proc customHandler(
-      conn: Connection, proto: string
+      stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     try:
-      check "line1" == string.fromBytes(await conn.readLp(1024))
-      await conn.writeLp("line2")
-      check "line3" == string.fromBytes(await conn.readLp(1024))
-      await conn.writeLp("line4")
+      check "line1" == string.fromBytes(await stream.readLp(1024))
+      await stream.writeLp("line2")
+      check "line3" == string.fromBytes(await stream.readLp(1024))
+      await stream.writeLp("line4")
     except LPStreamError:
       raiseAssert "LPStreamError while handling connection"
     finally:
-      await conn.close()
+      await stream.close()
 
   asyncSetup:
     # Create a custom prototype
@@ -133,167 +133,167 @@ suite "Circuit Relay":
 
   asyncTest "Handle CanHop":
     msg = createMsg(Opt.some(CanHop))
-    conn = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
-    await conn.writeLp(msg.buffer)
-    rcv = RelayMessage.decode(await conn.readLp(1024))
+    stream = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
+    await stream.writeLp(msg.buffer)
+    rcv = RelayMessage.decode(await stream.readLp(1024))
     rcv.checkMsg(Opt.some(RelayType.Status), Opt.some(StatusV1.Success))
 
-    conn = await src.dial(dst.peerInfo.peerId, dst.peerInfo.addrs, RelayV1Codec)
-    await conn.writeLp(msg.buffer)
-    rcv = RelayMessage.decode(await conn.readLp(1024))
+    stream = await src.dial(dst.peerInfo.peerId, dst.peerInfo.addrs, RelayV1Codec)
+    await stream.writeLp(msg.buffer)
+    rcv = RelayMessage.decode(await stream.readLp(1024))
     rcv.checkMsg(Opt.some(RelayType.Status), Opt.some(HopCantSpeakRelay))
 
-    await conn.close()
+    await stream.close()
 
   asyncTest "Malformed":
-    conn = await srelay.dial(dst.peerInfo.peerId, dst.peerInfo.addrs, RelayV1Codec)
+    stream = await srelay.dial(dst.peerInfo.peerId, dst.peerInfo.addrs, RelayV1Codec)
     msg = createMsg(Opt.some(RelayType.Status))
-    await conn.writeLp(msg.buffer)
-    rcv = RelayMessage.decode(await conn.readLp(1024))
-    await conn.close()
+    await stream.writeLp(msg.buffer)
+    rcv = RelayMessage.decode(await stream.readLp(1024))
+    await stream.close()
     rcv.checkMsg(Opt.some(RelayType.Status), Opt.some(StatusV1.MalformedMessage))
 
   asyncTest "Handle Stop Error":
-    conn = await srelay.dial(dst.peerInfo.peerId, dst.peerInfo.addrs, RelayV1Codec)
+    stream = await srelay.dial(dst.peerInfo.peerId, dst.peerInfo.addrs, RelayV1Codec)
     msg = createMsg(
       Opt.some(RelayType.Stop),
       Opt.none(StatusV1),
       Opt.none(RelayPeer),
       Opt.some(RelayPeer(peerId: dst.peerInfo.peerId, addrs: dst.peerInfo.addrs)),
     )
-    await conn.writeLp(msg.buffer)
-    rcv = RelayMessage.decode(await conn.readLp(1024))
+    await stream.writeLp(msg.buffer)
+    rcv = RelayMessage.decode(await stream.readLp(1024))
     rcv.checkMsg(Opt.some(RelayType.Status), Opt.some(StopSrcMultiaddrInvalid))
 
-    conn = await srelay.dial(dst.peerInfo.peerId, dst.peerInfo.addrs, RelayV1Codec)
+    stream = await srelay.dial(dst.peerInfo.peerId, dst.peerInfo.addrs, RelayV1Codec)
     msg = createMsg(
       Opt.some(RelayType.Stop),
       Opt.none(StatusV1),
       Opt.some(RelayPeer(peerId: src.peerInfo.peerId, addrs: src.peerInfo.addrs)),
       Opt.none(RelayPeer),
     )
-    await conn.writeLp(msg.buffer)
-    rcv = RelayMessage.decode(await conn.readLp(1024))
+    await stream.writeLp(msg.buffer)
+    rcv = RelayMessage.decode(await stream.readLp(1024))
     rcv.checkMsg(Opt.some(RelayType.Status), Opt.some(StopDstMultiaddrInvalid))
 
-    conn = await srelay.dial(dst.peerInfo.peerId, dst.peerInfo.addrs, RelayV1Codec)
+    stream = await srelay.dial(dst.peerInfo.peerId, dst.peerInfo.addrs, RelayV1Codec)
     msg = createMsg(
       Opt.some(RelayType.Stop),
       Opt.none(StatusV1),
       Opt.some(RelayPeer(peerId: dst.peerInfo.peerId, addrs: dst.peerInfo.addrs)),
       Opt.some(RelayPeer(peerId: src.peerInfo.peerId, addrs: src.peerInfo.addrs)),
     )
-    await conn.writeLp(msg.buffer)
-    rcv = RelayMessage.decode(await conn.readLp(1024))
-    await conn.close()
+    await stream.writeLp(msg.buffer)
+    rcv = RelayMessage.decode(await stream.readLp(1024))
+    await stream.close()
     rcv.checkMsg(Opt.some(RelayType.Status), Opt.some(StopDstMultiaddrInvalid))
 
   asyncTest "Handle Hop Error":
-    conn = await src.dial(dst.peerInfo.peerId, dst.peerInfo.addrs, RelayV1Codec)
+    stream = await src.dial(dst.peerInfo.peerId, dst.peerInfo.addrs, RelayV1Codec)
     msg = createMsg(Opt.some(RelayType.Hop))
-    await conn.writeLp(msg.buffer)
-    rcv = RelayMessage.decode(await conn.readLp(1024))
+    await stream.writeLp(msg.buffer)
+    rcv = RelayMessage.decode(await stream.readLp(1024))
     rcv.checkMsg(Opt.some(RelayType.Status), Opt.some(HopCantSpeakRelay))
 
-    conn = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
+    stream = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
     msg = createMsg(
       Opt.some(RelayType.Hop),
       Opt.none(StatusV1),
       Opt.none(RelayPeer),
       Opt.some(RelayPeer(peerId: dst.peerInfo.peerId, addrs: dst.peerInfo.addrs)),
     )
-    await conn.writeLp(msg.buffer)
-    rcv = RelayMessage.decode(await conn.readLp(1024))
+    await stream.writeLp(msg.buffer)
+    rcv = RelayMessage.decode(await stream.readLp(1024))
     rcv.checkMsg(Opt.some(RelayType.Status), Opt.some(HopSrcMultiaddrInvalid))
 
-    conn = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
+    stream = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
     msg = createMsg(
       Opt.some(RelayType.Hop),
       Opt.none(StatusV1),
       Opt.some(RelayPeer(peerId: dst.peerInfo.peerId, addrs: dst.peerInfo.addrs)),
       Opt.some(RelayPeer(peerId: dst.peerInfo.peerId, addrs: dst.peerInfo.addrs)),
     )
-    await conn.writeLp(msg.buffer)
-    rcv = RelayMessage.decode(await conn.readLp(1024))
+    await stream.writeLp(msg.buffer)
+    rcv = RelayMessage.decode(await stream.readLp(1024))
     rcv.checkMsg(Opt.some(RelayType.Status), Opt.some(HopSrcMultiaddrInvalid))
 
-    conn = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
+    stream = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
     msg = createMsg(
       Opt.some(RelayType.Hop),
       Opt.none(StatusV1),
       Opt.some(RelayPeer(peerId: src.peerInfo.peerId, addrs: src.peerInfo.addrs)),
       Opt.none(RelayPeer),
     )
-    await conn.writeLp(msg.buffer)
-    rcv = RelayMessage.decode(await conn.readLp(1024))
+    await stream.writeLp(msg.buffer)
+    rcv = RelayMessage.decode(await stream.readLp(1024))
     rcv.checkMsg(Opt.some(RelayType.Status), Opt.some(HopDstMultiaddrInvalid))
 
-    conn = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
+    stream = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
     msg = createMsg(
       Opt.some(RelayType.Hop),
       Opt.none(StatusV1),
       Opt.some(RelayPeer(peerId: src.peerInfo.peerId, addrs: src.peerInfo.addrs)),
       Opt.some(RelayPeer(peerId: srelay.peerInfo.peerId, addrs: srelay.peerInfo.addrs)),
     )
-    await conn.writeLp(msg.buffer)
-    rcv = RelayMessage.decode(await conn.readLp(1024))
+    await stream.writeLp(msg.buffer)
+    rcv = RelayMessage.decode(await stream.readLp(1024))
     rcv.checkMsg(Opt.some(RelayType.Status), Opt.some(HopCantRelayToSelf))
 
-    conn = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
+    stream = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
     msg = createMsg(
       Opt.some(RelayType.Hop),
       Opt.none(StatusV1),
       Opt.some(RelayPeer(peerId: src.peerInfo.peerId, addrs: src.peerInfo.addrs)),
       Opt.some(RelayPeer(peerId: srelay.peerInfo.peerId, addrs: srelay.peerInfo.addrs)),
     )
-    await conn.writeLp(msg.buffer)
-    rcv = RelayMessage.decode(await conn.readLp(1024))
+    await stream.writeLp(msg.buffer)
+    rcv = RelayMessage.decode(await stream.readLp(1024))
     rcv.checkMsg(Opt.some(RelayType.Status), Opt.some(HopCantRelayToSelf))
 
-    conn = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
+    stream = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
     msg = createMsg(
       Opt.some(RelayType.Hop),
       Opt.none(StatusV1),
       Opt.some(RelayPeer(peerId: src.peerInfo.peerId, addrs: src.peerInfo.addrs)),
       Opt.some(RelayPeer(peerId: dst.peerInfo.peerId, addrs: dst.peerInfo.addrs)),
     )
-    await conn.writeLp(msg.buffer)
-    rcv = RelayMessage.decode(await conn.readLp(1024))
+    await stream.writeLp(msg.buffer)
+    rcv = RelayMessage.decode(await stream.readLp(1024))
     rcv.checkMsg(Opt.some(RelayType.Status), Opt.some(HopNoConnToDst))
 
     await srelay.connect(dst.peerInfo.peerId, dst.peerInfo.addrs)
 
     var tmp = r.maxCircuit
     r.maxCircuit = 0
-    conn = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
-    await conn.writeLp(msg.buffer)
-    rcv = RelayMessage.decode(await conn.readLp(1024))
+    stream = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
+    await stream.writeLp(msg.buffer)
+    rcv = RelayMessage.decode(await stream.readLp(1024))
     rcv.checkMsg(Opt.some(RelayType.Status), Opt.some(HopCantSpeakRelay))
     r.maxCircuit = tmp
-    await conn.close()
+    await stream.close()
 
     tmp = r.maxCircuitPerPeer
     r.maxCircuitPerPeer = 0
-    conn = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
-    await conn.writeLp(msg.buffer)
-    rcv = RelayMessage.decode(await conn.readLp(1024))
+    stream = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
+    await stream.writeLp(msg.buffer)
+    rcv = RelayMessage.decode(await stream.readLp(1024))
     rcv.checkMsg(Opt.some(RelayType.Status), Opt.some(HopCantSpeakRelay))
     r.maxCircuitPerPeer = tmp
-    await conn.close()
+    await stream.close()
 
     let dst2 = makeStandardSwitch(transport = TransportType.TCP)
     await dst2.start()
     await srelay.connect(dst2.peerInfo.peerId, dst2.peerInfo.addrs)
 
-    conn = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
+    stream = await src.dial(srelay.peerInfo.peerId, srelay.peerInfo.addrs, RelayV1Codec)
     msg = createMsg(
       Opt.some(RelayType.Hop),
       Opt.none(StatusV1),
       Opt.some(RelayPeer(peerId: src.peerInfo.peerId, addrs: src.peerInfo.addrs)),
       Opt.some(RelayPeer(peerId: dst2.peerInfo.peerId, addrs: dst2.peerInfo.addrs)),
     )
-    await conn.writeLp(msg.buffer)
-    rcv = RelayMessage.decode(await conn.readLp(1024))
+    await stream.writeLp(msg.buffer)
+    rcv = RelayMessage.decode(await stream.readLp(1024))
     rcv.checkMsg(Opt.some(RelayType.Status), Opt.some(HopCantDialDst))
     await allFutures(dst2.stop())
 
@@ -303,13 +303,13 @@ suite "Circuit Relay":
     let maddr = MultiAddress.init(maStr).tryGet()
     await src.connect(srelay.peerInfo.peerId, srelay.peerInfo.addrs)
     await srelay.connect(dst.peerInfo.peerId, dst.peerInfo.addrs)
-    conn = await src.dial(dst.peerInfo.peerId, @[maddr], protos[0])
+    stream = await src.dial(dst.peerInfo.peerId, @[maddr], protos[0])
 
-    await conn.writeLp("line1")
-    check string.fromBytes(await conn.readLp(1024)) == "line2"
+    await stream.writeLp("line1")
+    check string.fromBytes(await stream.readLp(1024)) == "line2"
 
-    await conn.writeLp("line3")
-    check string.fromBytes(await conn.readLp(1024)) == "line4"
+    await stream.writeLp("line3")
+    check string.fromBytes(await stream.readLp(1024)) == "line4"
 
   asyncTest "Bad MultiAddress":
     await src.connect(srelay.peerInfo.peerId, srelay.peerInfo.addrs)
@@ -319,19 +319,19 @@ suite "Circuit Relay":
         $srelay.peerInfo.addrs[0] & "/p2p/" & $srelay.peerInfo.peerId & "/p2p/" &
         $dst.peerInfo.peerId
       let maddr = MultiAddress.init(maStr).tryGet()
-      conn = await src.dial(dst.peerInfo.peerId, @[maddr], protos[0])
+      stream = await src.dial(dst.peerInfo.peerId, @[maddr], protos[0])
 
     expect DialFailedError:
       let maStr = $srelay.peerInfo.addrs[0] & "/p2p/" & $srelay.peerInfo.peerId
       let maddr = MultiAddress.init(maStr).tryGet()
-      conn = await src.dial(dst.peerInfo.peerId, @[maddr], protos[0])
+      stream = await src.dial(dst.peerInfo.peerId, @[maddr], protos[0])
 
     expect DialFailedError:
       let maStr = "/ip4/127.0.0.1"
       let maddr = MultiAddress.init(maStr).tryGet()
-      conn = await src.dial(dst.peerInfo.peerId, @[maddr], protos[0])
+      stream = await src.dial(dst.peerInfo.peerId, @[maddr], protos[0])
 
     expect LPError:
       let maStr = $dst.peerInfo.peerId
       let maddr = MultiAddress.init(maStr).tryGet()
-      conn = await src.dial(dst.peerInfo.peerId, @[maddr], protos[0])
+      stream = await src.dial(dst.peerInfo.peerId, @[maddr], protos[0])

--- a/tests/libp2p/protocols/test_relay_v2.nim
+++ b/tests/libp2p/protocols/test_relay_v2.nim
@@ -78,11 +78,11 @@ suite "Circuit Relay V2":
         rsvp.limitData == ldata
 
     asyncTest "Too many reservations":
-      let conn =
+      let stream =
         await cl2.switch.dial(rel.peerInfo.peerId, rel.peerInfo.addrs, RelayV2HopCodec)
       let pb = encode(HopMessage(msgType: HopMessageType.Reserve))
-      await conn.writeLp(pb.buffer)
-      let msg = HopMessage.decode(await conn.readLp(RelayMsgSize)).get()
+      await stream.writeLp(pb.buffer)
+      let msg = HopMessage.decode(await stream.readLp(RelayMsgSize)).get()
       check:
         msg.msgType == HopMessageType.Status
         msg.status == Opt.some(StatusV2.ReservationRefused)
@@ -148,7 +148,7 @@ suite "Circuit Relay V2":
         dst {.threadvar.}: Switch
         rel {.threadvar.}: Switch
         rsvp {.threadvar.}: Rsvp
-        conn {.threadvar.}: Connection
+        stream {.threadvar.}: Stream
 
       asyncSetup:
         customProtoCodec = "/test"
@@ -165,19 +165,19 @@ suite "Circuit Relay V2":
 
       asyncTest "Connection succeed":
         proto.handler = proc(
-            conn: Connection, proto: string
+            stream: Stream, proto: string
         ) {.async: (raises: [CancelledError]).} =
           try:
             check:
-              "test1" == string.fromBytes(await conn.readLp(1024))
-            await conn.writeLp("test2")
+              "test1" == string.fromBytes(await stream.readLp(1024))
+            await stream.writeLp("test2")
             check:
-              "test3" == string.fromBytes(await conn.readLp(1024))
-            await conn.writeLp("test4")
+              "test3" == string.fromBytes(await stream.readLp(1024))
+            await stream.writeLp("test4")
           except LPStreamError:
             raiseAssert "LPStreamError while handling connection"
           finally:
-            await conn.close()
+            await stream.close()
         rv2 = Relay.new(
           reservationTTL = initDuration(seconds = ttl),
           limitDuration = ldur,
@@ -202,33 +202,33 @@ suite "Circuit Relay V2":
 
         rsvp = await dstCl.reserve(rel.peerInfo.peerId, rel.peerInfo.addrs)
 
-        conn = await src.dial(dst.peerInfo.peerId, @[addrs], customProtoCodec)
-        await conn.writeLp("test1")
+        stream = await src.dial(dst.peerInfo.peerId, @[addrs], customProtoCodec)
+        await stream.writeLp("test1")
         check:
-          "test2" == string.fromBytes(await conn.readLp(1024))
-        await conn.writeLp("test3")
+          "test2" == string.fromBytes(await stream.readLp(1024))
+        await stream.writeLp("test3")
         check:
-          "test4" == string.fromBytes(await conn.readLp(1024))
-        await allFutures(conn.close())
+          "test4" == string.fromBytes(await stream.readLp(1024))
+        await allFutures(stream.close())
         await allFutures(src.stop(), dst.stop(), rel.stop())
 
       asyncTest "Connection duration exceeded":
         ldur = 3
         proto.handler = proc(
-            conn: Connection, proto: string
+            stream: Stream, proto: string
         ) {.async: (raises: [CancelledError]).} =
           try:
-            check "wanna sleep?" == string.fromBytes(await conn.readLp(1024))
-            await conn.writeLp("yeah!")
-            check "go!" == string.fromBytes(await conn.readLp(1024))
+            check "wanna sleep?" == string.fromBytes(await stream.readLp(1024))
+            await stream.writeLp("yeah!")
+            check "go!" == string.fromBytes(await stream.readLp(1024))
           except LPStreamError:
             raiseAssert "Unexpected LPStreamError when writing"
 
           await sleepAsync(chronos.timer.seconds(ldur + 1))
 
           expect LPStreamError:
-            await conn.writeLp("that was a cool power nap")
-          await conn.close()
+            await stream.writeLp("that was a cool power nap")
+          await stream.close()
         rv2 = Relay.new(
           reservationTTL = initDuration(seconds = ttl),
           limitDuration = ldur,
@@ -252,27 +252,27 @@ suite "Circuit Relay V2":
         await dst.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
 
         rsvp = await dstCl.reserve(rel.peerInfo.peerId, rel.peerInfo.addrs)
-        conn = await src.dial(dst.peerInfo.peerId, @[addrs], customProtoCodec)
-        await conn.writeLp("wanna sleep?")
+        stream = await src.dial(dst.peerInfo.peerId, @[addrs], customProtoCodec)
+        await stream.writeLp("wanna sleep?")
         check:
-          "yeah!" == string.fromBytes(await conn.readLp(1024))
-        await conn.writeLp("go!")
+          "yeah!" == string.fromBytes(await stream.readLp(1024))
+        await stream.writeLp("go!")
         expect LPStreamEOFError:
-          discard await conn.readLp(1024)
-        await allFutures(conn.close())
+          discard await stream.readLp(1024)
+        await allFutures(stream.close())
         await allFutures(src.stop(), dst.stop(), rel.stop())
 
       asyncTest "Connection data exceeded":
         ldata = 1000
         proto.handler = proc(
-            conn: Connection, proto: string
+            stream: Stream, proto: string
         ) {.async: (raises: [CancelledError]).} =
           try:
             check "count me the better story you know" ==
-              string.fromBytes(await conn.readLp(1024))
-            await conn.writeLp("do you expect a lorem ipsum or...?")
-            check "surprise me!" == string.fromBytes(await conn.readLp(1024))
-            await conn.writeLp(
+              string.fromBytes(await stream.readLp(1024))
+            await stream.writeLp("do you expect a lorem ipsum or...?")
+            check "surprise me!" == string.fromBytes(await stream.readLp(1024))
+            await stream.writeLp(
               """Call me Ishmael. Some years ago--never mind how long
     precisely--having little or no money in my purse, and nothing
     particular to interest me on shore, I thought I would sail about a
@@ -292,7 +292,7 @@ suite "Circuit Relay V2":
           except LPStreamError:
             discard # will get here after data exceeded
           finally:
-            await conn.close()
+            await stream.close()
         rv2 = Relay.new(
           reservationTTL = initDuration(seconds = ttl),
           limitDuration = ldur,
@@ -316,33 +316,33 @@ suite "Circuit Relay V2":
         await dst.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
 
         rsvp = await dstCl.reserve(rel.peerInfo.peerId, rel.peerInfo.addrs)
-        conn = await src.dial(dst.peerInfo.peerId, @[addrs], customProtoCodec)
-        await conn.writeLp("count me the better story you know")
+        stream = await src.dial(dst.peerInfo.peerId, @[addrs], customProtoCodec)
+        await stream.writeLp("count me the better story you know")
         check:
           "do you expect a lorem ipsum or...?" ==
-            string.fromBytes(await conn.readLp(1024))
-        await conn.writeLp("surprise me!")
+            string.fromBytes(await stream.readLp(1024))
+        await stream.writeLp("surprise me!")
         expect LPStreamEOFError:
-          discard await conn.readLp(1024)
-        await allFutures(conn.close())
+          discard await stream.readLp(1024)
+        await allFutures(stream.close())
         await allFutures(src.stop(), dst.stop(), rel.stop())
 
       asyncTest "Reservation ttl expire during connection":
         ttl = 3
         proto.handler = proc(
-            conn: Connection, proto: string
+            stream: Stream, proto: string
         ) {.async: (raises: [CancelledError]).} =
           try:
             check:
-              "test1" == string.fromBytes(await conn.readLp(1024))
-            await conn.writeLp("test2")
+              "test1" == string.fromBytes(await stream.readLp(1024))
+            await stream.writeLp("test2")
             check:
-              "test3" == string.fromBytes(await conn.readLp(1024))
-            await conn.writeLp("test4")
+              "test3" == string.fromBytes(await stream.readLp(1024))
+            await stream.writeLp("test4")
           except LPStreamError:
             raiseAssert "LPStreamError while handling connection"
           finally:
-            await conn.close()
+            await stream.close()
         rv2 = Relay.new(
           reservationTTL = initDuration(seconds = ttl),
           limitDuration = ldur,
@@ -366,21 +366,21 @@ suite "Circuit Relay V2":
         await dst.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
 
         rsvp = await dstCl.reserve(rel.peerInfo.peerId, rel.peerInfo.addrs)
-        conn = await src.dial(dst.peerInfo.peerId, @[addrs], customProtoCodec)
-        await conn.writeLp("test1")
+        stream = await src.dial(dst.peerInfo.peerId, @[addrs], customProtoCodec)
+        await stream.writeLp("test1")
         check:
-          "test2" == string.fromBytes(await conn.readLp(1024))
-        await conn.writeLp("test3")
+          "test2" == string.fromBytes(await stream.readLp(1024))
+        await stream.writeLp("test3")
         check:
-          "test4" == string.fromBytes(await conn.readLp(1024))
+          "test4" == string.fromBytes(await stream.readLp(1024))
         await src.disconnect(rel.peerInfo.peerId)
         await sleepAsync(chronos.timer.seconds(ttl + 1))
 
         expect DialFailedError:
-          await conn.close()
+          await stream.close()
           await src.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
-          conn = await src.dial(dst.peerInfo.peerId, @[addrs], customProtoCodec)
-        await allFutures(conn.close())
+          stream = await src.dial(dst.peerInfo.peerId, @[addrs], customProtoCodec)
+        await allFutures(stream.close())
         await allFutures(src.stop(), dst.stop(), rel.stop())
 
       asyncTest "Connection over relay":
@@ -389,7 +389,7 @@ suite "Circuit Relay V2":
         # dst reserve rel2
         # src try to connect with dst
         proto.handler = proc(
-            conn: Connection, proto: string
+            stream: Stream, proto: string
         ) {.async: (raises: [CancelledError]).} =
           raiseAssert "Should not receive connection"
 
@@ -423,9 +423,9 @@ suite "Circuit Relay V2":
         discard await dstCl.reserve(rel2.peerInfo.peerId, rel2.peerInfo.addrs)
 
         expect DialFailedError:
-          conn = await src.dial(dst.peerInfo.peerId, addrs, customProtoCodec)
-        if not conn.isNil():
-          await allFutures(conn.close())
+          stream = await src.dial(dst.peerInfo.peerId, addrs, customProtoCodec)
+        if not stream.isNil():
+          await allFutures(stream.close())
         await allFutures(src.stop(), dst.stop(), rel.stop(), rel2.stop())
 
       asyncTest "Connection using ClientRelay":
@@ -435,49 +435,49 @@ suite "Circuit Relay V2":
           protoCAB = new LPProtocol
         protoABC.codec = "/abctest"
         protoABC.handler = proc(
-            conn: Connection, proto: string
+            stream: Stream, proto: string
         ) {.async: (raises: [CancelledError]).} =
           try:
             check:
-              "testABC1" == string.fromBytes(await conn.readLp(1024))
-            await conn.writeLp("testABC2")
+              "testABC1" == string.fromBytes(await stream.readLp(1024))
+            await stream.writeLp("testABC2")
             check:
-              "testABC3" == string.fromBytes(await conn.readLp(1024))
-            await conn.writeLp("testABC4")
+              "testABC3" == string.fromBytes(await stream.readLp(1024))
+            await stream.writeLp("testABC4")
           except LPStreamError:
             raiseAssert "LPStreamError while handling connection"
           finally:
-            await conn.close()
+            await stream.close()
         protoBCA.codec = "/bcatest"
         protoBCA.handler = proc(
-            conn: Connection, proto: string
+            stream: Stream, proto: string
         ) {.async: (raises: [CancelledError]).} =
           try:
             check:
-              "testBCA1" == string.fromBytes(await conn.readLp(1024))
-            await conn.writeLp("testBCA2")
+              "testBCA1" == string.fromBytes(await stream.readLp(1024))
+            await stream.writeLp("testBCA2")
             check:
-              "testBCA3" == string.fromBytes(await conn.readLp(1024))
-            await conn.writeLp("testBCA4")
+              "testBCA3" == string.fromBytes(await stream.readLp(1024))
+            await stream.writeLp("testBCA4")
           except LPStreamError:
             raiseAssert "LPStreamError while handling connection"
           finally:
-            await conn.close()
+            await stream.close()
         protoCAB.codec = "/cabtest"
         protoCAB.handler = proc(
-            conn: Connection, proto: string
+            stream: Stream, proto: string
         ) {.async: (raises: [CancelledError]).} =
           try:
             check:
-              "testCAB1" == string.fromBytes(await conn.readLp(1024))
-            await conn.writeLp("testCAB2")
+              "testCAB1" == string.fromBytes(await stream.readLp(1024))
+            await stream.writeLp("testCAB2")
             check:
-              "testCAB3" == string.fromBytes(await conn.readLp(1024))
-            await conn.writeLp("testCAB4")
+              "testCAB3" == string.fromBytes(await stream.readLp(1024))
+            await stream.writeLp("testCAB4")
           except LPStreamError:
             raiseAssert "LPStreamError while handling connection"
           finally:
-            await conn.close()
+            await stream.close()
 
         let
           clientA = RelayClient.new(canHop = true)

--- a/tests/libp2p/pubsub/component/test_gossipsub_custom_stream.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_custom_stream.nim
@@ -10,33 +10,33 @@ import
 import ../../../tools/[lifecycle, topology, unittest]
 import ../utils
 
-type DummyConnection* = ref object of Connection
+type DummyStream* = ref object of Connection
   data: seq[byte]
 
 method write*(
-    self: DummyConnection, msg: seq[byte]
+    self: DummyStream, msg: seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
   self.data.add(msg)
 
-suite "GossipSub Component - Custom Connection Support":
+suite "GossipSub Component - Custom Stream Support":
   const topic = "foobar"
 
   teardown:
     checkTrackers()
 
-  asyncTest "publish with useCustomConn triggers custom connection and peer selection":
+  asyncTest "publish with useCustomStream triggers custom stream and peer selection":
     let nodes = generateNodes(2, gossip = true).toGossipSub()
 
     var
-      dummyConn = DummyConnection()
+      dummyStream = DummyStream()
       peerSelectionCalled = false
 
-    nodes[0].customConnCallbacks = Opt.some(
-      CustomConnectionCallbacks(
-        customConnCreationCB: proc(
+    nodes[0].customStreamCallbacks = Opt.some(
+      CustomStreamCallbacks(
+        customStreamCreationCB: proc(
             destAddr: Opt[MultiAddress], destPeerId: PeerId, codec: string
-        ): Connection =
-          return dummyConn,
+        ): Stream =
+          return dummyStream,
         customPeerSelectionCB: proc(
             allPeers: HashSet[PubSubPeer],
             directPeers: HashSet[PubSubPeer],
@@ -57,14 +57,14 @@ suite "GossipSub Component - Custom Connection Support":
     tryPublish await nodes[0].publish(
       topic,
       "hello".toBytes(),
-      publishParams = Opt.some(PublishParams(useCustomConn: true)),
+      publishParams = Opt.some(PublishParams(useCustomStream: true)),
     ), 1
 
     check:
       peerSelectionCalled
-      dummyConn.data.len > 0
+      dummyStream.data.len > 0
 
-  asyncTest "publish with useCustomConn triggers assertion if custom callbacks not set":
+  asyncTest "publish with useCustomStream triggers assertion if custom callbacks not set":
     let nodes = generateNodes(2, gossip = true).toGossipSub()
 
     startAndDeferStop(nodes)
@@ -77,5 +77,5 @@ suite "GossipSub Component - Custom Connection Support":
       discard await nodes[0].publish(
         topic,
         "hello".toBytes(),
-        publishParams = Opt.some(PublishParams(useCustomConn: true)),
+        publishParams = Opt.some(PublishParams(useCustomStream: true)),
       )

--- a/tests/libp2p/pubsub/test_behavior.nim
+++ b/tests/libp2p/pubsub/test_behavior.nim
@@ -580,7 +580,7 @@ suite "GossipSub Behavior":
       await teardownGossipSub(gossipSub, conns)
 
     for peer in peers:
-      peer.sendConn.transportDir = Direction.In
+      peer.sendStream.transportDir = Direction.In
 
     # And configure dHigh to current mesh size, dOut higher than current outbound count
     gossipSub.parameters.dHigh = 5
@@ -588,7 +588,7 @@ suite "GossipSub Behavior":
 
     # And Peer to graft is outbound and not in the mesh
     gossipSub.mesh.removePeer(topic, peer)
-    peer.sendConn.transportDir = Direction.Out
+    peer.sendStream.transportDir = Direction.Out
 
     # And initially mesh has 5 peers at dHigh, but 0 outbound peers < dOut (2)
     check:
@@ -616,10 +616,10 @@ suite "GossipSub Behavior":
 
     # Configure some existing peers as outbound to meet dOut threshold, peer to graft + 2 in the mesh
     for i in 0 ..< 3:
-      peers[i].sendConn.transportDir = Direction.Out
+      peers[i].sendStream.transportDir = Direction.Out
     # Rest as inbound
     for i in 3 ..< 6:
-      peers[i].sendConn.transportDir = Direction.In
+      peers[i].sendStream.transportDir = Direction.In
 
     # And configure dHigh to current mesh size, dOut to current outbound count
     gossipSub.parameters.dHigh = 5
@@ -1014,7 +1014,7 @@ suite "GossipSub Behavior":
     check gossipSub.mesh[topic].len > gossipSub.parameters.dLow
     var outbound = 0
     for peer in gossipSub.mesh[topic]:
-      if peer.sendConn.transportDir == Direction.Out:
+      if peer.sendStream.transportDir == Direction.Out:
         inc outbound
     # ensure we give priority and keep at least dOut outbound peers
     check outbound >= gossipSub.parameters.dOut

--- a/tests/libp2p/pubsub/test_priority_queues.nim
+++ b/tests/libp2p/pubsub/test_priority_queues.nim
@@ -9,10 +9,10 @@ import ../../../libp2p/protocols/pubsub/gossipsub/types
 import ../../../libp2p/peerid
 import ../../tools/[unittest, crypto]
 
-proc dummyGetConn(): Future[Connection] {.
-    async: (raises: [CancelledError, GetConnDialError])
+proc dummyGetConn(): Future[Stream] {.
+    async: (raises: [CancelledError, GetStreamDialError])
 .} =
-  raise newException(GetConnDialError, "this is not a real connection")
+  raise newException(GetStreamDialError, "this is not a real connection")
 
 type PendingConnection = ref object of Connection
   # These futures never finish, they're used to grow the high priority queue
@@ -137,7 +137,7 @@ suite "Priority queue behavior":
     defer:
       peer.stopSendNonHighPriorityTask()
 
-    peer.sendConn = conn
+    peer.sendStream = conn
 
     # These sends stay pending, keeping the high-priority backlog visible until
     # the underlying transport write completes.
@@ -156,7 +156,7 @@ suite "Priority queue behavior":
       not conn.pendingWrites[1].finished
       not conn.pendingWrites[2].finished
       not disconnectRequestedForTest[]
-      peer.hasSendConn()
+      peer.hasSendStream()
 
     await conn.close()
     let drain1 = callbacksDrained(conn.pendingWrites[0])
@@ -178,7 +178,7 @@ suite "Priority queue behavior":
     defer:
       peer.stopSendNonHighPriorityTask()
 
-    peer.sendConn = conn
+    peer.sendStream = conn
 
     let highMsg = @[1'u8, 2, 3]
     let mediumMsgs = @[@[10'u8, 0, 0], @[11'u8, 0, 0]]
@@ -201,7 +201,7 @@ suite "Priority queue behavior":
 
     check:
       not disconnectRequestedForTest[]
-      peer.hasSendConn()
+      peer.hasSendStream()
 
   asyncTest "Low priority messages wait while high priority send is pending":
     let disconnectRequestedForTest = new bool
@@ -213,7 +213,7 @@ suite "Priority queue behavior":
     defer:
       peer.stopSendNonHighPriorityTask()
 
-    peer.sendConn = conn
+    peer.sendStream = conn
 
     let highMsg = @[1'u8, 2, 3]
     let lowMsgs = @[@[20'u8, 0, 0], @[21'u8, 0, 0]]
@@ -236,7 +236,7 @@ suite "Priority queue behavior":
 
     check:
       not disconnectRequestedForTest[]
-      peer.hasSendConn()
+      peer.hasSendStream()
 
   asyncTest "Empty queues fast-path medium and low sends while returning completed futures":
     let mediumPeer = createTestPeer()
@@ -248,8 +248,8 @@ suite "Priority queue behavior":
       lowPeer.stopSendNonHighPriorityTask()
 
     # This is required so we can test the send path
-    mediumPeer.sendConn = mediumConn
-    lowPeer.sendConn = lowConn
+    mediumPeer.sendStream = mediumConn
+    lowPeer.sendStream = lowConn
 
     let mediumFut = mediumPeer.sendEncoded(@[1'u8, 2, 3], MessagePriority.Medium)
     let lowFut = lowPeer.sendEncoded(@[4'u8, 5, 6], MessagePriority.Low)
@@ -259,8 +259,8 @@ suite "Priority queue behavior":
       lowFut.finished
       mediumConn.pendingWrites.len == 1
       lowConn.pendingWrites.len == 1
-      mediumPeer.hasSendConn()
-      lowPeer.hasSendConn()
+      mediumPeer.hasSendStream()
+      lowPeer.hasSendStream()
 
     await mediumConn.close()
     await lowConn.close()

--- a/tests/libp2p/pubsub/utils.nim
+++ b/tests/libp2p/pubsub/utils.nim
@@ -88,15 +88,16 @@ proc randomPeerId*(): PeerId =
     raise newException(Defect, exc.msg)
 
 proc getPubSubPeer*(p: TestGossipSub, peerId: PeerId): PubSubPeer =
-  proc getConn(): Future[Connection] {.
-      async: (raises: [CancelledError, GetConnDialError])
+  proc getStream(): Future[Stream] {.
+      async: (raises: [CancelledError, GetStreamDialError])
   .} =
     try:
       return await p.switch.dial(peerId, GossipSubCodec_12)
     except DialFailedError as e:
-      raise (ref GetConnDialError)(parent: e, msg: e.msg)
+      raise (ref GetStreamDialError)(parent: e, msg: e.msg)
 
-  let pubSubPeer = PubSubPeer.new(peerId, getConn, nil, GossipSubCodec_12, 1024 * 1024)
+  let pubSubPeer =
+    PubSubPeer.new(peerId, getStream, nil, GossipSubCodec_12, 1024 * 1024)
   debug "created new pubsub peer", peerId
 
   p.peers[peerId] = pubSubPeer
@@ -110,7 +111,7 @@ proc setupGossipSubWithPeers*(
     populateGossipsub: bool = false,
     populateMesh: bool = false,
     populateFanout: bool = false,
-): (TestGossipSub, seq[Connection], seq[PubSubPeer]) =
+): (TestGossipSub, seq[Stream], seq[PubSubPeer]) =
   let gossipSub = TestGossipSub.init(makeStandardSwitch(), rng = rng())
 
   for topic in topics:
@@ -120,7 +121,7 @@ proc setupGossipSubWithPeers*(
     gossipSub.gossipsub[topic] = initHashSet[PubSubPeer]()
     gossipSub.fanout[topic] = initHashSet[PubSubPeer]()
 
-  var conns = newSeq[Connection]()
+  var conns = newSeq[Stream]()
   var peers = newSeq[PubSubPeer]()
   for i in 0 ..< numPeers:
     let conn = TestBufferStream.new(noop)
@@ -128,7 +129,7 @@ proc setupGossipSubWithPeers*(
     let peerId = randomPeerId()
     conn.peerId = peerId
     let peer = gossipSub.getPubSubPeer(peerId)
-    peer.sendConn = conn
+    peer.sendStream = conn
     peer.handler = voidPeerHandler
     peers &= peer
     for topic in topics:
@@ -148,12 +149,12 @@ proc setupGossipSubWithPeers*(
     populateGossipsub: bool = false,
     populateMesh: bool = false,
     populateFanout: bool = false,
-): (TestGossipSub, seq[Connection], seq[PubSubPeer]) =
+): (TestGossipSub, seq[Stream], seq[PubSubPeer]) =
   return setupGossipSubWithPeers(
     numPeers, @[topic], populateGossipsub, populateMesh, populateFanout
   )
 
-proc teardownGossipSub*(gossipSub: TestGossipSub, conns: seq[Connection]) {.async.} =
+proc teardownGossipSub*(gossipSub: TestGossipSub, conns: seq[Stream]) {.async.} =
   await allFuturesRaising(conns.mapIt(it.close()))
 
 func defaultMsgIdProvider*(m: Message): Result[MessageId, ValidationResult] =

--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -16,7 +16,7 @@ type TestMuxer = ref object of Muxer
 
 method newStream*(
     m: TestMuxer, name: string = "", lazy: bool = false
-): Future[Connection] {.async: (raises: [CancelledError, LPStreamError, MuxerError]).} =
+): Future[MuxedStream] {.async: (raises: [CancelledError, LPStreamError, MuxerError]).} =
   Connection.new(m.peerId, Direction.Out)
 
 proc newMaxTotal(maxConnections = 10, maxConnsPerPeer = 1): ConnManager =

--- a/tests/libp2p/test_multistream.nim
+++ b/tests/libp2p/test_multistream.nim
@@ -189,7 +189,7 @@ proc newTestNaStream(na: NaHandler): TestNaStream =
   result.step = 1
 
 proc noReachHandler(
-    conn: Connection, proto: string
+    stream: Stream, proto: string
 ): Future[void] {.async: (raises: [CancelledError]).} =
   raiseAssert "must not be reached"
 
@@ -199,79 +199,79 @@ suite "Multistream select":
 
   asyncTest "test select custom proto":
     let ms = MultistreamSelect.new()
-    let conn = newTestSelectStream()
-    check (await ms.select(conn, @["/test/proto/1.0.0"])) == "/test/proto/1.0.0"
-    await conn.close()
+    let stream = newTestSelectStream()
+    check (await ms.select(stream, @["/test/proto/1.0.0"])) == "/test/proto/1.0.0"
+    await stream.close()
 
   asyncTest "test handle custom proto":
     let ms = MultistreamSelect.new()
-    let conn = newTestSelectStream()
+    let stream = newTestSelectStream()
 
     var protocol: LPProtocol = new LPProtocol
     proc testHandler(
-        conn: Connection, proto: string
+        stream: Stream, proto: string
     ): Future[void] {.async: (raises: [CancelledError]).} =
       check proto == "/test/proto/1.0.0"
-      await conn.close()
+      await stream.close()
 
     protocol.handler = testHandler
     ms.addHandler("/test/proto/1.0.0", protocol)
-    await ms.handle(conn)
+    await ms.handle(stream)
 
   asyncTest "test handle `ls`":
     let ms = MultistreamSelect.new()
 
-    var conn: Connection = nil
+    var stream: Stream = nil
     let done = newFuture[void]()
     proc testLsHandler(
         proto: seq[byte]
     ) {.async: (raises: [CancelledError, LPStreamError]).} =
       var strProto: string = string.fromBytes(proto)
       check strProto == "\x26/test/proto1/1.0.0\n/test/proto2/1.0.0\n"
-      await conn.close()
+      await stream.close()
       done.complete()
 
-    conn = Connection(newTestLsStream(testLsHandler))
+    stream = Connection(newTestLsStream(testLsHandler))
 
     var protocol: LPProtocol = new LPProtocol
     protocol.handler = noReachHandler
     ms.addHandler("/test/proto1/1.0.0", protocol)
     ms.addHandler("/test/proto2/1.0.0", protocol)
-    await ms.handle(conn)
+    await ms.handle(stream)
     await done.wait(5.seconds)
 
   asyncTest "test handle `na`":
     let ms = MultistreamSelect.new()
 
-    var conn: Connection = nil
+    var stream: Stream = nil
     proc testNaHandler(
         msg: string
     ): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
       check msg == "\x03na\n"
-      await conn.close()
+      await stream.close()
 
-    conn = newTestNaStream(testNaHandler)
+    stream = newTestNaStream(testNaHandler)
 
     var protocol: LPProtocol = new LPProtocol
     protocol.handler = noReachHandler
     ms.addHandler("/unabvailable/proto/1.0.0", protocol)
 
-    await ms.handle(conn)
+    await ms.handle(stream)
 
   asyncTest "e2e - handle":
     let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
 
     var protocol: LPProtocol = new LPProtocol
     proc testHandler(
-        conn: Connection, proto: string
+        stream: Stream, proto: string
     ): Future[void] {.async: (raises: [CancelledError]).} =
       check proto == "/test/proto/1.0.0"
       try:
-        await conn.writeLp("Hello!")
+        await stream.writeLp("Hello!")
       except LPStreamError:
         raiseAssert "LPStreamError while handling connection"
       finally:
-        await conn.close()
+        await stream.close()
 
     protocol.handler = testHandler
     let msListen = MultistreamSelect.new()
@@ -281,21 +281,21 @@ suite "Multistream select":
     asyncSpawn transport1.start(ma)
 
     proc acceptHandler(): Future[void] {.async.} =
-      let conn = await transport1.accept()
-      await msListen.handle(conn)
-      await conn.close()
+      let stream = await transport1.accept()
+      await msListen.handle(stream)
+      await stream.close()
 
     let handlerWait = acceptHandler()
 
     let msDial = MultistreamSelect.new()
     let transport2 = TcpTransport.new(upgrade = Upgrade())
-    let conn = await transport2.dial(transport1.addrs[0])
+    let stream = await transport2.dial(transport1.addrs[0])
 
-    check (await msDial.select(conn, "/test/proto/1.0.0")) == true
+    check (await msDial.select(stream, "/test/proto/1.0.0")) == true
 
-    let hello = string.fromBytes(await conn.readLp(1024))
+    let hello = string.fromBytes(await stream.readLp(1024))
     check hello == "Hello!"
-    await conn.close()
+    await stream.close()
 
     await transport2.stop()
     await transport1.stop()
@@ -310,15 +310,15 @@ suite "Multistream select":
     # Try to start a new one, which should fail
     # Unblock the 5 streams, check that we can open a new one
     proc testHandler(
-        conn: Connection, proto: string
+        stream: Stream, proto: string
     ): Future[void] {.async: (raises: [CancelledError]).} =
       try:
         await blocker.wait()
-        await conn.writeLp("Hello!")
+        await stream.writeLp("Hello!")
       except LPStreamError:
         raiseAssert "LPStreamError while handling connection"
       finally:
-        await conn.close()
+        await stream.close()
 
     var protocol: LPProtocol =
       LPProtocol.new(@["/test/proto/1.0.0"], testHandler, maxIncomingStreams = 5)
@@ -330,14 +330,14 @@ suite "Multistream select":
     let transport1 = TcpTransport.new(upgrade = Upgrade())
     await transport1.start(ma)
 
-    proc acceptedOne(c: Connection) {.async.} =
+    proc acceptedOne(c: Stream) {.async.} =
       await msListen.handle(c)
       await c.close()
 
     proc acceptHandler() {.async.} =
       while true:
-        let conn = await transport1.accept()
-        asyncSpawn acceptedOne(conn)
+        let stream = await transport1.accept()
+        asyncSpawn acceptedOne(stream)
 
     var handlerWait = acceptHandler()
 
@@ -345,12 +345,12 @@ suite "Multistream select":
     let transport2 = TcpTransport.new(upgrade = Upgrade())
 
     proc connector() {.async.} =
-      let conn = await transport2.dial(transport1.addrs[0])
+      let stream = await transport2.dial(transport1.addrs[0])
       check:
-        (await msDial.select(conn, "/test/proto/1.0.0")) == true
+        (await msDial.select(stream, "/test/proto/1.0.0")) == true
       check:
-        string.fromBytes(await conn.readLp(1024)) == "Hello!"
-      await conn.close()
+        string.fromBytes(await stream.readLp(1024)) == "Hello!"
+      await stream.close()
 
     # Fill up the 5 allowed streams
     var dialers: seq[Future[void]]
@@ -392,27 +392,27 @@ suite "Multistream select":
     let listenFut = transport1.start(ma)
 
     proc acceptHandler(): Future[void] {.async.} =
-      let conn = await transport1.accept()
+      let stream = await transport1.accept()
       try:
-        await msListen.handle(conn)
+        await msListen.handle(stream)
       except LPStreamEOFError as e:
         raiseAssert "unexpected error: " & e.msg
       except LPStreamClosedError as e:
         raiseAssert "unexpected error: " & e.msg
       finally:
-        await conn.close()
+        await stream.close()
 
     let acceptFut = acceptHandler()
     let msDial = MultistreamSelect.new()
     let transport2: TcpTransport = TcpTransport.new(upgrade = Upgrade())
-    let conn = await transport2.dial(transport1.addrs[0])
+    let stream = await transport2.dial(transport1.addrs[0])
 
-    let ls = await msDial.list(conn)
+    let ls = await msDial.list(stream)
     let protos: seq[string] = @["/test/proto1/1.0.0", "/test/proto2/1.0.0"]
 
     check ls == protos
 
-    await conn.close()
+    await stream.close()
     await acceptFut
     await transport2.stop()
     await transport1.stop()
@@ -423,15 +423,15 @@ suite "Multistream select":
 
     var protocol: LPProtocol = new LPProtocol
     proc testHandler(
-        conn: Connection, proto: string
+        stream: Stream, proto: string
     ): Future[void] {.async: (raises: [CancelledError]).} =
       check proto == "/test/proto/1.0.0"
       try:
-        await conn.writeLp("Hello!")
+        await stream.writeLp("Hello!")
       except LPStreamError:
         raiseAssert "LPStreamError while handling connection"
       finally:
-        await conn.close()
+        await stream.close()
 
     protocol.handler = testHandler
     let msListen = MultistreamSelect.new()
@@ -441,21 +441,21 @@ suite "Multistream select":
     asyncSpawn transport1.start(ma)
 
     proc acceptHandler(): Future[void] {.async.} =
-      let conn = await transport1.accept()
-      await msListen.handle(conn)
+      let stream = await transport1.accept()
+      await msListen.handle(stream)
 
     let acceptFut = acceptHandler()
     let msDial = MultistreamSelect.new()
     let transport2: TcpTransport = TcpTransport.new(upgrade = Upgrade())
-    let conn = await transport2.dial(transport1.addrs[0])
+    let stream = await transport2.dial(transport1.addrs[0])
 
-    check (await msDial.select(conn, @["/test/proto/1.0.0", "/test/no/proto/1.0.0"])) ==
+    check (await msDial.select(stream, @["/test/proto/1.0.0", "/test/no/proto/1.0.0"])) ==
       "/test/proto/1.0.0"
 
-    let hello = string.fromBytes(await conn.readLp(1024))
+    let hello = string.fromBytes(await stream.readLp(1024))
     check hello == "Hello!"
 
-    await conn.close()
+    await stream.close()
     await acceptFut
     await transport2.stop()
     await transport1.stop()
@@ -465,14 +465,14 @@ suite "Multistream select":
 
     var protocol: LPProtocol = new LPProtocol
     proc testHandler(
-        conn: Connection, proto: string
+        stream: Stream, proto: string
     ): Future[void] {.async: (raises: [CancelledError]).} =
       try:
-        await conn.writeLp(&"Hello from {proto}!")
+        await stream.writeLp(&"Hello from {proto}!")
       except LPStreamError:
         raiseAssert "LPStreamError while handling connection"
       finally:
-        await conn.close()
+        await stream.close()
 
     protocol.handler = testHandler
     let msListen = MultistreamSelect.new()
@@ -483,20 +483,20 @@ suite "Multistream select":
     asyncSpawn transport1.start(ma)
 
     proc acceptHandler(): Future[void] {.async.} =
-      let conn = await transport1.accept()
-      await msListen.handle(conn)
+      let stream = await transport1.accept()
+      await msListen.handle(stream)
 
     let acceptFut = acceptHandler()
     let msDial = MultistreamSelect.new()
     let transport2: TcpTransport = TcpTransport.new(upgrade = Upgrade())
-    let conn = await transport2.dial(transport1.addrs[0])
+    let stream = await transport2.dial(transport1.addrs[0])
 
-    check (await msDial.select(conn, @["/test/proto2/1.0.0", "/test/proto1/1.0.0"])) ==
+    check (await msDial.select(stream, @["/test/proto2/1.0.0", "/test/proto1/1.0.0"])) ==
       "/test/proto2/1.0.0"
 
-    check string.fromBytes(await conn.readLp(1024)) == "Hello from /test/proto2/1.0.0!"
+    check string.fromBytes(await stream.readLp(1024)) == "Hello from /test/proto2/1.0.0!"
 
-    await conn.close()
+    await stream.close()
     await acceptFut
     await transport2.stop()
     await transport1.stop()

--- a/tests/libp2p/test_switch.nim
+++ b/tests/libp2p/test_switch.nim
@@ -39,15 +39,15 @@ suite "Switch":
 
   asyncTest "e2e use switch dial proto string":
     let handleFinished = newWaitGroup(1)
-    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+    proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
       try:
-        let msg = string.fromBytes(await conn.readLp(1024))
+        let msg = string.fromBytes(await stream.readLp(1024))
         check "Hello!" == msg
-        await conn.writeLp("Hello!")
+        await stream.writeLp("Hello!")
       except LPStreamError:
         raiseAssert "Unexpected LPStreamError in protocol handler"
       finally:
-        await conn.close()
+        await stream.close()
         handleFinished.done()
 
     let testProto = new TestProto
@@ -61,16 +61,16 @@ suite "Switch":
     await switch1.start()
     await switch2.start()
 
-    let conn =
+    let stream =
       await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, TestCodec)
 
     check switch1.isConnected(switch2.peerInfo.peerId)
     check switch2.isConnected(switch1.peerInfo.peerId)
 
-    await conn.writeLp("Hello!")
-    let msg = string.fromBytes(await conn.readLp(1024))
+    await stream.writeLp("Hello!")
+    let msg = string.fromBytes(await stream.readLp(1024))
     check "Hello!" == msg
-    await conn.close()
+    await stream.close()
 
     await allFuturesRaising(
       handleFinished.wait(5.seconds), switch1.stop(), switch2.stop()
@@ -81,15 +81,15 @@ suite "Switch":
 
   asyncTest "e2e use switch dial proto string with custom matcher":
     let handleFinished = newWaitGroup(1)
-    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+    proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
       try:
-        let msg = string.fromBytes(await conn.readLp(1024))
+        let msg = string.fromBytes(await stream.readLp(1024))
         check "Hello!" == msg
-        await conn.writeLp("Hello!")
+        await stream.writeLp("Hello!")
       except LPStreamError:
         raiseAssert "Unexpected LPStreamError in custom matcher protocol handler"
       finally:
-        await conn.close()
+        await stream.close()
         handleFinished.done()
 
     let testProto = new TestProto
@@ -108,16 +108,16 @@ suite "Switch":
     await switch1.start()
     await switch2.start()
 
-    let conn =
+    let stream =
       await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, callProto)
 
     check switch1.isConnected(switch2.peerInfo.peerId)
     check switch2.isConnected(switch1.peerInfo.peerId)
 
-    await conn.writeLp("Hello!")
-    let msg = string.fromBytes(await conn.readLp(1024))
+    await stream.writeLp("Hello!")
+    let msg = string.fromBytes(await stream.readLp(1024))
     check "Hello!" == msg
-    await conn.close()
+    await stream.close()
 
     await allFuturesRaising(
       handleFinished.wait(5.seconds), switch1.stop(), switch2.stop()
@@ -128,15 +128,15 @@ suite "Switch":
 
   asyncTest "e2e should not leak bufferstreams and connections on channel close":
     let handleFinished = newWaitGroup(1)
-    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+    proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
       try:
-        let msg = string.fromBytes(await conn.readLp(1024))
+        let msg = string.fromBytes(await stream.readLp(1024))
         check "Hello!" == msg
-        await conn.writeLp("Hello!")
+        await stream.writeLp("Hello!")
       except LPStreamError:
         raiseAssert "Unexpected LPStreamError in bufferstream leak test handler"
       finally:
-        await conn.close()
+        await stream.close()
         handleFinished.done()
 
     let testProto = new TestProto
@@ -150,16 +150,16 @@ suite "Switch":
     await switch1.start()
     await switch2.start()
 
-    let conn =
+    let stream =
       await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, TestCodec)
 
     check switch1.isConnected(switch2.peerInfo.peerId)
     check switch2.isConnected(switch1.peerInfo.peerId)
 
-    await conn.writeLp("Hello!")
-    let msg = string.fromBytes(await conn.readLp(1024))
+    await stream.writeLp("Hello!")
+    let msg = string.fromBytes(await stream.readLp(1024))
     check "Hello!" == msg
-    await conn.close()
+    await stream.close()
 
     await allFuturesRaising(
       handleFinished.wait(5.seconds), switch1.stop(), switch2.stop()
@@ -169,15 +169,15 @@ suite "Switch":
     check not switch2.isConnected(switch1.peerInfo.peerId)
 
   asyncTest "e2e use connect then dial":
-    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+    proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
       try:
-        let msg = string.fromBytes(await conn.readLp(1024))
+        let msg = string.fromBytes(await stream.readLp(1024))
         check "Hello!" == msg
-        await conn.writeLp("Hello!")
+        await stream.writeLp("Hello!")
       except LPStreamError:
         raiseAssert "Unexpected LPStreamError in connect-then-dial test handler"
       finally:
-        await conn.close()
+        await stream.close()
 
     let testProto = new TestProto
     testProto.codec = TestCodec
@@ -191,17 +191,17 @@ suite "Switch":
     await switch2.start()
 
     await switch2.connect(switch1.peerInfo.peerId, switch1.peerInfo.addrs)
-    let conn =
+    let stream =
       await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, TestCodec)
 
     check switch1.isConnected(switch2.peerInfo.peerId)
     check switch2.isConnected(switch1.peerInfo.peerId)
 
-    await conn.writeLp("Hello!")
-    let msg = string.fromBytes(await conn.readLp(1024))
+    await stream.writeLp("Hello!")
+    let msg = string.fromBytes(await stream.readLp(1024))
     check "Hello!" == msg
 
-    await allFuturesRaising(conn.close(), switch1.stop(), switch2.stop())
+    await allFuturesRaising(stream.close(), switch1.stop(), switch2.stop())
 
     check not switch1.isConnected(switch2.peerInfo.peerId)
     check not switch2.isConnected(switch1.peerInfo.peerId)
@@ -642,15 +642,15 @@ suite "Switch":
 
     await allFuturesRaising(switches[0].stop())
 
-  asyncTest "e2e closing remote conn should not leak":
+  asyncTest "e2e closing remote raw connection should not leak":
     let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
 
     let transport = TcpTransport.new(upgrade = Upgrade())
     await transport.start(ma)
 
     proc acceptHandler() {.async.} =
-      let conn = await transport.accept()
-      await conn.closeWithEOF()
+      let rawConn = await transport.accept()
+      await rawConn.closeWithEOF()
 
     let handlerWait = acceptHandler()
     let switch = makeStandardSwitch(transport = TransportType.TCP)
@@ -670,9 +670,9 @@ suite "Switch":
     await allFuturesRaising(transport.stop(), switch.stop())
 
   asyncTest "e2e calling closeWithEOF on the same stream should not assert":
-    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+    proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
       try:
-        discard await conn.readLp(100)
+        discard await stream.readLp(100)
       except LPStreamError:
         check true # should be here
 
@@ -687,11 +687,11 @@ suite "Switch":
 
     await switch1.start()
 
-    let conn =
+    let stream =
       await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, TestCodec)
 
     proc closeReader() {.async.} =
-      await conn.closeWithEOF()
+      await stream.closeWithEOF()
 
     var readers: seq[Future[void]]
     for i in 0 .. 10:
@@ -833,15 +833,15 @@ suite "Switch":
 
   asyncTest "e2e peer store":
     let handleFinished = newWaitGroup(1)
-    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+    proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
       try:
-        let msg = string.fromBytes(await conn.readLp(1024))
+        let msg = string.fromBytes(await stream.readLp(1024))
         check "Hello!" == msg
-        await conn.writeLp("Hello!")
+        await stream.writeLp("Hello!")
       except LPStreamError:
         raiseAssert "Unexpected LPStreamError in peer store test handler"
       finally:
-        await conn.close()
+        await stream.close()
         handleFinished.done()
 
     let testProto = new TestProto
@@ -857,16 +857,16 @@ suite "Switch":
       .build()
     await switch2.start()
 
-    let conn =
+    let stream =
       await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, TestCodec)
 
     check switch1.isConnected(switch2.peerInfo.peerId)
     check switch2.isConnected(switch1.peerInfo.peerId)
 
-    await conn.writeLp("Hello!")
-    let msg = string.fromBytes(await conn.readLp(1024))
+    await stream.writeLp("Hello!")
+    let msg = string.fromBytes(await stream.readLp(1024))
     check "Hello!" == msg
-    await conn.close()
+    await stream.close()
 
     await allFuturesRaising(
       handleFinished.wait(5.seconds), switch1.stop(), switch2.stop()
@@ -886,15 +886,15 @@ suite "Switch":
 
   asyncTest "e2e LastSeenOutboundBook tracks outbound connections":
     let handleFinished = newWaitGroup(1)
-    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+    proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
       try:
-        let msg = string.fromBytes(await conn.readLp(1024))
+        let msg = string.fromBytes(await stream.readLp(1024))
         check "Hello!" == msg
-        await conn.writeLp("Hello!")
+        await stream.writeLp("Hello!")
       except LPStreamError:
         raiseAssert "Unexpected LPStreamError in LastSeenOutboundBook test handler"
       finally:
-        await conn.close()
+        await stream.close()
         handleFinished.done()
 
     let testProto = new TestProto
@@ -909,16 +909,16 @@ suite "Switch":
     await switch2.start()
 
     # Switch2 dials switch1 (outbound from switch2's perspective)
-    let conn =
+    let stream =
       await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, TestCodec)
 
     check switch1.isConnected(switch2.peerInfo.peerId)
     check switch2.isConnected(switch1.peerInfo.peerId)
 
-    await conn.writeLp("Hello!")
-    let msg = string.fromBytes(await conn.readLp(1024))
+    await stream.writeLp("Hello!")
+    let msg = string.fromBytes(await stream.readLp(1024))
     check "Hello!" == msg
-    await conn.close()
+    await stream.close()
 
     await allFuturesRaising(
       handleFinished.wait(5.seconds), switch1.stop(), switch2.stop()
@@ -939,17 +939,15 @@ suite "Switch":
       # this randomly locks the Windows CI job
       skip()
     else:
-      proc handle(
-          conn: Connection, proto: string
-      ) {.async: (raises: [CancelledError]).} =
+      proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
         try:
-          let msg = string.fromBytes(await conn.readLp(1024))
+          let msg = string.fromBytes(await stream.readLp(1024))
           check "Hello!" == msg
-          await conn.writeLp("Hello!")
+          await stream.writeLp("Hello!")
         except LPStreamError:
           raiseAssert "Unexpected LPStreamError in multiple local addresses test handler"
         finally:
-          await conn.close()
+          await stream.close()
 
       let testProto = new TestProto
       testProto.codec = TestCodec
@@ -974,16 +972,16 @@ suite "Switch":
       check IP4.matchPartial(switch1.peerInfo.addrs[0])
       check IP6.matchPartial(switch1.peerInfo.addrs[1])
 
-      let conn = await switch2.dial(
+      let stream = await switch2.dial(
         switch1.peerInfo.peerId, @[switch1.peerInfo.addrs[0]], TestCodec
       )
 
       check switch1.isConnected(switch2.peerInfo.peerId)
       check switch2.isConnected(switch1.peerInfo.peerId)
 
-      await conn.writeLp("Hello!")
-      check "Hello!" == string.fromBytes(await conn.readLp(1024))
-      await conn.close()
+      await stream.writeLp("Hello!")
+      check "Hello!" == string.fromBytes(await stream.readLp(1024))
+      await stream.close()
 
       let connv6 = await switch3.dial(
         switch1.peerInfo.peerId, @[switch1.peerInfo.addrs[1]], TestCodec
@@ -1138,14 +1136,14 @@ suite "Switch":
 
   asyncTest "mount unstarted protocol":
     let handleFinished = newWaitGroup(1)
-    proc handle(conn: Connection, proto: string) {.async: (raises: [CancelledError]).} =
+    proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
       try:
-        check "test123" == string.fromBytes(await conn.readLp(1024))
-        await conn.writeLp("test456")
+        check "test123" == string.fromBytes(await stream.readLp(1024))
+        await stream.writeLp("test456")
       except LPStreamError:
         raiseAssert "Unexpected LPStreamError in mount unstarted protocol test handler"
       finally:
-        await conn.close()
+        await stream.close()
         handleFinished.done()
 
     let
@@ -1164,11 +1162,11 @@ suite "Switch":
     await testProto.start()
     dst.mount(testProto)
 
-    let conn = await src.dial(dst.peerInfo.peerId, dst.peerInfo.addrs, TestCodec)
+    let stream = await src.dial(dst.peerInfo.peerId, dst.peerInfo.addrs, TestCodec)
 
-    await conn.writeLp("test123")
-    check "test456" == string.fromBytes(await conn.readLp(1024))
-    await conn.close()
+    await stream.writeLp("test123")
+    check "test456" == string.fromBytes(await stream.readLp(1024))
+    await stream.close()
     await handleFinished.wait(5.seconds)
 
   asyncTest "switch failing to start stops properly":
@@ -1245,9 +1243,9 @@ suite "Switch :: IdentifyPusher Service":
     # mount new protocol to switch2
     let codecs = "/switch/protocol/1.0.0"
     proc dummyHandler(
-        conn: Connection, proto: string
+        stream: Stream, proto: string
     ): Future[void] {.async: (raises: [CancelledError]).} =
-      await conn.close()
+      await stream.close()
 
     let dummy = LPProtocol.new(@[codecs], dummyHandler)
     await dummy.start()

--- a/tests/libp2p/transports/stream_tests.nim
+++ b/tests/libp2p/transports/stream_tests.nim
@@ -17,7 +17,7 @@ template runTransportTest(
     streamProvider: StreamProvider,
     address: MultiAddress,
 ) =
-  proc serverStreamHandler(stream: Connection) {.async: (raises: []).} =
+  proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
     noExceptionWithStreamClose(stream):
       var buffer: array[clientMessage.len, byte]
       await stream.readExactly(addr buffer, clientMessage.len)
@@ -25,7 +25,7 @@ template runTransportTest(
 
       await stream.write(serverMessage)
 
-  proc clientStreamHandler(stream: Connection) {.async: (raises: []).} =
+  proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
     noExceptionWithStreamClose(stream):
       await stream.write(clientMessage)
 
@@ -58,12 +58,12 @@ template streamTransportTest*(
     runTransportTest(transportProvider, streamProvider, addressIP6.get())
 
   asyncTest "read/write Lp":
-    proc serverStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         check (await stream.readLp(100)) == fromHex("1234")
         await stream.writeLp(fromHex("5678"))
 
-    proc clientStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         await stream.writeLp(fromHex("1234"))
         check (await stream.readLp(100)) == fromHex("5678")
@@ -79,7 +79,7 @@ template streamTransportTest*(
   asyncTest "EOF handling - first readOnce at EOF + repeated reads":
     var serverHandlerDone = newFuture[void]()
 
-    proc serverStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         var buffer: array[serverMessage.len, byte]
         await stream.readExactly(addr buffer, serverMessage.len)
@@ -99,7 +99,7 @@ template streamTransportTest*(
 
         serverHandlerDone.complete()
 
-    proc clientStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         await stream.write(serverMessage)
         await stream.closeWrite()
@@ -118,7 +118,7 @@ template streamTransportTest*(
     var clientHandlerDone = newFuture[void]()
     var serverReadDone = newFuture[void]()
 
-    proc serverStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         # step 2: read message from client (ensure connection is established)
         var buffer: array[serverMessage.len, byte]
@@ -182,7 +182,7 @@ template streamTransportTest*(
   asyncTest "incomplete read":
     var serverHandlerDone = newFuture[void]()
 
-    proc serverStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         var buffer: array[2 * serverMessage.len, byte]
 
@@ -194,7 +194,7 @@ template streamTransportTest*(
 
         serverHandlerDone.complete()
 
-    proc clientStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         await stream.write(serverMessage)
         await stream.closeWrite()
@@ -209,7 +209,7 @@ template streamTransportTest*(
     )
 
   asyncTest "client closeWrite - server can still write":
-    proc serverStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         # Client reads server data
         var buffer: array[serverMessage.len, byte]
@@ -223,7 +223,7 @@ template streamTransportTest*(
         # Client should still be able to write back to server
         await stream.write(clientMessage)
 
-    proc clientStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         # Server sends data and closes its write side
         await stream.write(serverMessage)
@@ -247,14 +247,14 @@ template streamTransportTest*(
     )
 
   asyncTest "multiple empty writes before closeWrite":
-    proc serverStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         # Even with multiple empty writes, reading should eventually get EOF
         var buffer: array[1, byte]
         let bytesRead = await stream.readOnce(addr buffer[0], 1)
         check bytesRead == 0 # Should get EOF
 
-    proc clientStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         # Multiple empty writes
         await stream.write(@[])
@@ -271,14 +271,14 @@ template streamTransportTest*(
     )
 
   asyncTest "closeWrite immediately after newStream":
-    proc serverStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         # Should get EOF immediately
         var buffer: array[1, byte]
         let bytesRead = await stream.readOnce(addr buffer[0], 1)
         check bytesRead == 0
 
-    proc clientStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         # Close write immediately without any data
         await stream.closeWrite()
@@ -297,7 +297,7 @@ template streamTransportTest*(
     const numComplete = numStreams - numIncomplete
     let successfulReadsWG = newWaitGroup(numComplete)
 
-    proc serverStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         try:
           var buffer: array[clientMessage.len, byte]
@@ -349,14 +349,14 @@ template streamTransportTest*(
     let message = newData(messageSize)
     var serverHandlerDone = newFuture[void]()
 
-    proc serverStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         let receivedData =
           await readStreamByChunkTillEOF(stream, chunkSize, messageSize)
         check receivedData == message
         serverHandlerDone.complete()
 
-    proc clientStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         await stream.write(message)
         await serverHandlerDone
@@ -375,7 +375,7 @@ template streamTransportTest*(
     const parallelWrites = 10
     var serverHandlerDone = newFuture[void]()
 
-    proc serverStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         const expectedSize = messageSize * parallelWrites
         let receivedData =
@@ -396,7 +396,7 @@ template streamTransportTest*(
 
         serverHandlerDone.complete()
 
-    proc clientStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         var writeFuts: seq[Future[void]] = @[]
         for i in 0 ..< parallelWrites:
@@ -423,7 +423,7 @@ template streamTransportTest*(
     var serverReadOrder: seq[byte] = @[]
     let serverHandlerWG = newWaitGroup(numStreams)
 
-    proc serverStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         var receivedData: seq[byte] = @[]
 
@@ -455,7 +455,7 @@ template streamTransportTest*(
 
         # Use a capturing proc to properly bind loop variables
         proc startWriteAndClose(
-            stream: Connection, streamId: int
+            stream: MuxedStream, streamId: int
         ): Future[void] {.async.} =
           # Write data in chunks with random delays
           for j in 0 ..< chunkCount:
@@ -517,9 +517,9 @@ template streamTransportTest*(
       var futs: seq[Future[void]]
       for i in 0 ..< numConnections:
         # Use a proc to properly capture loop index
-        proc setupConnection(conn: Connection, handlerIndex: int) =
+        proc setupConnection(conn: RawConn, handlerIndex: int) =
           let muxer = streamProvider(conn, false)
-          muxer.streamHandler = proc(stream: Connection) {.async: (raises: []).} =
+          muxer.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
             noExceptionWithStreamClose(stream):
               # Read data in chunks with random delay
               var receivedData: seq[byte] = @[]

--- a/tests/libp2p/transports/test_quic.nim
+++ b/tests/libp2p/transports/test_quic.nim
@@ -18,7 +18,7 @@ proc quicTransProvider(): Transport {.gcsafe, raises: [].} =
   except ResultError[crypto.CryptoError]:
     raiseAssert "should not happen"
 
-proc streamProvider(conn: Connection, handle: bool = true): Muxer {.raises: [].} =
+proc streamProvider(conn: RawConn, handle: bool = true): Muxer {.raises: [].} =
   try:
     return QuicMuxer.new(conn)
   except CatchableError:
@@ -53,14 +53,14 @@ suite "Quic transport":
   asyncTest "Connection.reset aborts the initiator stream":
     var serverResetDone = newFuture[void]()
 
-    proc serverStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         let msg = await stream.readLp(100)
         check msg == fromHex("1234")
         await stream.reset()
         serverResetDone.complete()
 
-    proc clientStreamHandler(stream: Connection) {.async: (raises: []).} =
+    proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         await stream.writeLp(fromHex("1234"))
         await serverResetDone

--- a/tests/libp2p/transports/test_tcp.nim
+++ b/tests/libp2p/transports/test_tcp.nim
@@ -21,7 +21,7 @@ import ./tcp_tests
 proc tcpTransProvider(): Transport =
   TcpTransport.new(upgrade = Upgrade())
 
-proc streamProvider(conn: Connection, handle: bool = true): Muxer =
+proc streamProvider(conn: RawConn, handle: bool = true): Muxer =
   let muxer = Mplex.new(conn)
   if handle:
     asyncSpawn muxer.handle()

--- a/tests/libp2p/transports/test_tor.nim
+++ b/tests/libp2p/transports/test_tor.nim
@@ -31,7 +31,7 @@ suite "Tor transport":
   proc torTransProvider(): Transport =
     TorTransport.new(torServer, {ReuseAddr}, Upgrade())
 
-  proc streamProvider(conn: Connection, handle: bool = true): Muxer =
+  proc streamProvider(conn: RawConn, handle: bool = true): Muxer =
     let muxer = Mplex.new(conn)
     if handle:
       asyncSpawn muxer.handle()
@@ -139,18 +139,16 @@ suite "Tor transport":
 
     proc new(T: typedesc[TestProto]): T =
       # every incoming connections will be in handled in this closure
-      proc handle(
-          conn: Connection, proto: string
-      ) {.async: (raises: [CancelledError]).} =
+      proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
         try:
           var resp: array[6, byte]
-          await conn.readExactly(addr resp, 6)
+          await stream.readExactly(addr resp, 6)
           check string.fromBytes(resp) == "client"
-          await conn.write("server")
+          await stream.write("server")
         except LPStreamError:
           raiseAssert "Unexpected LPStreamError in Tor onion3 test handler"
         finally:
-          await conn.close()
+          await stream.close()
 
       return T.new(codecs = @[TestCodec], handler = handle)
 

--- a/tests/libp2p/transports/test_ws.nim
+++ b/tests/libp2p/transports/test_ws.nim
@@ -40,7 +40,7 @@ proc wsSecureTransProvider(): Transport {.gcsafe, raises: [].} =
     tlsFlags = {TLSFlags.NoVerifyHost, TLSFlags.NoVerifyServerName},
   )
 
-proc streamProvider(conn: Connection, handle: bool = true): Muxer =
+proc streamProvider(conn: RawConn, handle: bool = true): Muxer =
   let muxer = Mplex.new(conn)
   if handle:
     asyncSpawn muxer.handle()

--- a/tests/libp2p/transports/utils.nim
+++ b/tests/libp2p/transports/utils.nim
@@ -105,9 +105,9 @@ proc createQuicTransport*(
 type TransportProvider* = proc(): Transport {.gcsafe, raises: [].}
 
 type StreamProvider* =
-  proc(conn: Connection, handle: bool = true): Muxer {.gcsafe, raises: [].}
+  proc(conn: RawConn, handle: bool = true): Muxer {.gcsafe, raises: [].}
 
-type StreamHandler* = proc(stream: Connection) {.async: (raises: []).}
+type StreamHandler* = proc(stream: MuxedStream) {.async: (raises: []).}
 
 proc extractPort*(ma: MultiAddress): int =
   var codec =
@@ -123,7 +123,7 @@ proc extractPort*(ma: MultiAddress): int =
   let port = int(fromBytesBE(uint16, portBytes))
   port
 
-template noExceptionWithStreamClose*(stream: Connection, body) =
+template noExceptionWithStreamClose*(stream: Stream, body) =
   try:
     body
   except CatchableError as exc:

--- a/tests/tools/stream.nim
+++ b/tests/tools/stream.nim
@@ -11,7 +11,7 @@ proc newData*(size: int, val: byte = byte(0xFF)): seq[byte] =
   data
 
 proc readStreamByChunkTillEOF*(
-    stream: Connection, chunkSize: int, maxBytes: int = int.high
+    stream: Stream, chunkSize: int, maxBytes: int = int.high
 ): Future[seq[byte]] {.async.} =
   ## Reads from stream until EOF is reached or the received data size meets/exceeds maxBytes
   var receivedData: seq[byte] = @[]


### PR DESCRIPTION
## Summary

This PR is a semantic naming cleanup. It does not change runtime behavior.

It introduces clearer aliases for existing connection endpoints:

- `Stream` for protocol-facing stream endpoints
- `RawConn` for transport and upgrade boundaries before security/muxing
- `MuxedStream` for streams opened or handled by muxers

These names are aliases over the existing implementation types, not a semantic type split. The goal is to make APIs read closer to what each value represents today, while making a future stronger refactor easier to stage.

The PR also updates call sites, bindings, examples, tutorials, and tests to use stream-oriented names consistently. Public pubsub send/custom stream names now use `Stream` terminology, and the upgrade path names the secure stage with `SecureConn` before muxing.

## Affected Areas

- [x] Gossipsub
  Pubsub peer send/custom stream APIs now use `sendStream`, `GetStream`, `CustomStreamCallbacks`, and `useCustomStream` naming.
- [x] Transports
  Transport accept/dial and upgrade boundaries use `RawConn`; relay keeps `RelayConnection` as the transport-facing wrapper over a relay protocol stream.
- [x] Peer Management / Discovery
  Connection manager and muxer-store APIs keep established peer sessions as `Muxer`, while Kademlia and discovery protocol stream call sites use stream naming.
- [x] Protocol Logic
  Protocol handlers, multistream negotiation, switch dialing, secure upgrade, and muxer stream handlers use `Stream`, `SecureConn`, or `MuxedStream` according to stack position.
- [x] Other
  cbind APIs, C examples, Nim examples, and tutorials now use stream-oriented names such as `StreamCallback` and `libp2p_stream_t *stream`.

## Impact on Library Users

There is no runtime behavior change.

For Nim users, `Connection` remains the underlying implementation type, so this does not introduce new runtime representations. Some public API names were changed to reflect stream semantics, such as pubsub send/custom stream callbacks and stream handler parameters.

For cbind users, stream callbacks and stream handles now use `StreamCallback` / `stream` naming instead of the older connection-oriented wording.

## Risk Assessment

Risk is low because the core change is semantic aliasing and call-site renaming. The main risk is stale naming in API docs, examples, bindings, or tests. This PR updates those alongside the library code.

No network behavior, protocol behavior, security behavior, or performance changes are intended.
