### PR TITLE
fix(wildcardresolver): deduplicate expanded listen addresses

### DIFF
--- a/libp2p/services/wildcardresolverservice.nim
+++ b/libp2p/services/wildcardresolverservice.nim
@@ -98,7 +98,8 @@ proc expandWildcardAddresses(
     for family in families:
       for ifaddr in networkInterfaceProvider(family):
         listenAddr.replaceIp(ifaddr.host.toIpAddress()).withValue(remapped):
-          addresses.add(remapped)
+          if remapped notin addresses:
+            addresses.add(remapped)
   addresses
 
 method setup*(

--- a/tests/libp2p/services/test_wildcard_resolver.nim
+++ b/tests/libp2p/services/test_wildcard_resolver.nim
@@ -16,11 +16,15 @@ proc getAddressesMock(
     if addrFamily == AddressFamily.IPv4:
       return @[
         InterfaceAddress.init(initTAddress("127.0.0.1:0"), 8),
+        InterfaceAddress.init(initTAddress("127.0.0.1:0"), 8),
+        InterfaceAddress.init(initTAddress("192.168.1.22:0"), 24),
         InterfaceAddress.init(initTAddress("192.168.1.22:0"), 24),
       ]
     else:
       return @[
         InterfaceAddress.init(initTAddress("::1:0"), 8),
+        InterfaceAddress.init(initTAddress("::1:0"), 8),
+        InterfaceAddress.init(initTAddress("fe80::1:0"), 64),
         InterfaceAddress.init(initTAddress("fe80::1:0"), 64),
       ]
   except TransportAddressError as e:


### PR DESCRIPTION
## Summary

Deduplicates wildcard-resolved listen addresses before adding them to the advertised address set.

This prevents duplicate multiaddresses when interface enumeration returns the same host more than once, or when wildcard expansion paths produce the same remapped address.

## Affected Areas

- [x] Other
  - Wildcard address resolver service

## Impact on Library Users

No API changes. Nodes may advertise fewer duplicate addresses when wildcard listen addresses are expanded.

## Risk Assessment

Low risk. The change only skips addresses already present in the mapper output, preserving the existing expansion order for unique addresses.
