### PR TITLE
feat(streams): use sink for write buffers

### DIFF
--- a/libp2p/muxers/mplex/coder.nim
+++ b/libp2p/muxers/mplex/coder.nim
@@ -73,7 +73,7 @@ proc writeMsg*(
 
   # Write all chunks in a single write to avoid async races where a close
   # message gets written before some of the chunks
-  conn.write(buf.buffer)
+  conn.write(move(buf.buffer))
 
 proc writeMsg*(
     conn: RawConn, id: uint64, msgType: MessageType, data: string

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -198,7 +198,7 @@ method readOnce*(
     raise newLPStreamConnDownError(exc)
 
 proc prepareWrite(
-    s: LPChannel, msg: seq[byte]
+    s: LPChannel, msg: sink seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
   # prepareWrite is the slow path of writing a message - see conditions in
   # write
@@ -267,12 +267,14 @@ proc completeWrite(
     s.writes -= 1
 
 method write*(
-    s: LPChannel, msg: seq[byte]
+    s: LPChannel, msg: sink seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   ## Write to mplex channel - there may be up to MaxWrite concurrent writes
   ## pending after which the peer is disconnected
 
-  let closed = s.closedLocal or s.conn.closed
+  let
+    msgLen = msg.len
+    closed = s.closedLocal or s.conn.closed
 
   let fut =
     if (not closed) and msg.len > 0 and s.writes < MaxWrites and s.isOpen:
@@ -281,9 +283,9 @@ method write*(
       # in prepareWrite
       s.conn.writeMsg(s.id, s.msgCode, msg)
     else:
-      prepareWrite(s, msg)
+      prepareWrite(s, move(msg))
 
-  s.completeWrite(fut, msg.len)
+  s.completeWrite(fut, msgLen)
 
 method getWrapped*(s: LPChannel): Connection =
   s.conn

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -383,7 +383,7 @@ proc sendLoop(channel: YamuxChannel) {.async: (raises: []).} =
 
     trace "try to send the buffer", h = $header
     try:
-      await channel.conn.write(sendBuffer)
+      await channel.conn.write(move(sendBuffer))
       channel.sendWindow.dec(inBuffer)
     except CancelledError:
       ## Just for compiler. This should never happen as sendLoop is started by asyncSpawn.
@@ -403,7 +403,7 @@ proc sendLoop(channel: YamuxChannel) {.async: (raises: []).} =
     channel.activity = true
 
 method write*(
-    channel: YamuxChannel, msg: seq[byte]
+    channel: YamuxChannel, msg: sink seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   ## Write to yamux channel
   ##
@@ -422,7 +422,7 @@ method write*(
     resFut.complete()
     return resFut
 
-  channel.sendQueue.add(ToSend(data: msg, sent: 0, fut: resFut))
+  channel.sendQueue.add(ToSend(data: move(msg), sent: 0, fut: resFut))
 
   when defined(libp2p_yamux_metrics):
     libp2p_yamux_send_queue.observe(channel.lengthSendQueue().int64)

--- a/libp2p/protocols/connectivity/relay/rconn.nim
+++ b/libp2p/protocols/connectivity/relay/rconn.nim
@@ -20,14 +20,15 @@ method readOnce*(
   self.stream.readOnce(pbytes, nbytes)
 
 method write*(
-    self: RelayConnection, msg: seq[byte]
+    self: RelayConnection, msg: sink seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
-  self.dataSent.inc(msg.len)
+  let msgLen = msg.len
+  self.dataSent.inc(msgLen)
   if self.limitData != 0 and self.dataSent > self.limitData:
     await self.close()
     return
   self.activity = true
-  await self.stream.write(msg)
+  await self.stream.write(move(msg))
 
 method closeImpl*(self: RelayConnection): Future[void] {.async: (raises: []).} =
   await self.stream.close()

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -443,7 +443,7 @@ proc encryptFrame(
   cipherFrame[2 + src.len() ..< cipherFrame.len] = tag
 
 method write*(
-    sconn: NoiseConnection, message: seq[byte]
+    sconn: NoiseConnection, message: sink seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   # Fast path: `{.async.}` would introduce a copy of `message`
   const FramingSize = 2 + sizeof(ChaChaPolyTag)
@@ -486,7 +486,7 @@ method write*(
 
   # Write all `cipherFrames` in a single write, to avoid interleaving /
   # sequencing issues
-  sconn.stream.write(cipherFrames)
+  sconn.stream.write(move(cipherFrames))
 
 method handshake*(
     p: Noise, conn: RawConn, initiator: bool, peerId: Opt[PeerId]

--- a/libp2p/stream/bridgestream.nim
+++ b/libp2p/stream/bridgestream.nim
@@ -7,7 +7,7 @@ import connection, bufferstream
 export connection
 
 type
-  WriteHandler = proc(data: seq[byte]): Future[void] {.
+  WriteHandler = proc(data: sink seq[byte]): Future[void] {.
     async: (raises: [CancelledError, LPStreamError])
   .}
 
@@ -16,9 +16,9 @@ type
     closeHandler: proc(): Future[void] {.async: (raises: []).}
 
 method write*(
-    s: BridgeStream, msg: seq[byte]
+    s: BridgeStream, msg: sink seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
-  s.writeHandler(msg)
+  s.writeHandler(move(msg))
 
 method closeImpl*(s: BridgeStream): Future[void] {.async: (raises: [], raw: true).} =
   if not isNil(s.closeHandler):
@@ -40,13 +40,13 @@ proc bridgedConnections*(
   connB.initStream()
 
   connA.writeHandler = proc(
-      data: seq[byte]
+      data: sink seq[byte]
   ) {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
-    connB.pushData(data)
+    connB.pushData(move(data))
   connB.writeHandler = proc(
-      data: seq[byte]
+      data: sink seq[byte]
   ) {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
-    connA.pushData(data)
+    connA.pushData(move(data))
 
   if closeTogether:
     connA.closeHandler = proc(): Future[void] {.async: (raises: []).} =

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -125,10 +125,11 @@ proc completeWrite(
         libp2p_peers_traffic_write.inc(msgLen.int64, labelValues = [s.shortAgent])
 
 method write*(
-    s: ChronosStream, msg: seq[byte]
+    s: ChronosStream, msg: sink seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   # Avoid a copy of msg being kept in the closure created by `{.async.}` as this
   # drives up memory usage
+  let msgLen = msg.len
   if msg.len == 0:
     trace "Empty byte seq, nothing to write"
     let fut = newFuture[void]("chronosstream.write.empty")
@@ -139,7 +140,7 @@ method write*(
     fut.fail(newLPStreamClosedError())
     return fut
 
-  s.completeWrite(s.client.write(msg), msg.len)
+  s.completeWrite(s.client.write(msg), msgLen)
 
 method closed*(s: ChronosStream): bool =
   s.client.closed

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -234,7 +234,7 @@ method readLp*(
   res
 
 method write*(
-    s: LPStream, msg: seq[byte]
+    s: LPStream, msg: sink seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true), base.} =
   # Write `msg` to stream, waiting for the write to be finished
   raiseAssert("[LPStream.write] abstract method not implemented!")
@@ -247,7 +247,7 @@ method writeLp*(
   var buf = newSeqUninit[byte](msg.len() + vbytes.len)
   buf[0 ..< vbytes.len] = vbytes.toOpenArray()
   buf[vbytes.len ..< buf.len] = msg
-  s.write(buf)
+  s.write(move(buf))
 
 method writeLp*(
     s: LPStream, msg: string

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -114,19 +114,20 @@ method readOnce*(
   return readLen
 
 method write*(
-    stream: QuicStream, bytes: seq[byte]
+    stream: QuicStream, bytes: sink seq[byte]
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
   if stream.wasResetLocally:
     raise newLPStreamClosedError()
 
+  let bytesLen = bytes.len
   try:
     await stream.stream.write(bytes)
-    libp2p_network_bytes.inc(bytes.len.int64, labelValues = ["out"])
+    libp2p_network_bytes.inc(bytesLen.int64, labelValues = ["out"])
     when defined(libp2p_agents_metrics):
       stream.session.trackPeerIdentity()
       if stream.session.tracked:
         libp2p_peers_traffic_write.inc(
-          bytes.len.int64, labelValues = [stream.shortAgent]
+          bytesLen.int64, labelValues = [stream.shortAgent]
         )
   except StreamError:
     raise newLPStreamResetError()

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -111,15 +111,16 @@ method readOnce*(
   return res
 
 method write*(
-    s: WsStream, msg: seq[byte]
+    s: WsStream, msg: sink seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
+  let msgLen = msg.len
   mapExceptions(await s.session.send(msg, Opcode.Binary))
   s.activity = true # reset activity flag
-  libp2p_network_bytes.inc(msg.len.int64, labelValues = ["out"])
+  libp2p_network_bytes.inc(msgLen.int64, labelValues = ["out"])
   when defined(libp2p_agents_metrics):
     s.trackPeerIdentity()
     if s.tracked:
-      libp2p_peers_traffic_write.inc(msg.len.int64, labelValues = [s.shortAgent])
+      libp2p_peers_traffic_write.inc(msgLen.int64, labelValues = [s.shortAgent])
 
 method closeImpl*(s: WsStream): Future[void] {.async: (raises: []).} =
   try:

--- a/tests/libp2p/muxers/test_mplex.nim
+++ b/tests/libp2p/muxers/test_mplex.nim
@@ -22,7 +22,7 @@ import
 import ../../tools/[unittest, trackers, futures, bufferstream, compare]
 
 proc noopWriteHandler(
-    data: seq[byte]
+    data: sink seq[byte]
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
   discard
 
@@ -33,7 +33,7 @@ suite "Mplex":
   suite "channel encoding":
     asyncTest "encode header with channel id 0":
       proc encHandler(
-          msg: seq[byte]
+          msg: sink seq[byte]
       ) {.async: (raises: [CancelledError, LPStreamError]).} =
         check msg == fromHex("000873747265616d2031")
 
@@ -43,7 +43,7 @@ suite "Mplex":
 
     asyncTest "encode header with channel id other than 0":
       proc encHandler(
-          msg: seq[byte]
+          msg: sink seq[byte]
       ) {.async: (raises: [CancelledError, LPStreamError]).} =
         check msg == fromHex("88010873747265616d2031")
 
@@ -53,7 +53,7 @@ suite "Mplex":
 
     asyncTest "encode header and body with channel id 0":
       proc encHandler(
-          msg: seq[byte]
+          msg: sink seq[byte]
       ) {.async: (raises: [CancelledError, LPStreamError]).} =
         check msg == fromHex("020873747265616d2031")
 
@@ -63,7 +63,7 @@ suite "Mplex":
 
     asyncTest "encode header and body with channel id other than 0":
       proc encHandler(
-          msg: seq[byte]
+          msg: sink seq[byte]
       ) {.async: (raises: [CancelledError, LPStreamError]).} =
         check msg == fromHex("8a010873747265616d2031")
 

--- a/tests/libp2p/pubsub/component/test_gossipsub_custom_stream.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_custom_stream.nim
@@ -14,7 +14,7 @@ type DummyStream* = ref object of Connection
   data: seq[byte]
 
 method write*(
-    self: DummyStream, msg: seq[byte]
+    self: DummyStream, msg: sink seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
   self.data.add(msg)
 

--- a/tests/libp2p/pubsub/utils.nim
+++ b/tests/libp2p/pubsub/utils.nim
@@ -70,7 +70,7 @@ type
     dOut*: Opt[int]
     dLazy*: Opt[int]
 
-proc noop*(data: seq[byte]) {.async: (raises: [CancelledError, LPStreamError]).} =
+proc noop*(data: sink seq[byte]) {.async: (raises: [CancelledError, LPStreamError]).} =
   discard
 
 proc voidTopicHandler*(topic: string, data: seq[byte]) {.async.} =

--- a/tests/libp2p/test_multistream.nim
+++ b/tests/libp2p/test_multistream.nim
@@ -57,7 +57,7 @@ method readOnce*(
   fut
 
 method write*(
-    s: TestSelectStream, msg: seq[byte]
+    s: TestSelectStream, msg: sink seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   newFutureCompleted[void]()
 
@@ -113,7 +113,7 @@ method readOnce*(
   fut
 
 method write*(
-    s: TestLsStream, msg: seq[byte]
+    s: TestLsStream, msg: sink seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   if s.step == 4:
     return s.ls(msg)
@@ -172,7 +172,7 @@ method readOnce*(
   fut
 
 method write*(
-    s: TestNaStream, msg: seq[byte]
+    s: TestNaStream, msg: sink seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
   if s.step == 4:
     return s.na(string.fromBytes(msg))

--- a/tests/tools/bufferstream.nim
+++ b/tests/tools/bufferstream.nim
@@ -5,7 +5,7 @@ import chronos
 import ../../libp2p/stream/[chronosstream, bufferstream, lpstream]
 
 type
-  WriteHandler* = proc(data: seq[byte]): Future[void] {.
+  WriteHandler* = proc(data: sink seq[byte]): Future[void] {.
     async: (raises: [CancelledError, LPStreamError])
   .}
 
@@ -13,9 +13,9 @@ type
     writeHandler*: WriteHandler
 
 method write*(
-    s: TestBufferStream, msg: seq[byte]
+    s: TestBufferStream, msg: sink seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
-  s.writeHandler(msg)
+  s.writeHandler(move(msg))
 
 method getWrapped*(s: TestBufferStream): Connection =
   nil


### PR DESCRIPTION
## Summary

This PR changes the stream write boundary to accept owned `seq[byte]` buffers via `sink`, allowing write buffers to be moved instead of copied where ownership is transferred.

The change updates the base `LPStream.write` method and matching write implementations across the transport, muxer, secure channel, relay, and bridge stream paths. It also moves locally constructed buffers at clear ownership handoff points, such as length-prefixed writes, muxer send queues, encrypted Noise frames, and relay forwarding.

## Affected Areas

- [x] Transports
  QUIC, WebSocket, and Chronos stream write implementations now match the sink-aware stream API.
- [x] Protocol Logic
  Noise and relay stream writes move owned buffers when forwarding to the next stream layer.
- [x] Other
  Mplex, Yamux, BridgeStream, and stream test mocks were updated to match the new write signature.

## Impact on Library Users

Callers can continue passing `seq[byte]` to `write`; Nim preserves normal value semantics and can move buffers when they are temporaries or last uses.

Implementations that override `LPStream.write` or `Connection.write` must update their method signature to `msg: sink seq[byte]`.

## Risk Assessment

The behavioral surface is intended to stay the same: the change affects ownership at stream write boundaries, not wire format or protocol logic.

The main compatibility risk is source-level for downstream custom stream implementations that override `write` with the old `seq[byte]` parameter.
