### PR TITLE
test(service-disco): add repro test for #2499

### DIFF
--- a/tests/libp2p/service_discovery/component/test_advertise_discover.nim
+++ b/tests/libp2p/service_discovery/component/test_advertise_discover.nim
@@ -2,11 +2,12 @@
 # Copyright (c) Status Research & Development GmbH
 {.used.}
 
-import chronos, results, std/[sequtils, tables]
+import chronos, results, std/[sequtils, sets, tables]
 import
   ../../../../libp2p/[
     crypto/crypto,
     peerid,
+    protocols/kademlia/routing_table,
     protocols/kademlia/types,
     protocols/service_discovery,
     protocols/service_discovery/advertiser,
@@ -319,3 +320,61 @@ suite "Service Discovery Component - Advertise Discover":
         let foundA = await discovererNode.lookup(serviceAId)
         let foundB = await discovererNode.lookup(serviceBId)
         foundA.containsPeer(advertiserNode) and foundB.containsPeer(advertiserNode)
+
+  asyncTest "addProvidedService drops a known registrar at Kad bucketIndex 16":
+    # TODO: nim-libp2p#2499 service-disco: valid service registrars are dropped when Kad bucketIndex is 16 or higher
+    # Precomputed private key to pin the registrar identity and service name.
+    # Their Kad bucketIndex is exactly 16 for this serviceId.
+    # A ServiceDiscovery service table accepts indexes 0 through 15.
+    const
+      serviceName = "service-bucket-indexing-component"
+      droppedRegistrarPrivateKey =
+        "08011240239527C04B874F2C1754D2DA3F502C1EDA30FDF582ED7A914D2341F6" &
+        "B329C384698E046CD619D98957A92AC02D1701511571CA1E12A47830D29A4871C9F9C26B"
+
+    let
+      conf = ServiceDiscoveryConfig.new(safetyParam = 0.0)
+      droppedRegistrarKey = PrivateKey.init(droppedRegistrarPrivateKey).get()
+      droppedRegistrarNode = setupServiceDiscoveryNode(
+        discoConfig = conf, privateKey = Opt.some(droppedRegistrarKey)
+      )
+      workingRegistrarNode = setupServiceDiscoveryNode(discoConfig = conf)
+      advertiserNode = setupServiceDiscoveryNode(discoConfig = conf)
+
+    startAndDeferStop(@[droppedRegistrarNode, workingRegistrarNode, advertiserNode])
+    await connect(droppedRegistrarNode, advertiserNode)
+    await connect(workingRegistrarNode, advertiserNode)
+
+    # The advertiser knows both registrars in the main Kad routing table.
+    # The droppedRegistrar sits just outside the service table bucket range.
+    # The workingRegistrar sits inside the service table bucket range.
+    let
+      service = makeServiceInfo(serviceName)
+      serviceId = service.id.hashServiceId()
+      droppedRegistrarPeerKey = droppedRegistrarNode.switch.peerInfo.peerId.toKey()
+      workingRegistrarPeerKey = workingRegistrarNode.switch.peerInfo.peerId.toKey()
+
+    check:
+      bucketIndex(serviceId, droppedRegistrarPeerKey, Opt.none(XorDHasher)) ==
+        conf.bucketsCount
+      bucketIndex(serviceId, workingRegistrarPeerKey, Opt.none(XorDHasher)) <
+        conf.bucketsCount
+      advertiserNode.rtable.hasPeer(droppedRegistrarPeerKey)
+      advertiserNode.rtable.hasPeer(workingRegistrarPeerKey)
+
+    # addProvidedService seeds the service table from the main Kad routing table.
+    advertiserNode.addProvidedService(service)
+
+    # The in-range registrar is kept and receives the ad.
+    # The out-of-range registrar is absent from the service table.
+    # No remote advertise task is scheduled for the out-of-range registrar.
+    let serviceTable = advertiserNode.rtManager.getTable(serviceId).get()
+    check:
+      serviceTable.hasPeer(workingRegistrarPeerKey)
+      not serviceTable.hasPeer(droppedRegistrarPeerKey)
+      advertiserNode.advertiser.running.len() == 2
+      droppedRegistrarNode.countAdsInCache(serviceId) == 0
+
+    checkUntilTimeout:
+      workingRegistrarNode.countAdsInCache(serviceId) == 1
+      droppedRegistrarNode.countAdsInCache(serviceId) == 0

--- a/tests/libp2p/service_discovery/component/test_advertise_discover.nim
+++ b/tests/libp2p/service_discovery/component/test_advertise_discover.nim
@@ -322,7 +322,7 @@ suite "Service Discovery Component - Advertise Discover":
         foundA.containsPeer(advertiserNode) and foundB.containsPeer(advertiserNode)
 
   asyncTest "addProvidedService drops a known registrar at Kad bucketIndex 16":
-    # TODO: nim-libp2p#2499 service-disco: valid service registrars are dropped when Kad bucketIndex is 16 or higher
+    # TODO: nim-libp2p#2499 service-disco: valid service-table peers are dropped when Kad bucketIndex is 16 or higher
     # Precomputed private key to pin the registrar identity and service name.
     # Their Kad bucketIndex is exactly 16 for this serviceId.
     # A ServiceDiscovery service table accepts indexes 0 through 15.

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -69,15 +69,19 @@ proc makeAdvertisement*(
   )
   SignedExtendedPeerRecord.init(privateKey, extRecord).get()
 
-proc createSwitch*(): Switch =
-  SwitchBuilder
+proc createSwitch*(privateKey: Opt[PrivateKey] = Opt.none(PrivateKey)): Switch =
+  var builder = SwitchBuilder
     .new()
     .withRng(rng())
     .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
     .withTcpTransport()
     .withMplex()
     .withNoise()
-    .build()
+
+  privateKey.withValue(key):
+    discard builder.withPrivateKey(key)
+
+  builder.build()
 
 proc testKadDHTConfig(): KadDHTConfig =
   KadDHTConfig.new(
@@ -95,8 +99,9 @@ proc setupServiceDiscoveryNode*(
     xprPublishing: bool = true,
     services: seq[ServiceInfo] = @[],
     client: bool = false,
+    privateKey: Opt[PrivateKey] = Opt.none(PrivateKey),
 ): ServiceDiscovery =
-  let switch = createSwitch()
+  let switch = createSwitch(privateKey)
   let node = ServiceDiscovery.new(
     switch,
     bootstrapNodes = bootstrapNodes,


### PR DESCRIPTION
## Summary

This PR adds a ServiceDiscovery component test for #2499.

The test pins one registrar identity so its Kad `bucketIndex` is exactly `16` for the advertised service. That registrar is present in the advertiser's main Kad routing table, but it is dropped when `addProvidedService` seeds the service-specific table.

A second registrar stays inside the current bucket range and proves the happy path still works.

The test also updates the ServiceDiscovery test helper so tests can create a node with a fixed private key.

## Affected Areas

- [x] Tests

## Impact on Library Users

None.

## Risk Assessment

None.

## References

- https://github.com/vacp2p/nim-libp2p/issues/2499
- https://github.com/logos-co/logos-lips/blob/master/docs/anoncomms/raw/logos-service-discovery.md?plain=1#L304-L317