### PR TITLE
test(service-disco): non-32-byte keys + misc component

### DIFF
--- a/tests/libp2p/service_discovery/component/test_advertise_discover.nim
+++ b/tests/libp2p/service_discovery/component/test_advertise_discover.nim
@@ -227,6 +227,37 @@ suite "Service Discovery Component - Advertise Discover":
     let ads = registrarNode.getAdsInCache(serviceId)
     check ads[0].data.peerId == advertiserNode.switch.peerInfo.peerId
 
+  asyncTest "advertiser re-advertises after advertExpiry":
+    let conf = ServiceDiscoveryConfig.new(advertExpiry = 500.millis, safetyParam = 0.0)
+    let registrarNode = setupServiceDiscoveryNode(discoConfig = conf)
+    let advertiserNode = setupServiceDiscoveryNode(discoConfig = conf)
+    startAndDeferStop(@[registrarNode, advertiserNode])
+    await connect(registrarNode, advertiserNode)
+
+    let service = makeServiceInfo("service")
+    let serviceId = service.id.hashServiceId()
+
+    # addProvidedService starts an advertiseToRegistrar task.
+    # The task keeps running after the first REGISTER is Confirmed.
+    # It waits advertExpiry, then sends REGISTER again for the same ad.
+    # The registrar keeps one ad and refreshes cacheTimestamps.
+    advertiserNode.addProvidedService(service)
+
+    checkUntilTimeout:
+      registrarNode.countAdsInCache(serviceId) == 1
+
+    let
+      cachedAd = registrarNode.getAdsInCache(serviceId)[0]
+      adKey = cachedAd.toAdvertisementKey()
+      firstTimestamp = registrarNode.registrar.cacheTimestamps[adKey]
+
+    checkUntilTimeout:
+      block:
+        let ads = registrarNode.getAdsInCache(serviceId)
+        ads.len == 1 and ads[0].toAdvertisementKey() == adKey and
+          registrarNode.registrar.cacheTimestamps.hasKey(adKey) and
+          registrarNode.registrar.cacheTimestamps[adKey] > firstTimestamp
+
   asyncTest "advertiser stops after the registrar replies Rejected":
     let registrarNode = setupServiceDiscoveryNode()
     let advertiserNode = setupServiceDiscoveryNode()

--- a/tests/libp2p/service_discovery/component/test_error.nim
+++ b/tests/libp2p/service_discovery/component/test_error.nim
@@ -164,3 +164,57 @@ suite "Service Discovery Component - Error Handling":
     expect LPStreamError:
       discard
         await clientSwitch.sendRawMessage(registrarNode, oversizedMsg).wait(2.seconds)
+
+  asyncTest "REGISTER with non-32-byte key returns Rejected":
+    # Spec calls for rejection on bad key length.
+    # Impl has no length check, the key reaches the service-membership check.
+    let registrarNode = setupServiceDiscoveryNode()
+    let clientNode = setupServiceDiscoveryNode()
+    startAndDeferStop(@[registrarNode, clientNode])
+    await connect(registrarNode, clientNode)
+
+    let adBytes =
+      makeAdvertisement("service", clientNode.switch.peerInfo.privateKey).encode().get()
+
+    for keyLen in [0, 31, 33, 64]:
+      var key = newSeq[byte](keyLen)
+      for i in 0 ..< keyLen:
+        key[i] = i.byte
+
+      let msg = kad_protobuf.Message(
+        msgType: kad_protobuf.MessageType.register,
+        key: key,
+        register: Opt.some(
+          kad_protobuf.RegisterMessage(
+            advertisement: adBytes,
+            status: Opt.none(kad_protobuf.RegistrationStatus),
+            ticket: Opt.none(kad_protobuf.Ticket),
+          )
+        ),
+      )
+
+      let response = await clientNode.sendMessage(registrarNode, msg)
+      check:
+        response.register.get().status.get() == kad_protobuf.RegistrationStatus.Rejected
+        registrarNode.countAdsInCache(key) == 0
+
+  asyncTest "GET_ADS with non-32-byte key returns empty response":
+    # Spec calls for rejection on bad key length.
+    # Impl has no length check, cache lookup misses on the arbitrary key.
+    let registrarNode = setupServiceDiscoveryNode()
+    let clientNode = setupServiceDiscoveryNode()
+    startAndDeferStop(@[registrarNode, clientNode])
+    await connect(registrarNode, clientNode)
+
+    for keyLen in [0, 31, 33, 64]:
+      var key = newSeq[byte](keyLen)
+      for i in 0 ..< keyLen:
+        key[i] = i.byte
+
+      let msg = kad_protobuf.Message(msgType: kad_protobuf.MessageType.getAds, key: key)
+
+      let response = await clientNode.sendMessage(registrarNode, msg)
+      check:
+        response.msgType == kad_protobuf.MessageType.getAds
+        response.getAds.isSome()
+        response.getAds.get().advertisements.len == 0

--- a/tests/libp2p/service_discovery/component/test_error.nim
+++ b/tests/libp2p/service_discovery/component/test_error.nim
@@ -177,9 +177,7 @@ suite "Service Discovery Component - Error Handling":
       makeAdvertisement("service", clientNode.switch.peerInfo.privateKey).encode().get()
 
     for keyLen in [0, 31, 33, 64]:
-      var key = newSeq[byte](keyLen)
-      for i in 0 ..< keyLen:
-        key[i] = i.byte
+      let key = newSeq[byte](keyLen)
 
       let msg = kad_protobuf.Message(
         msgType: kad_protobuf.MessageType.register,
@@ -207,9 +205,7 @@ suite "Service Discovery Component - Error Handling":
     await connect(registrarNode, clientNode)
 
     for keyLen in [0, 31, 33, 64]:
-      var key = newSeq[byte](keyLen)
-      for i in 0 ..< keyLen:
-        key[i] = i.byte
+      let key = newSeq[byte](keyLen)
 
       let msg = kad_protobuf.Message(msgType: kad_protobuf.MessageType.getAds, key: key)
 

--- a/tests/libp2p/service_discovery/component/test_lookup_get_ads.nim
+++ b/tests/libp2p/service_discovery/component/test_lookup_get_ads.nim
@@ -19,22 +19,50 @@ import ../../../../libp2p/protocols/kademlia/protobuf as kad_protobuf
 import ../../../tools/[lifecycle, unittest]
 import ../utils
 
+const MaxRegistrarSetupAttempts = 1000
+
+proc bucketOf(r: ServiceDiscovery, serviceId: ServiceId): int =
+  bucketIndex(serviceId, r.switch.peerInfo.peerId.toKey(), Opt.none(XorDHasher))
+
 proc setupRegistrarsInDistinctBuckets(
     conf: ServiceDiscoveryConfig, serviceId: ServiceId
 ): tuple[queriedFirst, queriedSecond: ServiceDiscovery] =
   ## Two registrars in distinct buckets of the routing table rooted at `serviceId`.
   ## Returned in the order `lookup()` would visit them (lower bucket index first).
-  proc bucketOf(r: ServiceDiscovery): int =
-    bucketIndex(serviceId, r.switch.peerInfo.peerId.toKey(), Opt.none(XorDHasher))
-
   var a = setupServiceDiscoveryNode(discoConfig = conf)
   var b = setupServiceDiscoveryNode(discoConfig = conf)
-  while bucketOf(a) == bucketOf(b):
+  for _ in 0 ..< MaxRegistrarSetupAttempts:
+    if bucketOf(a, serviceId) != bucketOf(b, serviceId):
+      if bucketOf(a, serviceId) < bucketOf(b, serviceId):
+        return (a, b)
+      else:
+        return (b, a)
+
     b = setupServiceDiscoveryNode(discoConfig = conf)
-  if bucketOf(a) < bucketOf(b):
-    (a, b)
-  else:
-    (b, a)
+
+  raiseAssert "could not find registrars in distinct buckets"
+
+proc setupRegistrarsInSameBucket(
+    conf: ServiceDiscoveryConfig, serviceId: ServiceId, count: int
+): seq[ServiceDiscovery] =
+  ## Registrars that land in one service routing table bucket.
+  doAssert count > 0, "count must be > 0"
+
+  var registrarsByBucket = initTable[int, seq[ServiceDiscovery]]()
+  for _ in 0 ..< MaxRegistrarSetupAttempts:
+    let registrar = setupServiceDiscoveryNode(discoConfig = conf)
+    let bucket = bucketOf(registrar, serviceId)
+    if bucket >= conf.bucketsCount:
+      continue
+
+    if not registrarsByBucket.hasKey(bucket):
+      registrarsByBucket[bucket] = @[]
+    registrarsByBucket[bucket].add(registrar)
+
+    if registrarsByBucket[bucket].len == count:
+      return registrarsByBucket[bucket]
+
+  raiseAssert "could not find enough registrars in one bucket"
 
 suite "Service Discovery Component - Lookup Get Ads":
   teardown:
@@ -148,6 +176,27 @@ suite "Service Discovery Component - Lookup Get Ads":
     check:
       found.get().len == fLookup
       not found.get().anyIt(it.data.peerId == otherPeerId)
+
+  asyncTest "lookup queries K_lookup registrars per bucket":
+    const kLookup = 2
+    let conf = ServiceDiscoveryConfig.new(
+      safetyParam = 0.0, kLookup = kLookup, fLookup = 30, fReturn = 1
+    )
+    let discovererNode = setupServiceDiscoveryNode(discoConfig = conf)
+
+    let serviceName = "service"
+    let serviceId = serviceName.hashServiceId()
+    let registrars = setupRegistrarsInSameBucket(conf, serviceId, kLookup + 2)
+
+    startAndDeferStop(@[discovererNode] & registrars)
+    for registrar in registrars:
+      await connect(discovererNode, registrar)
+      registrar.registrar.cache[serviceId] = @[makeAdvertisement(serviceName)]
+
+    let found = await discovererNode.lookup(serviceId)
+    check:
+      found.isOk()
+      found.get().len == kLookup
 
   asyncTest "lookup iterates buckets from farthest to closest":
     # fLookup=1, only the first-queried registrar's ad is returned

--- a/tests/libp2p/service_discovery/test_advertiser.nim
+++ b/tests/libp2p/service_discovery/test_advertiser.nim
@@ -159,6 +159,7 @@ suite "Advertiser - record creation":
     checkTrackers()
 
   test "record creation does not enforce service data size limit":
+    # TODO: nim-libp2p#2487 service-disco: add size validation for ServiceInfo.data and encoded XPR
     let serviceData = newSeq[byte](MaxMsgSize + 1)
     let disco = setupServiceDiscoveryNode(
       services = @[ServiceInfo(id: "service", data: serviceData)]
@@ -174,6 +175,7 @@ suite "Advertiser - record creation":
       record.get().data.services[0].data.len == serviceData.len
 
   test "record creation does not enforce encoded XPR size limit":
+    # TODO: nim-libp2p#2487 service-disco: add size validation for ServiceInfo.data and encoded XPR
     let disco = setupServiceDiscoveryNode(services = @[makeServiceInfo("service")])
     # Repeating the same address is just a simple way to make a large valid XPR.
     # With this address, 328 repeats is the first value over MaxMsgSize.


### PR DESCRIPTION
## Summary

Adds new tests:

- advertiser REGISTER refresh after advertExpiry
- K_lookup limiting when multiple registrars are in the same bucket
- REGISTER with non-32-byte keys returning Rejected
- GET_ADS with non-32-byte keys returning an empty response

## Affected Areas

- [x] Tests

## Impact on Library Users

None.

## Risk Assessment

None.