### PR TITLE
fix(service-disco): build advert once to keep adverts byte-identical

### DIFF
--- a/libp2p/protocols/service_discovery/advertiser.nim
+++ b/libp2p/protocols/service_discovery/advertiser.nim
@@ -76,21 +76,13 @@ proc advertiseToRegistrar*(
     serviceId: ServiceId,
     registrar: PeerId,
     ticket: Opt[Ticket],
-    advert: Opt[seq[byte]],
+    advert: seq[byte],
 ) {.async: (raises: [CancelledError]).} =
   doAssert not disco.clientMode, "not supported in client mode"
 
   if not disco.rtManager.hasService(serviceId):
     error "no service routing table found", serviceId
     return
-
-  let advertBuff = advert.valueOr:
-    let extRecord = disco.record().valueOr:
-      error "failed create extended peer record", error
-      return
-    extRecord.encode().valueOr:
-      error "failed to encode advertisement", error
-      return
 
   cd_advertiser_actions_executed.inc()
 
@@ -100,7 +92,7 @@ proc advertiseToRegistrar*(
 
   while true:
     let response = (
-      await disco.sendRegister(registrar, serviceId, advertBuff, currentTicket)
+      await disco.sendRegister(registrar, serviceId, advert, currentTicket)
     ).valueOr:
       error "failed to register ad", error
       return
@@ -156,6 +148,21 @@ proc addProvidedService*(
     error "service not found", serviceId
     return
 
+  # Build the advert once so every registrar caches the same bytes.
+  # disco.record() sets seqNo from a clock with 1-second resolution.
+  # An advert built inside each advertiseToRegistrar task could differ in seqNo 
+  # when those builds land in different seconds.
+  let advertBytes =
+    if advert.isSome():
+      advert.get()
+    else:
+      let extRecord = disco.record().valueOr:
+        error "failed to create extended peer record", error
+        return
+      extRecord.encode().valueOr:
+        error "failed to encode advertisement", error
+        return
+
   # Remote advertising
   for bucket in advTable.buckets:
     if bucket.peers.len == 0:
@@ -170,13 +177,13 @@ proc addProvidedService*(
         continue
 
       let fut =
-        disco.advertiseToRegistrar(serviceId, registrar, Opt.none(Ticket), advert)
+        disco.advertiseToRegistrar(serviceId, registrar, Opt.none(Ticket), advertBytes)
       disco.advertiser.running.incl(AdvertiseTask(fut: fut, serviceId: serviceId))
       cd_advertiser_pending_actions.inc()
 
   # Local advertising
   let fut = disco.advertiseToRegistrar(
-    serviceId, disco.switch.peerInfo.peerId, Opt.none(Ticket), advert
+    serviceId, disco.switch.peerInfo.peerId, Opt.none(Ticket), advertBytes
   )
   disco.advertiser.running.incl(AdvertiseTask(fut: fut, serviceId: serviceId))
   cd_advertiser_pending_actions.inc()

--- a/tests/libp2p/service_discovery/component/test_advertise_discover.nim
+++ b/tests/libp2p/service_discovery/component/test_advertise_discover.nim
@@ -111,40 +111,44 @@ suite "Service Discovery Component - Advertise Discover":
         found.get().len == 2 and found.containsPeer(advertiserA) and
           found.containsPeer(advertiserB)
 
-  asyncTest "one advertiser provides two services - both discoverable":
-    # TODO: vacp2p/nim-libp2p#2430 service-disco: missing API for multi-service registration
-    let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0, ipSimCoefficient = 0.0)
-    let registrarNode = setupServiceDiscoveryNode(discoConfig = conf)
-    let advertiserNode = setupServiceDiscoveryNode(discoConfig = conf)
-    let discovererNode = setupServiceDiscoveryNode(discoConfig = conf)
-    startAndDeferStop(@[registrarNode, advertiserNode, discovererNode])
+  for i in 0 ..< 10:
+    asyncTest "one advertiser provides two services - both discoverable" & $i:
+      # TODO: vacp2p/nim-libp2p#2430 service-disco: missing API for multi-service registration
+      let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0, ipSimCoefficient = 0.0)
+      let registrarNode = setupServiceDiscoveryNode(discoConfig = conf)
+      let advertiserNode = setupServiceDiscoveryNode(discoConfig = conf)
+      let discovererNode = setupServiceDiscoveryNode(discoConfig = conf)
+      startAndDeferStop(@[registrarNode, advertiserNode, discovererNode])
 
-    await connectHub(registrarNode, @[advertiserNode, discovererNode])
+      await connectHub(registrarNode, @[advertiserNode, discovererNode])
 
-    let svcA = makeServiceInfo("service-A")
-    let svcB = makeServiceInfo("service-B")
-    let svcAId = svcA.id.hashServiceId()
-    let svcBId = svcB.id.hashServiceId()
+      let svcA = makeServiceInfo("service-A")
+      let svcB = makeServiceInfo("service-B")
+      let svcAId = svcA.id.hashServiceId()
+      let svcBId = svcB.id.hashServiceId()
 
-    advertiserNode.addProvidedService(svcA)
+      advertiserNode.addProvidedService(svcA)
 
-    checkUntilTimeout:
-      registrarNode.countAdsInCache(svcAId) == 1
+      checkUntilTimeout:
+        registrarNode.countAdsInCache(svcAId) == 1
 
-    advertiserNode.addProvidedService(svcB)
+      advertiserNode.addProvidedService(svcB)
 
-    checkUntilTimeout:
-      registrarNode.countAdsInCache(svcBId) == 1
+      checkUntilTimeout:
+        registrarNode.countAdsInCache(svcBId) == 1
 
-    checkUntilTimeout:
-      block:
-        let foundA = await discovererNode.lookup(svcAId)
-        let foundB = await discovererNode.lookup(svcBId)
-        foundA.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId) and
-          foundA.get().len == 1 and
+      checkUntilTimeout:
+        block:
+          let foundA = await discovererNode.lookup(svcAId)
+          echo foundA
+          foundA.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId) and
+            foundA.get().len == 1
+        block:
+          let foundB = await discovererNode.lookup(svcBId)
+          echo foundB
           foundB.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId) and
-          foundB.get().len == 1
-          # Regression for vacp2p/nim-libp2p#2431: this lookup previously returned a duplicate.
+            foundB.get().len == 1
+            # Regression for vacp2p/nim-libp2p#2431: this lookup previously returned a duplicate.
 
   asyncTest "lookup dedups byte-identical adverts but keeps same (peerId, seqNo) variants":
     let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0)

--- a/tests/libp2p/service_discovery/component/test_advertise_discover.nim
+++ b/tests/libp2p/service_discovery/component/test_advertise_discover.nim
@@ -111,44 +111,41 @@ suite "Service Discovery Component - Advertise Discover":
         found.get().len == 2 and found.containsPeer(advertiserA) and
           found.containsPeer(advertiserB)
 
-  for i in 0 ..< 10:
-    asyncTest "one advertiser provides two services - both discoverable" & $i:
-      # TODO: vacp2p/nim-libp2p#2430 service-disco: missing API for multi-service registration
-      let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0, ipSimCoefficient = 0.0)
-      let registrarNode = setupServiceDiscoveryNode(discoConfig = conf)
-      let advertiserNode = setupServiceDiscoveryNode(discoConfig = conf)
-      let discovererNode = setupServiceDiscoveryNode(discoConfig = conf)
-      startAndDeferStop(@[registrarNode, advertiserNode, discovererNode])
+  asyncTest "one advertiser provides two services - both discoverable":
+    # TODO: vacp2p/nim-libp2p#2430 service-disco: missing API for multi-service registration
+    let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0, ipSimCoefficient = 0.0)
+    let registrarNode = setupServiceDiscoveryNode(discoConfig = conf)
+    let advertiserNode = setupServiceDiscoveryNode(discoConfig = conf)
+    let discovererNode = setupServiceDiscoveryNode(discoConfig = conf)
+    startAndDeferStop(@[registrarNode, advertiserNode, discovererNode])
 
-      await connectHub(registrarNode, @[advertiserNode, discovererNode])
+    await connectHub(registrarNode, @[advertiserNode, discovererNode])
 
-      let svcA = makeServiceInfo("service-A")
-      let svcB = makeServiceInfo("service-B")
-      let svcAId = svcA.id.hashServiceId()
-      let svcBId = svcB.id.hashServiceId()
+    let svcA = makeServiceInfo("service-A")
+    let svcB = makeServiceInfo("service-B")
+    let svcAId = svcA.id.hashServiceId()
+    let svcBId = svcB.id.hashServiceId()
 
-      advertiserNode.addProvidedService(svcA)
+    advertiserNode.addProvidedService(svcA)
 
-      checkUntilTimeout:
-        registrarNode.countAdsInCache(svcAId) == 1
+    checkUntilTimeout:
+      registrarNode.countAdsInCache(svcAId) == 1
 
-      advertiserNode.addProvidedService(svcB)
+    advertiserNode.addProvidedService(svcB)
 
-      checkUntilTimeout:
-        registrarNode.countAdsInCache(svcBId) == 1
+    checkUntilTimeout:
+      registrarNode.countAdsInCache(svcBId) == 1
 
-      checkUntilTimeout:
-        block:
-          let foundA = await discovererNode.lookup(svcAId)
-          echo foundA
-          foundA.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId) and
-            foundA.get().len == 1
-        block:
-          let foundB = await discovererNode.lookup(svcBId)
-          echo foundB
-          foundB.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId) and
-            foundB.get().len == 1
-            # Regression for vacp2p/nim-libp2p#2431: this lookup previously returned a duplicate.
+    checkUntilTimeout:
+      block:
+        let foundA = await discovererNode.lookup(svcAId)
+        foundA.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId) and
+          foundA.get().len == 1
+      block:
+        let foundB = await discovererNode.lookup(svcBId)
+        foundB.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId) and
+          foundB.get().len == 1
+          # Regression for vacp2p/nim-libp2p#2431: this lookup previously returned a duplicate.
 
   asyncTest "lookup dedups byte-identical adverts but keeps same (peerId, seqNo) variants":
     let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0)
@@ -283,7 +280,7 @@ suite "Service Discovery Component - Advertise Discover":
     )
 
     # Malformed bytes force a Rejected reply.
-    let badAdvert = Opt.some(@[1'u8, 2, 3, 4])
+    let badAdvert = @[1'u8, 2, 3, 4]
 
     # The advertiser should hit Rejected, break its retry loop, and return.
     await advertiserNode


### PR DESCRIPTION
## Summary

Fixes a flaky failure in the service discovery test "one advertiser provides two services - both discoverable". In CI, `lookup` would sometimes return the same provider twice.

**Why it failed.** When a node calls `addProvidedService`, it spawns several `advertiseToRegistrar` tasks: one per remote registrar, plus one for local advertising where the node registers the ad with itself. Each task built its own advertisement by calling `disco.record()`. That record stamps `seqNo` from `Moment.now().epochSeconds`, which has 1-second resolution. When two tasks ran on opposite sides of a second boundary, they produced records with different `seqNo`, and so different signatures and bytes.

The discoverer's `lookup` collects advertisements from every registrar and dedups them by exact byte identity. Two records of the same provider that differ only in `seqNo` are not byte-identical, so both survive and `lookup` returns the provider twice. CI's slower scheduling made straddling the second boundary more likely, so the test failed intermittently.

**The fix.** Build the advertisement once in `addProvidedService` and hand the same bytes to every `advertiseToRegistrar` task. Every registrar now caches a byte-identical record, the dedup collapses them, and `lookup` returns one entry per provider.

## Affected Areas

- [x] Service Discovery

## Impact on Library Users

`advertiseToRegistrar` is exported and its signature changed. `advert: Opt[seq[byte]]` is now `advert: seq[byte]`. Callers passing `Opt.some(bytes)` pass `bytes` directly. Callers that relied on `Opt.none` to get an auto-built record now build it themselves. `addProvidedService` and `startAdvertising` are unchanged.

## Risk Assessment

Low. The change makes advert generation deterministic instead of timing-dependent. One behavior change worth noting: the `services` list in an advert is now snapshotted when `addProvidedService` is called rather than when the spawned task first runs. The old timing was non-deterministic, so this tightens behavior rather than regressing it.