### PR TITLE
fix(rsa): reject imported keys below 2048 bits

### DIFF
--- a/libp2p/crypto/crypto.nim
+++ b/libp2p/crypto/crypto.nim
@@ -219,7 +219,7 @@ proc random*(
   ## Generate random key pair for scheme ``scheme``.
   ##
   ## ``bits`` is number of bits for RSA key, ``bits`` value must be in
-  ## [512, 4096], default value is 2048 bits.
+  ## [2048, 4096], default value is 3072 bits.
   case scheme
   of PKScheme.RSA:
     when supported(PKScheme.RSA):

--- a/libp2p/crypto/rsa.nim
+++ b/libp2p/crypto/rsa.nim
@@ -12,7 +12,7 @@
 import bearssl/[rsa, rand, hash]
 import minasn1
 import results
-import stew/ctops
+import stew/[bitops2, ctops]
 # We use `ncrutils` for constant-time hexadecimal encoding/decoding procedures.
 import nimcrypto/utils as ncrutils
 import ../utils/sequninit
@@ -97,6 +97,13 @@ template trimZeroes(b: seq[byte], pt, ptlen: untyped) =
     pt = cast[ptr byte](cast[uint](pt) + 1)
     ptlen -= 1
 
+proc bitLength(field: Asn1Field): int =
+  if len(field) == 0:
+    return 0
+
+  let first = field.buffer[field.offset]
+  ((len(field) - 1) shl 3) + bitWidth(first)
+
 proc random*[T: RsaKP](
     t: typedesc[T], rng: Rng, bits = DefaultKeySize, pubexp = DefaultPublicExponent
 ): RsaResult[T] =
@@ -106,7 +113,7 @@ proc random*[T: RsaKP](
   ## ``bits`` number of bits in RSA key, must be in
   ## range [2048, 4096] (default = 3072).
   ##
-  ## ``pubexp`` is RSA public exponent, which must be prime (default = 3).
+  ## ``pubexp`` is RSA public exponent, which must be prime (default = 65537).
   if bits < MinKeySize:
     return err(RsaLowSecurityError)
 
@@ -448,8 +455,9 @@ proc init*(key: var RsaPrivateKey, data: openArray[byte]): Result[void, Asn1Erro
   if rawiq.kind != Asn1Tag.Integer:
     return err(Asn1Error.Incorrect)
 
-  if len(rawn) >= (MinKeySize shr 3) and len(rawp) > 0 and len(rawq) > 0 and
-      len(rawdp) > 0 and len(rawdq) > 0 and len(rawiq) > 0:
+  let nBitlen = bitLength(rawn)
+  if nBitlen >= MinKeySize and len(rawp) > 0 and len(rawq) > 0 and len(rawdp) > 0 and
+      len(rawdq) > 0 and len(rawiq) > 0:
     key = new RsaPrivateKey
     key.buffer = @data
     key.pubk.n = addr key.buffer[rawn.offset]
@@ -468,7 +476,7 @@ proc init*(key: var RsaPrivateKey, data: openArray[byte]): Result[void, Asn1Erro
     key.seck.dqlen = uint(len(rawdq))
     key.seck.iqlen = uint(len(rawiq))
     key.pexplen = uint(len(rawprie))
-    key.seck.nBitlen = cast[uint32](len(rawn) shl 3)
+    key.seck.nBitlen = cast[uint32](nBitlen)
     ok()
   else:
     err(Asn1Error.Incorrect)
@@ -531,7 +539,7 @@ proc init*(key: var RsaPublicKey, data: openArray[byte]): Result[void, Asn1Error
   if rawe.kind != Asn1Tag.Integer:
     return err(Asn1Error.Incorrect)
 
-  if len(rawn) >= (MinKeySize shr 3) and len(rawe) > 0:
+  if bitLength(rawn) >= MinKeySize and len(rawe) > 0:
     key = new RsaPublicKey
     key.buffer = @data
     key.key.n = addr key.buffer[rawn.offset]

--- a/tests/libp2p/crypto/test_rsa.nim
+++ b/tests/libp2p/crypto/test_rsa.nim
@@ -608,9 +608,11 @@ suite "RSA 2048/3072/4096 test suite":
   proc rsa2047BitModulus(): array[MinKeySize shr 3, byte] =
     # 256 octets used to satisfy the old byte-length check, but the leading
     # 0x7f makes this a 2047-bit RSA modulus.
-    result[0] = 0x7F'u8
-    for i in 1 .. result.high:
-      result[i] = 0xFF'u8
+    var modulus: array[MinKeySize shr 3, byte]
+    modulus[0] = 0x7F'u8
+    for i in 1 .. modulus.high:
+      modulus[i] = 0xFF'u8
+    return modulus
 
   proc pkcs1PrivateKeyDer(modulus: openArray[byte]): seq[byte] =
     var b = Asn1Buffer.init()

--- a/tests/libp2p/crypto/test_rsa.nim
+++ b/tests/libp2p/crypto/test_rsa.nim
@@ -4,7 +4,7 @@
 {.used.}
 
 import nimcrypto/utils
-import ../../../libp2p/crypto/[crypto, rsa]
+import ../../../libp2p/crypto/[crypto, minasn1, rsa]
 import ../../tools/[unittest, crypto]
 
 const
@@ -604,3 +604,56 @@ suite "RSA 2048/3072/4096 test suite":
       key1.error == RsaLowSecurityError
       key2.error == RsaKeyIncorrectError
       key3.error == RsaKeyIncorrectError
+
+  proc rsa2047BitModulus(): array[MinKeySize shr 3, byte] =
+    # 256 octets used to satisfy the old byte-length check, but the leading
+    # 0x7f makes this a 2047-bit RSA modulus.
+    result[0] = 0x7F'u8
+    for i in 1 .. result.high:
+      result[i] = 0xFF'u8
+
+  proc pkcs1PrivateKeyDer(modulus: openArray[byte]): seq[byte] =
+    var b = Asn1Buffer.init()
+    var p = Asn1Composite.init(Asn1Tag.Sequence)
+    p.write(0'u64)
+    p.write(Asn1Tag.Integer, modulus)
+    p.write(uint64(DefaultPublicExponent))
+    # The RSA importer checks these fields are present before accepting the key.
+    # Placeholder values keep the fixture small; the modulus-size check must fail first.
+    for _ in 0 ..< 6:
+      p.write(1'u64)
+    p.finish()
+    b.write(p)
+    b.finish()
+    b.buffer
+
+  proc spkiPublicKeyDer(modulus: openArray[byte]): seq[byte] =
+    var b = Asn1Buffer.init()
+    var p = Asn1Composite.init(Asn1Tag.Sequence)
+    var c0 = Asn1Composite.init(Asn1Tag.Sequence)
+    var c1 = Asn1Composite.init(Asn1Tag.BitString)
+    var c10 = Asn1Composite.init(Asn1Tag.Sequence)
+    c0.write(Asn1Tag.Oid, Asn1OidRsaEncryption)
+    c0.write(Asn1Tag.Null)
+    c0.finish()
+    c10.write(Asn1Tag.Integer, modulus)
+    c10.write(uint64(DefaultPublicExponent))
+    c10.finish()
+    c1.write(c10)
+    c1.finish()
+    p.write(c0)
+    p.write(c1)
+    p.finish()
+    b.write(p)
+    b.finish()
+    b.buffer
+
+  test "[rsa2047] DER imports rejected":
+    let modulus = rsa2047BitModulus()
+    var key1 = RsaPrivateKey.init(pkcs1PrivateKeyDer(modulus))
+    var key2 = RsaPublicKey.init(spkiPublicKeyDer(modulus))
+    check:
+      key1.isErr() == true
+      key2.isErr() == true
+      key1.error == RsaKeyIncorrectError
+      key2.error == RsaKeyIncorrectError


### PR DESCRIPTION
## Summary
Reject imported RSA private and public keys whose modulus has fewer than 2048 significant bits.

The previous import check used DER INTEGER byte length, so a 2047-bit modulus encoded in 256 octets could pass the minimum-size gate. This PR switches import validation to actual modulus bit length and adds a regression test for 2047-bit DER imports.

It also updates RSA key-size documentation to match the existing 2048-bit minimum and 3072-bit default.

## Affected Areas
- [x] Other: RSA crypto key import and RSA tests.

## Impact on Library Users
RSA DER keys below 2048 bits are rejected on import, including edge cases that previously passed because their encoded modulus occupied 256 bytes. Valid 2048-bit and larger RSA keys are unaffected. No API changes.

## Risk Assessment
Low. The behavior change is stricter weak-key rejection. The main compatibility risk is for callers relying on importing RSA keys below 2048 bits.

## References
Fixes https://github.com/vacp2p/nim-libp2p/issues/266

## Additional Notes
Validated with:

```bash
nim c -r --path:src tests/libp2p/crypto/test_rsa.nim
```
