### PR TITLE
chore(autotls): remove libp2p_autotls_support flag

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -138,7 +138,6 @@ These flags are used in CI and tests:
 
 | Flag | Purpose |
 |------|---------|
-| `-d:libp2p_autotls_support` | Enable AutoTLS support |
 | `-d:libp2p_expensive_metrics` | Per-peer cardinality metrics |
 | `-d:libp2p_agents_metrics -d:KnownLibP2PAgents=nimbus,...` | Known agent metrics |
 | `-d:KnownLibP2PTopics=topic1,topic2` | GossipSub topic metrics |
@@ -147,9 +146,6 @@ These flags are used in CI and tests:
 | `-d:libp2p_multiaddress_exts=<path>` | MultiAddress extensions file |
 | `-d:libp2p_multibase_exts=<path>` | MultiBase extensions file |
 | `-d:libp2p_contentids_exts=<path>` | ContentIds extensions file |
-
-The test runner (`libp2p.nimble`) always compiles with:
-`-d:libp2p_autotls_support`
 
 ---
 
@@ -429,7 +425,7 @@ The test runner (`libp2p.nimble`) always compiles with:
 
 ### AutoTLS (`autotls/`)
 - Automatic TLS certificate management using the ACME protocol
-- `service.nim` — AutoTLS service (enabled with `-d:libp2p_autotls_support`)
+- `service.nim` — AutoTLS service
 - `acme/` — ACME client and API for certificate issuance
 
 ### Peer ID Authentication (`peeridauth/`)

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ NIM_FLAGS = \
   -f \
   --threads:on \
   --opt:speed \
-  -d:libp2p_autotls_support \
   $(NIMFLAGS)
 
 RUNNER_FLAGS = --output-level=VERBOSE --console

--- a/docs/compile_time_flags.md
+++ b/docs/compile_time_flags.md
@@ -1,11 +1,5 @@
 # Compile time flags
 
-Enable autotls support
-
-```bash
-nim c -d:libp2p_autotls_support some_file.nim
-```
-
 Enable expensive metrics (ie, metrics with per-peer cardinality):
 
 ```bash

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import json, uri
+import json, sequtils, strutils, uri
 from times import DateTime, parse
 import chronos/apps/http/httpclient, results, chronicles
 
+import ./jws
 import ./utils
 import ../../crypto/crypto
 import ../../crypto/rsa
@@ -108,9 +109,6 @@ type ACMECertificate* = object
   rawCertificate*: string
   certificateExpiry*: DateTime
   certKeyPair*: KeyPair
-
-import sequtils, strutils
-import ./jws
 
 const
   Alg = "RS256"

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -109,453 +109,446 @@ type ACMECertificate* = object
   certificateExpiry*: DateTime
   certKeyPair*: KeyPair
 
-when defined(libp2p_autotls_support):
-  import sequtils, strutils
-  import ./jws
+import sequtils, strutils
+import ./jws
 
-  const
-    Alg = "RS256"
-    DefaultChalCompletedRetries = 10
-    DefaultChalCompletedRetryTime = 1.seconds
-    DefaultFinalizeRetries = 10
-    ACMEHttpHeaders = [("Content-Type", "application/jose+json")]
+const
+  Alg = "RS256"
+  DefaultChalCompletedRetries = 10
+  DefaultChalCompletedRetryTime = 1.seconds
+  DefaultFinalizeRetries = 10
+  ACMEHttpHeaders = [("Content-Type", "application/jose+json")]
 
-  type JWK = object
-    kty: string
-    n: string
-    e: string
+type JWK = object
+  kty: string
+  n: string
+  e: string
 
-  # whether the request uses Kid or not
-  type ACMERequestType = enum
-    ACMEJwkRequest
-    ACMEKidRequest
+# whether the request uses Kid or not
+type ACMERequestType = enum
+  ACMEJwkRequest
+  ACMEKidRequest
 
-  type ACMERequestHeader = object
-    alg: string
-    typ: string
-    nonce: Nonce
-    url: string
-    case kind: ACMERequestType
-    of ACMEJwkRequest:
-      jwk: JWK
-    of ACMEKidRequest:
-      kid: Kid
+type ACMERequestHeader = object
+  alg: string
+  typ: string
+  nonce: Nonce
+  url: string
+  case kind: ACMERequestType
+  of ACMEJwkRequest:
+    jwk: JWK
+  of ACMEKidRequest:
+    kid: Kid
 
-  type Email = string
+type Email = string
 
-  type ACMERegisterRequest* = object
-    termsOfServiceAgreed: bool
-    contact: seq[Email]
+type ACMERegisterRequest* = object
+  termsOfServiceAgreed: bool
+  contact: seq[Email]
 
-  type ACMEAccountStatus = enum
-    valid = "valid"
-    deactivated = "deactivated"
-    revoked = "revoked"
+type ACMEAccountStatus = enum
+  valid = "valid"
+  deactivated = "deactivated"
+  revoked = "revoked"
 
-  type ACMERegisterResponseBody = object
-    status*: ACMEAccountStatus
+type ACMERegisterResponseBody = object
+  status*: ACMEAccountStatus
 
-  type ACMERegisterResponse* = object
-    kid*: Kid
-    status*: ACMEAccountStatus
+type ACMERegisterResponse* = object
+  kid*: Kid
+  status*: ACMEAccountStatus
 
-  type ACMEChallengeIdentifier = object
-    `type`: string
-    value: string
+type ACMEChallengeIdentifier = object
+  `type`: string
+  value: string
 
-  type ACMEChallengeRequest = object
-    identifiers: seq[ACMEChallengeIdentifier]
+type ACMEChallengeRequest = object
+  identifiers: seq[ACMEChallengeIdentifier]
 
-  type ACMEChallengeResponseBody = object
-    status: ACMEOrderStatus
-    authorizations: seq[Authorization]
-    finalize: string
+type ACMEChallengeResponseBody = object
+  status: ACMEOrderStatus
+  authorizations: seq[Authorization]
+  finalize: string
 
-  template handleError*(msg: string, body: untyped): untyped =
+template handleError*(msg: string, body: untyped): untyped =
+  try:
+    body
+  except ACMEError as exc:
+    raise exc
+  except CancelledError as exc:
+    raise exc
+  except JsonKindError as exc:
+    raise newException(ACMEError, msg & ": Failed to decode JSON", exc)
+  except ValueError as exc:
+    raise newException(ACMEError, msg & ": Failed to decode JSON", exc)
+  except HttpError as exc:
+    raise
+      newException(ACMENetworkError, msg & ": Failed to connect to ACME server", exc)
+  except CatchableError as exc:
+    raise newException(ACMEError, msg & ": Unexpected error", exc)
+
+proc checkAPIError(resp: HTTPResponse) {.raises: [ACMEError].} =
+  let respType =
     try:
-      body
-    except ACMEError as exc:
-      raise exc
-    except CancelledError as exc:
-      raise exc
-    except JsonKindError as exc:
-      raise newException(ACMEError, msg & ": Failed to decode JSON", exc)
-    except ValueError as exc:
-      raise newException(ACMEError, msg & ": Failed to decode JSON", exc)
-    except HttpError as exc:
-      raise
-        newException(ACMENetworkError, msg & ": Failed to connect to ACME server", exc)
-    except CatchableError as exc:
-      raise newException(ACMEError, msg & ": Unexpected error", exc)
+      resp.body["type"].getStr()
+    except KeyError:
+      return
 
-  proc checkAPIError(resp: HTTPResponse) {.raises: [ACMEError].} =
-    let respType =
+  if respType.contains("acme:error"):
+    let detail =
       try:
-        resp.body["type"].getStr()
+        resp.body["detail"].getStr()
       except KeyError:
-        return
-
-    if respType.contains("acme:error"):
-      let detail =
-        try:
-          resp.body["detail"].getStr()
-        except KeyError:
-          ""
-      raise newException(
-        ACMEError, "API request failed. type: " & respType & " detail: " & detail
-      )
-
-  method post*(
-    self: ACMEApi, uri: Uri, payload: string
-  ): Future[HTTPResponse] {.
-    async: (raises: [ACMEError, HttpError, CancelledError]), base
-  .}
-
-  method get*(
-    self: ACMEApi, uri: Uri
-  ): Future[HTTPResponse] {.
-    async: (raises: [ACMEError, HttpError, CancelledError]), base
-  .}
-
-  proc new*(
-      T: typedesc[ACMEApi], acmeServerURL: Uri = parseUri(LetsEncryptURL)
-  ): ACMEApi =
-    let session = HttpSessionRef.new()
-
-    ACMEApi(
-      session: session, directory: Opt.none(ACMEDirectory), acmeServerURL: acmeServerURL
+        ""
+    raise newException(
+      ACMEError, "API request failed. type: " & respType & " detail: " & detail
     )
 
-  proc getDirectory(
-      self: ACMEApi
-  ): Future[ACMEDirectory] {.async: (raises: [ACMEError, CancelledError]).} =
-    handleError("getDirectory"):
-      self.directory.valueOr:
-        let acmeResponse = await self.get(self.acmeServerURL / "directory")
-        let directory = acmeResponse.body.to(ACMEDirectory)
-        self.directory = Opt.some(directory)
-        directory
+method post*(
+  self: ACMEApi, uri: Uri, payload: string
+): Future[HTTPResponse] {.
+  async: (raises: [ACMEError, HttpError, CancelledError]), base
+.}
 
-  method requestNonce*(
-      self: ACMEApi
-  ): Future[Nonce] {.async: (raises: [ACMEError, CancelledError]), base.} =
-    handleError("requestNonce"):
-      let acmeResponse = await self.get(parseUri((await self.getDirectory()).newNonce))
-      Nonce(acmeResponse.headers.keyOrError("Replay-Nonce"))
+method get*(
+  self: ACMEApi, uri: Uri
+): Future[HTTPResponse] {.
+  async: (raises: [ACMEError, HttpError, CancelledError]), base
+.}
 
-  # TODO: save n and e in account so we don't have to recalculate every time
-  proc acmeHeader(
-      self: ACMEApi, uri: Uri, key: KeyPair, needsJwk: bool, kid: Opt[Kid]
-  ): Future[ACMERequestHeader] {.async: (raises: [ACMEError, CancelledError]).} =
-    if not needsJwk and kid.isNone():
-      raise newException(ACMEError, "kid not set")
+proc new*(
+    T: typedesc[ACMEApi], acmeServerURL: Uri = parseUri(LetsEncryptURL)
+): ACMEApi =
+  let session = HttpSessionRef.new()
 
-    if key.pubkey.scheme != PKScheme.RSA or key.seckey.scheme != PKScheme.RSA:
-      raise newException(ACMEError, "Unsupported signing key type")
+  ACMEApi(
+    session: session, directory: Opt.none(ACMEDirectory), acmeServerURL: acmeServerURL
+  )
 
-    let newNonce = await self.requestNonce()
-    if needsJwk:
-      let pubkey = key.pubkey.rsakey
-      let nArray = @(getArray(pubkey.buffer, pubkey.key.n, pubkey.key.nlen))
-      let eArray = @(getArray(pubkey.buffer, pubkey.key.e, pubkey.key.elen))
-      ACMERequestHeader(
-        kind: ACMEJwkRequest,
-        alg: Alg,
-        typ: "JWT",
-        nonce: newNonce,
-        url: $uri,
-        jwk: JWK(kty: "RSA", n: base64UrlEncode(nArray), e: base64UrlEncode(eArray)),
-      )
+proc getDirectory(
+    self: ACMEApi
+): Future[ACMEDirectory] {.async: (raises: [ACMEError, CancelledError]).} =
+  handleError("getDirectory"):
+    self.directory.valueOr:
+      let acmeResponse = await self.get(self.acmeServerURL / "directory")
+      let directory = acmeResponse.body.to(ACMEDirectory)
+      self.directory = Opt.some(directory)
+      directory
+
+method requestNonce*(
+    self: ACMEApi
+): Future[Nonce] {.async: (raises: [ACMEError, CancelledError]), base.} =
+  handleError("requestNonce"):
+    let acmeResponse = await self.get(parseUri((await self.getDirectory()).newNonce))
+    Nonce(acmeResponse.headers.keyOrError("Replay-Nonce"))
+
+# TODO: save n and e in account so we don't have to recalculate every time
+proc acmeHeader(
+    self: ACMEApi, uri: Uri, key: KeyPair, needsJwk: bool, kid: Opt[Kid]
+): Future[ACMERequestHeader] {.async: (raises: [ACMEError, CancelledError]).} =
+  if not needsJwk and kid.isNone():
+    raise newException(ACMEError, "kid not set")
+
+  if key.pubkey.scheme != PKScheme.RSA or key.seckey.scheme != PKScheme.RSA:
+    raise newException(ACMEError, "Unsupported signing key type")
+
+  let newNonce = await self.requestNonce()
+  if needsJwk:
+    let pubkey = key.pubkey.rsakey
+    let nArray = @(getArray(pubkey.buffer, pubkey.key.n, pubkey.key.nlen))
+    let eArray = @(getArray(pubkey.buffer, pubkey.key.e, pubkey.key.elen))
+    ACMERequestHeader(
+      kind: ACMEJwkRequest,
+      alg: Alg,
+      typ: "JWT",
+      nonce: newNonce,
+      url: $uri,
+      jwk: JWK(kty: "RSA", n: base64UrlEncode(nArray), e: base64UrlEncode(eArray)),
+    )
+  else:
+    ACMERequestHeader(
+      kind: ACMEKidRequest,
+      alg: Alg,
+      typ: "JWT",
+      nonce: newNonce,
+      url: $uri,
+      kid: kid.get(),
+    )
+
+method post*(
+    self: ACMEApi, uri: Uri, payload: string
+): Future[HTTPResponse] {.
+    async: (raises: [ACMEError, HttpError, CancelledError]), base
+.} =
+  let rawResponse = await HttpClientRequestRef
+    .post(self.session, $uri, body = payload, headers = ACMEHttpHeaders)
+    .get()
+    .send()
+  let body = await rawResponse.getResponseBody()
+  let resp = HTTPResponse(body: body, headers: rawResponse.headers)
+  checkAPIError(resp)
+  return resp
+
+method get*(
+    self: ACMEApi, uri: Uri
+): Future[HTTPResponse] {.
+    async: (raises: [ACMEError, HttpError, CancelledError]), base
+.} =
+  let rawResponse = await HttpClientRequestRef.get(self.session, $uri).get().send()
+  let body = await rawResponse.getResponseBody()
+  let resp = HTTPResponse(body: body, headers: rawResponse.headers)
+  checkAPIError(resp)
+  return resp
+
+proc createSignedAcmeRequest(
+    self: ACMEApi,
+    uri: Uri,
+    payload: auto,
+    key: KeyPair,
+    needsJwk: bool = false,
+    kid: Opt[Kid] = Opt.none(Kid),
+): Future[string] {.async: (raises: [ACMEError, CancelledError]).} =
+  if key.pubkey.scheme != PKScheme.RSA or key.seckey.scheme != PKScheme.RSA:
+    raise newException(ACMEError, "Unsupported signing key type")
+
+  let acmeHeader = await self.acmeHeader(uri, key, needsJwk, kid)
+  handleError("createSignedAcmeRequest"):
+    $toFlattenedJws(%*acmeHeader, %*payload, key.seckey.rsakey)
+
+proc requestRegister*(
+    self: ACMEApi, key: KeyPair
+): Future[ACMERegisterResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+  let registerRequest = ACMERegisterRequest(termsOfServiceAgreed: true)
+  handleError("acmeRegister"):
+    let payload = await self.createSignedAcmeRequest(
+      parseUri((await self.getDirectory()).newAccount),
+      registerRequest,
+      key,
+      needsJwk = true,
+    )
+    let acmeResponse =
+      await self.post(parseUri((await self.getDirectory()).newAccount), payload)
+    let acmeResponseBody = acmeResponse.body.to(ACMERegisterResponseBody)
+
+    ACMERegisterResponse(
+      status: acmeResponseBody.status, kid: acmeResponse.headers.keyOrError("location")
+    )
+
+proc requestNewOrder*(
+    self: ACMEApi, domains: seq[Domain], key: KeyPair, kid: Kid
+): Future[ACMEChallengeResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+  # request challenge from ACME server
+  let orderRequest = ACMEChallengeRequest(
+    identifiers: domains.mapIt(ACMEChallengeIdentifier(`type`: "dns", value: it))
+  )
+  handleError("requestNewOrder"):
+    let payload = await self.createSignedAcmeRequest(
+      parseUri((await self.getDirectory()).newOrder),
+      orderRequest,
+      key,
+      kid = Opt.some(kid),
+    )
+    let acmeResponse =
+      await self.post(parseUri((await self.getDirectory()).newOrder), payload)
+    let challengeResponseBody = acmeResponse.body.to(ACMEChallengeResponseBody)
+    if challengeResponseBody.authorizations.len == 0:
+      raise newException(ACMEError, "Authorizations field is empty")
+    ACMEChallengeResponse(
+      status: challengeResponseBody.status,
+      authorizations: challengeResponseBody.authorizations,
+      finalize: challengeResponseBody.finalize,
+      order: acmeResponse.headers.keyOrError("location"),
+    )
+
+proc requestAuthorizations*(
+    self: ACMEApi, authorizations: seq[Authorization], key: KeyPair, kid: Kid
+): Future[ACMEAuthorizationsResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+  handleError("requestAuthorizations"):
+    doAssert authorizations.len > 0
+
+    let acmeResponse = await self.get(parseUri(authorizations[0]))
+
+    var challenges: seq[ACMEChallenge]
+    for challenge in acmeResponse.body.getOrDefault("challenges").getElems():
+      try:
+        challenges.add(challenge.to(ACMEChallenge))
+      except ValueError, JsonKindError:
+        debug "Could not parse challenge", msg = getCurrentExceptionMsg()
+
+    if challenges.len == 0:
+      raise newException(ACMEError, "No challenges received")
+
+    ACMEAuthorizationsResponse(challenges: challenges)
+
+proc requestChallenge*(
+    self: ACMEApi, domains: seq[Domain], key: KeyPair, kid: Kid
+): Future[ACMEChallengeDns01Response] {.async: (raises: [ACMEError, CancelledError]).} =
+  let orderResp = await self.requestNewOrder(domains, key, kid)
+
+  let validRenewStatus = @[ACMEOrderStatus.PENDING, ACMEOrderStatus.READY]
+  if orderResp.status notin validRenewStatus:
+    raise newException(ACMEError, "Invalid new order status: " & $orderResp.status)
+
+  let authResp = await self.requestAuthorizations(orderResp.authorizations, key, kid)
+
+  var challenges = authResp.challenges.filterIt(it.`type` == ACMEChallengeType.DNS01)
+  if challenges.len == 0:
+    raise
+      newException(ACMEError, "Could not find supported DNS challenge type (dns-01)")
+
+  return ACMEChallengeDns01Response(
+    finalize: orderResp.finalize, order: orderResp.order, dns01: challenges[0]
+  )
+
+proc requestCheck*(
+    self: ACMEApi, checkURL: Uri, checkKind: ACMECheckKind, key: KeyPair, kid: Kid
+): Future[ACMECheckResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+  handleError("requestCheck"):
+    let acmeResponse = await self.get(checkURL)
+    let retryAfter =
+      try:
+        parseInt(acmeResponse.headers.keyOrError("Retry-After")).seconds
+      except ValueError:
+        DefaultChalCompletedRetryTime
+
+    case checkKind
+    of ACMEOrderCheck:
+      try:
+        ACMECheckResponse(
+          kind: checkKind,
+          orderStatus: parseEnum[ACMEOrderStatus](acmeResponse.body["status"].getStr),
+          retryAfter: retryAfter,
+        )
+      except ValueError:
+        raise newException(
+          ACMEError, "Invalid order status: " & acmeResponse.body["status"].getStr
+        )
+    of ACMEChallengeCheck:
+      try:
+        ACMECheckResponse(
+          kind: checkKind,
+          chalStatus: parseEnum[ACMEChallengeStatus](acmeResponse.body["status"].getStr),
+          retryAfter: retryAfter,
+        )
+      except ValueError:
+        raise newException(
+          ACMEError, "Invalid order status: " & acmeResponse.body["status"].getStr
+        )
+
+proc sendChallengeCompleted*(
+    self: ACMEApi, chalURL: Uri, key: KeyPair, kid: Kid
+): Future[ACMECompletedResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+  handleError("sendChallengeCompleted"):
+    let payload =
+      await self.createSignedAcmeRequest(chalURL, %*{}, key, kid = Opt.some(kid))
+    let acmeResponse = await self.post(chalURL, payload)
+    acmeResponse.body.to(ACMECompletedResponse)
+
+proc checkChallengeCompleted*(
+    self: ACMEApi,
+    checkURL: Uri,
+    key: KeyPair,
+    kid: Kid,
+    retries: int = DefaultChalCompletedRetries,
+): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
+  for i in 0 .. retries:
+    let checkResponse = await self.requestCheck(checkURL, ACMEChallengeCheck, key, kid)
+    case checkResponse.chalStatus
+    of ACMEChallengeStatus.PENDING:
+      await sleepAsync(checkResponse.retryAfter) # try again after some delay
+    of ACMEChallengeStatus.VALID:
+      return true
     else:
-      ACMERequestHeader(
-        kind: ACMEKidRequest,
-        alg: Alg,
-        typ: "JWT",
-        nonce: newNonce,
-        url: $uri,
-        kid: kid.get(),
+      raise newException(
+        ACMEError,
+        "Failed challenge completion: expected 'valid', got '" &
+          $checkResponse.chalStatus & "'",
       )
+  return false
 
-  method post*(
-      self: ACMEApi, uri: Uri, payload: string
-  ): Future[HTTPResponse] {.
-      async: (raises: [ACMEError, HttpError, CancelledError]), base
-  .} =
+proc completeChallenge*(
+    self: ACMEApi,
+    chalURL: Uri,
+    key: KeyPair,
+    kid: Kid,
+    retries: int = DefaultChalCompletedRetries,
+): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
+  discard await self.sendChallengeCompleted(chalURL, key, kid)
+  # check until acme server is done (poll validation)
+  return await self.checkChallengeCompleted(chalURL, key, kid, retries = retries)
+
+proc requestFinalize*(
+    self: ACMEApi,
+    domain: Domain,
+    finalize: Uri,
+    certKeyPair: KeyPair,
+    key: KeyPair,
+    kid: Kid,
+): Future[ACMEFinalizeResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+  handleError("requestFinalize"):
+    let payload = await self.createSignedAcmeRequest(
+      finalize, %*{"csr": createCSR(domain, certKeyPair)}, key, kid = Opt.some(kid)
+    )
+    let acmeResponse = await self.post(finalize, payload)
+    # server responds with updated order response
+    acmeResponse.body.to(ACMEFinalizeResponse)
+
+proc checkCertFinalized*(
+    self: ACMEApi,
+    order: Uri,
+    key: KeyPair,
+    kid: Kid,
+    retries: int = DefaultChalCompletedRetries,
+): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
+  for i in 0 .. retries:
+    let checkResponse = await self.requestCheck(order, ACMEOrderCheck, key, kid)
+    case checkResponse.orderStatus
+    of ACMEOrderStatus.VALID:
+      return true
+    of ACMEOrderStatus.PROCESSING:
+      await sleepAsync(checkResponse.retryAfter) # try again after some delay
+    else:
+      error "Failed certificate finalization",
+        description = "expected 'valid', got '" & $checkResponse.orderStatus & "'"
+      return false # do not try again
+
+  return false
+
+proc certificateFinalized*(
+    self: ACMEApi,
+    domain: Domain,
+    finalize: Uri,
+    order: Uri,
+    certKeyPair: KeyPair,
+    key: KeyPair,
+    kid: Kid,
+    retries: int = DefaultFinalizeRetries,
+): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
+  discard await self.requestFinalize(domain, finalize, certKeyPair, key, kid)
+  # keep checking order until cert is valid (done)
+  return await self.checkCertFinalized(order, key, kid, retries = retries)
+
+proc requestGetOrder*(
+    self: ACMEApi, order: Uri
+): Future[ACMEOrderResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+  handleError("requestGetOrder"):
+    let acmeResponse = await self.get(order)
+    acmeResponse.body.to(ACMEOrderResponse)
+
+proc downloadCertificate*(
+    self: ACMEApi, order: Uri
+): Future[ACMECertificateResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+  let orderResponse = await self.requestGetOrder(order)
+
+  handleError("downloadCertificate"):
     let rawResponse = await HttpClientRequestRef
-      .post(self.session, $uri, body = payload, headers = ACMEHttpHeaders)
+      .get(self.session, orderResponse.certificate)
       .get()
       .send()
-    let body = await rawResponse.getResponseBody()
-    let resp = HTTPResponse(body: body, headers: rawResponse.headers)
-    checkAPIError(resp)
-    return resp
-
-  method get*(
-      self: ACMEApi, uri: Uri
-  ): Future[HTTPResponse] {.
-      async: (raises: [ACMEError, HttpError, CancelledError]), base
-  .} =
-    let rawResponse = await HttpClientRequestRef.get(self.session, $uri).get().send()
-    let body = await rawResponse.getResponseBody()
-    let resp = HTTPResponse(body: body, headers: rawResponse.headers)
-    checkAPIError(resp)
-    return resp
-
-  proc createSignedAcmeRequest(
-      self: ACMEApi,
-      uri: Uri,
-      payload: auto,
-      key: KeyPair,
-      needsJwk: bool = false,
-      kid: Opt[Kid] = Opt.none(Kid),
-  ): Future[string] {.async: (raises: [ACMEError, CancelledError]).} =
-    if key.pubkey.scheme != PKScheme.RSA or key.seckey.scheme != PKScheme.RSA:
-      raise newException(ACMEError, "Unsupported signing key type")
-
-    let acmeHeader = await self.acmeHeader(uri, key, needsJwk, kid)
-    handleError("createSignedAcmeRequest"):
-      $toFlattenedJws(%*acmeHeader, %*payload, key.seckey.rsakey)
-
-  proc requestRegister*(
-      self: ACMEApi, key: KeyPair
-  ): Future[ACMERegisterResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-    let registerRequest = ACMERegisterRequest(termsOfServiceAgreed: true)
-    handleError("acmeRegister"):
-      let payload = await self.createSignedAcmeRequest(
-        parseUri((await self.getDirectory()).newAccount),
-        registerRequest,
-        key,
-        needsJwk = true,
-      )
-      let acmeResponse =
-        await self.post(parseUri((await self.getDirectory()).newAccount), payload)
-      let acmeResponseBody = acmeResponse.body.to(ACMERegisterResponseBody)
-
-      ACMERegisterResponse(
-        status: acmeResponseBody.status,
-        kid: acmeResponse.headers.keyOrError("location"),
-      )
-
-  proc requestNewOrder*(
-      self: ACMEApi, domains: seq[Domain], key: KeyPair, kid: Kid
-  ): Future[ACMEChallengeResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-    # request challenge from ACME server
-    let orderRequest = ACMEChallengeRequest(
-      identifiers: domains.mapIt(ACMEChallengeIdentifier(`type`: "dns", value: it))
-    )
-    handleError("requestNewOrder"):
-      let payload = await self.createSignedAcmeRequest(
-        parseUri((await self.getDirectory()).newOrder),
-        orderRequest,
-        key,
-        kid = Opt.some(kid),
-      )
-      let acmeResponse =
-        await self.post(parseUri((await self.getDirectory()).newOrder), payload)
-      let challengeResponseBody = acmeResponse.body.to(ACMEChallengeResponseBody)
-      if challengeResponseBody.authorizations.len == 0:
-        raise newException(ACMEError, "Authorizations field is empty")
-      ACMEChallengeResponse(
-        status: challengeResponseBody.status,
-        authorizations: challengeResponseBody.authorizations,
-        finalize: challengeResponseBody.finalize,
-        order: acmeResponse.headers.keyOrError("location"),
-      )
-
-  proc requestAuthorizations*(
-      self: ACMEApi, authorizations: seq[Authorization], key: KeyPair, kid: Kid
-  ): Future[ACMEAuthorizationsResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-    handleError("requestAuthorizations"):
-      doAssert authorizations.len > 0
-
-      let acmeResponse = await self.get(parseUri(authorizations[0]))
-
-      var challenges: seq[ACMEChallenge]
-      for challenge in acmeResponse.body.getOrDefault("challenges").getElems():
-        try:
-          challenges.add(challenge.to(ACMEChallenge))
-        except ValueError, JsonKindError:
-          debug "Could not parse challenge", msg = getCurrentExceptionMsg()
-
-      if challenges.len == 0:
-        raise newException(ACMEError, "No challenges received")
-
-      ACMEAuthorizationsResponse(challenges: challenges)
-
-  proc requestChallenge*(
-      self: ACMEApi, domains: seq[Domain], key: KeyPair, kid: Kid
-  ): Future[ACMEChallengeDns01Response] {.async: (raises: [ACMEError, CancelledError]).} =
-    let orderResp = await self.requestNewOrder(domains, key, kid)
-
-    let validRenewStatus = @[ACMEOrderStatus.PENDING, ACMEOrderStatus.READY]
-    if orderResp.status notin validRenewStatus:
-      raise newException(ACMEError, "Invalid new order status: " & $orderResp.status)
-
-    let authResp = await self.requestAuthorizations(orderResp.authorizations, key, kid)
-
-    var challenges = authResp.challenges.filterIt(it.`type` == ACMEChallengeType.DNS01)
-    if challenges.len == 0:
-      raise
-        newException(ACMEError, "Could not find supported DNS challenge type (dns-01)")
-
-    return ACMEChallengeDns01Response(
-      finalize: orderResp.finalize, order: orderResp.order, dns01: challenges[0]
+    ACMECertificateResponse(
+      rawCertificate: bytesToString(await rawResponse.getBodyBytes()),
+      certificateExpiry: parse(orderResponse.expires, "yyyy-MM-dd'T'HH:mm:ss'Z'"),
     )
 
-  proc requestCheck*(
-      self: ACMEApi, checkURL: Uri, checkKind: ACMECheckKind, key: KeyPair, kid: Kid
-  ): Future[ACMECheckResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-    handleError("requestCheck"):
-      let acmeResponse = await self.get(checkURL)
-      let retryAfter =
-        try:
-          parseInt(acmeResponse.headers.keyOrError("Retry-After")).seconds
-        except ValueError:
-          DefaultChalCompletedRetryTime
-
-      case checkKind
-      of ACMEOrderCheck:
-        try:
-          ACMECheckResponse(
-            kind: checkKind,
-            orderStatus: parseEnum[ACMEOrderStatus](acmeResponse.body["status"].getStr),
-            retryAfter: retryAfter,
-          )
-        except ValueError:
-          raise newException(
-            ACMEError, "Invalid order status: " & acmeResponse.body["status"].getStr
-          )
-      of ACMEChallengeCheck:
-        try:
-          ACMECheckResponse(
-            kind: checkKind,
-            chalStatus:
-              parseEnum[ACMEChallengeStatus](acmeResponse.body["status"].getStr),
-            retryAfter: retryAfter,
-          )
-        except ValueError:
-          raise newException(
-            ACMEError, "Invalid order status: " & acmeResponse.body["status"].getStr
-          )
-
-  proc sendChallengeCompleted*(
-      self: ACMEApi, chalURL: Uri, key: KeyPair, kid: Kid
-  ): Future[ACMECompletedResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-    handleError("sendChallengeCompleted"):
-      let payload =
-        await self.createSignedAcmeRequest(chalURL, %*{}, key, kid = Opt.some(kid))
-      let acmeResponse = await self.post(chalURL, payload)
-      acmeResponse.body.to(ACMECompletedResponse)
-
-  proc checkChallengeCompleted*(
-      self: ACMEApi,
-      checkURL: Uri,
-      key: KeyPair,
-      kid: Kid,
-      retries: int = DefaultChalCompletedRetries,
-  ): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
-    for i in 0 .. retries:
-      let checkResponse =
-        await self.requestCheck(checkURL, ACMEChallengeCheck, key, kid)
-      case checkResponse.chalStatus
-      of ACMEChallengeStatus.PENDING:
-        await sleepAsync(checkResponse.retryAfter) # try again after some delay
-      of ACMEChallengeStatus.VALID:
-        return true
-      else:
-        raise newException(
-          ACMEError,
-          "Failed challenge completion: expected 'valid', got '" &
-            $checkResponse.chalStatus & "'",
-        )
-    return false
-
-  proc completeChallenge*(
-      self: ACMEApi,
-      chalURL: Uri,
-      key: KeyPair,
-      kid: Kid,
-      retries: int = DefaultChalCompletedRetries,
-  ): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
-    discard await self.sendChallengeCompleted(chalURL, key, kid)
-    # check until acme server is done (poll validation)
-    return await self.checkChallengeCompleted(chalURL, key, kid, retries = retries)
-
-  proc requestFinalize*(
-      self: ACMEApi,
-      domain: Domain,
-      finalize: Uri,
-      certKeyPair: KeyPair,
-      key: KeyPair,
-      kid: Kid,
-  ): Future[ACMEFinalizeResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-    handleError("requestFinalize"):
-      let payload = await self.createSignedAcmeRequest(
-        finalize, %*{"csr": createCSR(domain, certKeyPair)}, key, kid = Opt.some(kid)
-      )
-      let acmeResponse = await self.post(finalize, payload)
-      # server responds with updated order response
-      acmeResponse.body.to(ACMEFinalizeResponse)
-
-  proc checkCertFinalized*(
-      self: ACMEApi,
-      order: Uri,
-      key: KeyPair,
-      kid: Kid,
-      retries: int = DefaultChalCompletedRetries,
-  ): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
-    for i in 0 .. retries:
-      let checkResponse = await self.requestCheck(order, ACMEOrderCheck, key, kid)
-      case checkResponse.orderStatus
-      of ACMEOrderStatus.VALID:
-        return true
-      of ACMEOrderStatus.PROCESSING:
-        await sleepAsync(checkResponse.retryAfter) # try again after some delay
-      else:
-        error "Failed certificate finalization",
-          description = "expected 'valid', got '" & $checkResponse.orderStatus & "'"
-        return false # do not try again
-
-    return false
-
-  proc certificateFinalized*(
-      self: ACMEApi,
-      domain: Domain,
-      finalize: Uri,
-      order: Uri,
-      certKeyPair: KeyPair,
-      key: KeyPair,
-      kid: Kid,
-      retries: int = DefaultFinalizeRetries,
-  ): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
-    discard await self.requestFinalize(domain, finalize, certKeyPair, key, kid)
-    # keep checking order until cert is valid (done)
-    return await self.checkCertFinalized(order, key, kid, retries = retries)
-
-  proc requestGetOrder*(
-      self: ACMEApi, order: Uri
-  ): Future[ACMEOrderResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-    handleError("requestGetOrder"):
-      let acmeResponse = await self.get(order)
-      acmeResponse.body.to(ACMEOrderResponse)
-
-  proc downloadCertificate*(
-      self: ACMEApi, order: Uri
-  ): Future[ACMECertificateResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-    let orderResponse = await self.requestGetOrder(order)
-
-    handleError("downloadCertificate"):
-      let rawResponse = await HttpClientRequestRef
-        .get(self.session, orderResponse.certificate)
-        .get()
-        .send()
-      ACMECertificateResponse(
-        rawCertificate: bytesToString(await rawResponse.getBodyBytes()),
-        certificateExpiry: parse(orderResponse.expires, "yyyy-MM-dd'T'HH:mm:ss'Z'"),
-      )
-
-  proc close*(self: ACMEApi) {.async: (raises: [CancelledError]).} =
-    await self.session.closeWait()
-
-else:
-  {.hint: "autotls disabled. Use -d:libp2p_autotls_support".}
+proc close*(self: ACMEApi) {.async: (raises: [CancelledError]).} =
+  await self.session.closeWait()

--- a/libp2p/autotls/acme/client.nim
+++ b/libp2p/autotls/acme/client.nim
@@ -3,9 +3,12 @@
 
 {.push raises: [].}
 
-import chronicles
+import uri
+import chronos, chronicles, results, stew/byteutils
 import ../../crypto/crypto
+import ../../crypto/rsa
 import ./api
+import ./utils
 
 export api
 
@@ -19,80 +22,71 @@ type ACMEClient* = ref object
 logScope:
   topics = "libp2p acme client"
 
-when defined(libp2p_autotls_support):
-  import uri
-  import chronos, results, stew/byteutils
-  import ../../crypto/rsa
-  import ./utils
+proc new*(
+    T: typedesc[ACMEClient],
+    rng: Rng,
+    api: ACMEApi = ACMEApi.new(acmeServerURL = parseUri(LetsEncryptURL)),
+    key: Opt[KeyPair] = Opt.none(KeyPair),
+    kid: Kid = Kid(""),
+): T {.raises: [].} =
+  let key = key.valueOr:
+    KeyPair.random(PKScheme.RSA, rng).get()
+  T(api: api, key: key, kid: kid)
 
-  proc new*(
-      T: typedesc[ACMEClient],
-      rng: Rng,
-      api: ACMEApi = ACMEApi.new(acmeServerURL = parseUri(LetsEncryptURL)),
-      key: Opt[KeyPair] = Opt.none(KeyPair),
-      kid: Kid = Kid(""),
-  ): T {.raises: [].} =
-    let key = key.valueOr:
-      KeyPair.random(PKScheme.RSA, rng).get()
-    T(api: api, key: key, kid: kid)
+proc getOrInitKid*(
+    self: ACMEClient
+): Future[Kid] {.async: (raises: [ACMEError, CancelledError]).} =
+  if self.kid.len == 0:
+    let registerResponse = await self.api.requestRegister(self.key)
+    self.kid = registerResponse.kid
+  return self.kid
 
-  proc getOrInitKid*(
-      self: ACMEClient
-  ): Future[Kid] {.async: (raises: [ACMEError, CancelledError]).} =
-    if self.kid.len == 0:
-      let registerResponse = await self.api.requestRegister(self.key)
-      self.kid = registerResponse.kid
-    return self.kid
+proc genKeyAuthorization*(self: ACMEClient, token: string): KeyAuthorization =
+  base64UrlEncode(@(sha256.digest((token & "." & thumbprint(self.key)).toBytes).data))
 
-  proc genKeyAuthorization*(self: ACMEClient, token: string): KeyAuthorization =
-    base64UrlEncode(@(sha256.digest((token & "." & thumbprint(self.key)).toBytes).data))
+proc getChallenge*(
+    self: ACMEClient, domains: seq[api.Domain]
+): Future[ACMEChallengeDns01Response] {.async: (raises: [ACMEError, CancelledError]).} =
+  await self.api.requestChallenge(domains, self.key, await self.getOrInitKid())
 
-  proc getChallenge*(
-      self: ACMEClient, domains: seq[api.Domain]
-  ): Future[ACMEChallengeDns01Response] {.async: (raises: [ACMEError, CancelledError]).} =
-    await self.api.requestChallenge(domains, self.key, await self.getOrInitKid())
+proc getCertificate*(
+    self: ACMEClient,
+    domain: api.Domain,
+    certKeyPair: KeyPair,
+    challenge: ACMEChallengeDns01Response,
+    acmeRetries: int = 10,
+    finalizeRetries: int = 10,
+): Future[ACMECertificateResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+  let chalURL = parseUri(challenge.dns01.url)
+  let orderURL = parseUri(challenge.order)
+  let finalizeURL = parseUri(challenge.finalize)
+  trace "Sending challenge completed notification"
+  discard
+    await self.api.sendChallengeCompleted(chalURL, self.key, await self.getOrInitKid())
 
-  proc getCertificate*(
-      self: ACMEClient,
-      domain: api.Domain,
-      certKeyPair: KeyPair,
-      challenge: ACMEChallengeDns01Response,
-      acmeRetries: int = 10,
-      finalizeRetries: int = 10,
-  ): Future[ACMECertificateResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-    let chalURL = parseUri(challenge.dns01.url)
-    let orderURL = parseUri(challenge.order)
-    let finalizeURL = parseUri(challenge.finalize)
-    trace "Sending challenge completed notification"
-    discard await self.api.sendChallengeCompleted(
-      chalURL, self.key, await self.getOrInitKid()
-    )
+  trace "Checking for completed challenge"
+  let completed = await self.api.checkChallengeCompleted(
+    chalURL, self.key, await self.getOrInitKid(), acmeRetries
+  )
+  if not completed:
+    raise
+      newException(ACMEError, "Failed to signal ACME server about challenge completion")
 
-    trace "Checking for completed challenge"
-    let completed = await self.api.checkChallengeCompleted(
-      chalURL, self.key, await self.getOrInitKid(), acmeRetries
-    )
-    if not completed:
-      raise newException(
-        ACMEError, "Failed to signal ACME server about challenge completion"
-      )
+  trace "Waiting for certificate to be finalized"
+  let finalized = await self.api.certificateFinalized(
+    domain,
+    finalizeURL,
+    orderURL,
+    certKeyPair,
+    self.key,
+    await self.getOrInitKid(),
+    finalizeRetries,
+  )
+  if not finalized:
+    raise newException(ACMEError, "Failed to finalize certificate for domain " & domain)
 
-    trace "Waiting for certificate to be finalized"
-    let finalized = await self.api.certificateFinalized(
-      domain,
-      finalizeURL,
-      orderURL,
-      certKeyPair,
-      self.key,
-      await self.getOrInitKid(),
-      finalizeRetries,
-    )
-    if not finalized:
-      raise
-        newException(ACMEError, "Failed to finalize certificate for domain " & domain)
+  trace "Downloading certificate"
+  await self.api.downloadCertificate(orderURL)
 
-    trace "Downloading certificate"
-    await self.api.downloadCertificate(orderURL)
-
-  proc close*(self: ACMEClient) {.async: (raises: [CancelledError]).} =
-    await self.api.close()
+proc close*(self: ACMEClient) {.async: (raises: [CancelledError]).} =
+  await self.api.close()

--- a/libp2p/autotls/acme/jws.nim
+++ b/libp2p/autotls/acme/jws.nim
@@ -11,41 +11,40 @@
 ## is vendored. This replaces the former `nim-jwt` dependency, of which only
 ## this slice was ever used.
 
-when defined(libp2p_autotls_support):
-  import json
-  import results
-  import stew/byteutils
-  import ./utils
-  import ../../crypto/rsa
+import json
+import results
+import stew/byteutils
+import ./utils
+import ../../crypto/rsa
 
-  const SupportedAlg = "RS256"
+const SupportedAlg = "RS256"
 
-  proc toFlattenedJws*(
-      protectedHeader: JsonNode, payload: JsonNode, key: rsa.RsaPrivateKey
-  ): JsonNode {.raises: [ACMEError].} =
-    ## Signs `protectedHeader`/`payload` with `key` (RS256) and returns the
-    ## flattened JWS JSON serialization: the base64url-encoded `protected`,
-    ## `payload` and `signature` members.
-    ##
-    ## The signature covers `BASE64URL(protected) || '.' || BASE64URL(payload)`
-    ## exactly as transmitted, so the JSON key ordering of the inputs does not
-    ## affect verification.
-    let alg = protectedHeader{"alg"}.getStr()
-    if alg != SupportedAlg:
-      raise newException(ACMEError, "Unsupported JWS algorithm: " & alg)
+proc toFlattenedJws*(
+    protectedHeader: JsonNode, payload: JsonNode, key: rsa.RsaPrivateKey
+): JsonNode {.raises: [ACMEError].} =
+  ## Signs `protectedHeader`/`payload` with `key` (RS256) and returns the
+  ## flattened JWS JSON serialization: the base64url-encoded `protected`,
+  ## `payload` and `signature` members.
+  ##
+  ## The signature covers `BASE64URL(protected) || '.' || BASE64URL(payload)`
+  ## exactly as transmitted, so the JSON key ordering of the inputs does not
+  ## affect verification.
+  let alg = protectedHeader{"alg"}.getStr()
+  if alg != SupportedAlg:
+    raise newException(ACMEError, "Unsupported JWS algorithm: " & alg)
 
-    let
-      protectedB64 = base64UrlEncode(($protectedHeader).toBytes)
-      payloadB64 = base64UrlEncode(($payload).toBytes)
-      signingInput = protectedB64 & "." & payloadB64
+  let
+    protectedB64 = base64UrlEncode(($protectedHeader).toBytes)
+    payloadB64 = base64UrlEncode(($payload).toBytes)
+    signingInput = protectedB64 & "." & payloadB64
 
-    let signature = key.sign(signingInput).valueOr:
-      raise newException(ACMEError, "Failed to create JWS signature")
-    let signatureBytes = signature.getBytes().valueOr:
-      raise newException(ACMEError, "Failed to encode JWS signature bytes")
+  let signature = key.sign(signingInput).valueOr:
+    raise newException(ACMEError, "Failed to create JWS signature")
+  let signatureBytes = signature.getBytes().valueOr:
+    raise newException(ACMEError, "Failed to encode JWS signature bytes")
 
-    %*{
-      "payload": payloadB64,
-      "protected": protectedB64,
-      "signature": base64UrlEncode(signatureBytes),
-    }
+  %*{
+    "payload": payloadB64,
+    "protected": protectedB64,
+    "signature": base64UrlEncode(signatureBytes),
+  }

--- a/libp2p/autotls/acme/mockapi.nim
+++ b/libp2p/autotls/acme/mockapi.nim
@@ -24,22 +24,21 @@ proc new*(
     acmeServerURL: parseUri(LetsEncryptURL),
   )
 
-when defined(libp2p_autotls_support):
-  method requestNonce*(
-      self: MockACMEApi
-  ): Future[Nonce] {.async: (raises: [ACMEError, CancelledError]).} =
-    return $self.acmeServerURL & "/acme/1234"
+method requestNonce*(
+    self: MockACMEApi
+): Future[Nonce] {.async: (raises: [ACMEError, CancelledError]).} =
+  return $self.acmeServerURL & "/acme/1234"
 
-  method post*(
-      self: MockACMEApi, uri: Uri, payload: string
-  ): Future[HTTPResponse] {.async: (raises: [ACMEError, HttpError, CancelledError]).} =
-    let resp = self.mockedResponses[0]
-    self.mockedResponses.delete(0)
-    resp
+method post*(
+    self: MockACMEApi, uri: Uri, payload: string
+): Future[HTTPResponse] {.async: (raises: [ACMEError, HttpError, CancelledError]).} =
+  let resp = self.mockedResponses[0]
+  self.mockedResponses.delete(0)
+  resp
 
-  method get*(
-      self: MockACMEApi, uri: Uri
-  ): Future[HTTPResponse] {.async: (raises: [ACMEError, HttpError, CancelledError]).} =
-    let resp = self.mockedResponses[0]
-    self.mockedResponses.delete(0)
-    resp
+method get*(
+    self: MockACMEApi, uri: Uri
+): Future[HTTPResponse] {.async: (raises: [ACMEError, HttpError, CancelledError]).} =
+  let resp = self.mockedResponses[0]
+  self.mockedResponses.delete(0)
+  resp

--- a/libp2p/autotls/acme/utils.nim
+++ b/libp2p/autotls/acme/utils.nim
@@ -1,67 +1,63 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
+import base64, strutils, json
+import chronos/apps/http/httpclient
 import ../../errors
+import ../../transports/tls/certificate_ffi
+import ../../crypto/crypto
+import ../../crypto/rsa
 
 type ACMEError* = object of LPError
 type ACMENetworkError* = object of ACMEError
 
-when defined(libp2p_autotls_support):
-  import base64, strutils, chronos/apps/http/httpclient, json
-  import ../../transports/tls/certificate_ffi
-  import ../../crypto/crypto
-  import ../../crypto/rsa
+proc keyOrError*(table: HttpTable, key: string): string {.raises: [ValueError].} =
+  if not table.contains(key):
+    raise newException(ValueError, "key " & key & " not present in headers")
+  table.getString(key)
 
-  proc keyOrError*(table: HttpTable, key: string): string {.raises: [ValueError].} =
-    if not table.contains(key):
-      raise newException(ValueError, "key " & key & " not present in headers")
-    table.getString(key)
+proc base64UrlEncode*(data: seq[byte]): string =
+  ## Encodes data using base64url (RFC 4648 §5) — no padding, URL-safe
+  var encoded = base64.encode(data, safe = true)
+  encoded.removeSuffix("=")
+  encoded.removeSuffix("=")
+  return encoded
 
-  proc base64UrlEncode*(data: seq[byte]): string =
-    ## Encodes data using base64url (RFC 4648 §5) — no padding, URL-safe
-    var encoded = base64.encode(data, safe = true)
-    encoded.removeSuffix("=")
-    encoded.removeSuffix("=")
-    return encoded
+proc thumbprint*(key: KeyPair): string =
+  doAssert key.seckey.scheme == PKScheme.RSA, "unsupported keytype"
+  let pubkey = key.pubkey.rsakey
+  let nArray = @(getArray(pubkey.buffer, pubkey.key.n, pubkey.key.nlen))
+  let eArray = @(getArray(pubkey.buffer, pubkey.key.e, pubkey.key.elen))
 
-  proc thumbprint*(key: KeyPair): string =
-    doAssert key.seckey.scheme == PKScheme.RSA, "unsupported keytype"
-    let pubkey = key.pubkey.rsakey
-    let nArray = @(getArray(pubkey.buffer, pubkey.key.n, pubkey.key.nlen))
-    let eArray = @(getArray(pubkey.buffer, pubkey.key.e, pubkey.key.elen))
+  let n = base64UrlEncode(nArray)
+  let e = base64UrlEncode(eArray)
+  let keyJson = %*{"e": e, "kty": "RSA", "n": n}
+  let digest = sha256.digest($keyJson)
+  return base64UrlEncode(@(digest.data))
 
-    let n = base64UrlEncode(nArray)
-    let e = base64UrlEncode(eArray)
-    let keyJson = %*{"e": e, "kty": "RSA", "n": n}
-    let digest = sha256.digest($keyJson)
-    return base64UrlEncode(@(digest.data))
+proc getResponseBody*(
+    response: HttpClientResponseRef
+): Future[JsonNode] {.async: (raises: [ACMEError, CancelledError]).} =
+  try:
+    let bodyBytes = await response.getBodyBytes()
+    if bodyBytes.len > 0:
+      return bytesToString(bodyBytes).parseJson()
+    return %*{} # empty body
+  except CancelledError as exc:
+    raise exc
+  except CatchableError as exc:
+    raise
+      newException(ACMEError, "Unexpected error occurred while getting body bytes", exc)
 
-  proc getResponseBody*(
-      response: HttpClientResponseRef
-  ): Future[JsonNode] {.async: (raises: [ACMEError, CancelledError]).} =
-    try:
-      let bodyBytes = await response.getBodyBytes()
-      if bodyBytes.len > 0:
-        return bytesToString(bodyBytes).parseJson()
-      return %*{} # empty body
-    except CancelledError as exc:
-      raise exc
-    except CatchableError as exc:
-      raise newException(
-        ACMEError, "Unexpected error occurred while getting body bytes", exc
-      )
+proc createCSR*(domain: string, certKeyPair: KeyPair): string {.raises: [ACMEError].} =
+  # convert KeyPair to cert_key_t
+  let rawSeckey: seq[byte] = certKeyPair.seckey.getRawBytes.valueOr:
+    raise newException(ACMEError, "Failed to get seckey raw bytes (DER)")
+  let certKey = cert_new_key_t(rawSeckey).valueOr:
+    raise newException(ACMEError, "Failed to convert key pair to cert_key_t")
 
-  proc createCSR*(
-      domain: string, certKeyPair: KeyPair
-  ): string {.raises: [ACMEError].} =
-    # convert KeyPair to cert_key_t
-    let rawSeckey: seq[byte] = certKeyPair.seckey.getRawBytes.valueOr:
-      raise newException(ACMEError, "Failed to get seckey raw bytes (DER)")
-    let certKey = cert_new_key_t(rawSeckey).valueOr:
-      raise newException(ACMEError, "Failed to convert key pair to cert_key_t")
+  # create CSR
+  let derCSR = cert_signing_req(domain, certKey).valueOr:
+    raise newException(ACMEError, "Failed to create CSR")
 
-    # create CSR
-    let derCSR = cert_signing_req(domain, certKey).valueOr:
-      raise newException(ACMEError, "Failed to create CSR")
-
-    base64.encode(derCSR, safe = true)
+  base64.encode(derCSR, safe = true)

--- a/libp2p/autotls/broker.nim
+++ b/libp2p/autotls/broker.nim
@@ -3,8 +3,16 @@
 
 {.push raises: [].}
 
+import json, sequtils, times, uri
 import chronos, chronicles, results
-import ../crypto/crypto, ../peeridauth/client, ./utils
+import chronos/apps/http/httpcommon
+import
+  ../crypto/crypto,
+  ../multiaddress,
+  ../peerinfo,
+  ../peeridauth/client,
+  ./acme/client,
+  ./utils
 
 export PeerIDAuthError
 
@@ -20,62 +28,55 @@ type AutotlsBroker* = ref object
   peerIdAuthClient: PeerIDAuthClient
   bearer: Opt[BearerToken]
 
-when defined(libp2p_autotls_support):
-  import json, sequtils, times, uri
-  import chronos/apps/http/httpcommon
-  import ../peerinfo, ../multiaddress
-  import ./acme/client
+proc new*(
+    T: typedesc[AutotlsBroker],
+    rng: Rng,
+    brokerURL: string = DefaultBrokerURL,
+    peerIdAuthClient: PeerIDAuthClient = PeerIDAuthClient.new(rng),
+): T =
+  T(
+    brokerURL: brokerURL,
+    peerIdAuthClient: peerIdAuthClient,
+    bearer: Opt.none(BearerToken),
+  )
 
-  proc new*(
-      T: typedesc[AutotlsBroker],
-      rng: Rng,
-      brokerURL: string = DefaultBrokerURL,
-      peerIdAuthClient: PeerIDAuthClient = PeerIDAuthClient.new(rng),
-  ): T =
-    T(
-      brokerURL: brokerURL,
-      peerIdAuthClient: peerIdAuthClient,
-      bearer: Opt.none(BearerToken),
+proc sendChallenge*(
+    self: AutotlsBroker,
+    peerInfo: PeerInfo,
+    addrs: seq[MultiAddress],
+    keyAuth: KeyAuthorization,
+): Future[void] {.async: (raises: [AutoTLSError, PeerIDAuthError, CancelledError]).} =
+  ## Authenticates with the AutoTLS broker and registers the ACME DNS-01
+  ## challenge for the given addresses. All request construction, the broker
+  ## URL, bearer-token handling and response validation are kept internal: the
+  ## caller only learns whether the challenge was accepted (no error) or not
+  ## (an exception).
+  if addrs.len == 0:
+    raise newException(AutoTLSError, "Unable to authenticate with broker: no addresses")
+
+  let strMultiaddresses = addrs.mapIt($it)
+  let payload = %*{"value": keyAuth, "addresses": strMultiaddresses}
+  let registrationURL = parseUri("https://" & self.brokerURL & "/v1/_acme-challenge")
+
+  # drop a bearer we already know to be expired so we re-authenticate
+  # instead of looping on `PeerIDAuthError("Bearer expired")`
+  if self.bearer.isSome():
+    let cached = self.bearer.get()
+    if cached.expires.isSome() and cached.expires.get() <= now():
+      self.bearer = Opt.none(BearerToken)
+
+  trace "Sending challenge to AutoTLS broker", brokerURL = self.brokerURL
+  let (bearer, response) =
+    await self.peerIdAuthClient.send(registrationURL, peerInfo, payload, self.bearer)
+  # remember the latest bearer in case the broker rotated it
+  self.bearer = Opt.some(bearer)
+
+  if response.status != HttpOk:
+    raise newException(
+      AutoTLSError,
+      "Failed to authenticate with AutoTLS broker " & self.brokerURL & " (status " &
+        $response.status & "): " & bytesToString(response.body),
     )
 
-  proc sendChallenge*(
-      self: AutotlsBroker,
-      peerInfo: PeerInfo,
-      addrs: seq[MultiAddress],
-      keyAuth: KeyAuthorization,
-  ): Future[void] {.async: (raises: [AutoTLSError, PeerIDAuthError, CancelledError]).} =
-    ## Authenticates with the AutoTLS broker and registers the ACME DNS-01
-    ## challenge for the given addresses. All request construction, the broker
-    ## URL, bearer-token handling and response validation are kept internal: the
-    ## caller only learns whether the challenge was accepted (no error) or not
-    ## (an exception).
-    if addrs.len == 0:
-      raise
-        newException(AutoTLSError, "Unable to authenticate with broker: no addresses")
-
-    let strMultiaddresses = addrs.mapIt($it)
-    let payload = %*{"value": keyAuth, "addresses": strMultiaddresses}
-    let registrationURL = parseUri("https://" & self.brokerURL & "/v1/_acme-challenge")
-
-    # drop a bearer we already know to be expired so we re-authenticate
-    # instead of looping on `PeerIDAuthError("Bearer expired")`
-    if self.bearer.isSome():
-      let cached = self.bearer.get()
-      if cached.expires.isSome() and cached.expires.get() <= now():
-        self.bearer = Opt.none(BearerToken)
-
-    trace "Sending challenge to AutoTLS broker", brokerURL = self.brokerURL
-    let (bearer, response) =
-      await self.peerIdAuthClient.send(registrationURL, peerInfo, payload, self.bearer)
-    # remember the latest bearer in case the broker rotated it
-    self.bearer = Opt.some(bearer)
-
-    if response.status != HttpOk:
-      raise newException(
-        AutoTLSError,
-        "Failed to authenticate with AutoTLS broker " & self.brokerURL & " (status " &
-          $response.status & "): " & bytesToString(response.body),
-      )
-
-  proc close*(self: AutotlsBroker) {.async: (raises: [CancelledError]).} =
-    await self.peerIdAuthClient.close()
+proc close*(self: AutotlsBroker) {.async: (raises: [CancelledError]).} =
+  await self.peerIdAuthClient.close()

--- a/libp2p/autotls/mockservice.nim
+++ b/libp2p/autotls/mockservice.nim
@@ -2,7 +2,6 @@
 # Copyright (c) Status Research & Development GmbH
 
 import ./service, ./acme/client, ./broker
-
 import ../crypto/crypto, ../crypto/rsa, websock/websock
 
 type MockAutotlsService* = ref object of AutotlsService

--- a/libp2p/autotls/mockservice.nim
+++ b/libp2p/autotls/mockservice.nim
@@ -1,36 +1,34 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-when defined(libp2p_autotls_support):
-  import ./service, ./acme/client, ./broker
+import ./service, ./acme/client, ./broker
 
-  import ../crypto/crypto, ../crypto/rsa, websock/websock
+import ../crypto/crypto, ../crypto/rsa, websock/websock
 
-  type MockAutotlsService* = ref object of AutotlsService
-    mockedCert*: TLSCertificate
-    mockedKey*: TLSPrivateKey
+type MockAutotlsService* = ref object of AutotlsService
+  mockedCert*: TLSCertificate
+  mockedKey*: TLSPrivateKey
 
-  proc new*(
-      T: typedesc[MockAutotlsService],
-      rng: Rng,
-      config: AutotlsConfig = AutotlsConfig.new(),
-  ): T =
-    T(
-      acmeClient: ACMEClient.new(
-        rng = rng, api = ACMEApi.new(acmeServerURL = config.acmeServerURL)
-      ),
-      broker: AutotlsBroker.new(rng, brokerURL = config.brokerURL),
-      cert: Opt.none(AutotlsCert),
-      certReady: newAsyncEvent(),
-      running: newAsyncEvent(),
-      config: config,
-      rng: rng,
-    )
+proc new*(
+    T: typedesc[MockAutotlsService],
+    rng: Rng,
+    config: AutotlsConfig = AutotlsConfig.new(),
+): T =
+  T(
+    acmeClient:
+      ACMEClient.new(rng = rng, api = ACMEApi.new(acmeServerURL = config.acmeServerURL)),
+    broker: AutotlsBroker.new(rng, brokerURL = config.brokerURL),
+    cert: Opt.none(AutotlsCert),
+    certReady: newAsyncEvent(),
+    running: newAsyncEvent(),
+    config: config,
+    rng: rng,
+  )
 
-  method getCertWhenReady*(
-      self: MockAutotlsService
-  ): Future[AutotlsCert] {.async: (raises: [AutoTLSError, CancelledError]).} =
-    AutotlsCert.new(self.mockedCert, self.mockedKey, Moment.now)
+method getCertWhenReady*(
+    self: MockAutotlsService
+): Future[AutotlsCert] {.async: (raises: [AutoTLSError, CancelledError]).} =
+  AutotlsCert.new(self.mockedCert, self.mockedKey, Moment.now)
 
-  method setup*(self: MockAutotlsService) {.base, async.} =
-    self.running.fire()
+method setup*(self: MockAutotlsService) {.base, async.} =
+  self.running.fire()

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -3,6 +3,8 @@
 
 {.push raises: [].}
 
+import sequtils
+import bearssl/pem
 import chronos, chronicles, net, results, uri
 import chronos/streams/tlsstream
 
@@ -11,10 +13,15 @@ import
   ./broker,
   ./utils,
   ../crypto/crypto,
+  ../crypto/rsa,
   ../nameresolving/nameresolver,
   ../nameresolving/dnsresolver,
   ../switch,
   ../peerinfo,
+  ../transports/transport,
+  ../transports/tcptransport,
+  ../utils/heartbeat,
+  ../utils/ipaddr,
   ../wire
 
 logScope:
@@ -25,6 +32,8 @@ export LetsEncryptURL, AutoTLSError, DefaultDnsServers, DefaultBrokerURL, Autotl
 const
   DefaultRenewCheckTime* = 1.hours
   DefaultRenewBufferTime* = 1.hours
+  DefaultIssueRetries = 3
+  DefaultIssueRetryTime = 1.seconds
 
   AutoTLSDNSServer* = "libp2p.direct"
 
@@ -61,217 +70,203 @@ type AutotlsService* = ref object of Service
   peerInfo: PeerInfo
   rng*: Rng
 
-when defined(libp2p_autotls_support):
-  import sequtils, bearssl/pem
+proc new*(
+    T: typedesc[AutotlsCert],
+    cert: TLSCertificate,
+    privkey: TLSPrivateKey,
+    expiry: Moment,
+): T =
+  T(cert: cert, privkey: privkey, expiry: expiry)
 
-  const
-    DefaultIssueRetries = 3
-    DefaultIssueRetryTime = 1.seconds
-  import
-    ../crypto/rsa,
-    ../utils/heartbeat,
-    ../transports/transport,
-    ../utils/ipaddr,
-    ../transports/tcptransport
+method getCertWhenReady*(
+    self: AutotlsService
+): Future[AutotlsCert] {.base, async: (raises: [AutoTLSError, CancelledError]).} =
+  await self.certReady.wait()
+  return self.cert.get
 
-  proc new*(
-      T: typedesc[AutotlsCert],
-      cert: TLSCertificate,
-      privkey: TLSPrivateKey,
-      expiry: Moment,
-  ): T =
-    T(cert: cert, privkey: privkey, expiry: expiry)
+proc new*(
+    T: typedesc[AutotlsConfig],
+    ipAddress: Opt[IpAddress] = Opt.none(IpAddress),
+    nameServers: seq[TransportAddress] = DefaultDnsServers,
+    acmeServerURL: Uri = parseUri(LetsEncryptURL),
+    renewCheckTime: Duration = DefaultRenewCheckTime,
+    renewBufferTime: Duration = DefaultRenewBufferTime,
+    issueRetries: int = DefaultIssueRetries,
+    issueRetryTime: Duration = DefaultIssueRetryTime,
+    brokerURL: string = DefaultBrokerURL,
+    dnsServerURL: string = AutoTLSDNSServer,
+    dnsRetries: int = 10,
+    dnsRetryTime: Duration = 1.seconds,
+    acmeRetries: int = 10,
+    acmeRetryTime: Duration = 1.seconds,
+    finalizeRetries: int = 10,
+    finalizeRetryTime: Duration = 1.seconds,
+): T =
+  T(
+    nameResolver: DnsResolver.new(nameServers),
+    acmeServerURL: acmeServerURL,
+    ipAddress: ipAddress,
+    renewCheckTime: renewCheckTime,
+    renewBufferTime: renewBufferTime,
+    issueRetries: issueRetries,
+    issueRetryTime: issueRetryTime,
+    brokerURL: brokerURL,
+    dnsServerURL: dnsServerURL,
+    dnsRetries: dnsRetries,
+    dnsRetryTime: dnsRetryTime,
+    acmeRetries: acmeRetries,
+    acmeRetryTime: acmeRetryTime,
+    finalizeRetries: finalizeRetries,
+    finalizeRetryTime: finalizeRetryTime,
+  )
 
-  method getCertWhenReady*(
-      self: AutotlsService
-  ): Future[AutotlsCert] {.base, async: (raises: [AutoTLSError, CancelledError]).} =
-    await self.certReady.wait()
-    return self.cert.get
+proc new*(
+    T: typedesc[AutotlsService], rng: Rng, config: AutotlsConfig = AutotlsConfig.new()
+): T =
+  T(
+    acmeClient:
+      ACMEClient.new(api = ACMEApi.new(acmeServerURL = config.acmeServerURL), rng = rng),
+    broker: AutotlsBroker.new(rng, brokerURL = config.brokerURL),
+    cert: Opt.none(AutotlsCert),
+    certReady: newAsyncEvent(),
+    running: newAsyncEvent(),
+    config: config,
+    managerFut: nil,
+    peerInfo: nil,
+    rng: rng,
+  )
 
-  proc new*(
-      T: typedesc[AutotlsConfig],
-      ipAddress: Opt[IpAddress] = Opt.none(IpAddress),
-      nameServers: seq[TransportAddress] = DefaultDnsServers,
-      acmeServerURL: Uri = parseUri(LetsEncryptURL),
-      renewCheckTime: Duration = DefaultRenewCheckTime,
-      renewBufferTime: Duration = DefaultRenewBufferTime,
-      issueRetries: int = DefaultIssueRetries,
-      issueRetryTime: Duration = DefaultIssueRetryTime,
-      brokerURL: string = DefaultBrokerURL,
-      dnsServerURL: string = AutoTLSDNSServer,
-      dnsRetries: int = 10,
-      dnsRetryTime: Duration = 1.seconds,
-      acmeRetries: int = 10,
-      acmeRetryTime: Duration = 1.seconds,
-      finalizeRetries: int = 10,
-      finalizeRetryTime: Duration = 1.seconds,
-  ): T =
-    T(
-      nameResolver: DnsResolver.new(nameServers),
-      acmeServerURL: acmeServerURL,
-      ipAddress: ipAddress,
-      renewCheckTime: renewCheckTime,
-      renewBufferTime: renewBufferTime,
-      issueRetries: issueRetries,
-      issueRetryTime: issueRetryTime,
-      brokerURL: brokerURL,
-      dnsServerURL: dnsServerURL,
-      dnsRetries: dnsRetries,
-      dnsRetryTime: dnsRetryTime,
-      acmeRetries: acmeRetries,
-      acmeRetryTime: acmeRetryTime,
-      finalizeRetries: finalizeRetries,
-      finalizeRetryTime: finalizeRetryTime,
-    )
+method setup*(self: AutotlsService, switch: Switch) {.raises: [ServiceSetupError].} =
+  trace "Setting up AutotlsService"
+  if self.config.ipAddress.isNone():
+    try:
+      self.config.ipAddress = Opt.some(getPublicIPAddress())
+    except ValueError, OSError:
+      raise newException(
+        ServiceSetupError,
+        "Failed to get public IP address. Reason: " & getCurrentExceptionMsg(),
+      )
 
-  proc new*(
-      T: typedesc[AutotlsService], rng: Rng, config: AutotlsConfig = AutotlsConfig.new()
-  ): T =
-    T(
-      acmeClient: ACMEClient.new(
-        api = ACMEApi.new(acmeServerURL = config.acmeServerURL), rng = rng
-      ),
-      broker: AutotlsBroker.new(rng, brokerURL = config.brokerURL),
-      cert: Opt.none(AutotlsCert),
-      certReady: newAsyncEvent(),
-      running: newAsyncEvent(),
-      config: config,
-      managerFut: nil,
-      peerInfo: nil,
-      rng: rng,
-    )
+method issueCertificate(
+    self: AutotlsService
+): Future[void] {.
+    base, async: (raises: [AutoTLSError, ACMEError, PeerIDAuthError, CancelledError])
+.} =
+  trace "Issuing certificate"
 
-  method setup*(self: AutotlsService, switch: Switch) {.raises: [ServiceSetupError].} =
-    trace "Setting up AutotlsService"
-    if self.config.ipAddress.isNone():
-      try:
-        self.config.ipAddress = Opt.some(getPublicIPAddress())
-      except ValueError, OSError:
-        raise newException(
-          ServiceSetupError,
-          "Failed to get public IP address. Reason: " & getCurrentExceptionMsg(),
-        )
+  if self.peerInfo.isNil():
+    raise newException(AutoTLSError, "Cannot issue new certificate: peerInfo not set")
 
-  method issueCertificate(
-      self: AutotlsService
-  ): Future[void] {.
-      base, async: (raises: [AutoTLSError, ACMEError, PeerIDAuthError, CancelledError])
-  .} =
-    trace "Issuing certificate"
+  # generate autotls domain string: "*.{peerID}.{dnsServerURL}"
+  let baseDomain =
+    api.Domain(encodePeerId(self.peerInfo.peerId) & "." & self.config.dnsServerURL)
 
-    if self.peerInfo.isNil():
-      raise newException(AutoTLSError, "Cannot issue new certificate: peerInfo not set")
+  trace "Requesting ACME challenge"
+  let dns01Challenge =
+    await self.acmeClient.getChallenge(@[api.Domain("*." & baseDomain)])
+  trace "Generating key authorization"
+  let keyAuth = self.acmeClient.genKeyAuthorization(dns01Challenge.dns01.token)
 
-    # generate autotls domain string: "*.{peerID}.{dnsServerURL}"
-    let baseDomain =
-      api.Domain(encodePeerId(self.peerInfo.peerId) & "." & self.config.dnsServerURL)
+  let addrs = await self.peerInfo.expandAddrs()
 
-    trace "Requesting ACME challenge"
-    let dns01Challenge =
-      await self.acmeClient.getChallenge(@[api.Domain("*." & baseDomain)])
-    trace "Generating key authorization"
-    let keyAuth = self.acmeClient.genKeyAuthorization(dns01Challenge.dns01.token)
+  # broker encapsulates request construction, bearer handling and response
+  # validation: it either registers the challenge or raises on failure
+  await self.broker.sendChallenge(self.peerInfo, addrs, keyAuth)
 
-    let addrs = await self.peerInfo.expandAddrs()
+  let dnsSet = await checkDNSRecords(
+    self.config.nameResolver,
+    self.config.ipAddress.get(),
+    baseDomain,
+    keyAuth,
+    self.config.dnsRetries,
+    self.config.dnsRetryTime,
+  )
+  if not dnsSet:
+    raise newException(AutoTLSError, "DNS records not set")
 
-    # broker encapsulates request construction, bearer handling and response
-    # validation: it either registers the challenge or raises on failure
-    await self.broker.sendChallenge(self.peerInfo, addrs, keyAuth)
+  trace "Notifying challenge completion to ACME and downloading cert"
+  let certKeyPair = KeyPair.random(PKScheme.RSA, self.rng).valueOr:
+    raise newException(AutoTLSError, "Unable to generate certificate key pair")
+  let derPrivKey = certKeyPair.seckey.rsakey.getBytes.valueOr:
+    raise newException(AutoTLSError, "Unable to get TLS private key")
 
-    let dnsSet = await checkDNSRecords(
-      self.config.nameResolver,
-      self.config.ipAddress.get(),
-      baseDomain,
-      keyAuth,
-      self.config.dnsRetries,
-      self.config.dnsRetryTime,
-    )
-    if not dnsSet:
-      raise newException(AutoTLSError, "DNS records not set")
+  let certificate = await self.acmeClient.getCertificate(
+    api.Domain("*." & baseDomain),
+    certKeyPair,
+    dns01Challenge,
+    self.config.acmeRetries,
+    self.config.finalizeRetries,
+  )
 
-    trace "Notifying challenge completion to ACME and downloading cert"
-    let certKeyPair = KeyPair.random(PKScheme.RSA, self.rng).valueOr:
-      raise newException(AutoTLSError, "Unable to generate certificate key pair")
-    let derPrivKey = certKeyPair.seckey.rsakey.getBytes.valueOr:
-      raise newException(AutoTLSError, "Unable to get TLS private key")
+  trace "Installing certificate"
+  let newCert =
+    try:
+      AutotlsCert.new(
+        TLSCertificate.init(certificate.rawCertificate),
+        TLSPrivateKey.init(derPrivKey.pemEncode("PRIVATE KEY")),
+        asMoment(certificate.certificateExpiry),
+      )
+    except TLSStreamProtocolError as exc:
+      raise newException(
+        AutoTLSError, "Could not parse downloaded certificates: " & exc.msg, exc
+      )
+  self.cert = Opt.some(newCert)
+  self.certReady.fire()
+  notice "AutoTLS successfully renewed certificate"
 
-    let certificate = await self.acmeClient.getCertificate(
-      api.Domain("*." & baseDomain),
-      certKeyPair,
-      dns01Challenge,
-      self.config.acmeRetries,
-      self.config.finalizeRetries,
-    )
+proc hasTcpStarted(switch: Switch): bool =
+  switch.transports.filterIt(it of TcpTransport and it.running).len == 0
 
-    trace "Installing certificate"
-    let newCert =
-      try:
-        AutotlsCert.new(
-          TLSCertificate.init(certificate.rawCertificate),
-          TLSPrivateKey.init(derPrivKey.pemEncode("PRIVATE KEY")),
-          asMoment(certificate.certificateExpiry),
-        )
-      except TLSStreamProtocolError as exc:
-        raise newException(
-          AutoTLSError, "Could not parse downloaded certificates: " & exc.msg, exc
-        )
-    self.cert = Opt.some(newCert)
-    self.certReady.fire()
-    notice "AutoTLS successfully renewed certificate"
-
-  proc hasTcpStarted(switch: Switch): bool =
-    switch.transports.filterIt(it of TcpTransport and it.running).len == 0
-
-  proc tryIssueCertificate(self: AutotlsService) {.async: (raises: [CancelledError]).} =
-    for _ in 0 ..< self.config.issueRetries:
-      try:
-        await self.issueCertificate()
-        return
-      except CancelledError as exc:
-        raise exc
-      except CatchableError as exc:
-        error "Failed to issue certificate", err = exc.msg
-      await sleepAsync(self.config.issueRetryTime)
-    error "Failed to issue certificate"
-
-  method start*(
-      self: AutotlsService, switch: Switch
-  ) {.async: (raises: [CancelledError]).} =
-    trace "Starting Autotls management"
-    self.running.fire()
-    self.peerInfo = switch.peerInfo
-
-    # ensure that there's at least one TcpTransport running
-    # for communicating with autotls broker
-    if switch.hasTcpStarted():
-      error "Could not find a running TcpTransport in switch"
+proc tryIssueCertificate(self: AutotlsService) {.async: (raises: [CancelledError]).} =
+  for _ in 0 ..< self.config.issueRetries:
+    try:
+      await self.issueCertificate()
       return
+    except CancelledError as exc:
+      raise exc
+    except CatchableError as exc:
+      error "Failed to issue certificate", err = exc.msg
+    await sleepAsync(self.config.issueRetryTime)
+  error "Failed to issue certificate"
 
-    proc manageCert() {.async: (raises: []).} =
-      try:
-        heartbeat "Certificate Management", self.config.renewCheckTime:
-          if self.cert.isNone():
-            await self.tryIssueCertificate()
+method start*(
+    self: AutotlsService, switch: Switch
+) {.async: (raises: [CancelledError]).} =
+  trace "Starting Autotls management"
+  self.running.fire()
+  self.peerInfo = switch.peerInfo
 
-          # AutotlsService will renew the cert 1h before it expires
-          let cert = self.cert.valueOr:
-            error "Could not issue certificate"
-            return
-          let waitTime = cert.expiry - Moment.now - self.config.renewBufferTime
-          if waitTime <= self.config.renewBufferTime:
-            await self.tryIssueCertificate()
-      except CancelledError:
-        trace "Autotls management cancelled"
+  # ensure that there's at least one TcpTransport running
+  # for communicating with autotls broker
+  if switch.hasTcpStarted():
+    error "Could not find a running TcpTransport in switch"
+    return
 
-    self.managerFut = manageCert()
+  proc manageCert() {.async: (raises: []).} =
+    try:
+      heartbeat "Certificate Management", self.config.renewCheckTime:
+        if self.cert.isNone():
+          await self.tryIssueCertificate()
 
-  method stop*(
-      self: AutotlsService, switch: Switch
-  ) {.async: (raises: [CancelledError]).} =
-    if not self.acmeClient.isNil():
-      await self.acmeClient.close()
-    if not self.broker.isNil():
-      await self.broker.close()
-    if not self.managerFut.isNil():
-      await self.managerFut.cancelAndWait()
-      self.managerFut = nil
+        # AutotlsService will renew the cert 1h before it expires
+        let cert = self.cert.valueOr:
+          error "Could not issue certificate"
+          return
+        let waitTime = cert.expiry - Moment.now - self.config.renewBufferTime
+        if waitTime <= self.config.renewBufferTime:
+          await self.tryIssueCertificate()
+    except CancelledError:
+      trace "Autotls management cancelled"
+
+  self.managerFut = manageCert()
+
+method stop*(
+    self: AutotlsService, switch: Switch
+) {.async: (raises: [CancelledError]).} =
+  if not self.acmeClient.isNil():
+    await self.acmeClient.close()
+  if not self.broker.isNil():
+    await self.broker.close()
+  if not self.managerFut.isNil():
+    await self.managerFut.cancelAndWait()
+    self.managerFut = nil

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -2,7 +2,7 @@
 # Copyright (c) Status Research & Development GmbH
 {.push raises: [].}
 
-import chronicles
+import chronos, chronicles, strutils
 import ../errors
 
 logScope:
@@ -10,69 +10,66 @@ logScope:
 
 type AutoTLSError* = object of LPError
 
-when defined(libp2p_autotls_support):
-  import chronos, strutils
+const
+  DefaultDnsRetries = 3
+  DefaultDnsRetryTime = 1.seconds
 
-  const
-    DefaultDnsRetries = 3
-    DefaultDnsRetryTime = 1.seconds
+from times import DateTime, toTime, toUnix
+import stew/base36
+import
+  ../peerid,
+  ../multihash,
+  ../cid,
+  ../multicodec,
+  ../nameresolving/nameresolver,
+  ./acme/client
 
-  from times import DateTime, toTime, toUnix
-  import stew/base36
-  import
-    ../peerid,
-    ../multihash,
-    ../cid,
-    ../multicodec,
-    ../nameresolving/nameresolver,
-    ./acme/client
+proc asMoment*(dt: DateTime): Moment =
+  let unixTime: int64 = dt.toTime.toUnix
+  return Moment.init(unixTime, Second)
 
-  proc asMoment*(dt: DateTime): Moment =
-    let unixTime: int64 = dt.toTime.toUnix
-    return Moment.init(unixTime, Second)
+proc encodePeerId*(peerId: PeerId): string {.raises: [AutoTLSError].} =
+  var mh: MultiHash
+  let decodeResult = MultiHash.decode(peerId.data, mh)
+  if decodeResult.isErr() or decodeResult.get() == -1:
+    raise
+      newException(AutoTLSError, "Failed to decode PeerId: invalid multihash format")
 
-  proc encodePeerId*(peerId: PeerId): string {.raises: [AutoTLSError].} =
-    var mh: MultiHash
-    let decodeResult = MultiHash.decode(peerId.data, mh)
-    if decodeResult.isErr() or decodeResult.get() == -1:
-      raise
-        newException(AutoTLSError, "Failed to decode PeerId: invalid multihash format")
+  let cidResult = Cid.init(CIDv1, multiCodec("libp2p-key"), mh)
+  if cidResult.isErr():
+    raise newException(AutoTLSError, "Failed to initialize CID from multihash")
 
-    let cidResult = Cid.init(CIDv1, multiCodec("libp2p-key"), mh)
-    if cidResult.isErr():
-      raise newException(AutoTLSError, "Failed to initialize CID from multihash")
+  return Base36.encode(cidResult.get().data.buffer)
 
-    return Base36.encode(cidResult.get().data.buffer)
+proc checkDNSRecords*(
+    nameResolver: NameResolver,
+    ipAddress: IpAddress,
+    baseDomain: api.Domain,
+    keyAuth: KeyAuthorization,
+    retries: int = DefaultDnsRetries,
+    retryTime: Duration = DefaultDnsRetryTime,
+): Future[bool] {.async: (raises: [AutoTLSError, CancelledError]).} =
+  # if my ip address is 100.10.10.3 then the ip4Domain will be:
+  #     100-10-10-3.{peerIdBase36}.libp2p.direct
+  # and acme challenge TXT domain will be:
+  #     _acme-challenge.{peerIdBase36}.libp2p.direct
+  let dashedIpAddr = ($ipAddress).replace(".", "-")
+  let acmeChalDomain = api.Domain("_acme-challenge." & baseDomain)
+  let ip4Domain = api.Domain(dashedIpAddr & "." & baseDomain)
+  debug "Waiting for DNS record to be set", ip = ip4Domain, acme = acmeChalDomain
 
-  proc checkDNSRecords*(
-      nameResolver: NameResolver,
-      ipAddress: IpAddress,
-      baseDomain: api.Domain,
-      keyAuth: KeyAuthorization,
-      retries: int = DefaultDnsRetries,
-      retryTime: Duration = DefaultDnsRetryTime,
-  ): Future[bool] {.async: (raises: [AutoTLSError, CancelledError]).} =
-    # if my ip address is 100.10.10.3 then the ip4Domain will be:
-    #     100-10-10-3.{peerIdBase36}.libp2p.direct
-    # and acme challenge TXT domain will be:
-    #     _acme-challenge.{peerIdBase36}.libp2p.direct
-    let dashedIpAddr = ($ipAddress).replace(".", "-")
-    let acmeChalDomain = api.Domain("_acme-challenge." & baseDomain)
-    let ip4Domain = api.Domain(dashedIpAddr & "." & baseDomain)
-    debug "Waiting for DNS record to be set", ip = ip4Domain, acme = acmeChalDomain
+  var txt: seq[string]
+  var ip4: seq[TransportAddress]
+  for _ in 0 .. retries:
+    txt = await nameResolver.resolveTxt(acmeChalDomain)
+    try:
+      ip4 = await nameResolver.resolveIp(ip4Domain, 0.Port)
+    except CancelledError as exc:
+      raise exc
+    except CatchableError as exc:
+      error "Failed to resolve IP", description = exc.msg # retry
+  if txt.len > 0 and txt[0] == keyAuth and ip4.len > 0:
+    return true
+  await sleepAsync(retryTime)
 
-    var txt: seq[string]
-    var ip4: seq[TransportAddress]
-    for _ in 0 .. retries:
-      txt = await nameResolver.resolveTxt(acmeChalDomain)
-      try:
-        ip4 = await nameResolver.resolveIp(ip4Domain, 0.Port)
-      except CancelledError as exc:
-        raise exc
-      except CatchableError as exc:
-        error "Failed to resolve IP", description = exc.msg # retry
-    if txt.len > 0 and txt[0] == keyAuth and ip4.len > 0:
-      return true
-    await sleepAsync(retryTime)
-
-    return false
+  return false

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -3,7 +3,16 @@
 {.push raises: [].}
 
 import chronos, chronicles, strutils
-import ../errors
+import stew/base36
+from times import DateTime, toTime, toUnix
+import
+  ../errors,
+  ../peerid,
+  ../multihash,
+  ../cid,
+  ../multicodec,
+  ../nameresolving/nameresolver,
+  ./acme/client
 
 logScope:
   topics = "libp2p utils"
@@ -13,16 +22,6 @@ type AutoTLSError* = object of LPError
 const
   DefaultDnsRetries = 3
   DefaultDnsRetryTime = 1.seconds
-
-from times import DateTime, toTime, toUnix
-import stew/base36
-import
-  ../peerid,
-  ../multihash,
-  ../cid,
-  ../multicodec,
-  ../nameresolving/nameresolver,
-  ./acme/client
 
 proc asMoment*(dt: DateTime): Moment =
   let unixTime: int64 = dt.toTime.toUnix

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -368,12 +368,11 @@ proc withHolePunching*(
   b.hpService = Opt.some(hpService)
   b
 
-when defined(libp2p_autotls_support):
-  proc withAutotls*(
-      b: SwitchBuilder, config: AutotlsConfig = AutotlsConfig.new()
-  ): SwitchBuilder =
-    b.autotlsConfig = Opt.some(config)
-    b
+proc withAutotls*(
+    b: SwitchBuilder, config: AutotlsConfig = AutotlsConfig.new()
+): SwitchBuilder =
+  b.autotlsConfig = Opt.some(config)
+  b
 
 proc withCircuitRelay*(b: SwitchBuilder, r: Relay = Relay.new()): SwitchBuilder =
   if r.isNil:
@@ -480,11 +479,10 @@ proc buildSwitch(b: SwitchBuilder): Switch {.raises: [LPError].} =
 
   var services: seq[Service]
   var autotlsOpt = Opt.none(AutotlsService)
-  when defined(libp2p_autotls_support):
-    b.autotlsConfig.withValue(config):
-      let autotlsService = AutotlsService.new(b.rng, config)
-      autotlsOpt = Opt.some(autotlsService)
-      services.add(autotlsService)
+  b.autotlsConfig.withValue(config):
+    let autotlsService = AutotlsService.new(b.rng, config)
+    autotlsOpt = Opt.some(autotlsService)
+    services.add(autotlsService)
 
   var transports: seq[Transport]
   for tProvider in b.transports:

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -327,23 +327,22 @@ method start*(
   let addrsTa = self.toTransportAddress(addrs).valueOr:
     raise newException(TransportStartError, $error)
 
-  when defined(libp2p_autotls_support):
-    if not self.secure and self.autotls.isSome():
-      self.autotls.withValue(autotls):
-        if not await autotls.running.wait().withTimeout(DefaultAutotlsWaitTimeout):
-          error "Unable to upgrade, autotls not running"
-          await self.stop()
-          return
+  if not self.secure and self.autotls.isSome():
+    self.autotls.withValue(autotls):
+      if not await autotls.running.wait().withTimeout(DefaultAutotlsWaitTimeout):
+        error "Unable to upgrade, autotls not running"
+        await self.stop()
+        return
 
-        trace "Waiting for autotls certificate"
-        try:
-          let autotlsCert = await autotls.getCertWhenReady()
-          self.tlsCertificate = autotlsCert.cert
-          self.tlsPrivateKey = autotlsCert.privkey
-        except AutoTLSError as e:
-          raise newException(LPError, e.msg, e)
-        except TLSStreamProtocolError as e:
-          raise newException(LPError, e.msg, e)
+      trace "Waiting for autotls certificate"
+      try:
+        let autotlsCert = await autotls.getCertWhenReady()
+        self.tlsCertificate = autotlsCert.cert
+        self.tlsPrivateKey = autotlsCert.privkey
+      except AutoTLSError as e:
+        raise newException(LPError, e.msg, e)
+      except TLSStreamProtocolError as e:
+        raise newException(LPError, e.msg, e)
 
   self.wsserver =
     WSServer.new(factories = self.factories, rng = bearSslDrbgRef(self.rng))

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -33,7 +33,6 @@ pkgs.stdenv.mkDerivation {
       --skipUserCfg \
       --threads:on \
       --opt:speed \
-      -d:libp2p_autotls_support \
       -d:libp2p_mix_experimental_exit_is_dest \
       libp2p.nim
   '';

--- a/tests/integration/test_all.nim
+++ b/tests/integration/test_all.nim
@@ -4,5 +4,4 @@
 when defined(linux) and defined(amd64):
   {.used.}
 
-when defined(libp2p_autotls_support):
   import test_autotls_integration, test_peer_id_auth_integration, test_ws_integration

--- a/tests/integration/test_all.nim
+++ b/tests/integration/test_all.nim
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-when defined(linux) and defined(amd64):
-  {.used.}
+{.used.}
 
+when defined(linux) and defined(amd64):
   import test_autotls_integration, test_peer_id_auth_integration, test_ws_integration

--- a/tests/integration/test_autotls_integration.nim
+++ b/tests/integration/test_autotls_integration.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-when defined(linux) and defined(amd64) and defined(libp2p_autotls_support):
+when defined(linux) and defined(amd64):
   import chronos, chronos/apps/http/httpclient
   import
     ../../libp2p/[

--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -3,400 +3,393 @@
 
 {.used.}
 
-when defined(libp2p_autotls_support):
-  {.push raises: [].}
+{.push raises: [].}
 
-  import sequtils, json, uri, chronos, chronos/apps/http/httpclient
-  import
-    ../../../libp2p/[
-      stream/connection,
-      upgrademngrs/upgrade,
-      autotls/acme/mockapi,
-      autotls/acme/client,
-      wire,
-    ]
-  import ../../tools/[unittest, crypto]
+import sequtils, json, uri, chronos, chronos/apps/http/httpclient
+import
+  ../../../libp2p/[
+    stream/connection,
+    upgrademngrs/upgrade,
+    autotls/acme/mockapi,
+    autotls/acme/client,
+    wire,
+  ]
+import ../../tools/[unittest, crypto]
 
-  suite "AutoTLS ACME API":
-    var api {.threadvar.}: MockACMEApi
-    var key {.threadvar.}: KeyPair
+suite "AutoTLS ACME API":
+  var api {.threadvar.}: MockACMEApi
+  var key {.threadvar.}: KeyPair
 
-    asyncTeardown:
-      await api.close()
-      checkTrackers()
+  asyncTeardown:
+    await api.close()
+    checkTrackers()
 
-    asyncSetup:
-      api = await MockACMEApi.new()
-      key = KeyPair.random(PKScheme.RSA, rng()).get()
+  asyncSetup:
+    api = await MockACMEApi.new()
+    key = KeyPair.random(PKScheme.RSA, rng()).get()
 
-    asyncTest "register to acme server":
-      api.mockedResponses.add(
-        HTTPResponse(
-          body: %*{"status": "valid"},
-          headers: HttpTable.init(@[("location", "some-expected-kid")]),
-        )
+  asyncTest "register to acme server":
+    api.mockedResponses.add(
+      HTTPResponse(
+        body: %*{"status": "valid"},
+        headers: HttpTable.init(@[("location", "some-expected-kid")]),
       )
+    )
 
-      let registerResponse = await api.requestRegister(key)
-      check registerResponse.kid == "some-expected-kid"
+    let registerResponse = await api.requestRegister(key)
+    check registerResponse.kid == "some-expected-kid"
 
-    asyncTest "request challenge for a domain":
-      api.mockedResponses.add(
-        HTTPResponse(
-          body: %*{
-            "status": "pending",
-            "authorizations": ["http://example.com/expected-authorizations-url"],
-            "finalize": "http://example.com/expected-finalize-url",
-          },
-          headers:
-            HttpTable.init(@[("location", "http://example.com/expected-order-url")]),
-        )
+  asyncTest "request challenge for a domain":
+    api.mockedResponses.add(
+      HTTPResponse(
+        body: %*{
+          "status": "pending",
+          "authorizations": ["http://example.com/expected-authorizations-url"],
+          "finalize": "http://example.com/expected-finalize-url",
+        },
+        headers:
+          HttpTable.init(@[("location", "http://example.com/expected-order-url")]),
       )
+    )
 
-      let challengeResponse =
-        await api.requestNewOrder(@["some.dummy.domain.com"], key, "kid")
-      check challengeResponse.status == ACMEOrderStatus.PENDING
-      check challengeResponse.authorizations ==
-        ["http://example.com/expected-authorizations-url"]
-      check challengeResponse.finalize == "http://example.com/expected-finalize-url"
-      check challengeResponse.order == "http://example.com/expected-order-url"
+    let challengeResponse =
+      await api.requestNewOrder(@["some.dummy.domain.com"], key, "kid")
+    check challengeResponse.status == ACMEOrderStatus.PENDING
+    check challengeResponse.authorizations ==
+      ["http://example.com/expected-authorizations-url"]
+    check challengeResponse.finalize == "http://example.com/expected-finalize-url"
+    check challengeResponse.order == "http://example.com/expected-order-url"
 
-      # reset mocked obj for second request
-      api.mockedResponses.add(
-        HTTPResponse(
-          body: %*{
-            "challenges": [
-              {
-                "url": "http://example.com/expected-dns01-url",
-                "type": "dns-01",
-                "status": "pending",
-                "token": "expected-dns01-token",
-              }
-            ]
-          },
-          headers:
-            HttpTable.init(@[("location", "http://example.com/expected-order-url")]),
-        )
+    # reset mocked obj for second request
+    api.mockedResponses.add(
+      HTTPResponse(
+        body: %*{
+          "challenges": [
+            {
+              "url": "http://example.com/expected-dns01-url",
+              "type": "dns-01",
+              "status": "pending",
+              "token": "expected-dns01-token",
+            }
+          ]
+        },
+        headers:
+          HttpTable.init(@[("location", "http://example.com/expected-order-url")]),
       )
+    )
 
-      let authorizationsResponse =
-        await api.requestAuthorizations(challengeResponse.authorizations, key, "kid")
-      check authorizationsResponse.challenges.len > 0
+    let authorizationsResponse =
+      await api.requestAuthorizations(challengeResponse.authorizations, key, "kid")
+    check authorizationsResponse.challenges.len > 0
 
-      let dns01 = authorizationsResponse.challenges.filterIt(
-        it.`type` == ACMEChallengeType.DNS01
-      )[0]
-      check dns01.url == "http://example.com/expected-dns01-url"
-      check dns01.`type` == ACMEChallengeType.DNS01
-      check dns01.token == ACMEChallengeToken("expected-dns01-token")
-      check dns01.status == ACMEChallengeStatus.PENDING
+    let dns01 = authorizationsResponse.challenges.filterIt(
+      it.`type` == ACMEChallengeType.DNS01
+    )[0]
+    check dns01.url == "http://example.com/expected-dns01-url"
+    check dns01.`type` == ACMEChallengeType.DNS01
+    check dns01.token == ACMEChallengeToken("expected-dns01-token")
+    check dns01.status == ACMEChallengeStatus.PENDING
 
-    asyncTest "register with unsupported keys":
-      let unsupportedSchemes = [PKScheme.Ed25519, PKScheme.Secp256k1, PKScheme.ECDSA]
-      for scheme in unsupportedSchemes:
-        let unsupportedKey = KeyPair.random(scheme, rng()).get()
-        expect(ACMEError):
-          discard await api.requestRegister(unsupportedKey)
-
-    asyncTest "challenge completed successful":
-      api.mockedResponses.add(
-        HTTPResponse(
-          body: %*{"url": "http://example.com/some-check-url"},
-          headers: HttpTable.init(),
-        )
-      )
-      discard await api.sendChallengeCompleted(
-        parseUri("http://example.com/some-chal-url"), key, "kid"
-      )
-
-      api.mockedResponses.add(
-        HTTPResponse(
-          body: %*{"status": "valid"}, headers: HttpTable.init(@[("Retry-After", "0")])
-        )
-      )
-      let completed = await api.checkChallengeCompleted(
-        parseUri("http://example.com/some-chal-url"), key, "kid"
-      )
-      check completed == true
-
-    asyncTest "challenge completed max retries reached":
-      api.mockedResponses.add(
-        HTTPResponse(
-          body: %*{"url": "http://example.com/some-check-url"},
-          headers: HttpTable.init(),
-        )
-      )
-      discard await api.sendChallengeCompleted(
-        parseUri("http://example.com/some-chal-url"), key, "kid"
-      )
-
-      # add this mocked response a few times since checkChallengeCompleted might get more than once
-      for _ in 0 .. 5:
-        api.mockedResponses.add(
-          HTTPResponse(
-            body: %*{"status": "pending"},
-            headers: HttpTable.init(@[("Retry-After", "0")]),
-          )
-        )
-      let completed = await api.checkChallengeCompleted(
-        parseUri("http://example.com/some-chal-url"), key, "kid", retries = 1
-      )
-      check completed == false
-
-    asyncTest "challenge completed invalid":
-      api.mockedResponses.add(
-        HTTPResponse(
-          body: %*{"url": "http://example.com/some-check-url"},
-          headers: HttpTable.init(),
-        )
-      )
-      discard await api.sendChallengeCompleted(
-        parseUri("http://example.com/some-chal-url"), key, "kid"
-      )
-
-      # add this mocked response a few times since checkChallengeCompleted might get more than once
-      for _ in 0 .. 5:
-        api.mockedResponses.add(
-          HTTPResponse(
-            body: %*{"status": "invalid"},
-            headers: HttpTable.init(@[("Retry-After", "0")]),
-          )
-        )
-
+  asyncTest "register with unsupported keys":
+    let unsupportedSchemes = [PKScheme.Ed25519, PKScheme.Secp256k1, PKScheme.ECDSA]
+    for scheme in unsupportedSchemes:
+      let unsupportedKey = KeyPair.random(scheme, rng()).get()
       expect(ACMEError):
-        discard await api.checkChallengeCompleted(
-          parseUri("http://example.com/some-chal-url"), key, "kid"
-        )
+        discard await api.requestRegister(unsupportedKey)
 
-    asyncTest "finalize certificate successful":
-      # first status is processing, then valid
+  asyncTest "challenge completed successful":
+    api.mockedResponses.add(
+      HTTPResponse(
+        body: %*{"url": "http://example.com/some-check-url"}, headers: HttpTable.init()
+      )
+    )
+    discard await api.sendChallengeCompleted(
+      parseUri("http://example.com/some-chal-url"), key, "kid"
+    )
+
+    api.mockedResponses.add(
+      HTTPResponse(
+        body: %*{"status": "valid"}, headers: HttpTable.init(@[("Retry-After", "0")])
+      )
+    )
+    let completed = await api.checkChallengeCompleted(
+      parseUri("http://example.com/some-chal-url"), key, "kid"
+    )
+    check completed == true
+
+  asyncTest "challenge completed max retries reached":
+    api.mockedResponses.add(
+      HTTPResponse(
+        body: %*{"url": "http://example.com/some-check-url"}, headers: HttpTable.init()
+      )
+    )
+    discard await api.sendChallengeCompleted(
+      parseUri("http://example.com/some-chal-url"), key, "kid"
+    )
+
+    # add this mocked response a few times since checkChallengeCompleted might get more than once
+    for _ in 0 .. 5:
       api.mockedResponses.add(
         HTTPResponse(
-          body: %*{"status": "processing"},
+          body: %*{"status": "pending"},
           headers: HttpTable.init(@[("Retry-After", "0")]),
         )
       )
-      api.mockedResponses.add(
-        HTTPResponse(
-          body: %*{"status": "valid"}, headers: HttpTable.init(@[("Retry-After", "0")])
-        )
-      )
-      let finalized = await api.certificateFinalized(
-        "some-domain",
-        parseUri("http://example.com/some-finalize-url"),
-        parseUri("http://example.com/some-order-url"),
-        KeyPair.random(PKScheme.RSA, rng()).get,
-        key,
-        "kid",
-      )
-      check finalized == true
+    let completed = await api.checkChallengeCompleted(
+      parseUri("http://example.com/some-chal-url"), key, "kid", retries = 1
+    )
+    check completed == false
 
-    asyncTest "finalize certificate max retries reached":
-      # add this mocked response a few times since checkCertFinalized might get more than once
-      for _ in 0 .. 5:
-        api.mockedResponses.add(
-          HTTPResponse(
-            body: %*{"status": "processing"},
-            headers: HttpTable.init(@[("Retry-After", "0")]),
-          )
-        )
-      let finalized = await api.certificateFinalized(
-        "some-domain",
-        parseUri("http://example.com/some-finalize-url"),
-        parseUri("http://example.com/some-order-url"),
-        KeyPair.random(PKScheme.RSA, rng()).get,
-        key,
-        "kid",
-        retries = 1,
+  asyncTest "challenge completed invalid":
+    api.mockedResponses.add(
+      HTTPResponse(
+        body: %*{"url": "http://example.com/some-check-url"}, headers: HttpTable.init()
       )
-      check finalized == false
+    )
+    discard await api.sendChallengeCompleted(
+      parseUri("http://example.com/some-chal-url"), key, "kid"
+    )
 
-    asyncTest "finalize certificate invalid":
-      # first request is processing, then invalid
-      api.mockedResponses.add(
-        HTTPResponse(
-          body: %*{"status": "processing"},
-          headers: HttpTable.init(@[("Retry-After", "0")]),
-        )
-      )
+    # add this mocked response a few times since checkChallengeCompleted might get more than once
+    for _ in 0 .. 5:
       api.mockedResponses.add(
         HTTPResponse(
           body: %*{"status": "invalid"},
           headers: HttpTable.init(@[("Retry-After", "0")]),
         )
       )
-      let finalized = await api.certificateFinalized(
-        "some-domain",
-        parseUri("http://example.com/some-finalize-url"),
-        parseUri("http://example.com/some-order-url"),
-        KeyPair.random(PKScheme.RSA, rng()).get,
-        key,
-        "kid",
+
+    expect(ACMEError):
+      discard await api.checkChallengeCompleted(
+        parseUri("http://example.com/some-chal-url"), key, "kid"
       )
-      check finalized == false
 
-    asyncTest "expect error on invalid JSON response":
-      # add a couple invalid responses as they get popped by every get or post call
-      for _ in 0 .. 20:
-        api.mockedResponses.add(
-          HTTPResponse(
-            body: %*{"inexistent field": "invalid value"}, headers: HttpTable.init()
-          )
-        )
+  asyncTest "finalize certificate successful":
+    # first status is processing, then valid
+    api.mockedResponses.add(
+      HTTPResponse(
+        body: %*{"status": "processing"},
+        headers: HttpTable.init(@[("Retry-After", "0")]),
+      )
+    )
+    api.mockedResponses.add(
+      HTTPResponse(
+        body: %*{"status": "valid"}, headers: HttpTable.init(@[("Retry-After", "0")])
+      )
+    )
+    let finalized = await api.certificateFinalized(
+      "some-domain",
+      parseUri("http://example.com/some-finalize-url"),
+      parseUri("http://example.com/some-order-url"),
+      KeyPair.random(PKScheme.RSA, rng()).get,
+      key,
+      "kid",
+    )
+    check finalized == true
 
-      expect(ACMEError):
-        # avoid calling overloaded mock method requestNonce here since we want to test the actual thing
-        discard await procCall requestNonce(ACMEApi(api))
-
-      expect(ACMEError):
-        discard await api.requestRegister(key)
-
-      expect(ACMEError):
-        discard await api.requestNewOrder(@["some-domain"], key, "kid")
-
-      expect(ACMEError):
-        discard await api.requestAuthorizations(@["auth-1", "auth-2"], key, "kid")
-
-      # clear leftover invalid responses so the mixed response is next in queue
-      api.mockedResponses = @[]
+  asyncTest "finalize certificate max retries reached":
+    # add this mocked response a few times since checkCertFinalized might get more than once
+    for _ in 0 .. 5:
       api.mockedResponses.add(
-        HTTPResponse(
-          body: %*{
-            "identifier": {"type": "dns", "value": "example.com"},
-            "status": "pending",
-            "challenges": [
-              {
-                "type": "dns-persist-01",
-                "url": "http://example.com/unknown-challenge",
-                "status": "pending",
-                "token": "unknown-token",
-              },
-              {
-                "type": "dns-01",
-                "url": "http://example.com/recognized-challenge",
-                "status": "pending",
-                "token": "recognized-token",
-              },
-            ],
-          },
-          headers: HttpTable.init(),
-        )
-      )
-
-      let mixedAuthResp = await api.requestAuthorizations(@["auth-3"], key, "kid")
-      check mixedAuthResp.challenges.len == 2
-
-      # replenish invalid responses for the remaining expect(ACMEError) blocks
-      for _ in 0 .. 5:
-        api.mockedResponses.add(
-          HTTPResponse(
-            body: %*{"inexistent field": "invalid value"}, headers: HttpTable.init()
-          )
-        )
-
-      expect(ACMEError):
-        discard await api.requestChallenge(@["domain-1", "domain-2"], key, "kid")
-
-      expect(ACMEError):
-        discard await api.requestCheck(
-          parseUri("http://example.com/some-check-url"),
-          ACMECheckKind.ACMEOrderCheck,
-          key,
-          "kid",
-        )
-
-      expect(ACMEError):
-        discard await api.requestCheck(
-          parseUri("http://example.com/some-check-url"),
-          ACMECheckKind.ACMEChallengeCheck,
-          key,
-          "kid",
-        )
-
-      expect(ACMEError):
-        discard await api.sendChallengeCompleted(
-          parseUri("http://example.com/some-chal-url"), key, "kid"
-        )
-
-      expect(ACMEError):
-        discard await api.requestFinalize(
-          "some-domain",
-          parseUri("http://example.com/some-finalize-url"),
-          KeyPair.random(PKScheme.RSA, rng()).get,
-          key,
-          "kid",
-        )
-
-      expect(ACMEError):
-        discard await api.requestGetOrder(parseUri("http://example.com/some-order-url"))
-
-  suite "AutoTLS ACME Client":
-    var acmeApi {.threadvar.}: MockACMEApi
-    var acme {.threadvar.}: ACMEClient
-
-    asyncSetup:
-      acmeApi = await MockACMEApi.new()
-
-    asyncTeardown:
-      await acme.close()
-      checkTrackers()
-
-    asyncTest "client registers new account when instantiated":
-      acmeApi.mockedResponses.add(
-        HTTPResponse(
-          body: %*{"status": "valid"},
-          headers: HttpTable.init(@[("location", "some-expected-kid")]),
-        )
-      )
-
-      acme = ACMEClient.new(rng = rng(), api = ACMEApi(acmeApi))
-      let kid = await acme.getOrInitKid()
-      check kid == "some-expected-kid"
-
-    asyncTest "getCertificate succeeds on sendChallengeCompleted but fails on requestFinalize":
-      # register successful
-      acmeApi.mockedResponses.add(
-        HTTPResponse(
-          body: %*{"status": "valid"},
-          headers: HttpTable.init(@[("location", "some-expected-kid")]),
-        )
-      )
-      # request completed successful
-      acmeApi.mockedResponses.add(
-        HTTPResponse(
-          body: %*{"url": "http://example.com/some-check-url"},
-          headers: HttpTable.init(),
-        )
-      )
-      # finalize is invalid
-      # first request is processing, then invalid
-      acmeApi.mockedResponses.add(
         HTTPResponse(
           body: %*{"status": "processing"},
           headers: HttpTable.init(@[("Retry-After", "0")]),
         )
       )
-      acmeApi.mockedResponses.add(
-        HTTPResponse(
-          body: %*{"status": "invalid"},
-          headers: HttpTable.init(@[("Retry-After", "0")]),
-        )
-      )
-      acme = ACMEClient.new(rng = rng(), api = ACMEApi(acmeApi))
-      let kid = await acme.getOrInitKid()
-      check kid == "some-expected-kid"
+    let finalized = await api.certificateFinalized(
+      "some-domain",
+      parseUri("http://example.com/some-finalize-url"),
+      parseUri("http://example.com/some-order-url"),
+      KeyPair.random(PKScheme.RSA, rng()).get,
+      key,
+      "kid",
+      retries = 1,
+    )
+    check finalized == false
 
-      let challenge = ACMEChallengeDns01Response(
-        finalize: "https://finalize.com",
-        order: "https://order.com",
-        dns01: ACMEChallenge(
-          url: "https://some.domain",
-          `type`: ACMEChallengeType.DNS01,
-          status: ACMEChallengeStatus.VALID,
-          token: ACMEChallengeToken("some-token"),
-        ),
+  asyncTest "finalize certificate invalid":
+    # first request is processing, then invalid
+    api.mockedResponses.add(
+      HTTPResponse(
+        body: %*{"status": "processing"},
+        headers: HttpTable.init(@[("Retry-After", "0")]),
       )
-      expect(ACMEError):
-        discard await acme.getCertificate(
-          api.Domain("some.domain"), KeyPair.random(PKScheme.RSA, rng()).get, challenge
+    )
+    api.mockedResponses.add(
+      HTTPResponse(
+        body: %*{"status": "invalid"}, headers: HttpTable.init(@[("Retry-After", "0")])
+      )
+    )
+    let finalized = await api.certificateFinalized(
+      "some-domain",
+      parseUri("http://example.com/some-finalize-url"),
+      parseUri("http://example.com/some-order-url"),
+      KeyPair.random(PKScheme.RSA, rng()).get,
+      key,
+      "kid",
+    )
+    check finalized == false
+
+  asyncTest "expect error on invalid JSON response":
+    # add a couple invalid responses as they get popped by every get or post call
+    for _ in 0 .. 20:
+      api.mockedResponses.add(
+        HTTPResponse(
+          body: %*{"inexistent field": "invalid value"}, headers: HttpTable.init()
         )
+      )
+
+    expect(ACMEError):
+      # avoid calling overloaded mock method requestNonce here since we want to test the actual thing
+      discard await procCall requestNonce(ACMEApi(api))
+
+    expect(ACMEError):
+      discard await api.requestRegister(key)
+
+    expect(ACMEError):
+      discard await api.requestNewOrder(@["some-domain"], key, "kid")
+
+    expect(ACMEError):
+      discard await api.requestAuthorizations(@["auth-1", "auth-2"], key, "kid")
+
+    # clear leftover invalid responses so the mixed response is next in queue
+    api.mockedResponses = @[]
+    api.mockedResponses.add(
+      HTTPResponse(
+        body: %*{
+          "identifier": {"type": "dns", "value": "example.com"},
+          "status": "pending",
+          "challenges": [
+            {
+              "type": "dns-persist-01",
+              "url": "http://example.com/unknown-challenge",
+              "status": "pending",
+              "token": "unknown-token",
+            },
+            {
+              "type": "dns-01",
+              "url": "http://example.com/recognized-challenge",
+              "status": "pending",
+              "token": "recognized-token",
+            },
+          ],
+        },
+        headers: HttpTable.init(),
+      )
+    )
+
+    let mixedAuthResp = await api.requestAuthorizations(@["auth-3"], key, "kid")
+    check mixedAuthResp.challenges.len == 2
+
+    # replenish invalid responses for the remaining expect(ACMEError) blocks
+    for _ in 0 .. 5:
+      api.mockedResponses.add(
+        HTTPResponse(
+          body: %*{"inexistent field": "invalid value"}, headers: HttpTable.init()
+        )
+      )
+
+    expect(ACMEError):
+      discard await api.requestChallenge(@["domain-1", "domain-2"], key, "kid")
+
+    expect(ACMEError):
+      discard await api.requestCheck(
+        parseUri("http://example.com/some-check-url"),
+        ACMECheckKind.ACMEOrderCheck,
+        key,
+        "kid",
+      )
+
+    expect(ACMEError):
+      discard await api.requestCheck(
+        parseUri("http://example.com/some-check-url"),
+        ACMECheckKind.ACMEChallengeCheck,
+        key,
+        "kid",
+      )
+
+    expect(ACMEError):
+      discard await api.sendChallengeCompleted(
+        parseUri("http://example.com/some-chal-url"), key, "kid"
+      )
+
+    expect(ACMEError):
+      discard await api.requestFinalize(
+        "some-domain",
+        parseUri("http://example.com/some-finalize-url"),
+        KeyPair.random(PKScheme.RSA, rng()).get,
+        key,
+        "kid",
+      )
+
+    expect(ACMEError):
+      discard await api.requestGetOrder(parseUri("http://example.com/some-order-url"))
+
+suite "AutoTLS ACME Client":
+  var acmeApi {.threadvar.}: MockACMEApi
+  var acme {.threadvar.}: ACMEClient
+
+  asyncSetup:
+    acmeApi = await MockACMEApi.new()
+
+  asyncTeardown:
+    await acme.close()
+    checkTrackers()
+
+  asyncTest "client registers new account when instantiated":
+    acmeApi.mockedResponses.add(
+      HTTPResponse(
+        body: %*{"status": "valid"},
+        headers: HttpTable.init(@[("location", "some-expected-kid")]),
+      )
+    )
+
+    acme = ACMEClient.new(rng = rng(), api = ACMEApi(acmeApi))
+    let kid = await acme.getOrInitKid()
+    check kid == "some-expected-kid"
+
+  asyncTest "getCertificate succeeds on sendChallengeCompleted but fails on requestFinalize":
+    # register successful
+    acmeApi.mockedResponses.add(
+      HTTPResponse(
+        body: %*{"status": "valid"},
+        headers: HttpTable.init(@[("location", "some-expected-kid")]),
+      )
+    )
+    # request completed successful
+    acmeApi.mockedResponses.add(
+      HTTPResponse(
+        body: %*{"url": "http://example.com/some-check-url"}, headers: HttpTable.init()
+      )
+    )
+    # finalize is invalid
+    # first request is processing, then invalid
+    acmeApi.mockedResponses.add(
+      HTTPResponse(
+        body: %*{"status": "processing"},
+        headers: HttpTable.init(@[("Retry-After", "0")]),
+      )
+    )
+    acmeApi.mockedResponses.add(
+      HTTPResponse(
+        body: %*{"status": "invalid"}, headers: HttpTable.init(@[("Retry-After", "0")])
+      )
+    )
+    acme = ACMEClient.new(rng = rng(), api = ACMEApi(acmeApi))
+    let kid = await acme.getOrInitKid()
+    check kid == "some-expected-kid"
+
+    let challenge = ACMEChallengeDns01Response(
+      finalize: "https://finalize.com",
+      order: "https://order.com",
+      dns01: ACMEChallenge(
+        url: "https://some.domain",
+        `type`: ACMEChallengeType.DNS01,
+        status: ACMEChallengeStatus.VALID,
+        token: ACMEChallengeToken("some-token"),
+      ),
+    )
+    expect(ACMEError):
+      discard await acme.getCertificate(
+        api.Domain("some.domain"), KeyPair.random(PKScheme.RSA, rng()).get, challenge
+      )

--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -3,8 +3,6 @@
 
 {.used.}
 
-{.push raises: [].}
-
 import sequtils, json, uri, chronos, chronos/apps/http/httpclient
 import
   ../../../libp2p/[

--- a/tests/libp2p/autotls/test_autotls_config.nim
+++ b/tests/libp2p/autotls/test_autotls_config.nim
@@ -3,8 +3,6 @@
 
 {.used.}
 
-{.push raises: [].}
-
 import chronos, uri
 import ../../../libp2p/[autotls/service, autotls/acme/api, autotls/acme/client, wire]
 import ../../tools/[unittest, crypto]

--- a/tests/libp2p/autotls/test_autotls_config.nim
+++ b/tests/libp2p/autotls/test_autotls_config.nim
@@ -3,83 +3,82 @@
 
 {.used.}
 
-when defined(libp2p_autotls_support):
-  {.push raises: [].}
+{.push raises: [].}
 
-  import chronos, uri
-  import ../../../libp2p/[autotls/service, autotls/acme/api, autotls/acme/client, wire]
-  import ../../tools/[unittest, crypto]
+import chronos, uri
+import ../../../libp2p/[autotls/service, autotls/acme/api, autotls/acme/client, wire]
+import ../../tools/[unittest, crypto]
 
-  suite "AutoTLS Configuration Tests":
-    asyncTeardown:
-      checkTrackers()
+suite "AutoTLS Configuration Tests":
+  asyncTeardown:
+    checkTrackers()
 
-    asyncTest "AutotlsConfig constructor with default values":
-      let config = AutotlsConfig.new()
+  asyncTest "AutotlsConfig constructor with default values":
+    let config = AutotlsConfig.new()
 
-      check:
-        config.acmeServerURL == parseUri(LetsEncryptURL)
-        config.renewCheckTime == DefaultRenewCheckTime
-        config.renewBufferTime == DefaultRenewBufferTime
-        config.brokerURL == DefaultBrokerURL
-        config.dnsServerURL == AutoTLSDNSServer
-        config.dnsRetries == 10
-        config.dnsRetryTime == 1.seconds
-        config.acmeRetries == 10
-        config.acmeRetryTime == 1.seconds
-        config.finalizeRetries == 10
-        config.finalizeRetryTime == 1.seconds
+    check:
+      config.acmeServerURL == parseUri(LetsEncryptURL)
+      config.renewCheckTime == DefaultRenewCheckTime
+      config.renewBufferTime == DefaultRenewBufferTime
+      config.brokerURL == DefaultBrokerURL
+      config.dnsServerURL == AutoTLSDNSServer
+      config.dnsRetries == 10
+      config.dnsRetryTime == 1.seconds
+      config.acmeRetries == 10
+      config.acmeRetryTime == 1.seconds
+      config.finalizeRetries == 10
+      config.finalizeRetryTime == 1.seconds
 
-    asyncTest "AutotlsConfig constructor with custom values":
-      let customBrokerURL = "custom-broker.example.com"
-      let customDnsServerURL = "custom-dns.example.com"
-      let customDnsRetries = 5
-      let customDnsRetryTime = 2.seconds
-      let customAcmeRetries = 15
-      let customAcmeRetryTime = 3.seconds
-      let customFinalizeRetries = 20
-      let customFinalizeRetryTime = 4.seconds
+  asyncTest "AutotlsConfig constructor with custom values":
+    let customBrokerURL = "custom-broker.example.com"
+    let customDnsServerURL = "custom-dns.example.com"
+    let customDnsRetries = 5
+    let customDnsRetryTime = 2.seconds
+    let customAcmeRetries = 15
+    let customAcmeRetryTime = 3.seconds
+    let customFinalizeRetries = 20
+    let customFinalizeRetryTime = 4.seconds
 
-      let config = AutotlsConfig.new(
-        brokerURL = customBrokerURL,
-        dnsServerURL = customDnsServerURL,
-        dnsRetries = customDnsRetries,
-        dnsRetryTime = customDnsRetryTime,
-        acmeRetries = customAcmeRetries,
-        acmeRetryTime = customAcmeRetryTime,
-        finalizeRetries = customFinalizeRetries,
-        finalizeRetryTime = customFinalizeRetryTime,
-      )
+    let config = AutotlsConfig.new(
+      brokerURL = customBrokerURL,
+      dnsServerURL = customDnsServerURL,
+      dnsRetries = customDnsRetries,
+      dnsRetryTime = customDnsRetryTime,
+      acmeRetries = customAcmeRetries,
+      acmeRetryTime = customAcmeRetryTime,
+      finalizeRetries = customFinalizeRetries,
+      finalizeRetryTime = customFinalizeRetryTime,
+    )
 
-      check:
-        config.brokerURL == customBrokerURL
-        config.dnsServerURL == customDnsServerURL
-        config.dnsRetries == customDnsRetries
-        config.dnsRetryTime == customDnsRetryTime
-        config.acmeRetries == customAcmeRetries
-        config.acmeRetryTime == customAcmeRetryTime
-        config.finalizeRetries == customFinalizeRetries
-        config.finalizeRetryTime == customFinalizeRetryTime
+    check:
+      config.brokerURL == customBrokerURL
+      config.dnsServerURL == customDnsServerURL
+      config.dnsRetries == customDnsRetries
+      config.dnsRetryTime == customDnsRetryTime
+      config.acmeRetries == customAcmeRetries
+      config.acmeRetryTime == customAcmeRetryTime
+      config.finalizeRetries == customFinalizeRetries
+      config.finalizeRetryTime == customFinalizeRetryTime
 
-    asyncTest "AutotlsService uses custom broker URL in registration":
-      let customBrokerURL = "test-broker.example.com"
-      let config = AutotlsConfig.new(brokerURL = customBrokerURL)
-      let service = AutotlsService.new(rng(), config = config)
+  asyncTest "AutotlsService uses custom broker URL in registration":
+    let customBrokerURL = "test-broker.example.com"
+    let config = AutotlsConfig.new(brokerURL = customBrokerURL)
+    let service = AutotlsService.new(rng(), config = config)
 
-      # Verify the config was stored correctly
-      check service.config.brokerURL == customBrokerURL
+    # Verify the config was stored correctly
+    check service.config.brokerURL == customBrokerURL
 
-    asyncTest "Backward compatibility with existing AutotlsConfig usage":
-      # Test that existing code using AutotlsConfig.new() without new parameters still works
-      let config1 = AutotlsConfig.new()
-      let config2 = AutotlsConfig.new(
-        acmeServerURL = parseUri(LetsEncryptURLStaging), renewCheckTime = 5.minutes
-      )
+  asyncTest "Backward compatibility with existing AutotlsConfig usage":
+    # Test that existing code using AutotlsConfig.new() without new parameters still works
+    let config1 = AutotlsConfig.new()
+    let config2 = AutotlsConfig.new(
+      acmeServerURL = parseUri(LetsEncryptURLStaging), renewCheckTime = 5.minutes
+    )
 
-      check:
-        config1.acmeServerURL == parseUri(LetsEncryptURL)
-        config2.acmeServerURL == parseUri(LetsEncryptURLStaging)
-        config2.renewCheckTime == 5.minutes
-        # New fields should have default values
-        config1.brokerURL == DefaultBrokerURL
-        config2.brokerURL == DefaultBrokerURL
+    check:
+      config1.acmeServerURL == parseUri(LetsEncryptURL)
+      config2.acmeServerURL == parseUri(LetsEncryptURLStaging)
+      config2.renewCheckTime == 5.minutes
+      # New fields should have default values
+      config1.brokerURL == DefaultBrokerURL
+      config2.brokerURL == DefaultBrokerURL

--- a/tests/libp2p/autotls/test_jws.nim
+++ b/tests/libp2p/autotls/test_jws.nim
@@ -2,64 +2,62 @@
 # Copyright (c) Status Research & Development GmbH
 
 {.used.}
+{.push raises: [].}
 
-when defined(libp2p_autotls_support):
-  {.push raises: [].}
+import json, base64, strutils
+import stew/byteutils
+import ../../../libp2p/[crypto/crypto, crypto/rsa]
+import ../../../libp2p/autotls/acme/[jws, utils]
+import ../../tools/[unittest, crypto]
 
-  import json, base64, strutils
-  import stew/byteutils
-  import ../../../libp2p/[crypto/crypto, crypto/rsa]
-  import ../../../libp2p/autotls/acme/[jws, utils]
-  import ../../tools/[unittest, crypto]
+proc b64UrlDecode(s: string): seq[byte] {.raises: [ValueError].} =
+  var padded = s.replace('-', '+').replace('_', '/')
+  while padded.len mod 4 != 0:
+    padded &= "="
+  base64.decode(padded).toBytes()
 
-  proc b64UrlDecode(s: string): seq[byte] {.raises: [ValueError].} =
-    var padded = s.replace('-', '+').replace('_', '/')
-    while padded.len mod 4 != 0:
-      padded &= "="
-    base64.decode(padded).toBytes()
+suite "ACME JWS":
+  var key {.threadvar.}: KeyPair
 
-  suite "ACME JWS":
-    var key {.threadvar.}: KeyPair
+  setup:
+    key = KeyPair.random(PKScheme.RSA, rng()).get()
 
-    setup:
-      key = KeyPair.random(PKScheme.RSA, rng()).get()
+  test "produces a valid RS256 flattened JWS":
+    let header = %*{"alg": "RS256", "typ": "JWT", "nonce": "abc", "url": "https://e"}
+    let payload = %*{"termsOfServiceAgreed": true}
 
-    test "produces a valid RS256 flattened JWS":
-      let header = %*{"alg": "RS256", "typ": "JWT", "nonce": "abc", "url": "https://e"}
-      let payload = %*{"termsOfServiceAgreed": true}
+    let jws = toFlattenedJws(header, payload, key.seckey.rsakey)
 
-      let jws = toFlattenedJws(header, payload, key.seckey.rsakey)
+    # Flattened JWS has exactly the three members (no unprotected header).
+    check jws.kind == JObject
+    check jws.len == 3
+    for field in ["protected", "payload", "signature"]:
+      check jws.hasKey(field)
 
-      # Flattened JWS has exactly the three members (no unprotected header).
-      check jws.kind == JObject
-      check jws.len == 3
-      for field in ["protected", "payload", "signature"]:
-        check jws.hasKey(field)
+    # protected/payload base64url-decode back to the original JSON inputs.
+    check parseJson(string.fromBytes(b64UrlDecode(jws["protected"].getStr))) == header
+    check parseJson(string.fromBytes(b64UrlDecode(jws["payload"].getStr))) == payload
 
-      # protected/payload base64url-decode back to the original JSON inputs.
-      check parseJson(string.fromBytes(b64UrlDecode(jws["protected"].getStr))) == header
-      check parseJson(string.fromBytes(b64UrlDecode(jws["payload"].getStr))) == payload
+    # The signature verifies as RS256 over `protected.payload`.
+    let signingInput = jws["protected"].getStr & "." & jws["payload"].getStr
+    let sig = RsaSignature.init(b64UrlDecode(jws["signature"].getStr)).get()
+    check rsa.verify(sig, signingInput, key.pubkey.rsakey)
 
-      # The signature verifies as RS256 over `protected.payload`.
-      let signingInput = jws["protected"].getStr & "." & jws["payload"].getStr
-      let sig = RsaSignature.init(b64UrlDecode(jws["signature"].getStr)).get()
-      check rsa.verify(sig, signingInput, key.pubkey.rsakey)
+  test "base64url members carry no padding":
+    let jws = toFlattenedJws(%*{"alg": "RS256"}, %*{"a": 1}, key.seckey.rsakey)
+    for field in ["protected", "payload", "signature"]:
+      check not jws[field].getStr.contains('=')
+      check not jws[field].getStr.contains('+')
+      check not jws[field].getStr.contains('/')
 
-    test "base64url members carry no padding":
-      let jws = toFlattenedJws(%*{"alg": "RS256"}, %*{"a": 1}, key.seckey.rsakey)
-      for field in ["protected", "payload", "signature"]:
-        check not jws[field].getStr.contains('=')
-        check not jws[field].getStr.contains('+')
-        check not jws[field].getStr.contains('/')
+  test "an empty payload still signs and verifies":
+    let jws = toFlattenedJws(%*{"alg": "RS256"}, %*{}, key.seckey.rsakey)
+    let signingInput = jws["protected"].getStr & "." & jws["payload"].getStr
+    let sig = RsaSignature.init(b64UrlDecode(jws["signature"].getStr)).get()
+    check rsa.verify(sig, signingInput, key.pubkey.rsakey)
 
-    test "an empty payload still signs and verifies":
-      let jws = toFlattenedJws(%*{"alg": "RS256"}, %*{}, key.seckey.rsakey)
-      let signingInput = jws["protected"].getStr & "." & jws["payload"].getStr
-      let sig = RsaSignature.init(b64UrlDecode(jws["signature"].getStr)).get()
-      check rsa.verify(sig, signingInput, key.pubkey.rsakey)
-
-    test "rejects an unsupported algorithm":
-      expect(ACMEError):
-        discard toFlattenedJws(%*{"alg": "ES256"}, %*{"a": 1}, key.seckey.rsakey)
-      expect(ACMEError):
-        discard toFlattenedJws(%*{"typ": "JWT"}, %*{"a": 1}, key.seckey.rsakey)
+  test "rejects an unsupported algorithm":
+    expect(ACMEError):
+      discard toFlattenedJws(%*{"alg": "ES256"}, %*{"a": 1}, key.seckey.rsakey)
+    expect(ACMEError):
+      discard toFlattenedJws(%*{"typ": "JWT"}, %*{"a": 1}, key.seckey.rsakey)

--- a/tests/libp2p/autotls/test_jws.nim
+++ b/tests/libp2p/autotls/test_jws.nim
@@ -2,7 +2,6 @@
 # Copyright (c) Status Research & Development GmbH
 
 {.used.}
-{.push raises: [].}
 
 import json, base64, strutils
 import stew/byteutils
@@ -17,10 +16,7 @@ proc b64UrlDecode(s: string): seq[byte] {.raises: [ValueError].} =
   base64.decode(padded).toBytes()
 
 suite "ACME JWS":
-  var key {.threadvar.}: KeyPair
-
-  setup:
-    key = KeyPair.random(PKScheme.RSA, rng()).get()
+  let key = KeyPair.random(PKScheme.RSA, rng()).get()
 
   test "produces a valid RS256 flattened JWS":
     let header = %*{"alg": "RS256", "typ": "JWT", "nonce": "abc", "url": "https://e"}

--- a/tests/libp2p/transports/test_ws.nim
+++ b/tests/libp2p/transports/test_ws.nim
@@ -7,6 +7,7 @@ import chronos, stew/byteutils
 import
   ../../../libp2p/[
     autotls/service,
+    autotls/mockservice,
     stream/connection,
     transports/transport,
     transports/wstransport,
@@ -201,10 +202,8 @@ suite "WebSocket transport":
 
     await transport1.stop()
 
-import ../../../libp2p/autotls/mockservice
-
 suite "WebSocket transport with autotls":
-  asyncTest "autotls certificate is used when manual tlscertificate is not spcified":
+  asyncTest "autotls certificate is used when manual tlscertificate is not specified":
     let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
 
     let key = KeyPair.random(PKScheme.RSA, rng()).get()

--- a/tests/libp2p/transports/test_ws.nim
+++ b/tests/libp2p/transports/test_ws.nim
@@ -201,77 +201,76 @@ suite "WebSocket transport":
 
     await transport1.stop()
 
-when defined(libp2p_autotls_support):
-  import ../../../libp2p/autotls/mockservice
+import ../../../libp2p/autotls/mockservice
 
-  suite "WebSocket transport with autotls":
-    asyncTest "autotls certificate is used when manual tlscertificate is not spcified":
-      let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
+suite "WebSocket transport with autotls":
+  asyncTest "autotls certificate is used when manual tlscertificate is not spcified":
+    let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
 
-      let key = KeyPair.random(PKScheme.RSA, rng()).get()
-      let (privkey, cert) = tlsCertGenerator(Opt.some(key))
-      let autotls = MockAutotlsService.new(rng())
-      autotls.mockedKey = privkey
-      autotls.mockedCert = cert
-      await autotls.setup()
+    let key = KeyPair.random(PKScheme.RSA, rng()).get()
+    let (privkey, cert) = tlsCertGenerator(Opt.some(key))
+    let autotls = MockAutotlsService.new(rng())
+    autotls.mockedKey = privkey
+    autotls.mockedCert = cert
+    await autotls.setup()
 
-      let wstransport = WsTransport.new(
-        Upgrade(),
-        nil, # TLSPrivateKey
-        nil, # TLSCertificate
-        Opt.some(AutotlsService(autotls)),
-        rng(),
-      )
-      await wstransport.start(ma)
-      defer:
-        await wstransport.stop()
+    let wstransport = WsTransport.new(
+      Upgrade(),
+      nil, # TLSPrivateKey
+      nil, # TLSCertificate
+      Opt.some(AutotlsService(autotls)),
+      rng(),
+    )
+    await wstransport.start(ma)
+    defer:
+      await wstransport.stop()
 
-      # TLSPrivateKey and TLSCertificate should be set
-      check wstransport.secure
+    # TLSPrivateKey and TLSCertificate should be set
+    check wstransport.secure
 
-      # autotls should be used
-      let autotlsCert = await autotls.getCertWhenReady()
-      check wstransport.tlsCertificate == autotlsCert.cert
+    # autotls should be used
+    let autotlsCert = await autotls.getCertWhenReady()
+    check wstransport.tlsCertificate == autotlsCert.cert
 
-    asyncTest "manually set tlscertificate is preferred over autotls when both are specified":
-      let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
+  asyncTest "manually set tlscertificate is preferred over autotls when both are specified":
+    let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
 
-      let key = KeyPair.random(PKScheme.RSA, rng()).get()
-      let (privkey, cert) = tlsCertGenerator(Opt.some(key))
-      let autotls = MockAutotlsService.new(rng())
-      autotls.mockedKey = privkey
-      autotls.mockedCert = cert
-      await autotls.setup()
+    let key = KeyPair.random(PKScheme.RSA, rng()).get()
+    let (privkey, cert) = tlsCertGenerator(Opt.some(key))
+    let autotls = MockAutotlsService.new(rng())
+    autotls.mockedKey = privkey
+    autotls.mockedCert = cert
+    await autotls.setup()
 
-      # Use different cert from autotls to verify manual cert is preferred
-      let (manualKey, manualCert) = tlsCertGenerator()
+    # Use different cert from autotls to verify manual cert is preferred
+    let (manualKey, manualCert) = tlsCertGenerator()
 
-      let wstransport = WsTransport.new(
-        Upgrade(), manualKey, manualCert, Opt.some(AutotlsService(autotls)), rng()
-      )
-      await wstransport.start(ma)
-      defer:
-        await wstransport.stop()
+    let wstransport = WsTransport.new(
+      Upgrade(), manualKey, manualCert, Opt.some(AutotlsService(autotls)), rng()
+    )
+    await wstransport.start(ma)
+    defer:
+      await wstransport.stop()
 
-      # TLSPrivateKey and TLSCertificate should be set
-      check wstransport.secure
+    # TLSPrivateKey and TLSCertificate should be set
+    check wstransport.secure
 
-      # autotls should be ignored - manual cert should be used
-      check wstransport.tlsCertificate == manualCert
-      check wstransport.tlsPrivateKey == manualKey
+    # autotls should be ignored - manual cert should be used
+    check wstransport.tlsCertificate == manualCert
+    check wstransport.tlsPrivateKey == manualKey
 
-    asyncTest "wstransport is not secure when both manual tlscertificate and autotls are not specified":
-      let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
-      let wstransport = WsTransport.new(
-        Upgrade(),
-        nil, # TLSPrivateKey
-        nil, # TLSCertificate
-        Opt.none(AutotlsService),
-        rng(),
-      )
-      await wstransport.start(ma)
-      defer:
-        await wstransport.stop()
+  asyncTest "wstransport is not secure when both manual tlscertificate and autotls are not specified":
+    let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
+    let wstransport = WsTransport.new(
+      Upgrade(),
+      nil, # TLSPrivateKey
+      nil, # TLSCertificate
+      Opt.none(AutotlsService),
+      rng(),
+    )
+    await wstransport.start(ma)
+    defer:
+      await wstransport.stop()
 
-      # TLSPrivateKey and TLSCertificate should not be set
-      check not wstransport.secure
+    # TLSPrivateKey and TLSCertificate should not be set
+    check not wstransport.secure


### PR DESCRIPTION
## Summary

  The `libp2p_autotls_support` compile-time flag existed only to
   keep most users from pulling in `bearssl/pkey/decoder`
  transitively. With the recent removals of the `dnsclient` and
  `nim-jwt` dependencies (#2536, #2539), the autotls module no
  longer reaches into anything that warrants gating, so the flag
   is now dead weight: it forces every consumer of autotls to
  remember `-d:libp2p_autotls_support`, and forces every
  Makefile/CI config to pass it.

  This PR drops the flag and compiles the autotls module
  unconditionally:

  - Flattens every `when defined(libp2p_autotls_support):` block
   in `libp2p/autotls/*`, `libp2p/builders.nim`, and
  `libp2p/transports/wstransport.nim` (`withAutotls`,
  `AutotlsService` construction, `WsTransport`'s autotls wait
  path).
  - Drops the `else: {.hint: "autotls disabled. Use
  -d:libp2p_autotls_support".}` branch in
  `libp2p/autotls/acme/api.nim`.
  - Removes the same guards from the autotls/jws/ws tests and
  from `tests/integration/test_all.nim` (autotls integration
  test now only gates on `linux and amd64`).
  - Removes `-d:libp2p_autotls_support` from `Makefile`,
  `nix/default.nix`, and the docs/copilot-instructions
  references.

  ## Affected Areas

  - [x] Transports — `WsTransport` autotls cert wait path is now
   always compiled.
  - [x] Build / Tooling — flag removed from `Makefile`,
  `nix/default.nix`, `docs/compile_time_flags.md`,
  `.github/copilot-instructions.md`.
  - [x] Other — `SwitchBuilder.withAutotls` and the entire
  `libp2p/autotls/` module are no longer gated.

  ## Impact on Library Users

  - `withAutotls` is now always available; downstreams that were
   passing `-d:libp2p_autotls_support` can drop the flag (it's
  now a no-op define, not an error).
  - No API or behavior change for code that was already building
   with the flag set.
  - Consumers who relied on autotls being absent from the binary
   by default will now pay its compile cost unconditionally —
  that's the intended tradeoff, since the dependency-weight
  argument no longer applies.

  ## Risk Assessment

  - No runtime behavior change: autotls only kicks in when
  `withAutotls(...)` is called on the builder, same as before.
  - Slight increase in compile time / binary size for users who
  never enabled autotls.
  - No network/protocol/security implications.

  ## References

  - #2534 — encapsulated broker interaction (preparatory work)
  - #2536 — replaced `dnsclient` with internal DNS codec
  - #2539 — replaced `nim-jwt` with internal JWS signer