### PR TITLE
chore(MultistreamSelect): handle cosmetics

### DIFF
--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -180,42 +180,44 @@ proc handle*(
     m: MultistreamSelect, stream: Stream, active: bool = false
 ) {.async: (raises: [CancelledError]).} =
   trace "Starting multistream handler", stream, handshaked = active
-  var
-    protos: seq[string]
-    matchers: seq[Matcher]
-  for h in m.handlers:
-    if h.match != nil:
-      matchers.add(h.match)
-    for proto in h.protos:
-      protos.add(proto)
-
-  try:
-    let ms = await MultistreamSelect.handle(stream, protos, matchers, active)
-    for h in m.handlers:
-      if (h.match != nil and h.match(ms)) or h.protos.contains(ms):
-        trace "found handler", stream, protocol = ms
-
-        let protocol = h.protocol
-
-        if not protocol.reserveIncoming(stream.peerId):
-          debug "Inbound stream budget exceeded, rejecting incoming stream",
-            stream, protocol = ms, peerId = stream.peerId
-          return
-
-        try:
-          await protocol.handler(stream, ms)
-        finally:
-          protocol.releaseIncoming(stream.peerId)
-        return
-    debug "no handlers", stream, ms
-  except CancelledError as exc:
-    raise exc
-  except CatchableError as exc:
-    trace "Exception in multistream", stream, description = exc.msg
-  finally:
+  defer:
+    trace "Stopped multistream handler", stream
     await stream.close()
 
-  trace "Stopped multistream handler", stream
+  let ms =
+    try:
+      var
+        protos: seq[string]
+        matchers: seq[Matcher]
+
+      for h in m.handlers:
+        if h.match != nil:
+          matchers.add(h.match)
+        for proto in h.protos:
+          protos.add(proto)
+      await MultistreamSelect.handle(stream, protos, matchers, active)
+    except LPStreamError as e:
+      trace "Exception in multistream", stream, description = e.msg
+      return
+    except MultiStreamError as e:
+      trace "Exception in multistream", stream, description = e.msg
+      return
+
+  m.lookupProtocol(ms).withValue(p):
+    trace "found handler", stream, protocol = ms
+
+    if not protocol.reserveIncoming(stream.peerId):
+      debug "Inbound stream budget exceeded, rejecting incoming stream",
+        stream, protocol = ms, peerId = stream.peerId
+      return
+
+    try:
+      let h = p.handler
+      await h(stream, ms)
+    finally:
+      p.releaseIncoming(stream.peerId)
+  else:
+    debug "no handlers", stream, ms
 
 proc addHandler*(
     m: MultistreamSelect,

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -176,6 +176,19 @@ proc lookupProtocol*(m: MultistreamSelect, proto: string): Opt[LPProtocol] =
       return Opt.some(h.protocol)
   return Opt.none(LPProtocol)
 
+func allProtosAndMatchers(m: MultistreamSelect): (seq[string], seq[Matcher]) =
+  var
+    protos: seq[string]
+    matchers: seq[Matcher]
+
+  for h in m.handlers:
+    if h.match != nil:
+      matchers.add(h.match)
+    for proto in h.protos:
+      protos.add(proto)
+
+  return (protos, matchers)
+
 proc handle*(
     m: MultistreamSelect, stream: Stream, active: bool = false
 ) {.async: (raises: [CancelledError]).} =
@@ -186,15 +199,7 @@ proc handle*(
 
   let ms =
     try:
-      var
-        protos: seq[string]
-        matchers: seq[Matcher]
-
-      for h in m.handlers:
-        if h.match != nil:
-          matchers.add(h.match)
-        for proto in h.protos:
-          protos.add(proto)
+      let (protos, matchers) = m.allProtosAndMatchers()
       await MultistreamSelect.handle(stream, protos, matchers, active)
     except LPStreamError as e:
       trace "Exception in MultistreamSelect.handle", stream, description = e.msg

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -217,7 +217,7 @@ proc handle*(
     finally:
       p.releaseIncoming(stream.peerId)
   else:
-    debug "no handlers", stream, ms
+    debug "no handlers", stream, protocol = ms
 
 proc addHandler*(
     m: MultistreamSelect,

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -182,7 +182,7 @@ proc handle*(
   trace "Starting multistream handler", stream, handshaked = active
   defer:
     trace "Stopped multistream handler", stream
-    await stream.close()
+    await noCancel stream.close()
 
   let ms =
     try:

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -197,16 +197,16 @@ proc handle*(
           protos.add(proto)
       await MultistreamSelect.handle(stream, protos, matchers, active)
     except LPStreamError as e:
-      trace "Exception in multistream", stream, description = e.msg
+      trace "Exception in MultistreamSelect.handle", stream, description = e.msg
       return
     except MultiStreamError as e:
-      trace "Exception in multistream", stream, description = e.msg
+      trace "Exception in MultistreamSelect.handle", stream, description = e.msg
       return
 
   m.lookupProtocol(ms).withValue(p):
     trace "found handler", stream, protocol = ms
 
-    if not protocol.reserveIncoming(stream.peerId):
+    if not p.reserveIncoming(stream.peerId):
       debug "Inbound stream budget exceeded, rejecting incoming stream",
         stream, protocol = ms, peerId = stream.peerId
       return

--- a/tests/libp2p/test_multistream.nim
+++ b/tests/libp2p/test_multistream.nim
@@ -213,6 +213,38 @@ suite "Multistream select":
     ms.addHandler("/test/proto/1.0.0", protocol)
     await ms.handle(stream)
 
+  asyncTest "test handle invokes only first matching handler":
+    let ms = MultistreamSelect.new()
+    let stream = newTestSelectStream()
+
+    var firstCalls = 0
+    var secondCalls = 0
+
+    var firstProtocol: LPProtocol = new LPProtocol
+    proc firstHandler(
+        stream: Stream, proto: string
+    ): Future[void] {.async: (raises: [CancelledError]).} =
+      firstCalls += 1
+      check proto == "/test/proto/1.0.0"
+      await stream.close()
+
+    var secondProtocol: LPProtocol = new LPProtocol
+    proc secondHandler(
+        stream: Stream, proto: string
+    ): Future[void] {.async: (raises: [CancelledError]).} =
+      secondCalls += 1
+      check proto == "/test/proto/1.0.0"
+      await stream.close()
+
+    firstProtocol.handler = firstHandler
+    secondProtocol.handler = secondHandler
+    ms.addHandler("/test/proto/1.0.0", firstProtocol)
+    ms.addHandler("/test/proto/1.0.0", secondProtocol)
+    await ms.handle(stream)
+
+    check firstCalls == 1
+    check secondCalls == 0
+
   asyncTest "test handle `ls`":
     let ms = MultistreamSelect.new()
 


### PR DESCRIPTION
<s>
this pr fixes issues when all matched protocol handlers are called. this is not correct as first matched protocol handler should win.

`go-libp2p` reference:
https://github.com/multiformats/go-multistream/blob/master/multistream.go#L178C1-L191C1
</s>

just cosmetics changes in the end, like reuse `lookupProtocol` and reduce `try-except` to parts that are only affected