### PR TITLE
fix(autotls): parsing failed due to missing enum value 

### DIFF
--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -370,19 +370,19 @@ when defined(libp2p_autotls_support):
   ): Future[ACMEChallengeResponseWrapper] {.
       async: (raises: [ACMEError, CancelledError])
   .} =
-    let orderResponse = await self.requestNewOrder(domains, key, kid)
-    if orderResponse.status != ACMEOrderStatus.PENDING and
-        orderResponse.status != ACMEOrderStatus.READY:
-      # ready is a valid status when renewing certs before expiry
-      raise
-        newException(ACMEError, "Invalid new order status: " & $orderResponse.status)
+    let orderResp = await self.requestNewOrder(domains, key, kid)
 
-    let resp = await self.requestAuthorizations(orderResponse.authorizations, key, kid)
+    let validRenewStatus = @[ACMEOrderStatus.PENDING, ACMEOrderStatus.READY]
+    if orderResp.status notin validRenewStatus:
+      raise newException(ACMEError, "Invalid new order status: " & $orderResp.status)
 
-    var challenges = resp.challenges.filterIt(it.`type` == ACMEChallengeType.DNS01)
+    let authResp = await self.requestAuthorizations(orderResp.authorizations, key, kid)
+
+    var challenges = authResp.challenges.filterIt(it.`type` == ACMEChallengeType.DNS01)
     if challenges.len == 0:
       # if there are no DNS01 use DNSPersist01
-      challenges = resp.challenges.filterIt(it.`type` == ACMEChallengeType.DNSPersist01)
+      challenges =
+        authResp.challenges.filterIt(it.`type` == ACMEChallengeType.DNSPersist01)
     if challenges.len == 0:
       raise newException(
         ACMEError,

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -390,7 +390,7 @@ when defined(libp2p_autotls_support):
       )
 
     return ACMEChallengeResponseWrapper(
-      finalize: orderResponse.finalize, order: orderResponse.order, dns01: challenges[0]
+      finalize: orderResp.finalize, order: orderResp.order, dns01: challenges[0]
     )
 
   proc requestCheck*(

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -380,9 +380,14 @@ when defined(libp2p_autotls_support):
     let authorizationsResponse =
       await self.requestAuthorizations(orderResponse.authorizations, key, kid)
 
-    let dns01challenges = authorizationsResponse.challenges.filterIt(
-      it.`type` == ACMEChallengeType.DNS01 or it.`type` == ACMEChallengeType.DNSPersist01
+    var dns01challenges = authorizationsResponse.challenges.filterIt(
+      it.`type` == ACMEChallengeType.DNS01
     )
+    if dns01challenges.len == 0:
+      # if there are no DNS01 use DNSPersist01
+      dns01challenges = authorizationsResponse.challenges.filterIt(
+        it.`type` == ACMEChallengeType.DNSPersist01
+      )
     if dns01challenges.len == 0:
       raise newException(
         ACMEError,

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -384,7 +384,10 @@ when defined(libp2p_autotls_support):
       it.`type` == ACMEChallengeType.DNS01 or it.`type` == ACMEChallengeType.DNSPersist01
     )
     if dns01challenges.len == 0:
-      raise newException(ACMEError, "Could not find DNS01 challenge type")
+      raise newException(
+        ACMEError,
+        "Could not find supported DNS challenge type (dns-01 or dns-persist-01)",
+      )
 
     return ACMEChallengeResponseWrapper(
       finalize: orderResponse.finalize,

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -377,27 +377,20 @@ when defined(libp2p_autotls_support):
       raise
         newException(ACMEError, "Invalid new order status: " & $orderResponse.status)
 
-    let authorizationsResponse =
-      await self.requestAuthorizations(orderResponse.authorizations, key, kid)
+    let resp = await self.requestAuthorizations(orderResponse.authorizations, key, kid)
 
-    var dns01challenges = authorizationsResponse.challenges.filterIt(
-      it.`type` == ACMEChallengeType.DNS01
-    )
-    if dns01challenges.len == 0:
+    var challenges = resp.challenges.filterIt(it.`type` == ACMEChallengeType.DNS01)
+    if challenges.len == 0:
       # if there are no DNS01 use DNSPersist01
-      dns01challenges = authorizationsResponse.challenges.filterIt(
-        it.`type` == ACMEChallengeType.DNSPersist01
-      )
-    if dns01challenges.len == 0:
+      challenges = resp.challenges.filterIt(it.`type` == ACMEChallengeType.DNSPersist01)
+    if challenges.len == 0:
       raise newException(
         ACMEError,
         "Could not find supported DNS challenge type (dns-01 or dns-persist-01)",
       )
 
     return ACMEChallengeResponseWrapper(
-      finalize: orderResponse.finalize,
-      order: orderResponse.order,
-      dns01: dns01challenges[0],
+      finalize: orderResponse.finalize, order: orderResponse.order, dns01: challenges[0]
     )
 
   proc requestCheck*(

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -380,13 +380,16 @@ when defined(libp2p_autotls_support):
     let authorizationsResponse =
       await self.requestAuthorizations(orderResponse.authorizations, key, kid)
 
+    let dns01challenges = authorizationsResponse.challenges.filterIt(
+      it.`type` == ACMEChallengeType.DNS01 or it.`type` == ACMEChallengeType.DNSPersist01
+    )
+    if dns01challenges.len == 0:
+      raise newException(ACMEError, "Could not find DNS01 challenge type")
+
     return ACMEChallengeResponseWrapper(
       finalize: orderResponse.finalize,
       order: orderResponse.order,
-      dns01: authorizationsResponse.challenges.filterIt(
-        it.`type` == ACMEChallengeType.DNS01
-      )[0],
-        # getting the first element is safe since we checked that authorizationsResponse.challenges.len != 0
+      dns01: dns01challenges[0],
     )
 
   proc requestCheck*(

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -54,6 +54,7 @@ type ACMEChallengeType* {.pure.} = enum
   DNS01 = "dns-01"
   HTTP01 = "http-01"
   TLSALPN01 = "tls-alpn-01"
+  DNSPersist01 = "dns-persist-01"
 
 type ACMEChallengeToken* = string
 
@@ -356,7 +357,8 @@ when defined(libp2p_autotls_support):
         try:
           challenges.add(challenge.to(ACMEChallenge))
         except ValueError, JsonKindError:
-          debug "Skipping challenge with unrecognized fields", challenge = $challenge
+          debug "Skipping challenge with unrecognized fields",
+            challenge = $challenge, msg = getCurrentExceptionMsg()
 
       if challenges.len == 0:
         raise newException(ACMEError, "No challenges received")

--- a/tests/integration/test_autotls_integration.nim
+++ b/tests/integration/test_autotls_integration.nim
@@ -26,7 +26,8 @@ when defined(linux) and defined(amd64) and defined(libp2p_autotls_support):
       challenge.finalize.len > 0
       challenge.order.len > 0
       challenge.dns01.url.len > 0
-      challenge.dns01.`type` == ACMEChallengeType.DNS01
+      challenge.dns01.`type` == ACMEChallengeType.DNS01 or
+        challenge.dns01.`type` == ACMEChallengeType.DNSPersist01
       challenge.dns01.status == ACMEChallengeStatus.PENDING
       challenge.dns01.token.len > 0
 

--- a/tests/integration/test_autotls_integration.nim
+++ b/tests/integration/test_autotls_integration.nim
@@ -4,8 +4,6 @@
 {.used.}
 
 when defined(linux) and defined(amd64) and defined(libp2p_autotls_support):
-  {.push raises: [].}
-
   import chronos, chronos/apps/http/httpclient
   import
     ../../libp2p/[

--- a/tests/integration/test_autotls_integration.nim
+++ b/tests/integration/test_autotls_integration.nim
@@ -18,11 +18,19 @@ when defined(linux) and defined(amd64) and defined(libp2p_autotls_support):
       multiaddress,
       utils/ipaddr,
       switch,
-      builders,
       nameresolving/dnsresolver,
       wire,
     ]
-  import ../tools/[unittest, crypto]
+  import ../tools/[unittest, crypto, switch_builder]
+
+  template assertChallenge(challenge: ACMEChallengeResponseWrapper): auto =
+    check:
+      challenge.finalize.len > 0
+      challenge.order.len > 0
+      challenge.dns01.url.len > 0
+      challenge.dns01.`type` == ACMEChallengeType.DNS01
+      challenge.dns01.status == ACMEChallengeStatus.PENDING
+      challenge.dns01.token.len > 0
 
   suite "AutoTLS Integration":
     asyncTeardown:
@@ -33,26 +41,24 @@ when defined(linux) and defined(amd64) and defined(libp2p_autotls_support):
       let acmeApi = ACMEApi.new(acmeServerURL = parseUri(LetsEncryptURLStaging))
       defer:
         await acmeApi.close()
-      try:
-        let registerResponse = await acmeApi.requestRegister(key)
-        # account was registered (kid set)
-        check registerResponse.kid != ""
-        if registerResponse.kid == "":
-          raiseAssert "unable to register acme account"
 
-        # challenge requested
-        let challenge = await acmeApi.requestChallenge(
-          @["some.dummy.domain.com"], key, registerResponse.kid
-        )
-        check challenge.finalize.len > 0
-        check challenge.order.len > 0
+      let challenge =
+        try:
+          let registerResponse = await acmeApi.requestRegister(key)
+          # account was registered (kid set)
+          check registerResponse.kid != ""
+          if registerResponse.kid == "":
+            raiseAssert "unable to register acme account"
 
-        check challenge.dns01.url.len > 0
-        check challenge.dns01.`type` == ACMEChallengeType.DNS01
-        check challenge.dns01.status == ACMEChallengeStatus.PENDING
-        check challenge.dns01.token.len > 0
-      except ACMENetworkError:
-        skip()
+          # challenge requested
+          await acmeApi.requestChallenge(
+            @["some.dummy.domain.com"], key, registerResponse.kid
+          )
+        except ACMENetworkError:
+          skip()
+          return
+
+      assertChallenge(challenge)
 
     asyncTest "request challenge with ACMEClient":
       let acme = ACMEClient.new(
@@ -60,36 +66,29 @@ when defined(linux) and defined(amd64) and defined(libp2p_autotls_support):
       )
       defer:
         await acme.close()
-      try:
-        let challenge = await acme.getChallenge(@["some.dummy.domain.com"])
 
-        check:
-          challenge.finalize.len > 0
-          challenge.order.len > 0
-          challenge.dns01.url.len > 0
-          challenge.dns01.`type` == ACMEChallengeType.DNS01
-          challenge.dns01.status == ACMEChallengeStatus.PENDING
-          challenge.dns01.token.len > 0
-      except ACMENetworkError:
-        skip()
+      let challenge =
+        try:
+          await acme.getChallenge(@["some.dummy.domain.com"])
+        except ACMENetworkError:
+          skip()
+          return
+
+      assertChallenge(challenge)
 
     asyncTest "AutotlsService correctly downloads challenges":
       if not hasPublicIPAddress():
         skip()
         return
 
-      let switch = SwitchBuilder
-        .new()
+      let switch = makeStandardSwitchBuilder(
+          MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()
+        )
         .withAutotls(
           config = AutotlsConfig.new(
             acmeServerURL = parseUri(LetsEncryptURLStaging), renewCheckTime = 1.seconds
           )
         )
-        .withRng(rng())
-        .withAddress(MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet())
-        .withTcpTransport()
-        .withYamux()
-        .withNoise()
         .build()
 
       await switch.start()

--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -284,7 +284,7 @@ when defined(libp2p_autotls_support):
       )
 
       let mixedAuthResp = await api.requestAuthorizations(@["auth-3"], key, "kid")
-      check mixedAuthResp.challenges.len == 1
+      check mixedAuthResp.challenges.len == 2
 
       # replenish invalid responses for the remaining expect(ACMEError) blocks
       for _ in 0 .. 5:


### PR DESCRIPTION
parsing was failing as `dns-persist-01` enum value was missing 

fixes dail test: https://github.com/vacp2p/nim-libp2p/actions/runs/26148895087/job/76911106481