### PR TITLE
fix(ping): keep inbound ping streams reusable

### DIFF
--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -7,11 +7,7 @@
 
 import chronos, chronicles
 import
-  ../stream/connection,
-  ../peerid,
-  ../crypto/crypto,
-  ../protocols/protocol,
-  ../errors
+  ../stream/connection, ../peerid, ../crypto/crypto, ../protocols/protocol, ../errors
 
 export chronicles, rng, connection
 
@@ -49,9 +45,6 @@ method init*(p: Ping) =
         await stream.write(@buf)
         if not isNil(p.pingHandler):
           await p.pingHandler(stream.peerId)
-    except CancelledError as exc:
-      trace "cancelled ping handler"
-      raise exc
     except LPStreamEOFError as exc:
       trace "ping stream closed", description = exc.msg, stream
     except LPStreamError as exc:

--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -7,11 +7,9 @@
 
 import chronos, chronicles
 import
-  ../peerinfo,
   ../stream/connection,
   ../peerid,
   ../crypto/crypto,
-  ../multiaddress,
   ../protocols/protocol,
   ../errors
 
@@ -28,13 +26,14 @@ type
   PingError* = object of LPError
   WrongPingAckError* = object of PingError
 
-  PingHandler* = proc(peer: PeerId): Future[void] {.gcsafe, raises: [].}
+  PingHandler* = proc(peer: PeerId): Future[void] {.async: (raises: []), gcsafe.}
 
   Ping* = ref object of LPProtocol
     pingHandler*: PingHandler
     rng: Rng
 
 proc new*(T: typedesc[Ping], handler: PingHandler = nil, rng: Rng): T =
+  doAssert not rng.isNil, "Rng is nil"
   let ping = Ping(pinghandler: handler, rng: rng)
   ping.init()
   ping
@@ -44,15 +43,18 @@ method init*(p: Ping) =
     try:
       trace "handling ping", stream
       var buf: array[PingSize, byte]
-      await stream.readExactly(addr buf[0], PingSize)
-      trace "echoing ping", stream, pingData = @buf
-      await stream.write(@buf)
-      if not isNil(p.pingHandler):
-        await p.pingHandler(stream.peerId)
+      while true:
+        await stream.readExactly(addr buf[0], PingSize)
+        trace "echoing ping", stream, pingData = @buf
+        await stream.write(@buf)
+        if not isNil(p.pingHandler):
+          await p.pingHandler(stream.peerId)
     except CancelledError as exc:
       trace "cancelled ping handler"
       raise exc
-    except CatchableError as exc:
+    except LPStreamEOFError as exc:
+      trace "ping stream closed", description = exc.msg, stream
+    except LPStreamError as exc:
       trace "exception in ping handler", description = exc.msg, stream
 
   p.handler = handle

--- a/tests/libp2p/protocols/test_ping.nim
+++ b/tests/libp2p/protocols/test_ping.nim
@@ -39,7 +39,7 @@ suite "Ping":
     transport1 = TcpTransport.new(upgrade = Upgrade())
     transport2 = TcpTransport.new(upgrade = Upgrade())
 
-    proc handlePing(peer: PeerId) {.async.} =
+    let handlePing = proc(peer: PeerId): Future[void] {.async: (raises: []), gcsafe.} =
       inc pingReceivedCount
 
     pingProto1 = Ping.new(rng = rng())
@@ -69,9 +69,11 @@ suite "Ping":
     stream = await transport2.dial(transport1.addrs[0])
 
     discard await msDial.select(stream, PingCodec)
-    let time = await pingProto2.ping(stream)
+    let first = await pingProto2.ping(stream)
+    let second = await pingProto2.ping(stream)
 
-    check not time.isZero()
+    check not first.isZero()
+    check not second.isZero()
 
   asyncTest "ping callback":
     msDial.addHandler(PingCodec, pingProto2)
@@ -80,6 +82,7 @@ suite "Ping":
       let c = await transport1.accept()
       discard await msListen.select(c, PingCodec)
       discard await pingProto1.ping(c)
+      await c.close()
 
     acceptFut = acceptHandler()
     stream = await transport2.dial(transport1.addrs[0])


### PR DESCRIPTION
## Summary

The libp2p ping spec says the dialing peer may send another 32-byte payload on the same stream and that the listening peer should loop and echo the next payload. This PR updates the Nim ping listener to follow that behavior by keeping inbound ping streams open for repeated payloads until the peer closes the stream.

It also:
- treats EOF as normal ping stream completion instead of logging it as a generic handler exception
- asserts that `Ping.new` receives a non-nil RNG
- removes unused imports from the ping protocol module
- gets rid of a `CatchableError`

## Affected Areas

- [x] Protocol Logic
  - Updates `/ipfs/ping/1.0.0` listener behavior and ping callback typing.

## Impact on Library Users

`PingHandler` is now typed as an async non-raising callback:

```nim
proc(peer: PeerId): Future[void] {.async: (raises: []), gcsafe.}
```

Callers passing a ping callback may need to make the callback match that stricter async signature.

## Risk Assessment

Low risk. The listener now keeps the negotiated ping stream alive for repeated payloads, matching the spec. The callback type change is a small API break for users that pass custom ping handlers.

## References

- [libp2p ping spec](https://github.com/libp2p/specs/blob/master/ping/ping.md)
