### PR TITLE
fix(SwitchBuilder): initialization of services dependent of Rng

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -89,9 +89,7 @@ type
     autonatV2ServerConfig: Opt[AutonatV2Config]
     autonatV2Config: Opt[AutonatV2ServiceConfig]
     autonatV2Client: AutonatV2Client
-    autonatV2Service: Opt[AutonatV2Service]
     holePunchingConfig: Opt[HolePunchingConfig]
-    hpService: Opt[HPService]
     natConfig: Opt[NATConfig]
     autotlsConfig: Opt[AutotlsConfig]
     circuitRelay: Opt[Relay]
@@ -117,9 +115,7 @@ proc new*(T: type[SwitchBuilder]): T =
     agentVersion: AgentVersion,
     autonatV2ServerConfig: Opt.none(AutonatV2Config),
     autonatV2Config: Opt.none(AutonatV2ServiceConfig),
-    autonatV2Service: Opt.none(AutonatV2Service),
     holePunchingConfig: Opt.none(HolePunchingConfig),
-    hpService: Opt.none(HPService),
     natConfig: Opt.none(NATConfig),
     autotlsConfig: Opt.none(AutotlsConfig),
     circuitRelay: Opt.none(Relay),
@@ -446,22 +442,6 @@ proc buildSwitch(b: SwitchBuilder): Switch {.raises: [LPError].} =
   let seckey = b.privKey.valueOr:
     PrivateKey.random(b.rng).expect("Expected default Private Key")
 
-  b.autonatV2Config.withValue(serviceConfig):
-    b.autonatV2Client = AutonatV2Client.new(b.rng)
-    b.autonatV2Service = Opt.some(
-      AutonatV2Service.new(b.rng, client = b.autonatV2Client, config = serviceConfig)
-    )
-
-  b.holePunchingConfig.withValue(config):
-    let
-      autonatService = AutonatService.new(AutonatClient(), b.rng)
-      autoRelayService = AutoRelayService.new(
-        config.maxNumRelays, RelayClient.new(), config.onReservationHandler, b.rng
-      )
-      hpService = HPService.new(autonatService, autoRelayService)
-
-    b.hpService = Opt.some(hpService)
-
   if b.secureManagers.len == 0:
     debug "no secure managers defined. Adding noise by default"
     b.secureManagers.add(SecureProtocol.Noise)
@@ -547,11 +527,20 @@ proc setupServices(b: SwitchBuilder, switch: Switch) {.raises: [LPError].} =
   if b.enableWildcardResolver:
     switch.services.add(WildcardAddressResolverService.new())
 
-  b.autonatV2Service.withValue(autonatV2Service):
-    switch.services.add(autonatV2Service)
+  b.autonatV2Config.withValue(serviceConfig):
+    b.autonatV2Client = AutonatV2Client.new(b.rng)
+    switch.services.add(
+      AutonatV2Service.new(b.rng, client = b.autonatV2Client, config = serviceConfig)
+    )
 
-  b.hpService.withValue(hpservice):
-    switch.services.add(hpservice)
+  b.holePunchingConfig.withValue(config):
+    let
+      autonatService = AutonatService.new(AutonatClient(), b.rng)
+      autoRelayService = AutoRelayService.new(
+        config.maxNumRelays, RelayClient.new(), config.onReservationHandler, b.rng
+      )
+
+    switch.services.add(HPService.new(autonatService, autoRelayService))
 
   b.natConfig.withValue(natCfg):
     switch.services.add(NATService.new(natCfg))

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -54,12 +54,18 @@ type
     connManager*: ConnManager
     rng*: Rng
 
+  RelayReservationHandler* = proc(addresses: seq[MultiAddress]) {.gcsafe, raises: [].}
+
   SecureProtocol* {.pure.} = enum
     Noise
 
   KadInfo = object
     config*: KadDHTConfig
     bootstrapNodes*: seq[(PeerId, seq[MultiAddress])]
+
+  HolePunchingConfig = object
+    maxNumRelays: int
+    onReservationHandler: RelayReservationHandler
 
   SwitchBuilder* = ref object
     privKey: Opt[PrivateKey]
@@ -81,8 +87,10 @@ type
     addressTtls: AddressConfidenceTtls
     autonatEnabled: bool
     autonatV2ServerConfig: Opt[AutonatV2Config]
+    autonatV2Config: Opt[AutonatV2ServiceConfig]
     autonatV2Client: AutonatV2Client
     autonatV2Service: Opt[AutonatV2Service]
+    holePunchingConfig: Opt[HolePunchingConfig]
     hpService: Opt[HPService]
     natConfig: Opt[NATConfig]
     autotlsConfig: Opt[AutotlsConfig]
@@ -107,6 +115,12 @@ proc new*(T: type[SwitchBuilder]): T =
     scoring: PeerScoring(),
     protoVersion: ProtoVersion,
     agentVersion: AgentVersion,
+    autonatV2ServerConfig: Opt.none(AutonatV2Config),
+    autonatV2Config: Opt.none(AutonatV2ServiceConfig),
+    autonatV2Service: Opt.none(AutonatV2Service),
+    holePunchingConfig: Opt.none(HolePunchingConfig),
+    hpService: Opt.none(HPService),
+    natConfig: Opt.none(NATConfig),
     autotlsConfig: Opt.none(AutotlsConfig),
     circuitRelay: Opt.none(Relay),
     rdvConfig: Opt.none(RendezVousConfig),
@@ -178,7 +192,7 @@ proc withMplex*(
   proc newMuxer(conn: RawConn): Muxer =
     Mplex.new(conn, inTimeout, outTimeout, maxChannCount)
 
-  assert b.muxers.countIt(it.codec == MplexCodec) == 0, "Mplex build multiple times"
+  doAssert b.muxers.countIt(it.codec == MplexCodec) == 0, "Mplex build multiple times"
   b.muxers.add(MuxerProvider.new(newMuxer, MplexCodec))
   b
 
@@ -198,7 +212,7 @@ proc withYamux*(
       outTimeout = outTimeout,
     )
 
-  assert b.muxers.countIt(it.codec == YamuxCodec) == 0, "Yamux build multiple times"
+  doAssert b.muxers.countIt(it.codec == YamuxCodec) == 0, "Yamux build multiple times"
   b.muxers.add(MuxerProvider.new(newMuxer, YamuxCodec))
   b
 
@@ -344,10 +358,7 @@ proc withAutonatV2*(
     b: SwitchBuilder,
     serviceConfig: AutonatV2ServiceConfig = AutonatV2ServiceConfig.new(),
 ): SwitchBuilder =
-  b.autonatV2Client = AutonatV2Client.new(b.rng)
-  b.autonatV2Service = Opt.some(
-    AutonatV2Service.new(b.rng, client = b.autonatV2Client, config = serviceConfig)
-  )
+  b.autonatV2Config = Opt.some(serviceConfig)
   b
 
 proc withNAT*(b: SwitchBuilder, config: NATConfig): SwitchBuilder =
@@ -357,15 +368,13 @@ proc withNAT*(b: SwitchBuilder, config: NATConfig): SwitchBuilder =
   b
 
 proc withHolePunching*(
-    b: SwitchBuilder, maxNumRelays: int, onReservationHandler: proc
+    b: SwitchBuilder, maxNumRelays: int, onReservationHandler: RelayReservationHandler
 ): SwitchBuilder =
-  let
-    autonatService = AutonatService.new(AutonatClient(), b.rng)
-    autoRelayService =
-      AutoRelayService.new(maxNumRelays, RelayClient.new(), onReservationHandler, b.rng)
-    hpService = HPService.new(autonatService, autoRelayService)
-
-  b.hpService = Opt.some(hpService)
+  b.holePunchingConfig = Opt.some(
+    HolePunchingConfig(
+      maxNumRelays: maxNumRelays, onReservationHandler: onReservationHandler
+    )
+  )
   b
 
 when defined(libp2p_autotls_support):
@@ -434,8 +443,24 @@ proc buildSwitch(b: SwitchBuilder): Switch {.raises: [LPError].} =
   if b.rng == nil: # newRng could fail
     raise newException(Defect, "Cannot initialize RNG")
 
-  let pkRes = PrivateKey.random(b.rng)
-  let seckey = b.privKey.get(otherwise = pkRes.expect("Expected default Private Key"))
+  let seckey = b.privKey.valueOr:
+    PrivateKey.random(b.rng).expect("Expected default Private Key")
+
+  b.autonatV2Config.withValue(serviceConfig):
+    b.autonatV2Client = AutonatV2Client.new(b.rng)
+    b.autonatV2Service = Opt.some(
+      AutonatV2Service.new(b.rng, client = b.autonatV2Client, config = serviceConfig)
+    )
+
+  b.holePunchingConfig.withValue(config):
+    let
+      autonatService = AutonatService.new(AutonatClient(), b.rng)
+      autoRelayService = AutoRelayService.new(
+        config.maxNumRelays, RelayClient.new(), config.onReservationHandler, b.rng
+      )
+      hpService = HPService.new(autonatService, autoRelayService)
+
+    b.hpService = Opt.some(hpService)
 
   if b.secureManagers.len == 0:
     debug "no secure managers defined. Adding noise by default"


### PR DESCRIPTION
## Summary

This fixes `SwitchBuilder` paths that created RNG-dependent services before the builder had initialized its default RNG.

The PR:
- Defers AutoNAT v2 and hole-punching service construction until `buildSwitch`, after RNG initialization
- Avoids generating a throwaway default private key when the caller already supplied one
- Makes duplicate muxer registration checks use `doAssert`
- Gives the hole-punching reservation callback an explicit type

## Affected Areas

- [x] Peer Management / Discovery
  - AutoNAT v2 and hole-punching builder initialization
- [x] Other
  - `SwitchBuilder` setup and validation

## Impact on Library Users

Users can configure AutoNAT v2 or hole punching before calling `withRng`, or rely on the builder's default RNG, without those services retaining a nil RNG.

The hole-punching reservation callback now has an explicit type, so incompatible callback signatures fail at compile time.

## Risk Assessment

Low. The change is limited to builder construction order and validation. It does not change the runtime behavior of the services after they are created.
