### PR TITLE
fix(peerinfo): wrap peer ID initialization errors

### DIFF
--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -150,16 +150,17 @@ proc new*(
     addressPolicy: PeerAddressPolicy = defaultAddressPolicy,
     announcedAddrs: openArray[MultiAddress] = [],
 ): PeerInfo {.raises: [LPError].} =
-  let pubkey =
-    try:
-      key.getPublicKey().tryGet()
-    except CatchableError as e:
-      raise newException(
-        PeerInfoError, "invalid private key creating PeerInfo: " & e.msg, e
-      )
+  let pubkey = key.getPublicKey().valueOr:
+    raise newException(
+      PeerInfoError, "invalid private key creating PeerInfo: " & $error
+    )
+  let peerId = PeerId.init(pubkey).valueOr:
+    raise newException(
+      PeerInfoError, "invalid public key creating PeerInfo peer id: " & $error
+    )
 
   PeerInfo(
-    peerId: PeerId.init(key).tryGet(),
+    peerId: peerId,
     publicKey: pubkey,
     privateKey: key,
     protoVersion: protoVersion,

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -151,9 +151,8 @@ proc new*(
     announcedAddrs: openArray[MultiAddress] = [],
 ): PeerInfo {.raises: [LPError].} =
   let pubkey = key.getPublicKey().valueOr:
-    raise newException(
-      PeerInfoError, "invalid private key creating PeerInfo: " & $error
-    )
+    raise
+      newException(PeerInfoError, "invalid private key creating PeerInfo: " & $error)
   let peerId = PeerId.init(pubkey).valueOr:
     raise newException(
       PeerInfoError, "invalid public key creating PeerInfo peer id: " & $error


### PR DESCRIPTION
## Summary

`PeerInfo.new` now derives the peer ID from the public key that was already validated while constructing `PeerInfo`.

This removes the remaining `tryGet` path in the constructor and makes peer ID initialization failures surface as `PeerInfoError`, consistent with public key initialization failures.

## Affected Areas

- [x] Peer Management / Discovery
  - PeerInfo construction and error reporting.

## Impact on Library Users

No API change. Invalid key/public-key data now fails through `PeerInfoError` instead of leaking a raw `ResultError` from peer ID initialization.

## Risk Assessment

Low. The successful construction path still uses the same key material; the change only tightens error handling during initialization.
