### PR TITLE
refactor(dial): keep low-level dial APIs off Dial interface

### DIFF
--- a/libp2p/dial.nim
+++ b/libp2p/dial.nim
@@ -5,7 +5,7 @@
 
 import chronos
 import results
-import peerid, stream/connection, transports/transport, muxers/muxer
+import peerid, stream/connection, transports/transport
 
 export results
 
@@ -43,22 +43,6 @@ method dial*(
 
   doAssert(false, "[Dial.dial] abstract method not implemented!")
 
-method dialAndUpgrade*(
-    self: Dial,
-    peerId: Opt[PeerId],
-    hostname: string,
-    addrs: MultiAddress,
-    dir = Direction.Out,
-): Future[Muxer] {.base, async: (raises: [CancelledError]).} =
-  doAssert(false, "[Dial.dialAndUpgrade] abstract method not implemented!")
-
-method dialAndUpgrade*(
-    self: Dial, peerId: Opt[PeerId], addrs: seq[MultiAddress], dir = Direction.Out
-): Future[Muxer] {.
-    base, async: (raises: [CancelledError, MaError, TransportAddressError, LPError])
-.} =
-  doAssert(false, "[Dial.dialAndUpgrade] abstract method not implemented!")
-
 method dial*(
     self: Dial,
     peerId: PeerId,
@@ -74,15 +58,3 @@ method dial*(
 
 method addTransport*(self: Dial, transport: Transport) {.base.} =
   doAssert(false, "[Dial.addTransport] abstract method not implemented!")
-
-method negotiateStream*(
-    self: Dial, stream: Stream, protos: seq[string]
-): Future[Stream] {.base, async: (raises: [CatchableError]).} =
-  doAssert(false, "[Dial.negotiateStream] abstract method not implemented!")
-
-method tryDial*(
-    self: Dial, peerId: PeerId, addrs: seq[MultiAddress]
-): Future[Opt[MultiAddress]] {.
-    base, async: (raises: [DialFailedError, CancelledError])
-.} =
-  doAssert(false, "[Dial.tryDial] abstract method not implemented!")

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -40,13 +40,16 @@ type Dialer* = ref object of Dial
   ms: MultistreamSelect
   ongoingReleaseOnClose: seq[Future[void].Raising([])]
 
-method dialAndUpgrade*(
+proc dialAndUpgrade*(
     self: Dialer,
     peerId: Opt[PeerId],
     hostname: string,
     addrs: MultiAddress,
     dir = Direction.Out,
 ): Future[Muxer] {.async: (raises: [CancelledError]).} =
+  ## Dial one resolved transport address and upgrade it to a muxer.
+  ## Returns nil when no transport can establish an upgraded connection.
+
   for transport in self.transports: # for each transport
     if transport.handles(addrs): # check if it can dial it
       trace "Dialing address", addrs, peerId = peerId.get(default(PeerId)), hostname
@@ -141,11 +144,14 @@ proc expandDnsAddr(
       addrs.add((resolvedAddress, peerId))
   addrs
 
-method dialAndUpgrade*(
+proc dialAndUpgrade*(
     self: Dialer, peerId: Opt[PeerId], addrs: seq[MultiAddress], dir = Direction.Out
 ): Future[Muxer] {.
     async: (raises: [CancelledError, MaError, TransportAddressError, LPError])
 .} =
+  ## Dial address candidates, resolving DNS addresses when configured.
+  ## Returns the first upgraded muxer, or nil when no address succeeds.
+
   debug "Dialing peer", peerId = peerId.get(default(PeerId)), addrs
 
   for rawAddress in addrs:
@@ -287,9 +293,13 @@ method connect*(
   return
     (await self.internalConnect(Opt.none(PeerId), @[address], false)).connection.peerId
 
-method negotiateStream*(
+proc negotiateStream*(
     self: Dialer, stream: Stream, protos: seq[string]
-): Future[Stream] {.async: (raises: [CatchableError]).} =
+): Future[Stream] {.async: (raises: [CancelledError, LPError]).} =
+  ## Negotiate one of `protos` over an open stream.
+  ## Raises DialFailedError when negotiation selects no supported protocol or
+  ## the selected protocol's outgoing stream budget is exhausted.
+
   trace "Negotiating stream", stream, protos
   let selected = await MultistreamSelect.select(stream, protos)
   if not protos.contains(selected):
@@ -319,12 +329,13 @@ method negotiateStream*(
 
   return stream
 
-method tryDial*(
+proc tryDial*(
     self: Dialer, peerId: PeerId, addrs: seq[MultiAddress]
 ): Future[Opt[MultiAddress]] {.async: (raises: [DialFailedError, CancelledError]).} =
   ## Create a protocol stream in order to check
   ## if a connection is possible.
   ## Doesn't use the Connection Manager to save it.
+  ## Returns the observed address when the probe succeeds.
   ##
 
   trace "Check if it can dial", peerId, addrs
@@ -407,7 +418,7 @@ method dial*(
     await cleanup()
     raise newException(DialFailedError, "failed new dial: " & exc.msg, exc)
 
-method addTransport*(self: Dialer, t: Transport) =
+method addTransport*(self: Dialer, t: Transport) {.raises: [].} =
   self.transports &= t
 
 proc new*(

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -52,7 +52,7 @@ type
     muxedUpgrade*: MuxedUpgrade
     ms*: MultistreamSelect
     acceptFuts: seq[Future[void]]
-    dialer*: Dial
+    dialer*: Dialer
     peerStore*: PeerStore
     nameResolver*: NameResolver
     started: bool


### PR DESCRIPTION
## Summary

This narrows `Dial` to the high-level connect/dial interface and keeps lower-level dialing operations on the concrete `Dialer`.

`dialAndUpgrade`, `negotiateStream`, and `tryDial` are no longer abstract `Dial` methods. They remain available on `Dialer`, where they are used as implementation-level helpers. `Switch.dialer` is typed as `Dialer` so internal callers can still access those helpers without exposing them through the `Switch`/`Dial` API. 

This is useful because otherwise the Switch had those three methods that would immediatly fail because they were unimplemented, and did not make sense for the switch to expose those

## Affected Areas

- [x] Other  
  Dial/Dialer/Switch interface boundaries.

## Impact on Library Users

Code using the high-level `connect` and `dial` APIs is unchanged.

Code that called `dialAndUpgrade`, `negotiateStream`, or `tryDial` through a `Dial` reference now needs access to a concrete `Dialer`.

## Risk Assessment

The main compatibility risk is for downstream code relying on the previous low-level methods being present on `Dial`. The underlying dialer implementations are otherwise kept in place.
