### PR TITLE
fix(rsa): cap max key size

### DIFF
--- a/libp2p/crypto/rsa.nim
+++ b/libp2p/crypto/rsa.nim
@@ -27,6 +27,9 @@ const
   MinKeySize* = 2048
     ## Minimal allowed RSA key size in bits.
     ## https://github.com/libp2p/go-libp2p-core/blob/master/crypto/rsa_common.go#L13
+  MaxKeySize* = 4096
+    ## Maximal allowed RSA key size in bits.
+    ## This matches BearSSL's BR_MAX_RSA_SIZE.
   DefaultKeySize* = 3072 ## Default RSA key size in bits.
 
   RsaOidSha1* = [byte 0x05, 0x2B, 0x0E, 0x03, 0x02, 0x1A]
@@ -65,6 +68,7 @@ type
     RsaKeyIncorrectError
     RsaSignatureError
     RsaLowSecurityError
+    RsaKeyTooLargeError
 
   RsaResult*[T] = Result[T, RsaError]
 
@@ -104,6 +108,9 @@ proc bitLength(field: Asn1Field): int =
   let first = field.buffer[field.offset]
   ((len(field) - 1) shl 3) + bitWidth(first)
 
+func validKeySize(bits: int): bool =
+  bits >= MinKeySize and bits <= MaxKeySize
+
 proc random*[T: RsaKP](
     t: typedesc[T], rng: Rng, bits = DefaultKeySize, pubexp = DefaultPublicExponent
 ): RsaResult[T] =
@@ -116,6 +123,8 @@ proc random*[T: RsaKP](
   ## ``pubexp`` is RSA public exponent, which must be prime (default = 65537).
   if bits < MinKeySize:
     return err(RsaLowSecurityError)
+  if bits > MaxKeySize:
+    return err(RsaKeyTooLargeError)
 
   let
     sko = 0
@@ -456,7 +465,7 @@ proc init*(key: var RsaPrivateKey, data: openArray[byte]): Result[void, Asn1Erro
     return err(Asn1Error.Incorrect)
 
   let nBitlen = bitLength(rawn)
-  if nBitlen >= MinKeySize and len(rawp) > 0 and len(rawq) > 0 and len(rawdp) > 0 and
+  if validKeySize(nBitlen) and len(rawp) > 0 and len(rawq) > 0 and len(rawdp) > 0 and
       len(rawdq) > 0 and len(rawiq) > 0:
     key = new RsaPrivateKey
     key.buffer = @data
@@ -539,7 +548,7 @@ proc init*(key: var RsaPublicKey, data: openArray[byte]): Result[void, Asn1Error
   if rawe.kind != Asn1Tag.Integer:
     return err(Asn1Error.Incorrect)
 
-  if bitLength(rawn) >= MinKeySize and len(rawe) > 0:
+  if validKeySize(bitLength(rawn)) and len(rawe) > 0:
     key = new RsaPublicKey
     key.buffer = @data
     key.key.n = addr key.buffer[rawn.offset]

--- a/tests/libp2p/crypto/test_rsa.nim
+++ b/tests/libp2p/crypto/test_rsa.nim
@@ -5,6 +5,7 @@
 
 import nimcrypto/utils
 import ../../../libp2p/crypto/[crypto, minasn1, rsa]
+import ../../../libp2p/protobuf/minprotobuf
 import ../../tools/[unittest, crypto]
 
 const
@@ -614,6 +615,13 @@ suite "RSA 2048/3072/4096 test suite":
       modulus[i] = 0xFF'u8
     return modulus
 
+  proc rsaOversizedModulus(): seq[byte] =
+    let bits = MaxKeySize + 1
+    result = newSeq[byte]((bits + 7) shr 3)
+    result[0] = 0x01'u8
+    for i in 1 .. result.high:
+      result[i] = 0xFF'u8
+
   proc pkcs1PrivateKeyDer(modulus: openArray[byte]): seq[byte] =
     var b = Asn1Buffer.init()
     var p = Asn1Composite.init(Asn1Tag.Sequence)
@@ -650,6 +658,13 @@ suite "RSA 2048/3072/4096 test suite":
     b.finish()
     b.buffer
 
+  proc libp2pPublicKeyBytes(rawDer: openArray[byte]): seq[byte] =
+    var pb = initProtoBuffer()
+    pb.write(1, uint64(PKScheme.RSA))
+    pb.write(2, rawDer)
+    pb.finish()
+    pb.buffer
+
   test "[rsa2047] DER imports rejected":
     let modulus = rsa2047BitModulus()
     var key1 = RsaPrivateKey.init(pkcs1PrivateKeyDer(modulus))
@@ -659,3 +674,20 @@ suite "RSA 2048/3072/4096 test suite":
       key2.isErr() == true
       key1.error == RsaKeyIncorrectError
       key2.error == RsaKeyIncorrectError
+
+  test "[rsa4097] not allowed test":
+    let modulus = rsaOversizedModulus()
+    let pubDer = spkiPublicKeyDer(modulus)
+    var key1 = RsaPrivateKey.random(rng(), MaxKeySize + 1)
+    var key2 = RsaPrivateKey.init(pkcs1PrivateKeyDer(modulus))
+    var key3 = RsaPublicKey.init(pubDer)
+    var key4 = PublicKey.init(libp2pPublicKeyBytes(pubDer))
+    check:
+      key1.isErr() == true
+      key2.isErr() == true
+      key3.isErr() == true
+      key4.isErr() == true
+      key1.error == RsaKeyTooLargeError
+      key2.error == RsaKeyIncorrectError
+      key3.error == RsaKeyIncorrectError
+      key4.error == KeyError

--- a/tests/libp2p/crypto/test_rsa.nim
+++ b/tests/libp2p/crypto/test_rsa.nim
@@ -616,11 +616,12 @@ suite "RSA 2048/3072/4096 test suite":
     return modulus
 
   proc rsaOversizedModulus(): seq[byte] =
-    let bits = MaxKeySize + 1
-    result = newSeq[byte]((bits + 7) shr 3)
-    result[0] = 0x01'u8
-    for i in 1 .. result.high:
-      result[i] = 0xFF'u8
+    let cap = (MaxKeySize + 1 + 7) shr 3
+    var modulus = newSeq[byte](cap)
+    modulus[0] = 0x01'u8
+    for i in 1 ..< cap:
+      modulus[i] = 0xFF'u8
+    modulus
 
   proc pkcs1PrivateKeyDer(modulus: openArray[byte]): seq[byte] =
     var b = Asn1Buffer.init()


### PR DESCRIPTION
## Summary
This PR caps accepted RSA key sizes at 4096 bits, matching the BearSSL `BR_MAX_RSA_SIZE` limit used by the current RSA backend.

Oversized RSA keys are now rejected during key generation and DER public/private key import, including the libp2p protobuf public-key wrapper path.

## Affected Areas
- [x] Other
  RSA key generation and parsing in `libp2p/crypto/rsa.nim`.

## Impact on Library Users
RSA keys larger than 4096 bits are rejected instead of being accepted by the parser and failing later during verification. Existing 2048, 3072, and 4096-bit RSA keys remain supported.

## Risk Assessment
Low risk. The behavior is constrained to RSA key-size validation and aligns accepted keys with the BearSSL backend limit.

## References
Fixes #1327

Related advisory: https://github.com/advisories/GHSA-876p-8259-xjgg
