### PR TITLE
fix(autotls): avoid `dns-persist-01` challenge and raise api errors

### DIFF
--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -188,23 +188,20 @@ when defined(libp2p_autotls_support):
       raise newException(ACMEError, msg & ": Unexpected error", exc)
 
   proc checkAPIError(resp: HTTPResponse) {.raises: [ACMEError].} =
-    const typeErrorPrefix = "urn:ietf:params:acme:error"
-
     let `type` =
       try:
         resp.body["type"].getStr()
       except KeyError:
         return
 
-    if `type`.startsWith(typeErrorPrefix):
-      let errorType = `type`[(typeErrorPrefix.len + 1) .. ^1]
+    if `type`.contains("acme:error"):
       let detail =
         try:
           resp.body["detail"].getStr()
         except KeyError:
           ""
       raise newException(
-        ACMEError, "API request failed. type: " & errorType & " detail: " & detail
+        ACMEError, "API request failed. type: " & `type` & " detail: " & detail
       )
 
   method post*(
@@ -385,7 +382,6 @@ when defined(libp2p_autotls_support):
             challenge = $challenge, msg = getCurrentExceptionMsg()
 
       if challenges.len == 0:
-        debug "requestAuthorizations response", response = $acmeResponse.body
         raise newException(ACMEError, "No challenges received")
 
       ACMEAuthorizationsResponse(challenges: challenges)

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -378,8 +378,7 @@ when defined(libp2p_autotls_support):
         try:
           challenges.add(challenge.to(ACMEChallenge))
         except ValueError, JsonKindError:
-          debug "Could not parse challenge",
-            msg = getCurrentExceptionMsg()
+          debug "Could not parse challenge", msg = getCurrentExceptionMsg()
 
       if challenges.len == 0:
         raise newException(ACMEError, "No challenges received")

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -188,20 +188,20 @@ when defined(libp2p_autotls_support):
       raise newException(ACMEError, msg & ": Unexpected error", exc)
 
   proc checkAPIError(resp: HTTPResponse) {.raises: [ACMEError].} =
-    let `type` =
+    let respType =
       try:
         resp.body["type"].getStr()
       except KeyError:
         return
 
-    if `type`.contains("acme:error"):
+    if respType.contains("acme:error"):
       let detail =
         try:
           resp.body["detail"].getStr()
         except KeyError:
           ""
       raise newException(
-        ACMEError, "API request failed. type: " & `type` & " detail: " & detail
+        ACMEError, "API request failed. type: " & respType & " detail: " & detail
       )
 
   method post*(

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -379,7 +379,7 @@ when defined(libp2p_autotls_support):
           challenges.add(challenge.to(ACMEChallenge))
         except ValueError, JsonKindError:
           debug "Could not parse challenge",
-            challenge = $challenge, msg = getCurrentExceptionMsg()
+            msg = getCurrentExceptionMsg()
 
       if challenges.len == 0:
         raise newException(ACMEError, "No challenges received")

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -187,6 +187,26 @@ when defined(libp2p_autotls_support):
     except CatchableError as exc:
       raise newException(ACMEError, msg & ": Unexpected error", exc)
 
+  proc checkAPIError(resp: HTTPResponse) {.raises: [ACMEError].} =
+    const typeErrorPrefix = "urn:ietf:params:acme:error"
+
+    let `type` =
+      try:
+        resp.body["type"].getStr()
+      except KeyError:
+        return
+
+    if `type`.startsWith(typeErrorPrefix):
+      let errorType = `type`[typeErrorPrefix.len .. ^1]
+      let detail =
+        try:
+          resp.body["detail"].getStr()
+        except KeyError:
+          ""
+      raise newException(
+        ACMEError, "API request failed. type: " & errorType & " detail: " & detail
+      )
+
   method post*(
     self: ACMEApi, uri: Uri, payload: string
   ): Future[HTTPResponse] {.
@@ -277,7 +297,9 @@ when defined(libp2p_autotls_support):
   .} =
     let rawResponse = await HttpClientRequestRef.get(self.session, $uri).get().send()
     let body = await rawResponse.getResponseBody()
-    HTTPResponse(body: body, headers: rawResponse.headers)
+    let resp = HTTPResponse(body: body, headers: rawResponse.headers)
+    checkAPIError(resp)
+    return resp
 
   proc createSignedAcmeRequest(
       self: ACMEApi,
@@ -351,16 +373,17 @@ when defined(libp2p_autotls_support):
       doAssert authorizations.len > 0
 
       let acmeResponse = await self.get(parseUri(authorizations[0]))
-      var challenges: seq[ACMEChallenge]
 
+      var challenges: seq[ACMEChallenge]
       for challenge in acmeResponse.body.getOrDefault("challenges").getElems():
         try:
           challenges.add(challenge.to(ACMEChallenge))
         except ValueError, JsonKindError:
-          debug "Skipping challenge with unrecognized fields",
+          debug "Could not parse challenge",
             challenge = $challenge, msg = getCurrentExceptionMsg()
 
       if challenges.len == 0:
+        debug "requestAuthorizations response", response = $acmeResponse.body
         raise newException(ACMEError, "No challenges received")
 
       ACMEAuthorizationsResponse(challenges: challenges)
@@ -380,14 +403,8 @@ when defined(libp2p_autotls_support):
 
     var challenges = authResp.challenges.filterIt(it.`type` == ACMEChallengeType.DNS01)
     if challenges.len == 0:
-      # if there are no DNS01 use DNSPersist01
-      challenges =
-        authResp.challenges.filterIt(it.`type` == ACMEChallengeType.DNSPersist01)
-    if challenges.len == 0:
-      raise newException(
-        ACMEError,
-        "Could not find supported DNS challenge type (dns-01 or dns-persist-01)",
-      )
+      raise
+        newException(ACMEError, "Could not find supported DNS challenge type (dns-01)")
 
     return ACMEChallengeResponseWrapper(
       finalize: orderResp.finalize, order: orderResp.order, dns01: challenges[0]

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -197,7 +197,7 @@ when defined(libp2p_autotls_support):
         return
 
     if `type`.startsWith(typeErrorPrefix):
-      let errorType = `type`[typeErrorPrefix.len .. ^1]
+      let errorType = `type`[(typeErrorPrefix.len + 1) .. ^1]
       let detail =
         try:
           resp.body["detail"].getStr()

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -288,7 +288,9 @@ when defined(libp2p_autotls_support):
       .get()
       .send()
     let body = await rawResponse.getResponseBody()
-    HTTPResponse(body: body, headers: rawResponse.headers)
+    let resp = HTTPResponse(body: body, headers: rawResponse.headers)
+    checkAPIError(resp)
+    return resp
 
   method get*(
       self: ACMEApi, uri: Uri

--- a/tests/integration/test_autotls_integration.nim
+++ b/tests/integration/test_autotls_integration.nim
@@ -26,8 +26,7 @@ when defined(linux) and defined(amd64) and defined(libp2p_autotls_support):
       challenge.finalize.len > 0
       challenge.order.len > 0
       challenge.dns01.url.len > 0
-      challenge.dns01.`type` == ACMEChallengeType.DNS01 or
-        challenge.dns01.`type` == ACMEChallengeType.DNSPersist01
+      challenge.dns01.`type` == ACMEChallengeType.DNS01
       challenge.dns01.status == ACMEChallengeStatus.PENDING
       challenge.dns01.token.len > 0
 


### PR DESCRIPTION
in previous pr https://github.com/vacp2p/nim-libp2p/pull/2497 `dns-persist-01` challenge was used as fallback when `dns01` challenges are not found. this was not correct as  `dns-persist-01`  is experimental and it not the same as `dns01`.

in addition to that, this pr also checks for api errors before proceeding with handling responses. code was currently expecting that all http requests will succeed and always attempting to parse it to response, this could lead to unexpected outcomes like having not challenges in response because response returned error details...

this pr does not fully deal api errors, it just raises them were they have not been raised before.