### PR TITLE
feat(pubsub): use sink for RPC buffers

### DIFF
--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -98,7 +98,7 @@ method unsubscribePeer*(f: FloodSub, peer: PeerId) =
 method rpcHandler*(
     f: FloodSub, peer: PubSubPeer, data: sink seq[byte]
 ) {.async: (raises: [CancelledError, PeerMessageDecodeError, PeerRateLimitError]).} =
-  var rpcMsg = decodeRpcMsg(data).valueOr:
+  var rpcMsg = decodeRpcMsg(move(data)).valueOr:
     debug "failed to decode msg from peer", peer, err = error
     raise newException(PeerMessageDecodeError, "Peer msg couldn't be decoded")
 

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -609,7 +609,7 @@ method rpcHandler*(
     g: GossipSub, peer: PubSubPeer, data: sink seq[byte]
 ) {.async: (raises: [CancelledError, PeerMessageDecodeError, PeerRateLimitError]).} =
   let msgSize = data.len
-  var rpcMsg = decodeRpcMsg(data).valueOr:
+  var rpcMsg = decodeRpcMsg(move(data)).valueOr:
     debug "failed to decode msg from peer", peer, err = error
     await rateLimit(g, peer, msgSize)
     # Raising in the handler closes the gossipsub connection (but doesn't

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -308,7 +308,7 @@ proc runHandleLoop*(
   while not stream.atEof:
     trace "waiting for data", stream, peer = p, closed = stream.closed
 
-    let data =
+    var data =
       try:
         await stream.readLp(p.maxMessageSize)
       except LPStreamEOFError:
@@ -321,7 +321,7 @@ proc runHandleLoop*(
     trace "read data from peer",
       stream, peer = p, closed = stream.closed, data = data.shortLog
 
-    await p.handler(p, data)
+    await p.handler(p, move(data))
 
 proc closeSendStream(
     p: PubSubPeer, event: PubSubPeerEventKind
@@ -445,7 +445,9 @@ proc sendMsgContinue(
     # will be recycled
     await stream.close() # This will clean up the send stream
 
-proc sendMsgSlow(p: PubSubPeer, msg: seq[byte]) {.async: (raises: [CancelledError]).} =
+proc sendMsgSlow(
+    p: PubSubPeer, msg: sink seq[byte]
+) {.async: (raises: [CancelledError]).} =
   # Slow path where msg is held in memory while send stream is being set up.
   if p.sendStream == nil:
     # Wait for a send stream to be setup. `connectOnce` will
@@ -461,7 +463,7 @@ proc sendMsgSlow(p: PubSubPeer, msg: seq[byte]) {.async: (raises: [CancelledErro
   await sendMsgContinue(stream, stream.writeLp(msg))
 
 proc sendMsg(
-    p: PubSubPeer, msg: seq[byte], useCustomStream: bool = false
+    p: PubSubPeer, msg: sink seq[byte], useCustomStream: bool = false
 ): Future[void] {.async: (raises: [CancelledError]).} =
   ## Starts a transport write and returns its lifecycle future for internal
   ## queue accounting. Do not await this from receive-handler paths.
@@ -491,7 +493,7 @@ proc sendMsg(
     await sendMsgContinue(stream, f)
   else:
     trace "sending encoded msg to peer via slow path"
-    await sendMsgSlow(p, msg)
+    await sendMsgSlow(p, move(msg))
 
 proc disconnectPeer(p: PubSubPeer): Future[void] =
   if not p.disconnected:
@@ -503,9 +505,9 @@ proc disconnectPeer(p: PubSubPeer): Future[void] =
   return newFutureCompleted[void]()
 
 proc sendHighPriorityMessage(
-    p: PubSubPeer, msg: seq[byte], useCustomStream: bool
+    p: PubSubPeer, msg: sink seq[byte], useCustomStream: bool
 ): Future[void] =
-  let f = p.sendMsg(msg, useCustomStream)
+  let f = p.sendMsg(move(msg), useCustomStream)
   if not f.finished:
     p.rpcmessagequeue.sendPriorityQueue.addLast(f)
     when defined(pubsubpeer_queue_metrics):
@@ -513,9 +515,9 @@ proc sendHighPriorityMessage(
   return newFutureCompleted[void]()
 
 proc enqueueNonHighPriorityMessage(
-    p: PubSubPeer, msg: seq[byte], useCustomStream: bool, priority: MessagePriority
+    p: PubSubPeer, msg: sink seq[byte], useCustomStream: bool, priority: MessagePriority
 ): Future[void] =
-  let queuedMsg = QueuedMessage(data: msg, useCustomStream: useCustomStream)
+  let queuedMsg = QueuedMessage(data: move(msg), useCustomStream: useCustomStream)
   case priority
   of MessagePriority.Medium:
     p.rpcmessagequeue.mediumPriorityQueue.addLast(queuedMsg)
@@ -550,7 +552,7 @@ proc dropNonHighPriorityMessage(
 
 proc sendEncoded*(
     p: PubSubPeer,
-    msg: seq[byte],
+    msg: sink seq[byte],
     priority: MessagePriority,
     useCustomStream: bool = false,
 ): Future[void] =
@@ -587,12 +589,12 @@ proc sendEncoded*(
     case action.priority
     of High:
       if action.send:
-        p.sendHighPriorityMessage(msg, useCustomStream)
+        p.sendHighPriorityMessage(move(msg), useCustomStream)
       else:
         p.disconnectPeer()
     of Medium, Low:
       if action.send:
-        p.enqueueNonHighPriorityMessage(msg, useCustomStream, action.priority)
+        p.enqueueNonHighPriorityMessage(move(msg), useCustomStream, action.priority)
       else:
         p.dropNonHighPriorityMessage(action.slowPeerPenaltyDelta, action.priority)
 
@@ -650,7 +652,7 @@ proc send*(
   # or malicious data on the wire - in particular, re-encoding protects against
   # some forms of valid but redundantly encoded protobufs with unknown or
   # duplicated fields
-  let encoded =
+  var encoded =
     if p.hasObservers():
       var mm = msg
       # trigger send hooks
@@ -668,11 +670,12 @@ proc send*(
 
   if encoded.len > maxEncodedMsgSize and msg.messages.len > 1:
     for encodedSplitMsg in splitRPCMsg(p, msg, maxEncodedMsgSize, anonymize):
-      asyncSpawn p.sendEncoded(encodedSplitMsg, priority, useCustomStream)
+      var ownedEncodedSplitMsg = encodedSplitMsg
+      asyncSpawn p.sendEncoded(move(ownedEncodedSplitMsg), priority, useCustomStream)
   else:
     # If the message size is within limits, send it as is
     trace "sending msg to peer", peer = p, rpcMsg = shortLog(msg)
-    asyncSpawn p.sendEncoded(encoded, priority, useCustomStream)
+    asyncSpawn p.sendEncoded(move(encoded), priority, useCustomStream)
 
 proc canAskIWant*(p: PubSubPeer, msgId: MessageId): bool =
   for sentIHave in p.sentIHaves.mitems():
@@ -690,7 +693,7 @@ proc sendNonHighPriorityTask(p: PubSubPeer) {.async: (raises: [CancelledError]).
       p.rpcmessagequeue.dataAvailableEvent.clear()
 
     var priority = MessagePriority.Low
-    let msg =
+    var msg =
       if p.rpcmessagequeue.mediumPriorityQueue.len != 0:
         priority = MessagePriority.Medium
         p.rpcmessagequeue.mediumPriorityQueue.popFirst()
@@ -715,7 +718,8 @@ proc sendNonHighPriorityTask(p: PubSubPeer) {.async: (raises: [CancelledError]).
       else:
         libp2p_gossipsub_low_priority_queue_size.dec(labelValues = [$p.peerId])
 
-    await p.sendMsg(msg.data, msg.useCustomStream)
+    let useCustomStream = msg.useCustomStream
+    await p.sendMsg(move(msg.data), useCustomStream)
 
 proc startSendNonHighPriorityTask(p: PubSubPeer) =
   debug "starting sendNonHighPriorityTask", p

--- a/libp2p/protocols/pubsub/rpc/messages.nim
+++ b/libp2p/protocols/pubsub/rpc/messages.nim
@@ -352,45 +352,51 @@ proc byteSize*(rpc: RPCMsg): int =
   rpc.preambleExtension.withValue(v):
     result += v.byteSize
 
-proc withIWant*(_: typedesc[ControlMessage], msgIds: seq[MessageId]): ControlMessage =
-  ControlMessage(iwant: @[ControlIWant(messageIDs: msgIds)])
+proc withIWant*(
+    _: typedesc[ControlMessage], msgIds: sink seq[MessageId]
+): ControlMessage =
+  ControlMessage(iwant: @[ControlIWant(messageIDs: move(msgIds))])
 
-proc withIWant*(_: typedesc[ControlMessage], msgId: MessageId): ControlMessage =
-  ControlMessage.withIWant(@[msgId])
+proc withIWant*(_: typedesc[ControlMessage], msgId: sink MessageId): ControlMessage =
+  ControlMessage.withIWant(@[move(msgId)])
 
 proc withIDontWant*(
-    _: typedesc[ControlMessage], msgIds: seq[MessageId]
+    _: typedesc[ControlMessage], msgIds: sink seq[MessageId]
 ): ControlMessage =
-  ControlMessage(idontwant: @[ControlIWant(messageIDs: msgIds)])
+  ControlMessage(idontwant: @[ControlIWant(messageIDs: move(msgIds))])
 
-proc withIDontWant*(_: typedesc[ControlMessage], msgId: MessageId): ControlMessage =
-  ControlMessage.withIDontWant(@[msgId])
+proc withIDontWant*(
+    _: typedesc[ControlMessage], msgId: sink MessageId
+): ControlMessage =
+  ControlMessage.withIDontWant(@[move(msgId)])
 
 proc withIHave*(
-    _: typedesc[ControlMessage], topicID: string, messageIDs: seq[MessageId]
+    _: typedesc[ControlMessage], topicID: sink string, messageIDs: sink seq[MessageId]
 ): ControlMessage =
-  ControlMessage(ihave: @[ControlIHave(topicID: topicID, messageIDs: messageIDs)])
+  ControlMessage(
+    ihave: @[ControlIHave(topicID: move(topicID), messageIDs: move(messageIDs))]
+  )
 
-proc withGraft*(_: typedesc[ControlMessage], topicID: string): ControlMessage =
-  ControlMessage(graft: @[ControlGraft(topicID: topicID)])
+proc withGraft*(_: typedesc[ControlMessage], topicID: sink string): ControlMessage =
+  ControlMessage(graft: @[ControlGraft(topicID: move(topicID))])
 
 proc withPrune*(
     _: typedesc[ControlMessage],
-    topicID: string,
+    topicID: sink string,
     backoff: uint64,
-    peers: seq[PeerInfoMsg],
+    peers: sink seq[PeerInfoMsg],
 ): ControlMessage =
   ControlMessage(
-    prune: @[ControlPrune(topicID: topicID, peers: peers, backoff: backoff)]
+    prune: @[ControlPrune(topicID: move(topicID), peers: move(peers), backoff: backoff)]
   )
 
 proc withExtensions*(
-    _: typedesc[ControlMessage], ext: ControlExtensions
+    _: typedesc[ControlMessage], ext: sink ControlExtensions
 ): ControlMessage =
-  ControlMessage(extensions: Opt.some(ext))
+  ControlMessage(extensions: Opt.some(move(ext)))
 
-proc withControl*(_: typedesc[RPCMsg], control: ControlMessage): RPCMsg =
-  RPCMsg(control: Opt.some(control))
+proc withControl*(_: typedesc[RPCMsg], control: sink ControlMessage): RPCMsg =
+  RPCMsg(control: Opt.some(move(control)))
 
 proc withMessages*(_: typedesc[RPCMsg], messages: sink seq[Message]): RPCMsg =
   RPCMsg(messages: move(messages))
@@ -398,17 +404,17 @@ proc withMessages*(_: typedesc[RPCMsg], messages: sink seq[Message]): RPCMsg =
 proc withMessages*(_: typedesc[RPCMsg], msg: sink Message): RPCMsg =
   RPCMsg.withMessages(@[move(msg)])
 
-proc withSubscriptions*(_: typedesc[RPCMsg], subscriptions: seq[SubOpts]): RPCMsg =
-  RPCMsg(subscriptions: subscriptions)
+proc withSubscriptions*(_: typedesc[RPCMsg], subscriptions: sink seq[SubOpts]): RPCMsg =
+  RPCMsg(subscriptions: move(subscriptions))
 
-proc withPing*(_: typedesc[RPCMsg], ping: seq[byte]): RPCMsg =
-  RPCMsg(pingpongExtension: Opt.some(PingPongExtensionRPC(ping: ping)))
+proc withPing*(_: typedesc[RPCMsg], ping: sink seq[byte]): RPCMsg =
+  RPCMsg(pingpongExtension: Opt.some(PingPongExtensionRPC(ping: move(ping))))
 
-proc withPong*(_: typedesc[RPCMsg], pong: seq[byte]): RPCMsg =
-  RPCMsg(pingpongExtension: Opt.some(PingPongExtensionRPC(pong: pong)))
+proc withPong*(_: typedesc[RPCMsg], pong: sink seq[byte]): RPCMsg =
+  RPCMsg(pingpongExtension: Opt.some(PingPongExtensionRPC(pong: move(pong))))
 
-proc withPreamble*(_: typedesc[RPCMsg], preamble: seq[Preamble]): RPCMsg =
-  RPCMsg(preambleExtension: Opt.some(PreambleExtensionRPC(preamble: preamble)))
+proc withPreamble*(_: typedesc[RPCMsg], preamble: sink seq[Preamble]): RPCMsg =
+  RPCMsg(preambleExtension: Opt.some(PreambleExtensionRPC(preamble: move(preamble))))
 
 proc withPreamble*(
     _: typedesc[RPCMsg], msgs: seq[Message], msgIds: seq[MessageId]
@@ -421,16 +427,25 @@ proc withPreamble*(
   RPCMsg.withPreamble(preambles)
 
 proc withPreamble*(
-    _: typedesc[RPCMsg], topic: string, msgId: MessageId, messageLength: int
+    _: typedesc[RPCMsg], topic: sink string, msgId: sink MessageId, messageLength: int
 ): RPCMsg =
   RPCMsg.withPreamble(
-    @[Preamble(topicID: topic, messageID: msgId, messageLength: messageLength.uint32)]
+    @[
+      Preamble(
+        topicID: move(topic),
+        messageID: move(msgId),
+        messageLength: messageLength.uint32,
+      )
+    ]
   )
 
-proc withIMReceiving*(_: typedesc[RPCMsg], imreceiving: seq[IMReceiving]): RPCMsg =
-  RPCMsg(preambleExtension: Opt.some(PreambleExtensionRPC(imreceiving: imreceiving)))
+proc withIMReceiving*(_: typedesc[RPCMsg], imreceiving: sink seq[IMReceiving]): RPCMsg =
+  RPCMsg(
+    preambleExtension: Opt.some(PreambleExtensionRPC(imreceiving: move(imreceiving)))
+  )
 
-proc withIMReceiving*(_: typedesc[RPCMsg], preamble: Preamble): RPCMsg =
+proc withIMReceiving*(_: typedesc[RPCMsg], preamble: sink Preamble): RPCMsg =
+  let messageLength = preamble.messageLength
   RPCMsg.withIMReceiving(
-    @[IMReceiving(messageID: preamble.messageID, messageLength: preamble.messageLength)]
+    @[IMReceiving(messageID: move(preamble.messageID), messageLength: messageLength)]
   )

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -602,9 +602,9 @@ proc decodePartialMessageExtensionRPC*(
 
   ok(Opt.some(pme))
 
-proc decodeRpcMsg*(msg: seq[byte]): ProtoResult[RPCMsg] {.inline.} =
+proc decodeRpcMsg*(msg: sink seq[byte]): ProtoResult[RPCMsg] {.inline.} =
   trace "decodeRpcMsg: decoding message", encodedData = msg.shortLog()
-  var pb = initProtoBuffer(msg)
+  var pb = initProtoBuffer(move(msg))
   var rpcMsg = RPCMsg()
   assign(rpcMsg.messages, ?pb.decodeMessages())
   assign(rpcMsg.subscriptions, ?pb.decodeSubscriptions())


### PR DESCRIPTION
## Summary

Use `sink seq[byte]` for PubSub RPC buffers that are encoded, queued, sent, or decoded.

This makes ownership explicit on the PubSub send/decode path and moves encoded buffers into queued messages instead of assigning them by value.

## Affected Areas

- [x] Gossipsub / PubSub RPC
  - Encoded send path
  - RPC queue storage
  - RPC constructor helpers
  - RPC decode entry point

## Impact on Library Users

No wire protocol behavior changes are intended. PubSub APIs that accept owned RPC buffers now express that ownership with `sink`.

## Risk Assessment

Low behavioral risk: this is an ownership/refcounting cleanup around existing PubSub message buffers. The main review risk is ensuring moved buffers are not reused after handoff.
