### PR TITLE
chore(SwitchBuilder): gracePeriod disabled by default

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -272,7 +272,7 @@ proc withWatermarkPolicy*(
     b: SwitchBuilder,
     lowWater: int,
     highWater: int,
-    gracePeriod: Duration = 1.minutes,
+    gracePeriod: Duration = 0.minutes,
     silencePeriod: Duration = 10.seconds,
 ): SwitchBuilder =
   ## Enable hi/lo watermark connection management.


### PR DESCRIPTION
there is no way of choosing right default value for grace period. 

the best solution is to have it as disabled, so when user really want grace period they will think and specify value they need.