### PR TITLE
fix: avoid nim range-backed integer types

### DIFF
--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -55,7 +55,7 @@ proc pop*(pr: ProviderRecords): ProviderRecord {.inline.} =
 proc len*(pr: ProviderRecords): int {.inline.} =
   pr.records.len()
 
-proc del*(pr: ProviderRecords, index: Natural) {.inline.} =
+proc del*(pr: ProviderRecords, index: int) {.inline.} =
   pr.records.del(index)
 
 proc find*(pr: ProviderRecords, record: ProviderRecord): int {.inline.} =

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -165,6 +165,10 @@ proc validateParameters*(parameters: GossipSubParams): Result[void, cstring] =
     err("gossipsub: gossipThreshold parameter error, Must be < 0")
   elif parameters.unsubscribeBackoff.seconds <= 0:
     err("gossipsub: unsubscribeBackoff parameter error, Must be > 0 seconds")
+  elif parameters.historyLength <= 0:
+    err("gossipsub: historyLength parameter error, Must be > 0")
+  elif parameters.historyGossip < 0:
+    err("gossipsub: historyGossip parameter error, Must be >= 0")
   elif parameters.publishThreshold >= parameters.gossipThreshold:
     err("gossipsub: publishThreshold parameter error, Must be < gossipThreshold")
   elif parameters.graylistThreshold >= parameters.publishThreshold:

--- a/libp2p/protocols/pubsub/mcache.nim
+++ b/libp2p/protocols/pubsub/mcache.nim
@@ -18,7 +18,7 @@ type
     msgs*: Table[MessageId, Message]
     history*: seq[seq[CacheEntry]]
     pos*: int
-    windowSize*: Natural
+    windowSize*: int
 
 func get*(c: MCache, msgId: MessageId): Opt[Message] =
   if msgId in c.msgs:
@@ -58,5 +58,8 @@ func shift*(c: var MCache) =
 
   reset(c.history[c.pos])
 
-func init*(T: type MCache, window, history: Natural): T =
+func init*(T: type MCache, window, history: int): T =
+  doAssert history > 0, "history must be > 0"
+  doAssert window >= 0, "window must be >= 0"
+
   T(history: newSeq[seq[CacheEntry]](history), windowSize: window)

--- a/libp2p/utils/collections.nim
+++ b/libp2p/utils/collections.nim
@@ -5,7 +5,9 @@
 
 import std/sets
 
-proc capLen*[T](s: var seq[T], length: Natural) =
+proc capLen*[T](s: var seq[T], length: int) =
+  doAssert length >= 0, "length must be >= 0"
+
   if s.len > length:
     s.setLen(length)
 

--- a/tests/libp2p/pubsub/test_gossipsub_params.nim
+++ b/tests/libp2p/pubsub/test_gossipsub_params.nim
@@ -73,6 +73,27 @@ suite "GossipSubParams validation":
     params.unsubscribeBackoff = 1.seconds
     check params.validateParameters().isOk()
 
+  test "historyLength fails when zero":
+    const errorMessage = "gossipsub: historyLength parameter error, Must be > 0"
+    var params = newDefaultValidParams()
+    params.historyLength = 0
+    let res = params.validateParameters()
+    check res.isErr()
+    check res.error == errorMessage
+
+  test "historyGossip fails when negative":
+    const errorMessage = "gossipsub: historyGossip parameter error, Must be >= 0"
+    var params = newDefaultValidParams()
+    params.historyGossip = -1
+    let res = params.validateParameters()
+    check res.isErr()
+    check res.error == errorMessage
+
+  test "historyGossip succeeds when zero":
+    var params = newDefaultValidParams()
+    params.historyGossip = 0
+    check params.validateParameters().isOk()
+
   test "publishThreshold fails when equal to gossipThreshold":
     const errorMessage =
       "gossipsub: publishThreshold parameter error, Must be < gossipThreshold"

--- a/tests/libp2p/pubsub/utils.nim
+++ b/tests/libp2p/pubsub/utils.nim
@@ -187,7 +187,7 @@ proc applyDValues*(parameters: var GossipSubParams, dValues: Opt[DValues]) =
     parameters.dLazy = values.dLazy.get
 
 proc generateNodes*(
-    num: Natural,
+    num: int,
     msgIdProvider: MsgIdProvider = defaultMsgIdProvider,
     gossip: bool = false,
     triggerSelf: bool = false,

--- a/tests/libp2p/utils/test_conversion.nim
+++ b/tests/libp2p/utils/test_conversion.nim
@@ -53,14 +53,6 @@ suite "Conversion":
     check not (compiles do:
       let converted: Color = safeConvert[Color](3))
 
-  test "successful safeConvert from range to int":
-    let res: int = safeConvert[int, range[1 .. 10]](5)
-    check res == 5
-
-  test "unsuccessful safeConvert from int to range":
-    check not (compiles do:
-      let converted: range[1 .. 10] = safeConvert[range[1 .. 10], int](11))
-
   test "unsuccessful safeConvert from int to uint":
     check not (compiles do:
       let converted: uint = safeConvert[uint](11))


### PR DESCRIPTION
## Summary

The style guide describes that we should avoid ranges and Natural. This PR Replaces range-backed integer types with plain `int` in the affected helpers and pubsub cache code, following the Status Nim style guidance to use standard integer types and avoid range types where implicit conversions can raise defects.

The previous non-negative constraints are now expressed explicitly:

- GossipSub validates `historyLength > 0` and `historyGossip >= 0` before initializing `MCache`.
- `MCache.init` and `capLen` assert their required non-negative/positive preconditions.
- Range-specific `safeConvert` test coverage is removed because range-backed conversions are no longer part of the intended usage.

## Affected Areas

- [x] Gossipsub
  - `MCache` uses `int` for `windowSize`, `window`, and `history`.
  - GossipSub parameter validation covers the history bounds previously implied by `Natural`.
- [x] Peer Management / Discovery
  - Kademlia provider record deletion uses an `int` index instead of `Natural`.
- [x] Other
  - Utility/test helpers avoid `Natural` and explicit `range[...]` usage.

## Impact on Library Users

Valid existing values are handled the same way. Invalid negative values now fail through explicit validation or assertions rather than through implicit range-backed integer conversion.

## Risk Assessment

Low. The change is limited to integer type annotations and explicit precondition checks around values that were already expected to be non-negative.

## References

- https://status-im.github.io/nim-style-guide/language.integers.html
- https://status-im.github.io/nim-style-guide/language.range.html
