### PR TITLE
chore: remove explicit inline pragmas

### DIFF
--- a/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_kademlia_requests.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_kademlia_requests.nim
@@ -44,9 +44,7 @@ type RandomRecordsResult* = object
   records*: ptr Libp2pExtendedPeerRecord
   recordsLen*: csize_t
 
-proc allocServiceInfoArrayFromSeq(
-    services: seq[ServiceInfo]
-): ptr Libp2pServiceInfo {.inline.} =
+proc allocServiceInfoArrayFromSeq(services: seq[ServiceInfo]): ptr Libp2pServiceInfo =
   if services.len == 0:
     return nil
   let ret =

--- a/libp2p/cid.nim
+++ b/libp2p/cid.nim
@@ -270,11 +270,11 @@ proc repr*(cid: Cid): string =
   s.add($(cid.mhash()))
   s
 
-proc write*(vb: var VBuffer, cid: Cid) {.inline.} =
+proc write*(vb: var VBuffer, cid: Cid) =
   ## Write CID value ``cid`` to buffer ``vb``.
   vb.writeArray(cid.data.buffer)
 
-proc hash*(cid: Cid): Hash {.inline.} =
+proc hash*(cid: Cid): Hash =
   hash(cid.data.buffer)
 
 proc `$`*(cid: Cid): string =

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -208,7 +208,7 @@ proc new*(
     scoring: scoring,
   )
 
-proc connCount*(c: ConnManager, peerId: PeerId): int {.inline.} =
+proc connCount*(c: ConnManager, peerId: PeerId): int =
   c.muxerStore.count(peerId)
 
 proc getReadyEvent(
@@ -497,7 +497,7 @@ proc getOutgoingSlot*(
 
   return ConnectionSlot(connManager: c, direction: Out)
 
-func semaphore(c: ConnManager, dir: Direction): AsyncSemaphore {.inline.} =
+func semaphore(c: ConnManager, dir: Direction): AsyncSemaphore =
   return if dir == In: c.inSema else: c.outSema
 
 proc availableSlots*(c: ConnManager, dir: Direction): int =

--- a/libp2p/crypto/crypto.nim
+++ b/libp2p/crypto/crypto.nim
@@ -608,7 +608,7 @@ proc init*(t: typedesc[Signature], data: string): CryptoResult[Signature] =
   ## Create new signature from serialized hexadecimal string form.
   t.init(ncrutils.fromHex(data))
 
-proc `==`*(key1, key2: PublicKey): bool {.inline.} =
+proc `==`*(key1, key2: PublicKey): bool =
   ## Return ``true`` if two public keys ``key1`` and ``key2`` of the same
   ## scheme and equal.
   if key1.scheme == key2.scheme:
@@ -865,7 +865,7 @@ template macOpenArray*(secret: Secret, id: int): untyped =
     goffset(secret, id, secret.ivsize + secret.keysize + secret.macsize - 1),
   )
 
-proc iv*(secret: Secret, id: int): seq[byte] {.inline.} =
+proc iv*(secret: Secret, id: int): seq[byte] =
   ## Get array of bytes with with initial vector.
   var buf = newSeqUninit[byte](secret.ivsize)
   var offset =
@@ -876,7 +876,7 @@ proc iv*(secret: Secret, id: int): seq[byte] {.inline.} =
   copyMem(addr buf[0], addr secret.data[offset], secret.ivsize)
   buf
 
-proc key*(secret: Secret, id: int): seq[byte] {.inline.} =
+proc key*(secret: Secret, id: int): seq[byte] =
   var buf = newSeqUninit[byte](secret.keysize)
   var offset =
     if id == 0:
@@ -887,7 +887,7 @@ proc key*(secret: Secret, id: int): seq[byte] {.inline.} =
   copyMem(addr buf[0], addr secret.data[offset], secret.keysize)
   buf
 
-proc mac*(secret: Secret, id: int): seq[byte] {.inline.} =
+proc mac*(secret: Secret, id: int): seq[byte] =
   var buf = newSeqUninit[byte](secret.macsize)
   var offset =
     if id == 0:
@@ -946,30 +946,26 @@ proc selectBest*(order: int, p1, p2: string): string =
 
 ## Serialization/Deserialization helpers
 
-proc write*(
-    vb: var VBuffer, pubkey: PublicKey
-) {.inline, raises: [ResultError[CryptoError]].} =
+proc write*(vb: var VBuffer, pubkey: PublicKey) {.raises: [ResultError[CryptoError]].} =
   ## Write PublicKey value ``pubkey`` to buffer ``vb``.
   vb.writeSeq(pubkey.getBytes().tryGet())
 
 proc write*(
     vb: var VBuffer, seckey: PrivateKey
-) {.inline, raises: [ResultError[CryptoError]].} =
+) {.raises: [ResultError[CryptoError]].} =
   ## Write PrivateKey value ``seckey`` to buffer ``vb``.
   vb.writeSeq(seckey.getBytes().tryGet())
 
-proc write*(
-    vb: var VBuffer, sig: PrivateKey
-) {.inline, raises: [ResultError[CryptoError]].} =
+proc write*(vb: var VBuffer, sig: PrivateKey) {.raises: [ResultError[CryptoError]].} =
   ## Write Signature value ``sig`` to buffer ``vb``.
   vb.writeSeq(sig.getBytes().tryGet())
 
 proc write*[T: PublicKey | PrivateKey](
     pb: var ProtoBuffer, field: int, key: T
-) {.inline, raises: [ResultError[CryptoError]].} =
+) {.raises: [ResultError[CryptoError]].} =
   write(pb, field, key.getBytes().tryGet())
 
-proc write*(pb: var ProtoBuffer, field: int, sig: Signature) {.inline, raises: [].} =
+proc write*(pb: var ProtoBuffer, field: int, sig: Signature) {.raises: [].} =
   write(pb, field, sig.getBytes())
 
 proc getField*[T: PublicKey | PrivateKey](

--- a/libp2p/crypto/curve25519.nim
+++ b/libp2p/crypto/curve25519.nim
@@ -34,7 +34,7 @@ proc intoCurve25519Key*(s: openArray[byte]): Curve25519Key =
 proc getBytes*(key: Curve25519Key): seq[byte] =
   @key
 
-proc byteswap(buf: var Curve25519Key) {.inline.} =
+proc byteswap(buf: var Curve25519Key) =
   for i in 0 ..< 16:
     let x = buf[i]
     buf[i] = buf[31 - i]

--- a/libp2p/crypto/ecnist.nim
+++ b/libp2p/crypto/ecnist.nim
@@ -72,25 +72,25 @@ type
 
 const EcSupportedCurvesCint* = @[cint(Secp256r1), cint(Secp384r1), cint(Secp521r1)]
 
-proc `-`(x: uint32): uint32 {.inline.} =
+proc `-`(x: uint32): uint32 =
   (0xFFFF_FFFF'u32 - x) + 1'u32
 
-proc GT(x, y: uint32): uint32 {.inline.} =
+proc GT(x, y: uint32): uint32 =
   var z = cast[uint32](y - x)
   (z xor ((x xor y) and (x xor z))) shr 31
 
-proc CMP(x, y: uint32): int32 {.inline.} =
+proc CMP(x, y: uint32): int32 =
   cast[int32](GT(x, y)) or -(cast[int32](GT(y, x)))
 
-proc EQ0(x: int32): uint32 {.inline.} =
+proc EQ0(x: int32): uint32 =
   var q = cast[uint32](x)
   not (q or -q) shr 31
 
-proc NEQ(x, y: uint32): uint32 {.inline.} =
+proc NEQ(x, y: uint32): uint32 =
   var q = cast[uint32](x xor y)
   ((q or -q) shr 31)
 
-proc LT0(x: int32): uint32 {.inline.} =
+proc LT0(x: int32): uint32 =
   cast[uint32](x) shr 31
 
 proc checkScalar(scalar: openArray[byte], curve: cint): uint32 =
@@ -124,13 +124,13 @@ proc checkPublic(key: openArray[byte], curve: cint): uint32 =
   discard impl.order(curve, orderlen)
   impl.mul(addr ckey[0], uint(len(ckey)), addr x[0], uint(len(x)), curve)
 
-proc getOffset(pubkey: EcPublicKey): int {.inline.} =
+proc getOffset(pubkey: EcPublicKey): int =
   let o = cast[uint](pubkey.key.q) - cast[uint](addr pubkey.buffer[0])
   if o + cast[uint](pubkey.key.qlen) > uint(len(pubkey.buffer)):
     return -1
   cast[int](o)
 
-proc getOffset(seckey: EcPrivateKey): int {.inline.} =
+proc getOffset(seckey: EcPrivateKey): int =
   let o = cast[uint](seckey.key.x) - cast[uint](addr seckey.buffer[0])
   if o + cast[uint](seckey.key.xlen) > uint(len(seckey.buffer)):
     return -1
@@ -182,7 +182,7 @@ proc copy*[T: EcPKI](dst: var T, src: T): bool =
       return true
   false
 
-proc copy*[T: EcPKI](src: T): T {.inline.} =
+proc copy*[T: EcPKI](src: T): T =
   ## Returns copy of EC `private key`, `public key` or `signature`
   ## object ``src``.
   var dst: T
@@ -703,7 +703,7 @@ proc init*(sig: var EcSignature, data: openArray[byte]): Result[void, Asn1Error]
   else:
     err(Asn1Error.Incorrect)
 
-proc init*[T: EcPKI](sospk: var T, data: string): Result[void, Asn1Error] {.inline.} =
+proc init*[T: EcPKI](sospk: var T, data: string): Result[void, Asn1Error] =
   ## Initialize EC `private key`, `public key` or `signature` ``sospk`` from
   ## ASN.1 DER hexadecimal string representation ``data``.
   ##
@@ -816,7 +816,7 @@ proc initRaw*(sig: var EcSignature, data: openArray[byte]): bool =
     return true
   false
 
-proc initRaw*[T: EcPKI](sospk: var T, data: string): bool {.inline.} =
+proc initRaw*[T: EcPKI](sospk: var T, data: string): bool =
   ## Initialize EC `private key`, `public key` or `signature` ``sospk`` from
   ## raw hexadecimal string representation ``data``.
   ##
@@ -852,7 +852,7 @@ proc initRaw*(t: typedesc[EcSignature], data: openArray[byte]): EcResult[EcSigna
   else:
     ok(res)
 
-proc initRaw*[T: EcPKI](t: typedesc[T], data: string): T {.inline.} =
+proc initRaw*[T: EcPKI](t: typedesc[T], data: string): T =
   ## Initialize EC `private key`, `public key` or `signature` from raw
   ## hexadecimal string representation ``data`` and return constructed object.
   t.initRaw(ncrutils.fromHex(data))
@@ -959,7 +959,7 @@ proc sign*[T: byte | char](
 
 proc verify*[T: byte | char](
     sig: EcSignature, message: openArray[T], pubkey: EcPublicKey
-): bool {.inline.} =
+): bool =
   ## Verify ECDSA signature ``sig`` using public key ``pubkey`` and data
   ## ``message``.
   ##

--- a/libp2p/crypto/ed25519/ed25519.nim
+++ b/libp2p/crypto/ed25519/ed25519.nim
@@ -44,10 +44,10 @@ type
   EdError* = enum
     EdIncorrectError
 
-proc `-`(x: uint32): uint32 {.inline.} =
+proc `-`(x: uint32): uint32 =
   (0xFFFF_FFFF'u32 - x) + 1'u32
 
-proc `-`(x: uint8): uint8 {.inline.} =
+proc `-`(x: uint8): uint8 =
   (0xFF'u8 - x) + 1'u8
 
 proc fe0(h: var Fe) =
@@ -2150,22 +2150,22 @@ proc geDoubleScalarMultVartime(
     geP1P1toP2(r, t)
     dec(k)
 
-proc GT(x, y: uint32): uint32 {.inline.} =
+proc GT(x, y: uint32): uint32 =
   var z = cast[uint32](y - x)
   (z xor ((x xor y) and (x xor z))) shr 31
 
-proc CMP(x, y: uint32): int32 {.inline.} =
+proc CMP(x, y: uint32): int32 =
   cast[int32](GT(x, y)) or -(cast[int32](GT(y, x)))
 
-proc EQ0(x: int32): uint32 {.inline.} =
+proc EQ0(x: int32): uint32 =
   var q = cast[uint32](x)
   not (q or -q) shr 31
 
-proc NEQ(x, y: uint32): uint32 {.inline.} =
+proc NEQ(x, y: uint32): uint32 =
   var q = cast[uint32](x xor y)
   (q or -q) shr 31
 
-proc LT0(x: int32): uint32 {.inline.} =
+proc LT0(x: int32): uint32 =
   cast[uint32](x) shr 31
 
 proc checkScalar*(scalar: openArray[byte]): uint32 =

--- a/libp2p/crypto/minasn1.nim
+++ b/libp2p/crypto/minasn1.nim
@@ -100,20 +100,20 @@ template isEmpty*(ab: Asn1Buffer): bool =
 template isEnough*(ab: Asn1Buffer, length: int64): bool =
   len(ab.buffer) >= ab.offset + length
 
-proc len*[T: Asn1Buffer | Asn1Composite](abc: T): int {.inline.} =
+proc len*[T: Asn1Buffer | Asn1Composite](abc: T): int =
   len(abc.buffer) - abc.offset
 
-proc len*(field: Asn1Field): int {.inline.} =
+proc len*(field: Asn1Field): int =
   field.length
 
 template getPtr*(field: untyped): pointer =
   cast[pointer](addr field.buffer[field.offset])
 
-proc extend*[T: Asn1Buffer | Asn1Composite](abc: var T, length: int) {.inline.} =
+proc extend*[T: Asn1Buffer | Asn1Composite](abc: var T, length: int) =
   ## Extend buffer or composite's internal buffer by ``length`` octets.
   abc.buffer.setLen(len(abc.buffer) + length)
 
-proc code*(tag: Asn1Tag): byte {.inline.} =
+proc code*(tag: Asn1Tag): byte =
   ## Converts Nim ``tag`` enum to ASN.1 tag code.
   case tag
   of Asn1Tag.NoSupport: 0x00'u8
@@ -641,7 +641,7 @@ proc read*(ab: var Asn1Buffer): Asn1Result[Asn1Field] =
     else:
       return err(Asn1Error.NoSupport)
 
-proc getBuffer*(field: Asn1Field): Asn1Buffer {.inline.} =
+proc getBuffer*(field: Asn1Field): Asn1Buffer =
   ## Return ``field`` as Asn1Buffer to enter composite types.
   Asn1Buffer(buffer: field.buffer, offset: field.offset, length: field.length)
 
@@ -827,6 +827,6 @@ proc write*[T: Asn1Buffer | Asn1Composite](abc: var T, value: Asn1Composite) =
     discard asn1EncodeContextTag(abc.toOpenArray(), value.buffer, value.idx)
   abc.offset += length
 
-proc finish*[T: Asn1Buffer | Asn1Composite](abc: var T) {.inline.} =
+proc finish*[T: Asn1Buffer | Asn1Composite](abc: var T) =
   ## Finishes buffer or composite and prepares it for writing.
   abc.offset = 0

--- a/libp2p/crypto/rsa.nim
+++ b/libp2p/crypto/rsa.nim
@@ -247,11 +247,11 @@ proc getPublicKey*(key: RsaPrivateKey): RsaPublicKey =
   pubkey.key.elen = key.pubk.elen
   pubkey
 
-proc seckey*(pair: RsaKeyPair): RsaPrivateKey {.inline.} =
+proc seckey*(pair: RsaKeyPair): RsaPrivateKey =
   ## Get RSA private key from pair ``pair``.
   cast[RsaPrivateKey](pair).copy()
 
-proc pubkey*(pair: RsaKeyPair): RsaPublicKey {.inline.} =
+proc pubkey*(pair: RsaKeyPair): RsaPublicKey =
   ## Get RSA public key from pair ``pair``.
   cast[RsaPrivateKey](pair).getPublicKey()
 
@@ -575,7 +575,7 @@ proc init*(sig: var RsaSignature, data: openArray[byte]): Result[void, Asn1Error
   else:
     err(Asn1Error.Incorrect)
 
-proc init*[T: RsaPKI](sospk: var T, data: string): Result[void, Asn1Error] {.inline.} =
+proc init*[T: RsaPKI](sospk: var T, data: string): Result[void, Asn1Error] =
   ## Initialize EC `private key`, `public key` or `scalar` ``sospk`` from
   ## hexadecimal string representation ``data``.
   ##
@@ -611,7 +611,7 @@ proc init*(t: typedesc[RsaSignature], data: openArray[byte]): RsaResult[RsaSigna
   else:
     ok(res)
 
-proc init*[T: RsaPKI](t: typedesc[T], data: string): T {.inline.} =
+proc init*[T: RsaPKI](t: typedesc[T], data: string): T =
   ## Initialize RSA `private key`, `public key` or `signature` from hexadecimal
   ## string representation ``data`` and return constructed object.
   t.init(ncrutils.fromHex(data))
@@ -785,7 +785,7 @@ proc sign*[T: byte | char](
 
 proc verify*[T: byte | char](
     sig: RsaSignature, message: openArray[T], pubkey: RsaPublicKey
-): bool {.inline.} =
+): bool =
   ## Verify RSA signature ``sig`` using public key ``pubkey`` and data
   ## ``message``.
   ##

--- a/libp2p/crypto/secp.nim
+++ b/libp2p/crypto/secp.nim
@@ -164,15 +164,15 @@ proc toBytes*(sig: SkSignature, data: var openArray[byte]): int =
   ## Secp256k1 signature.
   secp256k1.SkSignature(sig).toDer(data)
 
-proc getBytes*(key: SkPrivateKey): seq[byte] {.inline.} =
+proc getBytes*(key: SkPrivateKey): seq[byte] =
   ## Serialize Secp256k1 `private key` and return it.
   @(SkSecretKey(key).toRaw())
 
-proc getBytes*(key: SkPublicKey): seq[byte] {.inline.} =
+proc getBytes*(key: SkPublicKey): seq[byte] =
   ## Serialize Secp256k1 `public key` and return it.
   @(secp256k1.SkPublicKey(key).toRawCompressed())
 
-proc getBytes*(sig: SkSignature): seq[byte] {.inline.} =
+proc getBytes*(sig: SkSignature): seq[byte] =
   ## Serialize Secp256k1 `signature` and return it.
   var buf = newSeqUninit[byte](72)
   let length = toBytes(sig, buf)

--- a/libp2p/extended_peer_record.nim
+++ b/libp2p/extended_peer_record.nim
@@ -130,7 +130,7 @@ proc checkValid*(spr: SignedExtendedPeerRecord): Result[void, EnvelopeError] =
   else:
     ok()
 
-proc isValid*(si: ServiceInfo): bool {.inline.} =
+proc isValid*(si: ServiceInfo): bool =
   si.data.len <= MaxServiceDataSize
 
 proc isValid*(xpr: SignedExtendedPeerRecord): bool =

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -660,9 +660,7 @@ proc getParts[U, V](ma: MultiAddress, slice: HSlice[U, V]): MaResult[MultiAddres
     ?res.append(?ma[i])
   ok(res)
 
-proc `[]`*(
-    ma: MultiAddress, i: int | BackwardsIndex
-): MaResult[MultiAddress] {.inline.} =
+proc `[]`*(ma: MultiAddress, i: int | BackwardsIndex): MaResult[MultiAddress] =
   ## Returns part with index ``i`` of MultiAddress ``ma``.
   when i is BackwardsIndex:
     let maLength = ?len(ma)
@@ -670,7 +668,7 @@ proc `[]`*(
   else:
     ma.getPart(i)
 
-proc `[]`*(ma: MultiAddress, slice: HSlice): MaResult[MultiAddress] {.inline.} =
+proc `[]`*(ma: MultiAddress, slice: HSlice): MaResult[MultiAddress] =
   ## Returns parts with slice ``slice`` of MultiAddress ``ma``.
   ma.getParts(slice)
 
@@ -722,7 +720,7 @@ proc len*(ma: MultiAddress): MaResult[int] =
     counter.inc()
   ok(counter)
 
-proc contains*(ma: MultiAddress, codec: MultiCodec): MaResult[bool] {.inline.} =
+proc contains*(ma: MultiAddress, codec: MultiCodec): MaResult[bool] =
   ## Returns ``true``, if address with MultiCodec ``codec`` present in
   ## MultiAddress ``ma``.
   for item in ma.items:
@@ -731,7 +729,7 @@ proc contains*(ma: MultiAddress, codec: MultiCodec): MaResult[bool] {.inline.} =
       return ok(true)
   ok(false)
 
-proc `[]`*(ma: MultiAddress, codec: MultiCodec): MaResult[MultiAddress] {.inline.} =
+proc `[]`*(ma: MultiAddress, codec: MultiCodec): MaResult[MultiAddress] =
   ## Returns partial MultiAddress with MultiCodec ``codec`` and present in
   ## MultiAddress ``ma``.
   for item in ma.items:
@@ -788,13 +786,11 @@ proc hex*(value: MultiAddress): string =
   ## Return hexadecimal string representation of MultiAddress ``value``.
   $(value.data)
 
-proc write*(vb: var VBuffer, ma: MultiAddress) {.inline.} =
+proc write*(vb: var VBuffer, ma: MultiAddress) =
   ## Write MultiAddress value ``ma`` to buffer ``vb``.
   vb.writeArray(ma.data.buffer)
 
-proc encode*(
-    mbtype: typedesc[MultiBase], encoding: string, ma: MultiAddress
-): string {.inline.} =
+proc encode*(mbtype: typedesc[MultiBase], encoding: string, ma: MultiAddress): string =
   ## Get MultiBase encoded representation of ``ma`` using encoding
   ## ``encoding``.
   MultiBase.encode(encoding, ma.data.buffer)
@@ -859,7 +855,7 @@ proc init*(
 
 proc init*(
     mtype: typedesc[MultiAddress], protocol: MultiCodec, value: PeerId
-): MaResult[MultiAddress] {.inline.} =
+): MaResult[MultiAddress] =
   ## Initialize MultiAddress object from protocol id ``protocol`` and peer id
   ## ``value``.
   init(mtype, protocol, value.data)
@@ -906,7 +902,7 @@ proc getProtocolArgument*(ma: MultiAddress, codec: MultiCodec): MaResult[seq[byt
       return ok(?ritem.protoAddress())
   err("Multiaddress codec has not been found")
 
-proc getProtocol(name: string): MAProtocol {.inline.} =
+proc getProtocol(name: string): MAProtocol =
   let mc = MultiCodec.codec(name)
   if mc != InvalidMultiCodec:
     CodeAddresses.getOrDefault(mc)
@@ -1165,12 +1161,12 @@ proc `$`*(pat: MaPattern): string =
 proc bytes*(value: MultiAddress): seq[byte] =
   value.data.buffer
 
-proc write*(pb: var ProtoBuffer, field: int, value: MultiAddress) {.inline.} =
+proc write*(pb: var ProtoBuffer, field: int, value: MultiAddress) =
   write(pb, field, value.data.buffer)
 
 proc getField*(
     pb: ProtoBuffer, field: int, value: var MultiAddress
-): ProtoResult[bool] {.inline.} =
+): ProtoResult[bool] =
   var buffer: seq[byte]
   let res = ?pb.getField(field, buffer)
   if not (res):
@@ -1182,7 +1178,7 @@ proc getField*(
 
 proc getRepeatedField*(
     pb: ProtoBuffer, field: int, value: var seq[MultiAddress]
-): ProtoResult[bool] {.inline.} =
+): ProtoResult[bool] =
   ## Read repeated field from protobuf message. ``field`` is field number.
   ## If the message is malformed, an error is returned. If field is not present
   ## in message, then ``ok(false)`` is returned and value is empty. If field is

--- a/libp2p/multibase.nim
+++ b/libp2p/multibase.nim
@@ -96,7 +96,7 @@ proc b16el(length: int): int =
 proc b16dl(length: int): int =
   (length + 1) div 2
 
-proc b32ce(r: Base32Status): MultiBaseStatus {.inline.} =
+proc b32ce(r: Base32Status): MultiBaseStatus =
   if r == Base32Status.Incorrect:
     return MultiBaseStatus.Incorrect
   if r == Base32Status.Overrun:
@@ -105,7 +105,7 @@ proc b32ce(r: Base32Status): MultiBaseStatus {.inline.} =
     return MultiBaseStatus.Success
   MultiBaseStatus.Error
 
-proc b58ce(r: Base58Status): MultiBaseStatus {.inline.} =
+proc b58ce(r: Base58Status): MultiBaseStatus =
   if r == Base58Status.Incorrect:
     return MultiBaseStatus.Incorrect
   if r == Base58Status.Overrun:
@@ -114,7 +114,7 @@ proc b58ce(r: Base58Status): MultiBaseStatus {.inline.} =
     return MultiBaseStatus.Success
   MultiBaseStatus.Error
 
-proc b64ce(r: Base64Status): MultiBaseStatus {.inline.} =
+proc b64ce(r: Base64Status): MultiBaseStatus =
   if r == Base64Status.Incorrect:
     return MultiBaseStatus.Incorrect
   if r == Base64Status.Overrun:

--- a/libp2p/multicodec.nim
+++ b/libp2p/multicodec.nim
@@ -75,14 +75,14 @@ proc `$`*(mc: MultiCodec): string =
   doAssert(name != "")
   name
 
-proc `==`*(mc: MultiCodec, name: string): bool {.inline.} =
+proc `==`*(mc: MultiCodec, name: string): bool =
   ## Compares MultiCodec ``mc`` with string ``name``.
   let mcname = CodeCodecs.getOrDefault(int(mc), "")
   if mcname == "":
     return false
   mcname == name
 
-proc `==`*(mc: MultiCodec, code: int): bool {.inline.} =
+proc `==`*(mc: MultiCodec, code: int): bool =
   ## Compares MultiCodec ``mc`` with integer ``code``.
   (int(mc) == code)
 
@@ -90,17 +90,17 @@ proc `==`*(a, b: MultiCodec): bool =
   ## Returns ``true`` if MultiCodecs ``a`` and ``b`` are equal.
   int(a) == int(b)
 
-proc hash*(m: MultiCodec): Hash {.inline.} =
+proc hash*(m: MultiCodec): Hash =
   ## Hash procedure for tables.
   hash(int(m))
 
-proc codec*(mt: typedesc[MultiCodec], name: string): MultiCodec {.inline.} =
+proc codec*(mt: typedesc[MultiCodec], name: string): MultiCodec =
   ## Return MultiCodec from string representation ``name``.
   ## If ``name`` is not valid multicodec name, then ``InvalidMultiCodec`` will
   ## be returned.
   MultiCodec(NameCodecs.getOrDefault(name, -1))
 
-proc codec*(mt: typedesc[MultiCodec], code: int): MultiCodec {.inline.} =
+proc codec*(mt: typedesc[MultiCodec], code: int): MultiCodec =
   ## Return MultiCodec from integer representation ``code``.
   ## If ``code`` is not valid multicodec code, then ``InvalidMultiCodec`` will
   ## be returned.
@@ -110,6 +110,6 @@ proc codec*(mt: typedesc[MultiCodec], code: int): MultiCodec {.inline.} =
   else:
     MultiCodec(code)
 
-proc write*(vb: var VBuffer, mc: MultiCodec) {.inline.} =
+proc write*(vb: var VBuffer, mc: MultiCodec) =
   ## Write MultiCodec to buffer ``vb``.
   vb.writeVarint(cast[uint](mc))

--- a/libp2p/multihash.nim
+++ b/libp2p/multihash.nim
@@ -410,7 +410,7 @@ func digestSize*(hashname: string): MhResult[int] =
 
 proc digest*(
     mhtype: typedesc[MultiHash], hashname: string, data: openArray[byte]
-): MhResult[MultiHash] {.inline.} =
+): MhResult[MultiHash] =
   ## Perform digest calculation using hash algorithm with name ``hashname`` on
   ## data array ``data``.
   let mc = MultiCodec.codec(hashname)
@@ -425,7 +425,7 @@ proc digest*(
 
 proc digest*(
     mhtype: typedesc[MultiHash], mcodec: MultiCodec, data: openArray[byte]
-): MhResult[MultiHash] {.inline.} =
+): MhResult[MultiHash] =
   ## Perform digest calculation using hash algorithm with code ``hashcode`` on
   ## data array ``data``.
   let hash = CodeHashes.getOrDefault(mcodec)
@@ -436,7 +436,7 @@ proc digest*(
 
 proc init*[T](
     mhtype: typedesc[MultiHash], hashname: string, mdigest: MDigest[T]
-): MhResult[MultiHash] {.inline.} =
+): MhResult[MultiHash] =
   ## Create MultiHash from nimcrypto's `MDigest` object and hash algorithm name
   ## ``hashname``.
   let mc = MultiCodec.codec(hashname)
@@ -453,7 +453,7 @@ proc init*[T](
 
 proc init*[T](
     mhtype: typedesc[MultiHash], hashcode: MultiCodec, mdigest: MDigest[T]
-): MhResult[MultiHash] {.inline.} =
+): MhResult[MultiHash] =
   ## Create MultiHash from nimcrypto's `MDigest` and hash algorithm code
   ## ``hashcode``.
   let hash = CodeHashes.getOrDefault(hashcode)
@@ -466,7 +466,7 @@ proc init*[T](
 
 proc init*(
     mhtype: typedesc[MultiHash], hashname: string, bdigest: openArray[byte]
-): MhResult[MultiHash] {.inline.} =
+): MhResult[MultiHash] =
   ## Create MultiHash from array of bytes ``bdigest`` and hash algorithm code
   ## ``hashcode``.
   let mc = MultiCodec.codec(hashname)
@@ -483,7 +483,7 @@ proc init*(
 
 proc init*(
     mhtype: typedesc[MultiHash], hashcode: MultiCodec, bdigest: openArray[byte]
-): MhResult[MultiHash] {.inline.} =
+): MhResult[MultiHash] =
   ## Create MultiHash from array of bytes ``bdigest`` and hash algorithm code
   ## ``hashcode``.
   let hash = CodeHashes.getOrDefault(hashcode)
@@ -570,15 +570,13 @@ proc validate*(mhtype: typedesc[MultiHash], data: openArray[byte]): bool =
     return false
   true
 
-proc init*(
-    mhtype: typedesc[MultiHash], data: openArray[byte]
-): MhResult[MultiHash] {.inline.} =
+proc init*(mhtype: typedesc[MultiHash], data: openArray[byte]): MhResult[MultiHash] =
   ## Create MultiHash from bytes array ``data``.
   var hash: MultiHash
   discard ?MultiHash.decode(data, hash)
   ok(hash)
 
-proc init*(mhtype: typedesc[MultiHash], data: string): MhResult[MultiHash] {.inline.} =
+proc init*(mhtype: typedesc[MultiHash], data: string): MhResult[MultiHash] =
   ## Create MultiHash from hexadecimal string representation ``data``.
   var hash: MultiHash
   try:
@@ -587,14 +585,14 @@ proc init*(mhtype: typedesc[MultiHash], data: string): MhResult[MultiHash] {.inl
   except ValueError:
     err(ErrParseError)
 
-proc init58*(mhtype: typedesc[MultiHash], data: string): MultiHash {.inline.} =
+proc init58*(mhtype: typedesc[MultiHash], data: string): MultiHash =
   ## Create MultiHash from BASE58 encoded string representation ``data``.
   var hash: MultiHash
   if MultiHash.decode(Base58.decode(data), hash) == -1:
     raise newException(MultihashError, "Incorrect MultiHash binary format in init58")
   hash
 
-proc cmp(a: openArray[byte], b: openArray[byte]): bool {.inline.} =
+proc cmp(a: openArray[byte], b: openArray[byte]): bool =
   if len(a) != len(b):
     return false
   var n = len(a)
@@ -617,7 +615,7 @@ proc `==`*[T](mh: MultiHash, mdigest: MDigest[T]): bool =
     mdigest.data.toOpenArray(0, mdigest.data.high),
   )
 
-proc `==`*[T](mdigest: MDigest[T], mh: MultiHash): bool {.inline.} =
+proc `==`*[T](mdigest: MDigest[T], mh: MultiHash): bool =
   ## Compares MultiHash with nimcrypto's MDigest[T], returns ``true`` if
   ## hashes are equal, ``false`` otherwise.
   `==`(mh, mdigest)
@@ -649,13 +647,11 @@ proc `$`*(mh: MultiHash): string =
   let digest = toHex(mh.data.buffer.toOpenArray(mh.dpos, mh.dpos + mh.size - 1))
   $(mh.mcodec) & "/" & digest
 
-proc write*(vb: var VBuffer, mh: MultiHash) {.inline.} =
+proc write*(vb: var VBuffer, mh: MultiHash) =
   ## Write MultiHash value ``mh`` to buffer ``vb``.
   vb.writeArray(mh.data.buffer)
 
-proc encode*(
-    mbtype: typedesc[MultiBase], encoding: string, mh: MultiHash
-): string {.inline.} =
+proc encode*(mbtype: typedesc[MultiBase], encoding: string, mh: MultiHash): string =
   ## Get MultiBase encoded representation of ``mh`` using encoding
   ## ``encoding``.
   MultiBase.encode(encoding, mh.data.buffer)

--- a/libp2p/muxer_store.nim
+++ b/libp2p/muxer_store.nim
@@ -9,21 +9,21 @@ from stream/connection import Direction
 type MuxerStore* = ref object
   muxed: Table[PeerId, seq[Muxer]]
 
-proc getAll*(s: MuxerStore): Table[PeerId, seq[Muxer]] {.inline.} =
+proc getAll*(s: MuxerStore): Table[PeerId, seq[Muxer]] =
   return s.muxed
 
-proc countPeers*(s: MuxerStore): int {.inline.} =
+proc countPeers*(s: MuxerStore): int =
   return s.muxed.len
 
-proc count*(s: MuxerStore, peerId: PeerId): int {.inline.} =
+proc count*(s: MuxerStore, peerId: PeerId): int =
   s.muxed.withValue(peerId, muxers):
     return muxers[].len
   return 0
 
-proc contains*(s: MuxerStore, peerId: PeerId): bool {.inline.} =
+proc contains*(s: MuxerStore, peerId: PeerId): bool =
   peerId in s.muxed
 
-proc contains*(s: MuxerStore, muxer: Muxer): bool {.inline.} =
+proc contains*(s: MuxerStore, muxer: Muxer): bool =
   let peerId = muxer.connection.peerId
   s.muxed.withValue(peerId, muxers):
     return muxer in muxers[]

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -50,7 +50,7 @@ proc newTooManyChannels(): ref TooManyChannels =
 proc newInvalidChannelIdError(): ref InvalidChannelIdError =
   newException(InvalidChannelIdError, "max allowed channel count exceeded")
 
-proc cleanupChann(m: Mplex, chann: LPChannel) {.async: (raises: []), inline.} =
+proc cleanupChann(m: Mplex, chann: LPChannel) {.async: (raises: []).} =
   ## remove the local channel from the internal tables
   ##
   try:

--- a/libp2p/peerid.nim
+++ b/libp2p/peerid.nim
@@ -230,9 +230,7 @@ func write*(pb: var ProtoBuffer, field: int, pid: PeerId) =
   ## Write PeerId value ``peerid`` to object ``pb`` using ProtoBuf's encoding.
   write(pb, field, pid.data)
 
-func getField*(
-    pb: ProtoBuffer, field: int, pid: var PeerId
-): ProtoResult[bool] {.inline.} =
+func getField*(pb: ProtoBuffer, field: int, pid: var PeerId): ProtoResult[bool] =
   ## Read ``PeerId`` from ProtoBuf's message and validate it
   var buffer: seq[byte]
   let res = ?pb.getField(field, buffer)

--- a/libp2p/protobuf/minprotobuf.nim
+++ b/libp2p/protobuf/minprotobuf.nim
@@ -101,7 +101,7 @@ template getPtr*(pb: ProtoBuffer): pointer =
 template getLen*(pb: ProtoBuffer): int =
   len(pb.buffer) - pb.offset
 
-proc vsizeof*(field: ProtoField): int {.inline.} =
+proc vsizeof*(field: ProtoField): int =
   ## Returns number of bytes required to store protobuf's field ``field``.
   case field.kind
   of ProtoFieldKind.Varint:
@@ -258,7 +258,7 @@ proc write*[T: byte | char](pb: var ProtoBuffer, field: int, value: openArray[T]
     copyMem(addr pb.buffer[pb.offset], addr value[0], len(value))
     pb.offset += len(value)
 
-proc write*(pb: var ProtoBuffer, field: int, value: ProtoBuffer) {.inline.} =
+proc write*(pb: var ProtoBuffer, field: int, value: ProtoBuffer) =
   ## Encode Protobuf's sub-message ``value`` and store it to protobuf's buffer
   ## ``pb`` with field number ``field``.
   write(pb, field, value.buffer)
@@ -562,7 +562,7 @@ proc getField*[T: seq[byte] | string](
 
 proc getField*(
     pb: ProtoBuffer, field: int, output: var ProtoBuffer
-): ProtoResult[bool] {.inline.} =
+): ProtoResult[bool] =
   var buffer: seq[byte]
   if ?pb.getField(field, buffer):
     output = initProtoBuffer(buffer)
@@ -570,9 +570,7 @@ proc getField*(
   else:
     ok(false)
 
-proc getField*(
-    pb: ProtoBuffer, field: int, output: var bool
-): ProtoResult[bool] {.inline.} =
+proc getField*(pb: ProtoBuffer, field: int, output: var bool): ProtoResult[bool] =
   var boolValue: uint64
   if ?pb.getField(field, boolValue):
     output = bool(boolValue)
@@ -581,9 +579,7 @@ proc getField*(
     output = false
     ok(false)
 
-proc getField*(
-    pb: ProtoBuffer, field: int, output: var Opt[bool]
-): ProtoResult[bool] {.inline.} =
+proc getField*(pb: ProtoBuffer, field: int, output: var Opt[bool]): ProtoResult[bool] =
   var boolValue: uint64
   if ?pb.getField(field, boolValue):
     output = Opt.some(bool(boolValue))
@@ -594,7 +590,7 @@ proc getField*(
 
 proc getRequiredField*[T](
     pb: ProtoBuffer, field: int, output: var T
-): ProtoResult[void] {.inline.} =
+): ProtoResult[void] =
   if ?pb.getField(field, output):
     ok()
   else:
@@ -680,7 +676,7 @@ proc getRepeatedField*[T: ProtoScalar](
 
 proc getRequiredRepeatedField*[T](
     pb: ProtoBuffer, field: int, output: var seq[T]
-): ProtoResult[void] {.inline.} =
+): ProtoResult[void] =
   if ?pb.getRepeatedField(field, output):
     ok()
   else:

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -19,14 +19,14 @@ import ./[protobuf, types, find, kademlia_metrics]
 logScope:
   topics = "kad-dht provider"
 
-proc `==`*(a, b: ProviderRecord): bool {.inline.} =
+proc `==`*(a, b: ProviderRecord): bool =
   a.provider.id == b.provider.id and a.key == b.key
 
 # for HeapQueue
-proc `<`*(a, b: ProviderRecord): bool {.inline.} =
+proc `<`*(a, b: ProviderRecord): bool =
   a.expiresAt < b.expiresAt
 
-proc `<`*(a: ProviderRecord, b: chronos.Moment): bool {.inline.} =
+proc `<`*(a: ProviderRecord, b: chronos.Moment): bool =
   a.expiresAt < b
 
 proc deleteOldest(pk: ProvidedKeys) =
@@ -39,37 +39,37 @@ proc deleteOldest(pk: ProvidedKeys) =
       oldestMoment = moment
   pk.provided.del(oldest)
 
-proc isFull*(pk: ProvidedKeys): bool {.inline.} =
+proc isFull*(pk: ProvidedKeys): bool =
   pk.provided.len() >= pk.capacity
 
-proc len*(pk: ProvidedKeys): int {.inline.} =
+proc len*(pk: ProvidedKeys): int =
   pk.provided.len()
 
-proc hasKey*(pk: ProvidedKeys, k: Key): bool {.inline.} =
+proc hasKey*(pk: ProvidedKeys, k: Key): bool =
   pk.provided.hasKey(k)
 
-proc del*(pk: ProvidedKeys, k: Key) {.inline.} =
+proc del*(pk: ProvidedKeys, k: Key) =
   pk.provided.del(k)
 
-proc pop*(pr: ProviderRecords): ProviderRecord {.inline.} =
+proc pop*(pr: ProviderRecords): ProviderRecord =
   pr.records.pop()
 
-proc len*(pr: ProviderRecords): int {.inline.} =
+proc len*(pr: ProviderRecords): int =
   pr.records.len()
 
-proc del*(pr: ProviderRecords, index: int) {.inline.} =
+proc del*(pr: ProviderRecords, index: int) =
   pr.records.del(index)
 
-proc find*(pr: ProviderRecords, record: ProviderRecord): int {.inline.} =
+proc find*(pr: ProviderRecords, record: ProviderRecord): int =
   pr.records.find(record)
 
-proc push*(pr: ProviderRecords, record: ProviderRecord) {.inline.} =
+proc push*(pr: ProviderRecords, record: ProviderRecord) =
   pr.records.push(record)
 
-proc isFull*(pr: ProviderRecords): bool {.inline.} =
+proc isFull*(pr: ProviderRecords): bool =
   pr.records.len() >= pr.capacity
 
-proc `[]`*(pr: ProviderRecords, i: int): ProviderRecord {.inline.} =
+proc `[]`*(pr: ProviderRecords, i: int): ProviderRecord =
   pr.records[i]
 
 proc removeProviderRecord(pm: ProviderManager, record: ProviderRecord) =

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -235,10 +235,10 @@ proc randomKeyInBucket*(selfId: Key, bucketIndex: int, rng: Rng): Key =
 
   return raw
 
-proc allKeys*(bucket: Bucket): seq[Key] {.inline.} =
+proc allKeys*(bucket: Bucket): seq[Key] =
   return bucket.peers.mapIt(it.nodeId)
 
-proc allKeys*(rtable: RoutingTable): seq[Key] {.inline.} =
+proc allKeys*(rtable: RoutingTable): seq[Key] =
   rtable.buckets.mapIt(it.allKeys()).concat()
 
 proc randomKey*(bucket: Bucket, rng: Rng): Opt[Key] =

--- a/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
@@ -77,14 +77,10 @@ type
     groupState: Table[TopicGroupKey, GroupState]
     peerTopicOpts: Table[PeerTopicKey, TopicOpts]
 
-proc new(
-    T: typedesc[PeerTopicKey], peerId: PeerId, topic: string
-): PeerTopicKey {.inline.} =
+proc new(T: typedesc[PeerTopicKey], peerId: PeerId, topic: string): PeerTopicKey =
   PeerTopicKey(key: TableKey.makeKey(peerId, topic), peerId: peerId, topic: topic)
 
-proc new(
-    T: typedesc[TopicGroupKey], topic: string, groupId: GroupId
-): TopicGroupKey {.inline.} =
+proc new(T: typedesc[TopicGroupKey], topic: string, groupId: GroupId): TopicGroupKey =
   TopicGroupKey(key: TableKey.makeKey(topic, groupId), topic: topic, groupId: groupId)
 
 proc doAssert(config: PartialMessageExtensionConfig) =

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -201,7 +201,7 @@ type
     knownTopics*: HashSet[string]
     customStreamCallbacks*: Opt[CustomStreamCallbacks]
 
-proc topicLabel*(p: PubSub, topic: string): string {.inline.} =
+proc topicLabel*(p: PubSub, topic: string): string =
   ## returns value to be used for `topic` labels.
   ## 
 

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -209,7 +209,7 @@ proc encodeMessage*(msg: Message, anonymize: bool): seq[byte] =
 proc write*(pb: var ProtoBuffer, field: int, msg: Message, anonymize: bool) =
   pb.write(field, encodeMessage(msg, anonymize))
 
-proc decodeGraft*(pb: ProtoBuffer): ProtoResult[ControlGraft] {.inline.} =
+proc decodeGraft*(pb: ProtoBuffer): ProtoResult[ControlGraft] =
   when defined(libp2p_protobuf_metrics):
     libp2p_pubsub_rpc_bytes_read.inc(pb.getLen().int64, labelValues = ["graft"])
 
@@ -221,7 +221,7 @@ proc decodeGraft*(pb: ProtoBuffer): ProtoResult[ControlGraft] {.inline.} =
     trace "decodeGraft: topicID is missing"
   ok(control)
 
-proc decodePeerInfoMsg*(pb: ProtoBuffer): ProtoResult[PeerInfoMsg] {.inline.} =
+proc decodePeerInfoMsg*(pb: ProtoBuffer): ProtoResult[PeerInfoMsg] =
   trace "decodePeerInfoMsg: decoding message"
   var pi = PeerInfoMsg()
   if ?pb.getField(1, pi.peerId):
@@ -235,7 +235,7 @@ proc decodePeerInfoMsg*(pb: ProtoBuffer): ProtoResult[PeerInfoMsg] {.inline.} =
     trace "decodePeerInfoMsg: signedPeerRecord is missing"
   ok(pi)
 
-proc decodePrune*(pb: ProtoBuffer): ProtoResult[ControlPrune] {.inline.} =
+proc decodePrune*(pb: ProtoBuffer): ProtoResult[ControlPrune] =
   when defined(libp2p_protobuf_metrics):
     libp2p_pubsub_rpc_bytes_read.inc(pb.getLen().int64, labelValues = ["prune"])
 
@@ -253,7 +253,7 @@ proc decodePrune*(pb: ProtoBuffer): ProtoResult[ControlPrune] {.inline.} =
     trace "decodePrune: read backoff", backoff = control.backoff
   ok(control)
 
-proc decodeIHave*(pb: ProtoBuffer): ProtoResult[ControlIHave] {.inline.} =
+proc decodeIHave*(pb: ProtoBuffer): ProtoResult[ControlIHave] =
   when defined(libp2p_protobuf_metrics):
     libp2p_pubsub_rpc_bytes_read.inc(pb.getLen().int64, labelValues = ["ihave"])
 
@@ -269,7 +269,7 @@ proc decodeIHave*(pb: ProtoBuffer): ProtoResult[ControlIHave] {.inline.} =
     trace "decodeIHave: no messageIDs"
   ok(control)
 
-proc decodeIWant*(pb: ProtoBuffer): ProtoResult[ControlIWant] {.inline.} =
+proc decodeIWant*(pb: ProtoBuffer): ProtoResult[ControlIWant] =
   when defined(libp2p_protobuf_metrics):
     libp2p_pubsub_rpc_bytes_read.inc(pb.getLen().int64, labelValues = ["iwant"])
 
@@ -281,7 +281,7 @@ proc decodeIWant*(pb: ProtoBuffer): ProtoResult[ControlIWant] {.inline.} =
     trace "decodeIWant: no messageIDs"
   ok(control)
 
-proc decodePreamble*(pb: ProtoBuffer): ProtoResult[Preamble] {.inline.} =
+proc decodePreamble*(pb: ProtoBuffer): ProtoResult[Preamble] =
   when defined(libp2p_protobuf_metrics):
     libp2p_pubsub_rpc_bytes_read.inc(pb.getLen().int64, labelValues = ["preamble"])
 
@@ -301,7 +301,7 @@ proc decodePreamble*(pb: ProtoBuffer): ProtoResult[Preamble] {.inline.} =
     trace "decodePreamble: message Length is missing"
   ok(control)
 
-proc decodeIMReceiving*(pb: ProtoBuffer): ProtoResult[IMReceiving] {.inline.} =
+proc decodeIMReceiving*(pb: ProtoBuffer): ProtoResult[IMReceiving] =
   when defined(libp2p_protobuf_metrics):
     libp2p_pubsub_rpc_bytes_read.inc(pb.getLen().int64, labelValues = ["imreceiving"])
 
@@ -318,7 +318,7 @@ proc decodeIMReceiving*(pb: ProtoBuffer): ProtoResult[IMReceiving] {.inline.} =
     trace "decodeIMReceiving: message Length is missing"
   ok(control)
 
-proc decodeExtensions*(pb: ProtoBuffer): ProtoResult[ControlExtensions] {.inline.} =
+proc decodeExtensions*(pb: ProtoBuffer): ProtoResult[ControlExtensions] =
   when defined(libp2p_protobuf_metrics):
     libp2p_pubsub_rpc_bytes_read.inc(pb.getLen().int64, labelValues = ["extensions"])
 
@@ -352,7 +352,7 @@ proc decodeExtensions*(pb: ProtoBuffer): ProtoResult[ControlExtensions] {.inline
 
   ok(control)
 
-proc decodeControl*(pb: ProtoBuffer): ProtoResult[Opt[ControlMessage]] {.inline.} =
+proc decodeControl*(pb: ProtoBuffer): ProtoResult[Opt[ControlMessage]] =
   trace "decodeControl: decoding message"
   var buffer: seq[byte]
   if ?pb.getField(3, buffer):
@@ -392,7 +392,7 @@ proc decodeControl*(pb: ProtoBuffer): ProtoResult[Opt[ControlMessage]] {.inline.
   else:
     ok(Opt.none(ControlMessage))
 
-proc decodeSubscription*(pb: ProtoBuffer): ProtoResult[SubOpts] {.inline.} =
+proc decodeSubscription*(pb: ProtoBuffer): ProtoResult[SubOpts] =
   when defined(libp2p_protobuf_metrics):
     libp2p_pubsub_rpc_bytes_read.inc(pb.getLen().int64, labelValues = ["subs"])
 
@@ -422,7 +422,7 @@ proc decodeSubscription*(pb: ProtoBuffer): ProtoResult[SubOpts] {.inline.} =
 
   ok(sub)
 
-proc decodeSubscriptions*(pb: ProtoBuffer): ProtoResult[seq[SubOpts]] {.inline.} =
+proc decodeSubscriptions*(pb: ProtoBuffer): ProtoResult[seq[SubOpts]] =
   trace "decodeSubscriptions: decoding message"
   var subpbs: seq[seq[byte]]
   var subs: seq[SubOpts]
@@ -435,7 +435,7 @@ proc decodeSubscriptions*(pb: ProtoBuffer): ProtoResult[seq[SubOpts]] {.inline.}
       trace "decodeSubscription: no subscriptions found"
   ok(subs)
 
-proc decodeMessage*(pb: ProtoBuffer): ProtoResult[Message] {.inline.} =
+proc decodeMessage*(pb: ProtoBuffer): ProtoResult[Message] =
   when defined(libp2p_protobuf_metrics):
     libp2p_pubsub_rpc_bytes_read.inc(pb.getLen().int64, labelValues = ["message"])
 
@@ -468,7 +468,7 @@ proc decodeMessage*(pb: ProtoBuffer): ProtoResult[Message] {.inline.} =
     trace "decodeMessage: public key is missing"
   ok(msg)
 
-proc decodeMessages*(pb: ProtoBuffer): ProtoResult[seq[Message]] {.inline.} =
+proc decodeMessages*(pb: ProtoBuffer): ProtoResult[seq[Message]] =
   trace "decodeMessages: decoding message"
   var msgpbs: seq[seq[byte]]
   var msgs: seq[Message]
@@ -508,7 +508,7 @@ proc encodeRpcMsg*(msg: RPCMsg, anonymize: bool): seq[byte] =
 
 proc decodeTestExtensionRPC*(
     pb: ProtoBuffer, field: int
-): ProtoResult[Opt[TestExtensionRPC]] {.inline.} =
+): ProtoResult[Opt[TestExtensionRPC]] =
   trace "TestExtensionRPC: decoding message"
 
   var testExtension: seq[byte]
@@ -519,7 +519,7 @@ proc decodeTestExtensionRPC*(
 
 proc decodePingPongExtensionRPC*(
     pb: ProtoBuffer, field: int
-): ProtoResult[Opt[PingPongExtensionRPC]] {.inline.} =
+): ProtoResult[Opt[PingPongExtensionRPC]] =
   trace "PingPongExtensionRPC: decoding message"
 
   var bytes: seq[byte]
@@ -539,7 +539,7 @@ proc decodePingPongExtensionRPC*(
 
 proc decodePreambleExtensionRPC*(
     pb: ProtoBuffer, field: int
-): ProtoResult[Opt[PreambleExtensionRPC]] {.inline.} =
+): ProtoResult[Opt[PreambleExtensionRPC]] =
   trace "PreambleExtensionRPC: decoding message"
 
   var bytes: seq[byte]
@@ -565,7 +565,7 @@ proc decodePreambleExtensionRPC*(
 
 proc decodePartialMessageExtensionRPC*(
     pb: ProtoBuffer, field: int
-): ProtoResult[Opt[PartialMessageExtensionRPC]] {.inline.} =
+): ProtoResult[Opt[PartialMessageExtensionRPC]] =
   trace "PartialMessageExtensionRPC: decoding message"
 
   var partialMessgeExtensionsRPCBytes: seq[byte]
@@ -602,7 +602,7 @@ proc decodePartialMessageExtensionRPC*(
 
   ok(Opt.some(pme))
 
-proc decodeRpcMsg*(msg: sink seq[byte]): ProtoResult[RPCMsg] {.inline.} =
+proc decodeRpcMsg*(msg: sink seq[byte]): ProtoResult[RPCMsg] =
   trace "decodeRpcMsg: decoding message", encodedData = msg.shortLog()
   var pb = initProtoBuffer(move(msg))
   var rpcMsg = RPCMsg()

--- a/libp2p/protocols/pubsub/timedcache.nim
+++ b/libp2p/protocols/pubsub/timedcache.nim
@@ -122,7 +122,7 @@ func contains*[K](t: TimedCache[K], k: K): bool =
   let tmp = TimedEntry[K](key: k)
   tmp in t.entries
 
-func len*[K](t: TimedCache[K]): int {.inline.} =
+func len*[K](t: TimedCache[K]): int =
   ## Returns the number of entries in the cache.
   t.entries.len
 

--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -52,7 +52,7 @@ proc removeAd*(ipTree: IpTree, ad: Advertisement) {.raises: [].} =
   for ip in ad.data.addresses.filterIPv4():
     ipTree.removeIp(ip)
 
-proc isExpired(now, ts: Moment, expiry: Duration): bool {.inline.} =
+proc isExpired(now, ts: Moment, expiry: Duration): bool =
   now - ts > expiry
 
 proc pruneAdsForService(

--- a/libp2p/protocols/service_discovery/routing_table_manager.nim
+++ b/libp2p/protocols/service_discovery/routing_table_manager.nim
@@ -101,9 +101,7 @@ proc insertPeer*(
     cd_service_table_insertions.inc()
     manager.updateServiceTablesMetrics()
 
-proc hasService*(
-    manager: ServiceRoutingTableManager, serviceId: ServiceId
-): bool {.inline.} =
+proc hasService*(manager: ServiceRoutingTableManager, serviceId: ServiceId): bool =
   ## Check if routing table exists for a service
   serviceId in manager.tables
 
@@ -115,13 +113,13 @@ proc refreshAllTables*(
   for rtable in tables:
     await kad.refreshTable(rtable)
 
-proc count*(manager: ServiceRoutingTableManager): int {.inline.} =
+proc count*(manager: ServiceRoutingTableManager): int =
   return manager.tables.len
 
-proc serviceIds*(manager: ServiceRoutingTableManager): seq[ServiceId] {.inline.} =
+proc serviceIds*(manager: ServiceRoutingTableManager): seq[ServiceId] =
   return manager.tables.keys.toSeq()
 
-proc clear*(manager: ServiceRoutingTableManager) {.inline.} =
+proc clear*(manager: ServiceRoutingTableManager) =
   manager.tables.clear()
   manager.serviceStatus.clear()
   manager.updateServiceTablesMetrics()

--- a/libp2p/signed_envelope.nim
+++ b/libp2p/signed_envelope.nim
@@ -96,7 +96,7 @@ proc payload*(env: Envelope): seq[byte] =
 
 proc getField*(
     pb: ProtoBuffer, field: int, value: var Envelope, domain: string
-): ProtoResult[bool] {.inline.} =
+): ProtoResult[bool] =
   var buffer: seq[byte]
   let res = ?pb.getField(field, buffer)
   if not (res):
@@ -128,7 +128,7 @@ proc init*[T](
 
 proc getField*[T](
     pb: ProtoBuffer, field: int, value: var SignedPayload[T]
-): ProtoResult[bool] {.inline.} =
+): ProtoResult[bool] =
   if not ?getField(pb, field, value.envelope, T.payloadDomain):
     ok(false)
   else:

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -121,7 +121,7 @@ method closed*(s: LPStream): bool {.base.} =
 method atEof*(s: LPStream): bool {.base.} =
   s.isEof
 
-func wasResetLocally*(s: LPStream): bool {.inline.} =
+func wasResetLocally*(s: LPStream): bool =
   s.isResetLocally
 
 method readOnce*(

--- a/libp2p/transports/tls/certificate.nim
+++ b/libp2p/transports/tls/certificate.nim
@@ -54,7 +54,7 @@ func publicKey*(cert: P2pCertificate): PublicKey =
 func peerId*(cert: P2pCertificate): PeerId =
   return PeerId.init(cert.publicKey()).tryGet()
 
-func makeSignatureMessage(pubKey: seq[byte]): seq[byte] {.inline.} =
+func makeSignatureMessage(pubKey: seq[byte]): seq[byte] =
   ## Creates message used for certificate signature.
   ##
   let P2P_SIGNING_PREFIX = "libp2p-tls-handshake:".toBytes()
@@ -65,7 +65,7 @@ func makeSignatureMessage(pubKey: seq[byte]): seq[byte] {.inline.} =
 
   return msg
 
-func makeIssuerDN(identityKeyPair: KeyPair): string {.inline.} =
+func makeIssuerDN(identityKeyPair: KeyPair): string =
   let issuerDN =
     try:
       $(PeerId.init(identityKeyPair.pubkey).tryGet())
@@ -73,7 +73,7 @@ func makeIssuerDN(identityKeyPair: KeyPair): string {.inline.} =
       raiseAssert "pubkey must be set"
   return issuerDN
 
-proc makeASN1Time(time: Time): string {.inline.} =
+proc makeASN1Time(time: Time): string =
   let str =
     try:
       let f = initTimeFormat("yyyyMMddHHmmss")

--- a/libp2p/utils/bytesview.nim
+++ b/libp2p/utils/bytesview.nim
@@ -8,10 +8,10 @@ type BytesView* = object
 proc init*(t: typedesc[BytesView], data: sink seq[byte]): BytesView =
   BytesView(data: data, rpos: 0)
 
-func len*(v: BytesView): int {.inline.} =
+func len*(v: BytesView): int =
   v.data.len - v.rpos
 
-func consume*(v: var BytesView, n: int) {.inline.} =
+func consume*(v: var BytesView, n: int) =
   doAssert v.data.len >= v.rpos + n
   v.rpos += n
 

--- a/libp2p/utils/opt.nim
+++ b/libp2p/utils/opt.nim
@@ -22,7 +22,7 @@ template toOpt*[T, E](self: Result[T, E]): Opt[T] =
   else:
     Opt.none(type(T))
 
-proc toOpt*[T: ref object](x: T): Opt[T] {.inline.} =
+proc toOpt*[T: ref object](x: T): Opt[T] =
   if x.isNil:
     Opt.none(T)
   else:

--- a/libp2p/utils/zeroqueue.nim
+++ b/libp2p/utils/zeroqueue.nim
@@ -39,7 +39,7 @@ proc push*(q: var ZeroQueue, b: sink seq[byte]) =
     q.queuedBytes += b.len.int64
     q.chunks.addLast(newChunk(b))
 
-proc popChunk(q: var ZeroQueue, count: int): Chunk {.inline.} =
+proc popChunk(q: var ZeroQueue, count: int): Chunk =
   doAssert(count > 0, "count must be positive integer")
   var first = q.chunks.popFirst()
 

--- a/libp2p/varint.nim
+++ b/libp2p/varint.nim
@@ -94,7 +94,7 @@ template fromUleb(x: uint64, T: type hint64): T =
 template fromUleb(x: uint32, T: type hint32): T =
   cast[T](x)
 
-proc vsizeof*(x: SomeVarint): int {.inline.} =
+proc vsizeof*(x: SomeVarint): int =
   ## Returns number of bytes required to encode integer ``x`` as varint.
   Leb128.len(toUleb(x))
 
@@ -182,7 +182,7 @@ proc putUVarint*[T: PB | LP](
 
 proc getSVarint*(
     pbytes: openArray[byte], outsize: var int, outval: var (PBZigVarint | PBSomeSVarint)
-): VarintResult[void] {.inline.} =
+): VarintResult[void] =
   ## Decode signed integer (``int32`` or ``int64``) from buffer ``pbytes``
   ## and store it to ``outval``.
   ##
@@ -213,7 +213,7 @@ proc getSVarint*(
 
 proc putSVarint*(
     pbytes: var openArray[byte], outsize: var int, outval: (PBZigVarint | PBSomeSVarint)
-): VarintResult[void] {.inline.} =
+): VarintResult[void] =
   ## Encode signed integer ``outval`` using ProtoBuffer's zigzag encoding
   ## (``sint32`` or ``sint64``) and store it to array ``pbytes``.
   ##
@@ -234,7 +234,7 @@ template varintFatal(msg) =
 
 proc putVarint*[T: PB | LP](
     vtype: typedesc[T], pbytes: var openArray[byte], nbytes: var int, value: SomeVarint
-): VarintResult[void] {.inline.} =
+): VarintResult[void] =
   when vtype is PB:
     when (type(value) is PBSomeSVarint) or (type(value) is PBZigVarint):
       putSVarint(pbytes, nbytes, value)
@@ -254,7 +254,7 @@ proc putVarint*[T: PB | LP](
 
 proc getVarint*[T: PB | LP](
     vtype: typedesc[T], pbytes: openArray[byte], nbytes: var int, value: var SomeVarint
-): VarintResult[void] {.inline.} =
+): VarintResult[void] =
   when vtype is PB:
     when (type(value) is PBSomeSVarint) or (type(value) is PBZigVarint):
       getSVarint(pbytes, nbytes, value)
@@ -275,9 +275,7 @@ proc getVarint*[T: PB | LP](
 template toBytes*(vtype: typedesc[PB], value: PBSomeVarint): auto =
   toBytes(toUleb(value), Leb128)
 
-proc encodeVarint*(
-    vtype: typedesc[PB], value: PBSomeVarint
-): VarintResult[seq[byte]] {.inline.} =
+proc encodeVarint*(vtype: typedesc[PB], value: PBSomeVarint): VarintResult[seq[byte]] =
   ## Encode integer to Google ProtoBuf's `signed/unsigned varint` and returns
   ## sequence of bytes as buffer.
   var outsize = 0
@@ -296,9 +294,7 @@ proc encodeVarint*(
   else:
     err(res.error())
 
-proc encodeVarint*(
-    vtype: typedesc[LP], value: LPSomeVarint
-): VarintResult[seq[byte]] {.inline.} =
+proc encodeVarint*(vtype: typedesc[LP], value: LPSomeVarint): VarintResult[seq[byte]] =
   ## Encode integer to LibP2P `unsigned varint` and returns sequence of bytes
   ## as buffer.
   var outsize = 0

--- a/libp2p/vbuffer.nim
+++ b/libp2p/vbuffer.nim
@@ -150,7 +150,7 @@ proc peekArray*[T: char | byte](vb: var VBuffer, value: var openArray[T]): int =
   else:
     -1
 
-proc readVarint*(vb: var VBuffer, value: var LPSomeUVarint): int {.inline.} =
+proc readVarint*(vb: var VBuffer, value: var LPSomeUVarint): int =
   ## Read unsigned integer from buffer ``vb`` and store result to ``value``.
   ##
   ## Returns number of bytes consumed from ``vb`` or ``-1`` on error.
@@ -159,7 +159,7 @@ proc readVarint*(vb: var VBuffer, value: var LPSomeUVarint): int {.inline.} =
     vb.offset += r
   r
 
-proc readSeq*[T: string | seq[byte]](vb: var VBuffer, value: var T): int {.inline.} =
+proc readSeq*[T: string | seq[byte]](vb: var VBuffer, value: var T): int =
   ## Read length prefixed array from buffer ``vb`` and store result to
   ## ``value``.
   ##
@@ -169,9 +169,7 @@ proc readSeq*[T: string | seq[byte]](vb: var VBuffer, value: var T): int {.inlin
     vb.offset += r
   r
 
-proc readArray*[T: char | byte](
-    vb: var VBuffer, value: var openArray[T]
-): int {.inline.} =
+proc readArray*[T: char | byte](vb: var VBuffer, value: var openArray[T]): int =
   ## Read array from buffer ``vb`` and store result to ``value``.
   ##
   ## Returns number of bytes consumed from ``vb`` or ``-1`` on error.


### PR DESCRIPTION
## Summary

Removes explicit `{.inline.}` pragmas from existing Nim declarations across the codebase.

This follows the Status Nim style guide, which says to avoid explicit inline functions because they add clutter and leave inlining decisions to the compiler/LTO where possible.

## Affected Areas

- [x] Other

Code style cleanup across multiformats, crypto helpers, protobuf helpers, pubsub, Kademlia, service discovery, transports, stream utilities, and cbind helper code.

## Impact on Library Users

No API or network behavior change. This only removes explicit compiler hints from existing declarations.

## Risk Assessment

Low. The change is mechanical; remaining pragmas such as `raises` and `async` are preserved. Any risk is limited to compiler codegen choices after removing manual inline hints.

## References

- [Status Nim style guide: inline functions](https://status-im.github.io/nim-style-guide/language.inline.html)
