### PR TITLE
test(service-disco): invalid ticket tInit propagates into registrar-signed response

### DIFF
--- a/tests/libp2p/service_discovery/component/test_register.nim
+++ b/tests/libp2p/service_discovery/component/test_register.nim
@@ -2,7 +2,7 @@
 # Copyright (c) Status Research & Development GmbH
 {.used.}
 
-import chronos, results
+import chronos, results, tables
 import
   ../../../../libp2p/
     [protocols/service_discovery/advertiser, protocols/service_discovery/types, switch]
@@ -179,3 +179,95 @@ suite "Service Discovery Component - Register":
     check:
       cachedAd.data.seqNo == 2
       cachedAd.data.addresses[0].address == addrB
+
+  asyncTest "REGISTER with invalid-signature ticket copies tInit into response ticket":
+    # TODO: vacp2p/nim-libp2p#2542 service-disco: invalid retry tickets are not rejected
+    #       and preserve forged tInit in registrar-signed tickets
+    #
+    # An invalid ticket's tInit is preserved in the registrar-signed response.
+    # After cache occupancy rises, the old tInit gives unearned waiting-time credit,
+    # resulting in Confirmed while an honest peer still gets Wait.
+    let conf =
+      ServiceDiscoveryConfig.new(advertCacheCap = 10, registrationWindow = 5.secs)
+    let registrarNode = setupServiceDiscoveryNode(discoConfig = conf)
+    let maliciousNode = setupServiceDiscoveryNode(discoConfig = conf)
+    let legitimateNode = setupServiceDiscoveryNode(discoConfig = conf)
+    startAndDeferStop(@[registrarNode, maliciousNode, legitimateNode])
+    await connect(registrarNode, maliciousNode)
+    await connect(registrarNode, legitimateNode)
+
+    let serviceName = "service"
+    let serviceId = serviceName.hashServiceId()
+    let registrarPeerId = registrarNode.switch.peerInfo.peerId
+
+    let maliciousAdBytes = makeAdvertisement(
+        serviceName, maliciousNode.switch.peerInfo.privateKey
+      )
+      .encode()
+      .get()
+    let legitimateAdBytes = makeAdvertisement(
+        serviceName, legitimateNode.switch.peerInfo.privateKey
+      )
+      .encode()
+      .get()
+
+    # Ticket signed by the malicious key, not the registrar key.
+    # Moment.init at Second precision because protobuf truncates to whole seconds.
+    let oldTInit = Moment.init(Moment.now().epochSeconds - 3600, Second)
+    var invalidTicket = Ticket(
+      advertisement: maliciousAdBytes,
+      tInit: oldTInit,
+      tMod: Moment.now(),
+      tWaitFor: 0.secs,
+      signature: @[],
+    )
+    check invalidTicket.sign(maliciousNode.switch.peerInfo.privateKey).isOk()
+
+    let maliciousResp1 = await maliciousNode.sendRegister(
+      registrarPeerId, serviceId, maliciousAdBytes, Opt.some(invalidTicket)
+    )
+    check:
+      maliciousResp1.isOk()
+      maliciousResp1.get().status == kad_protobuf.RegistrationStatus.Wait
+    let maliciousTicket = maliciousResp1.get().ticket.get()
+
+    # The response ticket is registrar-signed but carries the unvalidated tInit.
+    check maliciousTicket.tInit == oldTInit
+
+    # Legitimate peer sends a normal REGISTER with no ticket.
+    let legitimateResp1 =
+      await legitimateNode.sendRegister(registrarPeerId, serviceId, legitimateAdBytes)
+    check:
+      legitimateResp1.isOk()
+      legitimateResp1.get().status == kad_protobuf.RegistrationStatus.Wait
+    let legitimateTicket = legitimateResp1.get().ticket.get()
+
+    # Both get the same tWaitFor because cache state has not changed.
+    check maliciousTicket.tWaitFor == legitimateTicket.tWaitFor
+
+    # Fill the registrar cache so t_wait rises significantly.
+    let now = Moment.now()
+    for i in 0 ..< 8:
+      let fillerName = "filler-" & $i
+      let fillerSid = fillerName.hashServiceId()
+      let fillerAd = makeAdvertisement(fillerName)
+      registrarNode.registrar.cache[fillerSid] = @[fillerAd]
+      registrarNode.registrar.cacheTimestamps[fillerAd.toAdvertisementKey()] = now
+
+    await sleepAsync(maliciousTicket.tWaitFor + 500.millis)
+
+    # Malicious peer retries: totalWaitSoFar = now - oldTInit far exceeds the new t_wait.
+    let maliciousResp2 = await maliciousNode.sendRegister(
+      registrarPeerId, serviceId, maliciousAdBytes, Opt.some(maliciousTicket)
+    )
+    check:
+      maliciousResp2.isOk()
+      maliciousResp2.get().status == kad_protobuf.RegistrationStatus.Confirmed
+
+    # Legitimate peer retries: real totalWaitSoFar is only a few seconds.
+    let legitimateResp2 = await legitimateNode.sendRegister(
+      registrarPeerId, serviceId, legitimateAdBytes, Opt.some(legitimateTicket)
+    )
+    check:
+      legitimateResp2.isOk()
+      legitimateResp2.get().status == kad_protobuf.RegistrationStatus.Wait


### PR DESCRIPTION
## Summary

 Add a component test that proves `processRetryTicket` copies `tInit` from an unvalidated ticket into the registrar-signed response. A malicious peer sends a REGISTER with a ticket signed by the wrong key and a `tInit` far in the past. The registrar ignores the bad signature but preserves the old `tInit` in the fresh ticket. After the cache fills up, the malicious peer retries and gets `Confirmed` while a legitimate peer with an honest `tInit` still gets `Wait`.

 This is a test-only change that documents the behavior tracked in #2542.

  ## Affected Areas

  - [x] Tests

  ## Impact on Library Users

  None.

  ## Risk Assessment

  None.

  ## References

  - #2542