### PR TITLE
fix(multiaddress): onion size and DNS/IP consistency

### DIFF
--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -404,7 +404,7 @@ const
       mcodec: multiCodec("ip6zone"), kind: Length, size: 0, coder: TranscoderIP6Zone
     ),
     MAProtocol(
-      mcodec: multiCodec("onion"), kind: Fixed, size: 10, coder: TranscoderOnion
+      mcodec: multiCodec("onion"), kind: Fixed, size: 12, coder: TranscoderOnion
     ),
     MAProtocol(
       mcodec: multiCodec("onion3"), kind: Fixed, size: 37, coder: TranscoderOnion3
@@ -834,14 +834,18 @@ proc init*(
     res.data = initVBuffer(32 + len(value))
     res.data.writeVarint(cast[uint64](proto.mcodec))
     case proto.kind
-    of Fixed, Length, Path:
+    of Fixed:
+      if len(value) != proto.size:
+        err("multiaddress: Incorrect fixed protocol value length")
+      else:
+        res.data.writeArray(value)
+        res.data.finish()
+        ok(res)
+    of Length, Path:
       if len(value) == 0:
         err("multiaddress: Value must not be empty array")
       else:
-        if proto.kind == Fixed:
-          res.data.writeArray(value)
-        else:
-          res.data.writeSeq(value)
+        res.data.writeSeq(value)
         res.data.finish()
         ok(res)
     of Marker:
@@ -1205,6 +1209,25 @@ proc getRepeatedField*(
 
 proc areAddrsConsistent*(a, b: MultiAddress): bool =
   ## Checks if two multiaddresses have the same protocol stack.
+  let
+    ip4 = multiCodec("ip4")
+    ip6 = multiCodec("ip6")
+    dns = multiCodec("dns")
+    dns4 = multiCodec("dns4")
+    dns6 = multiCodec("dns6")
+    dnsaddr = multiCodec("dnsaddr")
+
+  template isIp(proto: MultiCodec): bool =
+    proto == ip4 or proto == ip6
+
+  template isDnsAny(proto: MultiCodec): bool =
+    proto == dns or proto == dnsaddr
+
+  template isDnsIpEquivalent(protoA, protoB: MultiCodec): bool =
+    (isDnsAny(protoA) and isIp(protoB)) or (isDnsAny(protoB) and isIp(protoA)) or
+      (protoA == dns4 and protoB == ip4) or (protoA == ip4 and protoB == dns4) or
+      (protoA == dns6 and protoB == ip6) or (protoA == ip6 and protoB == dns6)
+
   let protosA = a.protocols().get()
   let protosB = b.protocols().get()
   if protosA.len != protosB.len:
@@ -1217,16 +1240,7 @@ proc areAddrsConsistent*(a, b: MultiAddress): bool =
     if protoA != protoB:
       if idx == 0:
         # allow DNS ↔ IP at the first component
-        if protoB == multiCodec("dns") or protoB == multiCodec("dnsaddr"):
-          if not (protoA == multiCodec("ip4") or protoA == multiCodec("ip6")):
-            return false
-        elif protoB == multiCodec("dns4"):
-          if protoA != multiCodec("ip4"):
-            return false
-        elif protoB == multiCodec("dns6"):
-          if protoA != multiCodec("ip6"):
-            return false
-        else:
+        if not isDnsIpEquivalent(protoA, protoB):
           return false
       else:
         return false

--- a/tests/libp2p/multiformat/test_multiaddress.nim
+++ b/tests/libp2p/multiformat/test_multiaddress.nim
@@ -354,9 +354,27 @@ suite "MultiAddress test suite":
     var
       address_v4: array[4, byte]
       address_v6: array[16, byte]
+    let
+      onionMa = MultiAddress.init("/onion/timaq4ygg2iegci7:1234/http").get()
+      onionPart = onionMa.getPart(multiCodec("onion")).get()
+      onionArg = onionPart.protoAddress().get()
     check:
       MultiAddress.init("/ip4/0.0.0.0").get().protoAddress().get() == address_v4
       MultiAddress.init("/ip6/::0").get().protoAddress().get() == address_v6
+      $onionMa == "/onion/timaq4ygg2iegci7:1234/http"
+      onionMa.protocols().get() == @[multiCodec("onion"), multiCodec("http")]
+      len(onionMa).get() == 2
+      onionArg.len == 12
+      onionArg[10] == 0x04'u8
+      onionArg[11] == 0xD2'u8
+
+  test "MultiAddress init fixed byte length validation":
+    check:
+      MultiAddress.init(multiCodec("ip4"), @[1'u8, 2, 3]).isErr()
+      MultiAddress.init(multiCodec("ip4"), @[1'u8, 2, 3, 4, 5]).isErr()
+      MultiAddress.init(multiCodec("ip4"), @[1'u8, 2, 3, 4]).isOk()
+      MultiAddress.init(multiCodec("tcp"), @[0'u8]).isErr()
+      MultiAddress.init(multiCodec("tcp"), @[0'u8, 80]).isOk()
 
   test "MultiAddress getPart":
     let ma = MultiAddress
@@ -514,6 +532,29 @@ suite "MultiAddress test suite":
       MultiAddress.init("/ip4/127.0.0.1/tcp/4040").get(),
       MultiAddress.init("/ip4/127.0.0.1/udp/4040").get(),
     )
+
+    # DNS/IP pairs should be symmetric for the first component
+    check:
+      areAddrsConsistent(
+        MultiAddress.init("/ip4/127.0.0.1/tcp/4040").get(),
+        MultiAddress.init("/dns4/example.com/tcp/4040").get(),
+      )
+      areAddrsConsistent(
+        MultiAddress.init("/dns4/example.com/tcp/4040").get(),
+        MultiAddress.init("/ip4/127.0.0.1/tcp/4040").get(),
+      )
+      areAddrsConsistent(
+        MultiAddress.init("/dns/example.com/tcp/4040").get(),
+        MultiAddress.init("/ip6/::1/tcp/4040").get(),
+      )
+      areAddrsConsistent(
+        MultiAddress.init("/ip6/::1/tcp/4040").get(),
+        MultiAddress.init("/dnsaddr/example.com/tcp/4040").get(),
+      )
+      not areAddrsConsistent(
+        MultiAddress.init("/dns4/example.com/tcp/4040").get(),
+        MultiAddress.init("/ip6/::1/tcp/4040").get(),
+      )
 
 suite "parseIpAddress":
   test "valid IPv4 addresses parse to IPv4 family":


### PR DESCRIPTION
## Summary

Fixes three multiaddress edge cases:

- corrects `/onion` fixed binary size from 10 to 12 bytes so the embedded port is included when parsing address components
- rejects byte-based construction of fixed-size protocols when the provided value length does not match the protocol size
- makes DNS/IP first-component stack consistency symmetric for `dns`, `dnsaddr`, `dns4`, and `dns6`

## Affected Areas

- [x] Protocol Logic
- [x] Other: multiaddress parsing and validation

## Impact on Library Users

No API changes. Invalid fixed-size protocol byte values now return an error instead of constructing malformed multiaddresses. DNS/IP consistency checks now accept equivalent stacks regardless of argument order.

## Risk Assessment

Low. The changes are scoped to multiaddress validation and protocol-stack comparison, with regression coverage for onion component parsing, fixed-size construction, and DNS/IP consistency.

## References

- https://github.com/multiformats/multiaddr/blob/master/protocols.csv
