### PR TITLE
chore: remove remaining result keyword usage

### DIFF
--- a/cbind/alloc.nim
+++ b/cbind/alloc.nim
@@ -50,19 +50,21 @@ proc alloc*(str: string): cstring =
 proc allocCStringArrayFromSeq*(addrs: seq[string]): ptr cstring =
   if addrs.len == 0:
     return nil
-  result = cast[ptr cstring](allocShared(sizeof(cstring) * addrs.len))
-  let arr = cast[ptr UncheckedArray[cstring]](result)
+  let ret = cast[ptr cstring](allocShared(sizeof(cstring) * addrs.len))
+  let arr = cast[ptr UncheckedArray[cstring]](ret)
   for i, addrStr in addrs:
     arr[i] = addrStr.alloc()
+  ret
 
 proc allocCStringArrayFromCArray*(src: ptr cstring, len: csize_t): ptr cstring =
   if src.isNil() or len == 0:
     return nil
-  result = cast[ptr cstring](allocShared(sizeof(cstring) * int(len)))
+  let ret = cast[ptr cstring](allocShared(sizeof(cstring) * int(len)))
   let srcArr = cast[ptr UncheckedArray[cstring]](src)
-  let dstArr = cast[ptr UncheckedArray[cstring]](result)
+  let dstArr = cast[ptr UncheckedArray[cstring]](ret)
   for i in 0 ..< int(len):
     dstArr[i] = srcArr[i].alloc()
+  ret
 
 proc allocSharedSeq*[T](s: seq[T]): SharedSeq[T] =
   let data = allocShared(sizeof(T) * s.len)

--- a/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_kademlia_requests.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_kademlia_requests.nim
@@ -49,9 +49,9 @@ proc allocServiceInfoArrayFromSeq(
 ): ptr Libp2pServiceInfo {.inline.} =
   if services.len == 0:
     return nil
-  result =
+  let ret =
     cast[ptr Libp2pServiceInfo](allocShared(sizeof(Libp2pServiceInfo) * services.len))
-  let servicesArr = cast[ptr UncheckedArray[Libp2pServiceInfo]](result)
+  let servicesArr = cast[ptr UncheckedArray[Libp2pServiceInfo]](ret)
   for i, svc in services:
     servicesArr[i].id = svc.id.alloc()
     servicesArr[i].dataLen = svc.data.len.csize_t
@@ -60,6 +60,7 @@ proc allocServiceInfoArrayFromSeq(
     else:
       servicesArr[i].data = cast[ptr byte](allocShared(svc.data.len))
       copyMem(servicesArr[i].data, addr svc.data[0], svc.data.len)
+  ret
 
 proc createShared*(
     T: type KademliaRequest,

--- a/examples/helloworld.nim
+++ b/examples/helloworld.nim
@@ -29,21 +29,19 @@ proc new(T: typedesc[TestProto]): T =
 # Helper to create a switch/node
 ##
 proc createSwitch(ma: MultiAddress, rng: Rng): Switch =
-  var switch = SwitchBuilder
+  SwitchBuilder
     .new()
     .withRng(rng)
-    # Give the application RNG
+  # Give the application RNG
     .withAddress(ma)
-    # Our local address(es)
+  # Our local address(es)
     .withTcpTransport()
-    # Use TCP as transport
+  # Use TCP as transport
     .withMplex()
-    # Use Mplex as muxer
+  # Use Mplex as muxer
     .withNoise()
-    # Use Noise as secure manager
+  # Use Noise as secure manager
     .build()
-
-  result = switch
 
 ##
 # The actual application

--- a/examples/hexdump.nim
+++ b/examples/hexdump.nim
@@ -28,14 +28,14 @@ proc dumpHex*(pbytes: pointer, nbytes: int, items = 1, ascii = true): string =
   ## ``items``  - number of bytes in group (supported ``items`` count is
   ##  1, 2, 4, 8)
   ## ``ascii``  - if ``true`` show ASCII representation of memory dump.
-  result = ""
+  var res = ""
   let hexSize = items * 2
   var i = 0
   var slider = pbytes
   var asciiText = ""
   while i < nbytes:
     if i %% 16 == 0:
-      result = result & toHex(cast[BiggestInt](slider), sizeof(BiggestInt) * 2) & ":  "
+      res &= toHex(cast[BiggestInt](slider), sizeof(BiggestInt) * 2) & ":  "
     var k = 0
     while k < items:
       var ch = cast[ptr char](cast[uint](slider) + k.uint)[]
@@ -46,28 +46,28 @@ proc dumpHex*(pbytes: pointer, nbytes: int, items = 1, ascii = true): string =
       inc(k)
     case items
     of 1:
-      result = result & toHex(cast[BiggestInt](cast[ptr uint8](slider)[]), hexSize)
+      res &= toHex(cast[BiggestInt](cast[ptr uint8](slider)[]), hexSize)
     of 2:
-      result = result & toHex(cast[BiggestInt](cast[ptr uint16](slider)[]), hexSize)
+      res &= toHex(cast[BiggestInt](cast[ptr uint16](slider)[]), hexSize)
     of 4:
-      result = result & toHex(cast[BiggestInt](cast[ptr uint32](slider)[]), hexSize)
+      res &= toHex(cast[BiggestInt](cast[ptr uint32](slider)[]), hexSize)
     of 8:
-      result = result & toHex(cast[BiggestInt](cast[ptr uint64](slider)[]), hexSize)
+      res &= toHex(cast[BiggestInt](cast[ptr uint64](slider)[]), hexSize)
     else:
       raise newException(ValueError, "Wrong items size!")
-    result = result & " "
+    res &= " "
     slider = cast[pointer](cast[uint](slider) + items.uint)
     i = i + items
     if i %% 16 == 0:
-      result = result & " " & asciiText
+      res &= " " & asciiText
       asciiText.setLen(0)
-      result = result & "\n"
+      res &= "\n"
 
   if i %% 16 != 0:
     var spacesCount = ((16 - (i %% 16)) div items) * (hexSize + 1) + 1
-    result = result & repeat(' ', spacesCount)
-    result = result & asciiText
-  result = result & "\n"
+    res &= repeat(' ', spacesCount)
+    res &= asciiText
+  res & "\n"
 
 proc dumpHex*[T](v: openArray[T], items: int = 0, ascii = true): string =
   ## Return hexadecimal memory dump representation of openArray[T] ``v``.
@@ -87,4 +87,4 @@ proc dumpHex*[T](v: openArray[T], items: int = 0, ascii = true): string =
       i = 1
   else:
     i = items
-  result = dumpHex(unsafeAddr v[0], sizeof(T) * len(v), i, ascii)
+  dumpHex(unsafeAddr v[0], sizeof(T) * len(v), i, ascii)

--- a/examples/tutorial_3_protobuf.nim
+++ b/examples/tutorial_3_protobuf.nim
@@ -44,10 +44,11 @@ type
 {.push raises: [].}
 
 proc encode(m: Metric): ProtoBuffer =
-  result = initProtoBuffer()
-  result.write(1, m.name)
-  result.write(2, m.value)
-  result.finish()
+  var pb = initProtoBuffer()
+  pb.write(1, m.name)
+  pb.write(2, m.value)
+  pb.finish()
+  pb
 
 proc decode(_: type Metric, buf: seq[byte]): Result[Metric, ProtoError] =
   var res: Metric
@@ -63,10 +64,11 @@ proc decode(_: type Metric, buf: seq[byte]): Result[Metric, ProtoError] =
   ok(res)
 
 proc encode(m: MetricList): ProtoBuffer =
-  result = initProtoBuffer()
+  var pb = initProtoBuffer()
   for metric in m.metrics:
-    result.write(1, metric.encode())
-  result.finish()
+    pb.write(1, metric.encode())
+  pb.finish()
+  pb
 
 proc decode(_: type MetricList, buf: seq[byte]): Result[MetricList, ProtoError] =
   var
@@ -146,11 +148,12 @@ proc main() {.async.} =
   let rng = newRng()
   proc randomMetricGenerator(): Future[MetricList] {.async: (raises: [CancelledError]).} =
     let metricCount = rng.generate(uint32) mod 16
+    var metricList: MetricList
     for i in 0 ..< metricCount + 1:
-      result.metrics.add(
+      metricList.metrics.add(
         Metric(name: "metric_" & $i, value: float(rng.generate(uint16)) / 1000.0)
       )
-    return result
+    metricList
 
   let
     metricProto1 = MetricProto.new(randomMetricGenerator)

--- a/examples/tutorial_4_gossipsub.nim
+++ b/examples/tutorial_4_gossipsub.nim
@@ -33,10 +33,11 @@ type
 {.push raises: [].}
 
 proc encode(m: Metric): ProtoBuffer =
-  result = initProtoBuffer()
-  result.write(1, m.name)
-  result.write(2, m.value)
-  result.finish()
+  var pb = initProtoBuffer()
+  pb.write(1, m.name)
+  pb.write(2, m.value)
+  pb.finish()
+  pb
 
 proc decode(_: type Metric, buf: seq[byte]): Result[Metric, ProtoError] =
   var res: Metric
@@ -46,11 +47,12 @@ proc decode(_: type Metric, buf: seq[byte]): Result[Metric, ProtoError] =
   ok(res)
 
 proc encode(m: MetricList): ProtoBuffer =
-  result = initProtoBuffer()
+  var pb = initProtoBuffer()
   for metric in m.metrics:
-    result.write(1, metric.encode())
-  result.write(2, m.hostname)
-  result.finish()
+    pb.write(1, metric.encode())
+  pb.write(2, m.hostname)
+  pb.finish()
+  pb
 
 proc decode(_: type MetricList, buf: seq[byte]): Result[MetricList, ProtoError] =
   var

--- a/performance/scripts/process_latency_stats.nim
+++ b/performance/scripts/process_latency_stats.nim
@@ -112,7 +112,7 @@ proc getMarkdownReport*(
   return markdown
 
 proc getCsvFilename*(outputDir: string, prNumber: string): string =
-  result = fmt"{outputDir}/pr{prNumber}_latency.csv"
+  fmt"{outputDir}/pr{prNumber}_latency.csv"
 
 proc getCsvReport*(
     results: Table[string, Stats], validNodes: Table[string, int]
@@ -127,7 +127,7 @@ proc getCsvReport*(
     let stats = results[scenarioName]
     let nodes = validNodes[scenarioName]
     output.add fmt"{stats.scenarioName},{nodes},{stats.totalSent},{stats.totalReceived},{stats.latency.minLatencyMs:.3f},{stats.latency.maxLatencyMs:.3f},{stats.latency.avgLatencyMs:.3f}"
-  result = output.join("\n")
+  output.join("\n")
 
 proc main() =
   let env = getGitHubEnv()

--- a/tests/libp2p/crypto/test_crypto.nim
+++ b/tests/libp2p/crypto/test_crypto.nim
@@ -315,9 +315,10 @@ const
   ]
 
 proc cmp(a, b: openArray[byte]): bool =
-  result = (@a == @b)
+  @a == @b
 
 proc testStretcher(s, e: int, cs: string, ds: string): bool =
+  var allMatch = false
   for i in s ..< e:
     var sharedsecret = fromHex(stripSpaces(Secrets[i]))
     var secret = stretchKeys(cs, ds, sharedsecret)
@@ -339,10 +340,11 @@ proc testStretcher(s, e: int, cs: string, ds: string): bool =
     var rA = cmp(secret.macOpenArray(1), mkey2) == true
     var rB = secret.mac(0) == mkey1
     var rC = secret.mac(1) == mkey2
-    result =
+    allMatch =
       r1 and r2 and r3 and r4 and r5 and r6 and r7 and r8 and r9 and rA and rB and rC
-    if not result:
+    if not allMatch:
       break
+  allMatch
 
 suite "Key interface test suite":
   test "Go test vectors":

--- a/tests/libp2p/protocols/test_autonat.nim
+++ b/tests/libp2p/protocols/test_autonat.nim
@@ -48,8 +48,9 @@ proc makeAutonatServicePrivate(): Switch =
     finally:
       await stream.close()
   autonatProtocol.codec = AutonatCodec
-  result = makeSwitch()
-  result.mount(autonatProtocol)
+  let switch = makeSwitch()
+  switch.mount(autonatProtocol)
+  switch
 
 suite "Autonat":
   teardown:

--- a/tests/libp2p/pubsub/component/test_floodsub.nim
+++ b/tests/libp2p/pubsub/component/test_floodsub.nim
@@ -77,7 +77,7 @@ suite "FloodSub Component":
     ): Future[ValidationResult] {.async.} =
       check topic == topic
       validatorFut.complete(true)
-      result = ValidationResult.Accept
+      ValidationResult.Accept
 
     nodes[1].addValidator(topic, validator)
 
@@ -101,7 +101,7 @@ suite "FloodSub Component":
         topic: string, message: Message
     ): Future[ValidationResult] {.async.} =
       validatorFut.complete(true)
-      result = ValidationResult.Reject
+      ValidationResult.Reject
 
     nodes[1].addValidator(topic, validator)
 
@@ -129,10 +129,7 @@ suite "FloodSub Component":
     proc validator(
         topic: string, message: Message
     ): Future[ValidationResult] {.async.} =
-      if topic == topicFoo:
-        result = ValidationResult.Accept
-      else:
-        result = ValidationResult.Reject
+      if topic == topicFoo: ValidationResult.Accept else: ValidationResult.Reject
 
     nodes[1].addValidator(topicFoo, topicBar, validator)
 

--- a/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
@@ -214,7 +214,7 @@ suite "GossipSub Component - Message Handling":
     ): Future[ValidationResult] {.async.} =
       check validatorTopic == topic
       validatorFut.complete(true)
-      result = ValidationResult.Accept
+      ValidationResult.Accept
 
     nodes[1].addValidator(topic, validator)
     tryPublish await nodes[0].publish(topic, "Hello!".toBytes()), 1
@@ -241,8 +241,8 @@ suite "GossipSub Component - Message Handling":
     proc validator(
         topic: string, message: Message
     ): Future[ValidationResult] {.async.} =
-      result = ValidationResult.Reject
       validatorFut.complete(true)
+      ValidationResult.Reject
 
     nodes[1].addValidator(topic, validator)
     tryPublish await nodes[0].publish(topic, "Hello!".toBytes()), 1
@@ -269,8 +269,8 @@ suite "GossipSub Component - Message Handling":
     proc validator(
         topic: string, message: Message
     ): Future[ValidationResult] {.async.} =
-      result = ValidationResult.Ignore
       validatorFut.complete(true)
+      ValidationResult.Ignore
 
     nodes[1].addValidator(topic, validator)
     tryPublish await nodes[0].publish(topic, "Hello!".toBytes()), 1
@@ -299,13 +299,12 @@ suite "GossipSub Component - Message Handling":
     proc validator(
         topic: string, message: Message
     ): Future[ValidationResult] {.async.} =
-      result =
-        if topic == topicFoo:
-          passed.complete(true)
-          ValidationResult.Accept
-        else:
-          failed.complete(true)
-          ValidationResult.Reject
+      if topic == topicFoo:
+        passed.complete(true)
+        ValidationResult.Accept
+      else:
+        failed.complete(true)
+        ValidationResult.Reject
 
     nodes[1].addValidator(topicFoo, topicBar, validator)
     tryPublish await nodes[0].publish(topicFoo, "Hello!".toBytes()), 1
@@ -355,8 +354,7 @@ suite "GossipSub Component - Message Handling":
     proc validator(
         topic: string, message: Message
     ): Future[ValidationResult] {.async.} =
-      result =
-        if topic == topicFoo: ValidationResult.Accept else: ValidationResult.Reject
+      if topic == topicFoo: ValidationResult.Accept else: ValidationResult.Reject
 
     nodes[1].addValidator(topicFoo, topicBar, validator)
 
@@ -445,10 +443,10 @@ suite "GossipSub Component - Message Handling":
           except KeyError:
             false
         )
-        result = ValidationResult.Accept
-        bFinished.done()
       except CancelledError:
         raiseAssert "err on slowValidator"
+      bFinished.done()
+      ValidationResult.Accept
 
     nodes[1].addValidator(topic, slowValidator)
 

--- a/tests/libp2p/pubsub/test_gossipsub_params.nim
+++ b/tests/libp2p/pubsub/test_gossipsub_params.nim
@@ -11,7 +11,7 @@ import ../../tools/unittest
 
 suite "GossipSubParams validation":
   proc newDefaultValidParams(): GossipSubParams =
-    result = GossipSubParams.init()
+    GossipSubParams.init()
 
   test "default parameters are valid":
     var params = newDefaultValidParams()
@@ -359,7 +359,7 @@ suite "GossipSubParams validation":
 
 suite "TopicParams validation":
   proc newDefaultValidTopicParams(): TopicParams =
-    result = TopicParams.init()
+    TopicParams.init()
 
   test "default topic parameters are valid":
     var params = newDefaultValidTopicParams()

--- a/tests/libp2p/pubsub/utils.nim
+++ b/tests/libp2p/pubsub/utils.nim
@@ -225,6 +225,7 @@ proc generateNodes*(
       Opt.none(PreambleExtensionConfig),
     transport: TransportType = TransportType.QUIC,
 ): seq[PubSub] =
+  var pubsubs: seq[PubSub]
   for i in 0 ..< num:
     let switch = makeStandardSwitchBuilder(transport = transport)
       .withSignedPeerRecord(sendSignedPeerRecord)
@@ -283,13 +284,14 @@ proc generateNodes*(
         ).PubSub
 
     switch.mount(pubsub)
-    result.add(pubsub)
+    pubsubs.add(pubsub)
+  pubsubs
 
 proc toFloodSub*(nodes: seq[PubSub]): seq[FloodSub] =
-  return nodes.mapIt(FloodSub(it))
+  nodes.mapIt(FloodSub(it))
 
 proc toGossipSub*(nodes: seq[PubSub]): seq[GossipSub] =
-  return nodes.mapIt(GossipSub(it))
+  nodes.mapIt(GossipSub(it))
 
 proc setDefaultTopicParams*(nodes: seq[GossipSub], topic: string): void =
   for node in nodes:

--- a/tests/libp2p/services/test_autorelay.nim
+++ b/tests/libp2p/services/test_autorelay.nim
@@ -16,7 +16,7 @@ import
 import ../../tools/[unittest, crypto]
 
 proc createSwitch(r: Relay, autorelay: Service = nil): Switch =
-  var switch = SwitchBuilder
+  let switch = SwitchBuilder
     .new()
     .withRng(rng())
     .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
@@ -28,12 +28,12 @@ proc createSwitch(r: Relay, autorelay: Service = nil): Switch =
 
   switch.add(autorelay)
 
-  return switch
+  switch
 
 proc buildRelayMA(switchRelay: Switch, switchClient: Switch): seq[MultiAddress] =
-  result = newSeq[MultiAddress]()
+  var addrs: seq[MultiAddress]
   for i in 0 ..< switchRelay.peerInfo.addrs.len():
-    result.add(
+    addrs.add(
       MultiAddress
         .init(
           $switchRelay.peerInfo.addrs[i] & "/p2p/" & $switchRelay.peerInfo.peerId &
@@ -41,6 +41,7 @@ proc buildRelayMA(switchRelay: Switch, switchClient: Switch): seq[MultiAddress] 
         )
         .get()
     )
+  addrs
 
 suite "Autorelay":
   asyncTeardown:

--- a/tests/libp2p/test_multistream.nim
+++ b/tests/libp2p/test_multistream.nim
@@ -67,8 +67,7 @@ method close(s: TestSelectStream) {.async: (raises: [], raw: true).} =
   newFutureCompleted[void]()
 
 proc newTestSelectStream(): TestSelectStream =
-  new result
-  result.step = 1
+  TestSelectStream(step: 1)
 
 ## Mock stream for handles `ls` test
 type
@@ -125,9 +124,7 @@ method close(s: TestLsStream): Future[void] {.async: (raises: [], raw: true).} =
   newFutureCompleted[void]()
 
 proc newTestLsStream(ls: LsHandler): TestLsStream {.gcsafe.} =
-  new result
-  result.ls = ls
-  result.step = 1
+  TestLsStream(ls: ls, step: 1)
 
 ## Mock stream for handles `na` test
 type
@@ -184,9 +181,7 @@ method close(s: TestNaStream): Future[void] {.async: (raises: [], raw: true).} =
   newFutureCompleted[void]()
 
 proc newTestNaStream(na: NaHandler): TestNaStream =
-  new result
-  result.na = na
-  result.step = 1
+  TestNaStream(na: na, step: 1)
 
 proc noReachHandler(
     stream: Stream, proto: string

--- a/tests/libp2p/test_utility.nim
+++ b/tests/libp2p/test_utility.nim
@@ -14,8 +14,7 @@ suite "Utility":
 
   test "unsuccessful safeConvert from int16 to int8":
     check not (compiles do:
-      result:
-        int8 = safeConvert[int8](32767'i16))
+      let converted: int8 = safeConvert[int8](32767'i16))
 
   test "successful safeConvert from uint8 to uint16":
     let res: uint16 = safeConvert[uint16](255'u8)
@@ -23,13 +22,11 @@ suite "Utility":
 
   test "unsuccessful safeConvert from uint16 to uint8":
     check not (compiles do:
-      result:
-        uint8 = safeConvert[uint8](256'u16))
+      let converted: uint8 = safeConvert[uint8](256'u16))
 
   test "unsuccessful safeConvert from int to char":
     check not (compiles do:
-      result:
-        char = safeConvert[char](128))
+      let converted: char = safeConvert[char](128))
 
   test "successful safeConvert from bool to int":
     let res: int = safeConvert[int](true)
@@ -37,8 +34,7 @@ suite "Utility":
 
   test "unsuccessful safeConvert from int to bool":
     check not (compiles do:
-      result:
-        bool = safeConvert[bool](2))
+      let converted: bool = safeConvert[bool](2))
 
   test "successful safeConvert from enum to int":
     type Color = enum
@@ -56,8 +52,7 @@ suite "Utility":
       blue
 
     check not (compiles do:
-      result:
-        Color = safeConvert[Color](3))
+      let converted: Color = safeConvert[Color](3))
 
   test "successful safeConvert from range to int":
     let res: int = safeConvert[int, range[1 .. 10]](5)
@@ -65,18 +60,15 @@ suite "Utility":
 
   test "unsuccessful safeConvert from int to range":
     check not (compiles do:
-      result:
-        range[1 .. 10] = safeConvert[range[1 .. 10], int](11))
+      let converted: range[1 .. 10] = safeConvert[range[1 .. 10], int](11))
 
   test "unsuccessful safeConvert from int to uint":
     check not (compiles do:
-      result:
-        uint = safeConvert[uint](11))
+      let converted: uint = safeConvert[uint](11))
 
   test "unsuccessful safeConvert from uint to int":
     check not (compiles do:
-      result:
-        uint = safeConvert[int](11.uint))
+      let converted: uint = safeConvert[int](11.uint))
 
   asyncTest "collectCompleted collects all futures that have finished":
     proc futFinishes(): Future[int] {.async: (raises: [CancelledError]).} =

--- a/tests/libp2p/test_varint.nim
+++ b/tests/libp2p/test_varint.nim
@@ -129,29 +129,31 @@ const LPedgeExpects = [
 ]
 
 proc hexChar*(c: byte, lowercase: bool = false): string =
-  var alpha: int
-  if lowercase:
-    alpha = ord('a')
-  else:
-    alpha = ord('A')
-  result = newString(2)
+  let alpha =
+    if lowercase:
+      ord('a')
+    else:
+      ord('A')
+  var hex = newString(2)
   let t1 = ord(c) shr 4
   let t0 = ord(c) and 0x0F
   case t1
   of 0 .. 9:
-    result[0] = chr(t1 + ord('0'))
+    hex[0] = chr(t1 + ord('0'))
   else:
-    result[0] = chr(t1 - 10 + alpha)
+    hex[0] = chr(t1 - 10 + alpha)
   case t0
   of 0 .. 9:
-    result[1] = chr(t0 + ord('0'))
+    hex[1] = chr(t0 + ord('0'))
   else:
-    result[1] = chr(t0 - 10 + alpha)
+    hex[1] = chr(t0 - 10 + alpha)
+  hex
 
 proc toHex*(a: openArray[byte], lowercase: bool = false): string =
-  result = ""
+  var hex = ""
   for i in a:
-    result = result & hexChar(i, lowercase)
+    hex &= hexChar(i, lowercase)
+  hex
 
 suite "Variable integer test suite":
   test "vsizeof() edge cases test":

--- a/tests/tools/unittest.nim
+++ b/tests/tools/unittest.nim
@@ -90,7 +90,7 @@ macro checkUntilTimeoutCustom*(
   # Build the combined expression
   let combinedBoolExpr = buildAndExpr(code)
 
-  result = quote:
+  quote:
     proc checkExpiringInternal(): Future[void] {.gensym, async.} =
       let start = Moment.now()
       while true:
@@ -130,7 +130,7 @@ macro checkUntilTimeout*(code: untyped): untyped =
   ##       a == 2
   ##       b == 1
   ##   ```
-  result = quote:
+  quote:
     checkUntilTimeoutCustom(timeoutDefault, sleepIntervalDefault, `code`)
 
 template finalCheckTrackers*(): untyped =


### PR DESCRIPTION
## Summary

This PR removes remaining uses of Nim's implicit `result` variable outside the `libp2p/` implementation tree.

The affected code now uses expression-based final values or explicit local accumulator variables. Early `return` branches remain where the code exits immediately, such as empty-input or nil cases.

## Affected Areas

- [x] Build / Tooling: performance report helper return values
- [x] Other: examples, cbind allocation helpers, test utilities, and pubsub/autonat/autorelay/crypto tests

## Impact on Library Users

No API or behavior change is intended. This is a style-only cleanup to make return values explicit without relying on Nim's implicit `result` variable.

## Risk Assessment

Low. The changes are local return-style refactors; the main review focus should be that async validators, helper constructors, and test compile checks still return the same values.
