### PR TITLE
feat(protobuf): Use sink in protobuf decode paths

### DIFF
--- a/libp2p/extended_peer_record.nim
+++ b/libp2p/extended_peer_record.nim
@@ -29,9 +29,9 @@ type
     services*: seq[ServiceInfo]
 
 proc decode*(
-    T: typedesc[ServiceInfo], buffer: seq[byte]
+    T: typedesc[ServiceInfo], buffer: sink seq[byte]
 ): Result[ServiceInfo, ProtoError] =
-  var pb = initProtoBuffer(buffer)
+  var pb = initProtoBuffer(move(buffer))
   var servInf = ServiceInfo()
 
   ?pb.getRequiredField(1, servInf.id)
@@ -40,9 +40,9 @@ proc decode*(
   ok(servInf)
 
 proc decode*(
-    T: typedesc[ExtendedPeerRecord], buffer: seq[byte]
+    T: typedesc[ExtendedPeerRecord], buffer: sink seq[byte]
 ): Result[ExtendedPeerRecord, ProtoError] =
-  var pb = initProtoBuffer(buffer)
+  var pb = initProtoBuffer(move(buffer))
   var record = ExtendedPeerRecord()
 
   ?pb.getRequiredField(1, record.peerId)
@@ -50,8 +50,8 @@ proc decode*(
 
   var addressInfos: seq[seq[byte]]
   if ?pb.getRepeatedField(3, addressInfos):
-    for addressBuf in addressInfos:
-      let addressInfo = AddressInfo.decode(addressBuf).valueOr:
+    for addressBuf in addressInfos.mitems:
+      let addressInfo = AddressInfo.decode(move(addressBuf)).valueOr:
         continue
 
       record.addresses &= addressInfo
@@ -61,8 +61,8 @@ proc decode*(
 
   var serviceInfos: seq[seq[byte]]
   if ?pb.getRepeatedField(4, serviceInfos):
-    for serviceBuf in serviceInfos:
-      record.services &= ?ServiceInfo.decode(serviceBuf)
+    for serviceBuf in serviceInfos.mitems:
+      record.services &= ?ServiceInfo.decode(move(serviceBuf))
 
   ok(record)
 

--- a/libp2p/protocols/connectivity/autonat/client.nim
+++ b/libp2p/protocols/connectivity/autonat/client.nim
@@ -83,7 +83,7 @@ method dialMe*(
   except CatchableError as e:
     raise newException(AutonatError, "read Dial response failed: " & e.msg, e)
 
-  let response = getResponseOrRaise(AutonatMsg.decode(respBytes))
+  let response = getResponseOrRaise(AutonatMsg.decode(move(respBytes)))
 
   return
     case response.status

--- a/libp2p/protocols/connectivity/autonat/types.nim
+++ b/libp2p/protocols/connectivity/autonat/types.nim
@@ -92,14 +92,14 @@ proc encode*(msg: AutonatMsg): ProtoBuffer =
   msg.response.withValue(res):
     return encode(res)
 
-proc decode*(_: typedesc[AutonatMsg], buf: seq[byte]): Opt[AutonatMsg] =
+proc decode*(_: typedesc[AutonatMsg], buf: sink seq[byte]): Opt[AutonatMsg] =
   var
     msgTypeOrd: uint32
     pbDial: ProtoBuffer
     pbResponse: ProtoBuffer
     msg: AutonatMsg
 
-  let pb = initProtoBuffer(buf)
+  let pb = initProtoBuffer(move(buf))
 
   if ?pb.getField(1, msgTypeOrd).toOpt() and
       not checkedEnumAssign(msg.msgType, msgTypeOrd):

--- a/libp2p/protocols/connectivity/dcutr/core.nim
+++ b/libp2p/protocols/connectivity/dcutr/core.nim
@@ -33,11 +33,13 @@ proc encode*(msg: DcutrMsg): ProtoBuffer =
     result.write(2, addr)
   result.finish()
 
-proc decode*(_: typedesc[DcutrMsg], buf: seq[byte]): DcutrMsg {.raises: [DcutrError].} =
+proc decode*(
+    _: typedesc[DcutrMsg], buf: sink seq[byte]
+): DcutrMsg {.raises: [DcutrError].} =
   var
     msgTypeOrd: uint32
     dcutrMsg: DcutrMsg
-  var pb = initProtoBuffer(buf)
+  var pb = initProtoBuffer(move(buf))
   var r1 = pb.getField(1, msgTypeOrd)
   let r2 = pb.getRepeatedField(2, dcutrMsg.addrs)
   if r1.isErr or r2.isErr or not checkedEnumAssign(dcutrMsg.msgType, msgTypeOrd):

--- a/libp2p/protocols/connectivity/relay/messages.nim
+++ b/libp2p/protocols/connectivity/relay/messages.nim
@@ -70,7 +70,7 @@ proc encode*(msg: RelayMessage): ProtoBuffer =
 
   result.finish()
 
-proc decode*(_: typedesc[RelayMessage], buf: seq[byte]): Opt[RelayMessage] =
+proc decode*(_: typedesc[RelayMessage], buf: sink seq[byte]): Opt[RelayMessage] =
   var
     rMsg: RelayMessage
     msgTypeOrd: uint32
@@ -80,7 +80,7 @@ proc decode*(_: typedesc[RelayMessage], buf: seq[byte]): Opt[RelayMessage] =
     pbSrc: ProtoBuffer
     pbDst: ProtoBuffer
 
-  let pb = initProtoBuffer(buf)
+  let pb = initProtoBuffer(move(buf))
 
   if ?pb.getField(1, msgTypeOrd).toOpt():
     if msgTypeOrd.int notin RelayType:
@@ -111,8 +111,8 @@ type Voucher* = object
   reservingPeerId*: PeerId # peer ID of the reserving peer
   expiration*: uint64 # UNIX UTC expiration time for the reservation
 
-proc decode*(_: typedesc[Voucher], buf: seq[byte]): Result[Voucher, ProtoError] =
-  let pb = initProtoBuffer(buf)
+proc decode*(_: typedesc[Voucher], buf: sink seq[byte]): Result[Voucher, ProtoError] =
+  let pb = initProtoBuffer(move(buf))
   var v = Voucher()
 
   ?pb.getRequiredField(1, v.relayPeerId)
@@ -227,9 +227,9 @@ proc encode*(msg: HopMessage): ProtoBuffer =
   pb.finish()
   pb
 
-proc decode*(_: typedesc[HopMessage], buf: seq[byte]): Opt[HopMessage] =
+proc decode*(_: typedesc[HopMessage], buf: sink seq[byte]): Opt[HopMessage] =
   var msg: HopMessage
-  let pb = initProtoBuffer(buf)
+  let pb = initProtoBuffer(move(buf))
 
   var msgTypeOrd: uint32
   ?pb.getRequiredField(1, msgTypeOrd).toOpt()
@@ -305,10 +305,10 @@ proc encode*(msg: StopMessage): ProtoBuffer =
   pb.finish()
   pb
 
-proc decode*(_: typedesc[StopMessage], buf: seq[byte]): Opt[StopMessage] =
+proc decode*(_: typedesc[StopMessage], buf: sink seq[byte]): Opt[StopMessage] =
   var msg: StopMessage
 
-  let pb = initProtoBuffer(buf)
+  let pb = initProtoBuffer(move(buf))
 
   var msgTypeOrd: uint32
   ?pb.getRequiredField(1, msgTypeOrd).toOpt()

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -100,7 +100,7 @@ proc encodeMsg(
 
   result.finish()
 
-proc decodeMsg*(buf: seq[byte]): Opt[IdentifyInfo] =
+proc decodeMsg*(buf: sink seq[byte]): Opt[IdentifyInfo] =
   var
     iinfo: IdentifyInfo
     pubkey: PublicKey
@@ -109,7 +109,7 @@ proc decodeMsg*(buf: seq[byte]): Opt[IdentifyInfo] =
     agentVersion: string
     signedPeerRecord: SignedPeerRecord
 
-  var pb = initProtoBuffer(buf)
+  var pb = initProtoBuffer(move(buf))
   if ?pb.getField(1, pubkey).toOpt():
     iinfo.pubkey = Opt.some(pubkey)
     if ?pb.getField(8, signedPeerRecord).toOpt() and
@@ -173,7 +173,7 @@ proc identify*(
     trace "identify: Empty message received!", stream
     raise newException(IdentityInvalidMsgError, "Empty message received!")
 
-  var info = decodeMsg(message).valueOr:
+  var info = decodeMsg(move(message)).valueOr:
     raise newException(IdentityInvalidMsgError, "Incorrect message received!")
   debug "identify: info received", stream, info
   let
@@ -210,7 +210,7 @@ proc init*(p: IdentifyPush) =
     try:
       var message = await stream.readLp(maxMsgSize)
 
-      var identInfo = decodeMsg(message).valueOr:
+      var identInfo = decodeMsg(move(message)).valueOr:
         raise newException(IdentityInvalidMsgError, "Incorrect message received!")
       debug "identify push: info received", stream, identInfo
 

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -87,7 +87,7 @@ proc new*(
     defer:
       await stream.close()
     while not stream.atEof:
-      let buf =
+      var buf =
         try:
           await stream.readLp(MaxMsgSize)
         except LPStreamEOFError:
@@ -95,12 +95,13 @@ proc new*(
         except LPStreamError as exc:
           debug "Read error when handling kademlia RPC", stream = stream, err = exc.msg
           return
-      let msg = Message.decode(buf).valueOr:
+      let bufLen = buf.len
+      let msg = Message.decode(move(buf)).valueOr:
         debug "Failed to decode message", err = error
         return
 
       kad_messages_received.inc(labelValues = [$msg.msgType])
-      kad_message_bytes_received.inc(buf.len.int64, labelValues = [$msg.msgType])
+      kad_message_bytes_received.inc(bufLen.int64, labelValues = [$msg.msgType])
 
       case msg.msgType
       of MessageType.findNode:

--- a/libp2p/protocols/kademlia/protobuf.nim
+++ b/libp2p/protocols/kademlia/protobuf.nim
@@ -313,8 +313,8 @@ proc decode*(T: type Message, pb: ProtoBuffer): ProtoResult[T] =
 
   return ok(m)
 
-proc decode*(T: type Message, buf: seq[byte]): ProtoResult[T] =
-  var pb = initProtoBuffer(buf)
+proc decode*(T: type Message, buf: sink seq[byte]): ProtoResult[T] =
+  var pb = initProtoBuffer(move(buf))
   return Message.decode(pb)
 
 proc toBytes*(ticket: Ticket): seq[byte] {.raises: [], gcsafe.} =

--- a/libp2p/routing_record.nim
+++ b/libp2p/routing_record.nim
@@ -21,9 +21,9 @@ type
     addresses*: seq[AddressInfo]
 
 proc decode*(
-    T: typedesc[AddressInfo], buffer: seq[byte]
+    T: typedesc[AddressInfo], buffer: sink seq[byte]
 ): Result[AddressInfo, ProtoError] =
-  let pb = initProtoBuffer(buffer)
+  let pb = initProtoBuffer(move(buffer))
   var addInfo = AddressInfo()
 
   ?pb.getRequiredField(1, addInfo.address)
@@ -31,9 +31,9 @@ proc decode*(
   ok(addInfo)
 
 proc decode*(
-    T: typedesc[PeerRecord], buffer: seq[byte]
+    T: typedesc[PeerRecord], buffer: sink seq[byte]
 ): Result[PeerRecord, ProtoError] =
-  let pb = initProtoBuffer(buffer)
+  let pb = initProtoBuffer(move(buffer))
   var record = PeerRecord()
 
   ?pb.getRequiredField(1, record.peerId)
@@ -41,8 +41,8 @@ proc decode*(
 
   var addressInfos: seq[seq[byte]]
   if ?pb.getRepeatedField(3, addressInfos):
-    for addressBuf in addressInfos:
-      let addressInfo = AddressInfo.decode(addressBuf).valueOr:
+    for addressBuf in addressInfos.mitems:
+      let addressInfo = AddressInfo.decode(move(addressBuf)).valueOr:
         continue
 
       record.addresses &= addressInfo

--- a/libp2p/signed_envelope.nim
+++ b/libp2p/signed_envelope.nim
@@ -41,9 +41,9 @@ proc getSignatureBuffer(e: Envelope): seq[byte] =
   buffer.buffer
 
 proc decode*(
-    T: typedesc[Envelope], buf: seq[byte], domain: string
+    T: typedesc[Envelope], buf: sink seq[byte], domain: string
 ): Result[Envelope, EnvelopeError] =
-  let pb = initProtoBuffer(buf)
+  let pb = initProtoBuffer(move(buf))
   var envelope = Envelope()
 
   envelope.domain = domain
@@ -102,7 +102,7 @@ proc getField*(
   if not (res):
     ok(false)
   else:
-    value = Envelope.decode(buffer, domain).valueOr:
+    value = Envelope.decode(move(buffer), domain).valueOr:
       return err(ProtoError.IncorrectBlob)
     ok(true)
 
@@ -137,10 +137,10 @@ proc getField*[T](
     ok(true)
 
 proc decode*[T](
-    _: typedesc[SignedPayload[T]], buffer: seq[byte]
+    _: typedesc[SignedPayload[T]], buffer: sink seq[byte]
 ): Result[SignedPayload[T], EnvelopeError] =
   let
-    envelope = ?Envelope.decode(buffer, T.payloadDomain)
+    envelope = ?Envelope.decode(move(buffer), T.payloadDomain)
     data = ?T.decode(envelope.payload).mapErr(x => EnvelopeInvalidProtobuf)
     signedPayload = SignedPayload[T](envelope: envelope, data: data)
 


### PR DESCRIPTION
## Summary

This PR updates protobuf-backed decode paths to accept owned byte buffers with `sink seq[byte]` and pass them into `initProtoBuffer` with `move`.

It applies this ownership pattern across routing records, extended peer records, signed envelopes, and protocol message decoding for Autonat, DCUtR, Relay, Identify, and Kademlia. The intent is to avoid unnecessary `seq[byte]` copies when decoding buffers that are already owned by the caller.

## Affected Areas

- [x] Peer Management / Discovery
  Routing record and extended peer record decode paths now move nested address/service buffers into their decoders.
- [x] Protocol Logic
  Autonat, DCUtR, Relay, Identify, Kademlia, and signed envelope decode paths now consume owned protobuf buffers.
- [x] Other
  Protobuf buffer ownership plumbing only; no wire-format changes.

## Impact on Library Users

Decode APIs that take byte buffers now use `sink seq[byte]`, allowing callers to pass temporaries or explicitly move owned buffers without keeping an extra copy.

## Risk Assessment

Behavior should remain unchanged because the parsing logic and encoded formats are not modified. The main review focus is ownership after `move`, especially at call sites that still need metadata such as buffer length after decoding.
