### PR TITLE
fix(cancellation): preserve CancelledError in broad handlers

### DIFF
--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -145,6 +145,8 @@ proc askPeer(
     except AsyncTimeoutError as error:
       debug "dialMe timed out", description = error.msg
       Unknown
+    except CancelledError as error:
+      raise error
     except CatchableError as error:
       debug "dialMe unexpected error", description = error.msg
       Unknown

--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -286,7 +286,7 @@ proc discover*[E](
 proc advertisePeer[E](
     rdv: GenericRendezVous[E], peer: PeerId, msg: seq[byte]
 ) {.async: (raises: [CancelledError]).} =
-  proc advertiseWrap() {.async: (raises: []).} =
+  proc advertiseWrap() {.async: (raises: [CancelledError]).} =
     try:
       let stream = await rdv.switch.dial(peer, rdv.codec)
       defer:
@@ -301,6 +301,8 @@ proc advertisePeer[E](
         trace "Refuse to register", peer, response = msgRecv.registerResponse
       else:
         trace "Successfully registered", peer, response = msgRecv.registerResponse
+    except CancelledError as exc:
+      raise exc
     except CatchableError as exc:
       trace "exception in the advertise", description = exc.msg
     finally:
@@ -501,12 +503,14 @@ proc unsubscribe*[E](
     Message(msgType: MessageType.Unregister, unregister: Opt.some(Unregister(ns: ns)))
   )
 
-  proc unsubscribePeer(peerId: PeerId) {.async: (raises: []).} =
+  proc unsubscribePeer(peerId: PeerId) {.async: (raises: [CancelledError]).} =
     try:
       let stream = await rdv.switch.dial(peerId, RendezVousCodec)
       defer:
         await stream.close()
       await stream.writeLp(msg)
+    except CancelledError as exc:
+      raise exc
     except CatchableError as exc:
       trace "exception while unsubscribing", description = exc.msg
 

--- a/libp2p/services/hpservice.nim
+++ b/libp2p/services/hpservice.nim
@@ -48,6 +48,8 @@ proc tryStartingDirectConn(
       let isRelayed = address.contains(multiCodec("p2p-circuit"))
       if not isRelayed.get(false) and address.isPublicMA():
         return await tryConnect(address)
+    except CancelledError as err:
+      raise err
     except CatchableError as err:
       debug "Failed to create direct connection.", description = err.msg
       continue

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -315,6 +315,8 @@ proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
   try:
     # Stop accepting incoming connections
     await s.acceptFuts.cancelAndWait().wait(1.seconds)
+  except CancelledError as exc:
+    raise exc
   except CatchableError as exc:
     debug "Cannot cancel accepts", description = exc.msg
 

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -79,6 +79,8 @@ template mapExceptions(body: untyped): untyped =
     raise newLPStreamEOFError()
   except WebSocketError:
     raise newLPStreamEOFError()
+  except CancelledError as exc:
+    raise exc
   except CatchableError:
     raise newLPStreamEOFError()
 


### PR DESCRIPTION
## Summary

Preserves `CancelledError` in places where broad `CatchableError` handlers were treating cancellation as ordinary failure.

This keeps task cancellation semantics intact for AutoNAT reachability checks, hole punching direct-connect attempts, switch shutdown, and WebSocket stream exception mapping.

## Affected Areas

- [x] Transports
  - WebSocket stream exception mapping now rethrows cancellation instead of mapping it to EOF.
- [x] Protocol Logic
  - AutoNAT reachability checks and hole punching direct-connect attempts now rethrow cancellation before handling other catchable failures.
- [x] Peer Management / Discovery
  - Switch shutdown now preserves cancellation while cancelling accept futures.

## Impact on Library Users

No API changes. The behavior change is internal: cancellation now propagates instead of being logged or converted into normal failure paths in the affected code.

## Risk Assessment

Low risk. The change only narrows broad exception handling for `CancelledError`; other `CatchableError` handling paths remain unchanged.

## References

Refs #1272
