### PR TITLE
chore(kad): limits

### DIFF
--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -69,7 +69,7 @@ proc new*(
     config: config,
     providerManager:
       ProviderManager.new(config.providerRecordCapacity, config.providedKeyCapacity),
-    rpcSem: newAsyncSemaphore(config.maxConcurrentRpcs),
+    rpcSem: newAsyncSemaphore(config.limits.maxConcurrentRpcs),
   )
 
   # Fill up buckets with initial bootstrap nodes

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -58,9 +58,6 @@ proc new*(
     client: bool = false,
     codec: string = KadCodec,
 ): K {.raises: [].} =
-  if config.maxProvidersPerKey.isSome and not config.providerRejection:
-    warn "maxProvidersPerKey has no effect when providerRejection is false"
-
   var rtable = RoutingTable.new(
     switch.peerInfo.peerId.toKey(),
     config = RoutingTableConfig.new(replication = config.replication),
@@ -72,6 +69,7 @@ proc new*(
     config: config,
     providerManager:
       ProviderManager.new(config.providerRecordCapacity, config.providedKeyCapacity),
+    rpcSem: newAsyncSemaphore(config.maxConcurrentRpcs),
   )
 
   # Fill up buckets with initial bootstrap nodes

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -50,9 +50,7 @@ proc getFarthest(
   else:
     Opt.none((PeerId, XorDistance))
 
-proc tryEvictFarthest(
-    state: var LookupState, newDist: XorDistance
-): bool {.raises: [].} =
+proc tryEvictFarthest(state: LookupState, newDist: XorDistance): bool {.raises: [].} =
   ## Drop the worst (farthest) peer from the shortlist if it is farther than
   ## ``newDist``. Considers all peers — including ones that already responded —
   ## because the iterative lookup needs the closer candidate to make progress.

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -34,6 +34,22 @@ type ReplyHandler* = proc(
 
 type StopCond* = proc(state: LookupState): bool {.raises: [], gcsafe.}
 
+proc getFarthest(
+    t: Table[PeerId, XorDistance]
+): Opt[(PeerId, XorDistance)] {.raises: [].} =
+  var worstPid: PeerId
+  var worstDist: XorDistance
+  var found = false
+  for pid, d in t.pairs():
+    if not found or worstDist < d:
+      worstPid = pid
+      worstDist = d
+      found = true
+  if found:
+    Opt.some((worstPid, worstDist))
+  else:
+    Opt.none((PeerId, XorDistance))
+
 proc tryEvictFarthest(
     state: var LookupState, newDist: XorDistance
 ): bool {.raises: [].} =
@@ -42,19 +58,13 @@ proc tryEvictFarthest(
   ## because the iterative lookup needs the closer candidate to make progress.
   ## A responded peer's contribution is already merged into the shortlist, so
   ## evicting it costs nothing beyond bookkeeping.
-  var worstPid: PeerId
-  var worstDist: XorDistance
-  var found = false
-  for pid, d in state.shortlist.pairs():
-    if not found or worstDist < d:
-      worstPid = pid
-      worstDist = d
-      found = true
-  if not found or newDist >= worstDist:
+  let (pid, dist) = state.shortlist.getFarthest().valueOr:
     return false
-  state.shortlist.del(worstPid)
-  state.attempts.del(worstPid)
-  state.responded.del(worstPid)
+  if newDist >= dist:
+    return false
+  state.shortlist.del(pid)
+  state.attempts.del(pid)
+  state.responded.del(pid)
   return true
 
 proc updateShortlist*(
@@ -156,44 +166,44 @@ proc dispatchFindNode*(
     target: Key,
     addrs: Opt[seq[MultiAddress]] = Opt.none(seq[MultiAddress]),
 ): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
-  withRpcSlot(kad):
-    let addrs = addrs.valueOr(kad.switch.peerStore[AddressBook][peer])
-    let streamRes = catch:
-      await kad.switch.dial(peer, addrs, kad.codec)
-    if streamRes.isErr:
-      return err(streamRes.error.msg)
-    let stream = streamRes.value()
-    defer:
-      await stream.close()
+  withRpcSlot(kad)
+  let addrs = addrs.valueOr(kad.switch.peerStore[AddressBook][peer])
+  let streamRes = catch:
+    await kad.switch.dial(peer, addrs, kad.codec)
+  if streamRes.isErr:
+    return err(streamRes.error.msg)
+  let stream = streamRes.value()
+  defer:
+    await stream.close()
 
-    let msg = Message(msgType: MessageType.findNode, key: target)
-    let encoded = msg.encode(kad.config.hideConnectionStatus)
+  let msg = Message(msgType: MessageType.findNode, key: target)
+  let encoded = msg.encode(kad.config.hideConnectionStatus)
 
-    kad_messages_sent.inc(labelValues = [$MessageType.findNode])
-    kad_message_bytes_sent.inc(
-      encoded.buffer.len.int64, labelValues = [$MessageType.findNode]
-    )
+  kad_messages_sent.inc(labelValues = [$MessageType.findNode])
+  kad_message_bytes_sent.inc(
+    encoded.buffer.len.int64, labelValues = [$MessageType.findNode]
+  )
 
-    var replyBuf: seq[byte]
-    var ioRes: Result[void, ref CatchableError]
-    kad_message_duration_ms.time(labelValues = [$MessageType.findNode]):
-      ioRes = catch:
-        await stream.writeLp(encoded.buffer)
-        replyBuf = await stream.readLp(MaxMsgSize)
-    if ioRes.isErr:
-      return err(ioRes.error.msg)
+  var replyBuf: seq[byte]
+  var ioRes: Result[void, ref CatchableError]
+  kad_message_duration_ms.time(labelValues = [$MessageType.findNode]):
+    ioRes = catch:
+      await stream.writeLp(encoded.buffer)
+      replyBuf = await stream.readLp(MaxMsgSize)
+  if ioRes.isErr:
+    return err(ioRes.error.msg)
 
-    kad_message_bytes_received.inc(
-      replyBuf.len.int64, labelValues = [$MessageType.findNode]
-    )
+  kad_message_bytes_received.inc(
+    replyBuf.len.int64, labelValues = [$MessageType.findNode]
+  )
 
-    let reply = Message.decode(replyBuf).valueOr:
-      return err("FindNode reply decode fail")
+  let reply = Message.decode(replyBuf).valueOr:
+    return err("FindNode reply decode fail")
 
-    if reply.closerPeers.len > 0:
-      kad_responses_with_closer_peers.inc(labelValues = [$MessageType.findNode])
+  if reply.closerPeers.len > 0:
+    kad_responses_with_closer_peers.inc(labelValues = [$MessageType.findNode])
 
-    return ok(reply)
+  return ok(reply)
 
 proc updatePeers*(
     switch: Switch,

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -34,15 +34,18 @@ type ReplyHandler* = proc(
 
 type StopCond* = proc(state: LookupState): bool {.raises: [], gcsafe.}
 
-proc tryEvictFarthestUnresponded(
+proc tryEvictFarthest(
     state: var LookupState, newDist: XorDistance
 ): bool {.raises: [].} =
+  ## Drop the worst (farthest) peer from the shortlist if it is farther than
+  ## ``newDist``. Considers all peers — including ones that already responded —
+  ## because the iterative lookup needs the closer candidate to make progress.
+  ## A responded peer's contribution is already merged into the shortlist, so
+  ## evicting it costs nothing beyond bookkeeping.
   var worstPid: PeerId
   var worstDist: XorDistance
   var found = false
   for pid, d in state.shortlist.pairs():
-    if state.responded.contains(pid):
-      continue
     if not found or worstDist < d:
       worstPid = pid
       worstDist = d
@@ -51,6 +54,7 @@ proc tryEvictFarthestUnresponded(
     return false
   state.shortlist.del(worstPid)
   state.attempts.del(worstPid)
+  state.responded.del(worstPid)
   return true
 
 proc updateShortlist*(
@@ -67,7 +71,7 @@ proc updateShortlist*(
 
     let dist = xorDistance(pid, state.target, state.kad.rtable.config.hasher)
 
-    if state.shortlist.len >= cap and not state.tryEvictFarthestUnresponded(dist):
+    if state.shortlist.len >= cap and not state.tryEvictFarthest(dist):
       continue
 
     state.shortlist[pid] = dist

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -34,11 +34,30 @@ type ReplyHandler* = proc(
 
 type StopCond* = proc(state: LookupState): bool {.raises: [], gcsafe.}
 
+proc tryEvictFarthestUnresponded(
+    state: var LookupState, newDist: XorDistance
+): bool {.raises: [].} =
+  var worstPid: PeerId
+  var worstDist: XorDistance
+  var found = false
+  for pid, d in state.shortlist.pairs():
+    if state.responded.contains(pid):
+      continue
+    if not found or worstDist < d:
+      worstPid = pid
+      worstDist = d
+      found = true
+  if not found or newDist >= worstDist:
+    return false
+  state.shortlist.del(worstPid)
+  state.attempts.del(worstPid)
+  return true
+
 proc updateShortlist*(
     state: var LookupState, msg: Message
 ): seq[PeerInfo] {.raises: [].} =
   var newPeerInfos: seq[PeerInfo]
-  let cap = state.kad.config.maxShortlistSize
+  let cap = state.kad.config.limits.maxShortlistSize
 
   for newPeer in msg.closerPeers:
     let pid = PeerId.init(newPeer.id).valueOr:
@@ -48,24 +67,8 @@ proc updateShortlist*(
 
     let dist = xorDistance(pid, state.target, state.kad.rtable.config.hasher)
 
-    if state.shortlist.len >= cap:
-      # Evict the farthest peer (if any) only when the new peer is closer.
-      # Peers that already responded are still useful for the result set, so
-      # we prefer evicting un-responded farthest entries.
-      var worstPid: PeerId
-      var worstDist: XorDistance
-      var found = false
-      for pid2, d in state.shortlist.pairs():
-        if state.responded.contains(pid2):
-          continue
-        if not found or worstDist < d:
-          worstPid = pid2
-          worstDist = d
-          found = true
-      if not found or dist >= worstDist:
-        continue
-      state.shortlist.del(worstPid)
-      state.attempts.del(worstPid)
+    if state.shortlist.len >= cap and not state.tryEvictFarthestUnresponded(dist):
+      continue
 
     state.shortlist[pid] = dist
     newPeerInfos.add(PeerInfo(peerId: pid, addrs: newPeer.addrs))

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -38,16 +38,37 @@ proc updateShortlist*(
     state: var LookupState, msg: Message
 ): seq[PeerInfo] {.raises: [].} =
   var newPeerInfos: seq[PeerInfo]
+  let cap = state.kad.config.maxShortlistSize
 
   for newPeer in msg.closerPeers:
     let pid = PeerId.init(newPeer.id).valueOr:
       continue
-    if not state.shortlist.contains(pid):
-      state.shortlist[pid] =
-        xorDistance(pid, state.target, state.kad.rtable.config.hasher)
+    if state.shortlist.contains(pid):
+      continue
 
-      let peerInfo = PeerInfo(peerId: pid, addrs: newPeer.addrs)
-      newPeerInfos.add(peerInfo)
+    let dist = xorDistance(pid, state.target, state.kad.rtable.config.hasher)
+
+    if state.shortlist.len >= cap:
+      # Evict the farthest peer (if any) only when the new peer is closer.
+      # Peers that already responded are still useful for the result set, so
+      # we prefer evicting un-responded farthest entries.
+      var worstPid: PeerId
+      var worstDist: XorDistance
+      var found = false
+      for pid2, d in state.shortlist.pairs():
+        if state.responded.contains(pid2):
+          continue
+        if not found or worstDist < d:
+          worstPid = pid2
+          worstDist = d
+          found = true
+      if not found or dist >= worstDist:
+        continue
+      state.shortlist.del(worstPid)
+      state.attempts.del(worstPid)
+
+    state.shortlist[pid] = dist
+    newPeerInfos.add(PeerInfo(peerId: pid, addrs: newPeer.addrs))
 
   return newPeerInfos
 
@@ -128,43 +149,44 @@ proc dispatchFindNode*(
     target: Key,
     addrs: Opt[seq[MultiAddress]] = Opt.none(seq[MultiAddress]),
 ): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
-  let addrs = addrs.valueOr(kad.switch.peerStore[AddressBook][peer])
-  let streamRes = catch:
-    await kad.switch.dial(peer, addrs, kad.codec)
-  if streamRes.isErr:
-    return err(streamRes.error.msg)
-  let stream = streamRes.value()
-  defer:
-    await stream.close()
+  withRpcSlot(kad):
+    let addrs = addrs.valueOr(kad.switch.peerStore[AddressBook][peer])
+    let streamRes = catch:
+      await kad.switch.dial(peer, addrs, kad.codec)
+    if streamRes.isErr:
+      return err(streamRes.error.msg)
+    let stream = streamRes.value()
+    defer:
+      await stream.close()
 
-  let msg = Message(msgType: MessageType.findNode, key: target)
-  let encoded = msg.encode(kad.config.hideConnectionStatus)
+    let msg = Message(msgType: MessageType.findNode, key: target)
+    let encoded = msg.encode(kad.config.hideConnectionStatus)
 
-  kad_messages_sent.inc(labelValues = [$MessageType.findNode])
-  kad_message_bytes_sent.inc(
-    encoded.buffer.len.int64, labelValues = [$MessageType.findNode]
-  )
+    kad_messages_sent.inc(labelValues = [$MessageType.findNode])
+    kad_message_bytes_sent.inc(
+      encoded.buffer.len.int64, labelValues = [$MessageType.findNode]
+    )
 
-  var replyBuf: seq[byte]
-  var ioRes: Result[void, ref CatchableError]
-  kad_message_duration_ms.time(labelValues = [$MessageType.findNode]):
-    ioRes = catch:
-      await stream.writeLp(encoded.buffer)
-      replyBuf = await stream.readLp(MaxMsgSize)
-  if ioRes.isErr:
-    return err(ioRes.error.msg)
+    var replyBuf: seq[byte]
+    var ioRes: Result[void, ref CatchableError]
+    kad_message_duration_ms.time(labelValues = [$MessageType.findNode]):
+      ioRes = catch:
+        await stream.writeLp(encoded.buffer)
+        replyBuf = await stream.readLp(MaxMsgSize)
+    if ioRes.isErr:
+      return err(ioRes.error.msg)
 
-  kad_message_bytes_received.inc(
-    replyBuf.len.int64, labelValues = [$MessageType.findNode]
-  )
+    kad_message_bytes_received.inc(
+      replyBuf.len.int64, labelValues = [$MessageType.findNode]
+    )
 
-  let reply = Message.decode(replyBuf).valueOr:
-    return err("FindNode reply decode fail")
+    let reply = Message.decode(replyBuf).valueOr:
+      return err("FindNode reply decode fail")
 
-  if reply.closerPeers.len > 0:
-    kad_responses_with_closer_peers.inc(labelValues = [$MessageType.findNode])
+    if reply.closerPeers.len > 0:
+      kad_responses_with_closer_peers.inc(labelValues = [$MessageType.findNode])
 
-  return ok(reply)
+    return ok(reply)
 
 proc updatePeers*(
     switch: Switch,

--- a/libp2p/protocols/kademlia/get.nim
+++ b/libp2p/protocols/kademlia/get.nim
@@ -14,45 +14,46 @@ logScope:
 proc dispatchGetVal*(
     kad: KadDHT, peer: PeerId, key: Key
 ): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
-  let streamRes = catch:
-    await kad.switch.dial(peer, kad.switch.peerStore[AddressBook][peer], kad.codec)
-  if streamRes.isErr:
-    return err(streamRes.error.msg)
-  let stream = streamRes.value()
-  defer:
-    await stream.close()
+  withRpcSlot(kad):
+    let streamRes = catch:
+      await kad.switch.dial(peer, kad.switch.peerStore[AddressBook][peer], kad.codec)
+    if streamRes.isErr:
+      return err(streamRes.error.msg)
+    let stream = streamRes.value()
+    defer:
+      await stream.close()
 
-  let msg = Message(msgType: MessageType.getValue, key: key)
-  let encoded = msg.encode(kad.config.hideConnectionStatus)
+    let msg = Message(msgType: MessageType.getValue, key: key)
+    let encoded = msg.encode(kad.config.hideConnectionStatus)
 
-  kad_messages_sent.inc(labelValues = [$MessageType.getValue])
-  kad_message_bytes_sent.inc(
-    encoded.buffer.len.int64, labelValues = [$MessageType.getValue]
-  )
+    kad_messages_sent.inc(labelValues = [$MessageType.getValue])
+    kad_message_bytes_sent.inc(
+      encoded.buffer.len.int64, labelValues = [$MessageType.getValue]
+    )
 
-  var replyBuf: seq[byte]
-  var ioRes: Result[void, ref CatchableError]
-  kad_message_duration_ms.time(labelValues = [$MessageType.getValue]):
-    ioRes = catch:
-      await stream.writeLp(encoded.buffer)
-      replyBuf = await stream.readLp(MaxMsgSize)
-  if ioRes.isErr:
-    return err(ioRes.error.msg)
+    var replyBuf: seq[byte]
+    var ioRes: Result[void, ref CatchableError]
+    kad_message_duration_ms.time(labelValues = [$MessageType.getValue]):
+      ioRes = catch:
+        await stream.writeLp(encoded.buffer)
+        replyBuf = await stream.readLp(MaxMsgSize)
+    if ioRes.isErr:
+      return err(ioRes.error.msg)
 
-  kad_message_bytes_received.inc(
-    replyBuf.len.int64, labelValues = [$MessageType.getValue]
-  )
+    kad_message_bytes_received.inc(
+      replyBuf.len.int64, labelValues = [$MessageType.getValue]
+    )
 
-  let reply = Message.decode(replyBuf).valueOr:
-    return err("GetValue reply decode fail")
+    let reply = Message.decode(replyBuf).valueOr:
+      return err("GetValue reply decode fail")
 
-  if reply.closerPeers.len > 0:
-    kad_responses_with_closer_peers.inc(labelValues = [$MessageType.getValue])
+    if reply.closerPeers.len > 0:
+      kad_responses_with_closer_peers.inc(labelValues = [$MessageType.getValue])
 
-  stream.observedAddr.withValue(observedAddr):
-    kad.updatePeers(@[PeerInfo(peerId: stream.peerId, addrs: @[observedAddr])])
+    stream.observedAddr.withValue(observedAddr):
+      kad.updatePeers(@[PeerInfo(peerId: stream.peerId, addrs: @[observedAddr])])
 
-  return ok(reply)
+    return ok(reply)
 
 proc bestValidRecord(
     kad: KadDHT, key: Key, received: ReceivedTable, quorum: int
@@ -94,6 +95,11 @@ proc getValue*(
   let onReply = proc(
       peer: PeerId, msgOpt: Opt[Message], state: var LookupState
   ): Future[void] {.async: (raises: []), gcsafe.} =
+    if not received.hasKey(peer) and received.len >= kad.config.maxReceivedSize:
+      debug "GetValue: ReceivedTable cap reached, dropping reply",
+        peer = peer, cap = kad.config.maxReceivedSize
+      return
+
     received[peer] = Opt.none(EntryRecord)
 
     let reply = msgOpt.valueOr:
@@ -111,6 +117,11 @@ proc getValue*(
 
     let value = record.value.valueOr:
       debug "GetValue returned record with no value", reply = reply
+      return
+
+    if value.len > kad.config.maxValueSize:
+      debug "GetValue dropped: value exceeds maxValueSize",
+        peer = peer, size = value.len, cap = kad.config.maxValueSize
       return
 
     let time = record.timeReceived.valueOr:
@@ -138,11 +149,11 @@ proc getValue*(
   for p, r in received:
     let record = r.valueOr:
       # peer doesn't have value
-      rpcBatch.add(kad.switch.dispatchPutVal(p, key, best.value, kad.codec))
+      rpcBatch.add(kad.dispatchPutVal(p, key, best.value))
       continue
     if record.value != best.value:
       # value is invalid or not best
-      rpcBatch.add(kad.switch.dispatchPutVal(p, key, best.value, kad.codec))
+      rpcBatch.add(kad.dispatchPutVal(p, key, best.value))
 
   await rpcBatch.allFuturesWaitOrTimeout(kad.config.timeout)
 

--- a/libp2p/protocols/kademlia/get.nim
+++ b/libp2p/protocols/kademlia/get.nim
@@ -95,9 +95,9 @@ proc getValue*(
   let onReply = proc(
       peer: PeerId, msgOpt: Opt[Message], state: var LookupState
   ): Future[void] {.async: (raises: []), gcsafe.} =
-    if not received.hasKey(peer) and received.len >= kad.config.maxReceivedSize:
+    if not received.hasKey(peer) and received.len >= kad.config.limits.maxReceivedSize:
       debug "GetValue: ReceivedTable cap reached, dropping reply",
-        peer = peer, cap = kad.config.maxReceivedSize
+        peer = peer, cap = kad.config.limits.maxReceivedSize
       return
 
     received[peer] = Opt.none(EntryRecord)
@@ -119,9 +119,9 @@ proc getValue*(
       debug "GetValue returned record with no value", reply = reply
       return
 
-    if value.len > kad.config.maxValueSize:
+    if value.len > kad.config.limits.maxValueSize:
       debug "GetValue dropped: value exceeds maxValueSize",
-        peer = peer, size = value.len, cap = kad.config.maxValueSize
+        peer = peer, size = value.len, cap = kad.config.limits.maxValueSize
       return
 
     let time = record.timeReceived.valueOr:

--- a/libp2p/protocols/kademlia/get.nim
+++ b/libp2p/protocols/kademlia/get.nim
@@ -14,46 +14,46 @@ logScope:
 proc dispatchGetVal*(
     kad: KadDHT, peer: PeerId, key: Key
 ): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
-  withRpcSlot(kad):
-    let streamRes = catch:
-      await kad.switch.dial(peer, kad.switch.peerStore[AddressBook][peer], kad.codec)
-    if streamRes.isErr:
-      return err(streamRes.error.msg)
-    let stream = streamRes.value()
-    defer:
-      await stream.close()
+  withRpcSlot(kad)
+  let streamRes = catch:
+    await kad.switch.dial(peer, kad.switch.peerStore[AddressBook][peer], kad.codec)
+  if streamRes.isErr:
+    return err(streamRes.error.msg)
+  let stream = streamRes.value()
+  defer:
+    await stream.close()
 
-    let msg = Message(msgType: MessageType.getValue, key: key)
-    let encoded = msg.encode(kad.config.hideConnectionStatus)
+  let msg = Message(msgType: MessageType.getValue, key: key)
+  let encoded = msg.encode(kad.config.hideConnectionStatus)
 
-    kad_messages_sent.inc(labelValues = [$MessageType.getValue])
-    kad_message_bytes_sent.inc(
-      encoded.buffer.len.int64, labelValues = [$MessageType.getValue]
-    )
+  kad_messages_sent.inc(labelValues = [$MessageType.getValue])
+  kad_message_bytes_sent.inc(
+    encoded.buffer.len.int64, labelValues = [$MessageType.getValue]
+  )
 
-    var replyBuf: seq[byte]
-    var ioRes: Result[void, ref CatchableError]
-    kad_message_duration_ms.time(labelValues = [$MessageType.getValue]):
-      ioRes = catch:
-        await stream.writeLp(encoded.buffer)
-        replyBuf = await stream.readLp(MaxMsgSize)
-    if ioRes.isErr:
-      return err(ioRes.error.msg)
+  var replyBuf: seq[byte]
+  var ioRes: Result[void, ref CatchableError]
+  kad_message_duration_ms.time(labelValues = [$MessageType.getValue]):
+    ioRes = catch:
+      await stream.writeLp(encoded.buffer)
+      replyBuf = await stream.readLp(MaxMsgSize)
+  if ioRes.isErr:
+    return err(ioRes.error.msg)
 
-    kad_message_bytes_received.inc(
-      replyBuf.len.int64, labelValues = [$MessageType.getValue]
-    )
+  kad_message_bytes_received.inc(
+    replyBuf.len.int64, labelValues = [$MessageType.getValue]
+  )
 
-    let reply = Message.decode(replyBuf).valueOr:
-      return err("GetValue reply decode fail")
+  let reply = Message.decode(replyBuf).valueOr:
+    return err("GetValue reply decode fail")
 
-    if reply.closerPeers.len > 0:
-      kad_responses_with_closer_peers.inc(labelValues = [$MessageType.getValue])
+  if reply.closerPeers.len > 0:
+    kad_responses_with_closer_peers.inc(labelValues = [$MessageType.getValue])
 
-    stream.observedAddr.withValue(observedAddr):
-      kad.updatePeers(@[PeerInfo(peerId: stream.peerId, addrs: @[observedAddr])])
+  stream.observedAddr.withValue(observedAddr):
+    kad.updatePeers(@[PeerInfo(peerId: stream.peerId, addrs: @[observedAddr])])
 
-    return ok(reply)
+  return ok(reply)
 
 proc bestValidRecord(
     kad: KadDHT, key: Key, received: ReceivedTable, quorum: int

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -2,9 +2,11 @@
 # Copyright (c) Status Research & Development GmbH
 
 ## Provider record management for the Kademlia DHT.
-## When ``KadDHTConfig.providerRejection`` is true: receivers enforce
-## ``maxProvidersPerKey`` and reply with accepted/rejected on field 11; senders
-## spill over to farther peers when a full batch is rejected.
+## Receivers always enforce ``KadDHTConfig.maxProvidersPerKey``; when
+## ``providerRejection`` is true they additionally reply accepted/rejected on
+## field 11 so senders can spill over to farther peers. Without
+## ``providerRejection`` the limit is enforced silently — over-cap
+## advertisements are dropped without a reply.
 ## Re-advertisements are always accepted.
 
 import std/[sequtils, tables, sets, heapqueue]
@@ -103,60 +105,50 @@ proc addProviderRecord(pm: ProviderManager, record: ProviderRecord) =
     raiseAssert("checked with hasKey")
 
 proc dispatchAddProvider(
-    switch: Switch,
-    peer: PeerId,
-    key: Key,
-    codec: string,
-    hideConnectionStatus: bool,
-    replyTimeout: Duration,
-    providerRejection: bool,
+    kad: KadDHT, peer: PeerId, key: Key
 ): Future[Result[AddProviderStatus, string]] {.async: (raises: [CancelledError]).} =
-  let streamRes = catch:
-    await switch.dial(peer, switch.peerStore[AddressBook][peer], codec)
-  if streamRes.isErr:
-    return err(streamRes.error.msg)
-  let stream = streamRes.value()
-  defer:
-    await stream.close()
+  withRpcSlot(kad):
+    let streamRes = catch:
+      await kad.switch.dial(peer, kad.switch.peerStore[AddressBook][peer], kad.codec)
+    if streamRes.isErr:
+      return err(streamRes.error.msg)
+    let stream = streamRes.value()
+    defer:
+      await stream.close()
 
-  let msg = Message(
-    msgType: MessageType.addProvider,
-    key: key,
-    providerPeers: @[switch.peerInfo.toPeer()],
-  )
-  let encoded = msg.encode(hideConnectionStatus)
-  kad_messages_sent.inc(labelValues = [$MessageType.addProvider])
-  kad_message_bytes_sent.inc(
-    encoded.buffer.len.int64, labelValues = [$MessageType.addProvider]
-  )
-  let writeRes = catch:
-    await stream.writeLp(encoded.buffer)
-  if writeRes.isErr:
-    return err(writeRes.error.msg)
+    let msg = Message(
+      msgType: MessageType.addProvider,
+      key: key,
+      providerPeers: @[kad.switch.peerInfo.toPeer()],
+    )
+    let encoded = msg.encode(kad.config.hideConnectionStatus)
+    kad_messages_sent.inc(labelValues = [$MessageType.addProvider])
+    kad_message_bytes_sent.inc(
+      encoded.buffer.len.int64, labelValues = [$MessageType.addProvider]
+    )
+    let writeRes = catch:
+      await stream.writeLp(encoded.buffer)
+    if writeRes.isErr:
+      return err(writeRes.error.msg)
 
-  if not providerRejection:
-    return ok(AddProviderStatus.accepted)
+    if not kad.config.providerRejection:
+      return ok(AddProviderStatus.accepted)
 
-  let readFut = stream.readLp(MaxMsgSize)
-  if not (await readFut.withTimeout(replyTimeout)):
-    return ok(AddProviderStatus.accepted)
-  let readRes = catch:
-    await readFut
-  if readRes.isErr:
-    return ok(AddProviderStatus.accepted)
+    let readFut = stream.readLp(MaxMsgSize)
+    if not (await readFut.withTimeout(kad.config.timeout)):
+      return ok(AddProviderStatus.accepted)
+    let readRes = catch:
+      await readFut
+    if readRes.isErr:
+      return ok(AddProviderStatus.accepted)
 
-  let reply = Message.decode(readRes.value).valueOr:
-    return ok(AddProviderStatus.accepted)
+    let reply = Message.decode(readRes.value).valueOr:
+      return ok(AddProviderStatus.accepted)
 
-  return ok(reply.providerStatus.get(AddProviderStatus.accepted))
+    return ok(reply.providerStatus.get(AddProviderStatus.accepted))
 
 proc sendBatch(kad: KadDHT, peers: seq[PeerId], key: Key): auto =
-  peers.mapIt(
-    kad.switch.dispatchAddProvider(
-      it, key, kad.codec, kad.config.hideConnectionStatus, kad.config.timeout,
-      kad.config.providerRejection,
-    )
-  )
+  peers.mapIt(kad.dispatchAddProvider(it, key))
 
 proc countResults[T](rpcBatch: seq[T]): (int, int) =
   var accepted, rejected: int
@@ -262,77 +254,84 @@ method handleAddProvider*(
   let validPeers =
     msg.providerPeers.filterIt(it.id == peerBytes and PeerId.init(it.id).isOk())
 
-  if kad.config.providerRejection:
-    kad.config.maxProvidersPerKey.withValue(limit):
-      let existingProviders =
-        kad.providerManager.knownKeys.getOrDefault(msg.key, initHashSet[Provider]())
-      let senderIsKnown = existingProviders.anyIt(it.id == peerBytes)
-      let effectiveCount = existingProviders.len - (if senderIsKnown: 1 else: 0)
-      if effectiveCount >= limit:
-        kad_provider_rejections_sent.inc()
-        debug "ADD_PROVIDER rejected: per-key limit reached",
-          key = msg.key, limit = limit
-        await stream.sendAddProviderResponse(kad, AddProviderStatus.rejected)
-        return
+  # Per-key cap is enforced regardless of providerRejection: when rejection is
+  # disabled the receiver still drops over-cap providers, just silently.
+  var atCap = false
+  kad.config.maxProvidersPerKey.withValue(limit):
+    let existingProviders =
+      kad.providerManager.knownKeys.getOrDefault(msg.key, initHashSet[Provider]())
+    let senderIsKnown = existingProviders.anyIt(it.id == peerBytes)
+    # Re-advertisements by the same provider are exempt: addProviderRecord
+    # replaces the existing record so the set size doesn't grow.
+    let effectiveCount = existingProviders.len - (if senderIsKnown: 1 else: 0)
+    if effectiveCount >= limit:
+      atCap = true
+      debug "ADD_PROVIDER rejected: per-key limit reached", key = msg.key, limit = limit
 
-  for peer in validPeers:
-    # add provider to providerManager
-    kad.providerManager.addProviderRecord(
-      ProviderRecord(
-        provider: peer,
-        expiresAt: chronos.Moment.now() + kad.config.providerExpirationInterval,
-        key: msg.key,
+  if not atCap:
+    for peer in validPeers:
+      kad.providerManager.addProviderRecord(
+        ProviderRecord(
+          provider: peer,
+          expiresAt: chronos.Moment.now() + kad.config.providerExpirationInterval,
+          key: msg.key,
+        )
       )
-    )
 
   if kad.config.providerRejection:
     let status =
-      if validPeers.len > 0: AddProviderStatus.accepted else: AddProviderStatus.rejected
+      if atCap or validPeers.len == 0:
+        AddProviderStatus.rejected
+      else:
+        AddProviderStatus.accepted
+    if status == AddProviderStatus.rejected:
+      kad_provider_rejections_sent.inc()
     await stream.sendAddProviderResponse(kad, status)
 
 proc dispatchGetProviders*(
     kad: KadDHT, peer: PeerId, key: Key
 ): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
-  let streamRes = catch:
-    await kad.switch.dial(peer, kad.switch.peerStore[AddressBook][peer], kad.codec)
-  if streamRes.isErr:
-    return err(streamRes.error.msg)
-  let stream = streamRes.value()
-  defer:
-    await stream.close()
-  let msg = Message(msgType: MessageType.getProviders, key: key)
-  let encoded = msg.encode(kad.config.hideConnectionStatus)
+  withRpcSlot(kad):
+    let streamRes = catch:
+      await kad.switch.dial(peer, kad.switch.peerStore[AddressBook][peer], kad.codec)
+    if streamRes.isErr:
+      return err(streamRes.error.msg)
+    let stream = streamRes.value()
+    defer:
+      await stream.close()
+    let msg = Message(msgType: MessageType.getProviders, key: key)
+    let encoded = msg.encode(kad.config.hideConnectionStatus)
 
-  kad_messages_sent.inc(labelValues = [$MessageType.getProviders])
-  kad_message_bytes_sent.inc(
-    encoded.buffer.len.int64, labelValues = [$MessageType.getProviders]
-  )
+    kad_messages_sent.inc(labelValues = [$MessageType.getProviders])
+    kad_message_bytes_sent.inc(
+      encoded.buffer.len.int64, labelValues = [$MessageType.getProviders]
+    )
 
-  var replyBuf: seq[byte]
-  var ioRes: Result[void, ref CatchableError]
-  kad_message_duration_ms.time(labelValues = [$MessageType.getProviders]):
-    ioRes = catch:
-      await stream.writeLp(encoded.buffer)
-      replyBuf = await stream.readLp(MaxMsgSize)
-  if ioRes.isErr:
-    return err(ioRes.error.msg)
+    var replyBuf: seq[byte]
+    var ioRes: Result[void, ref CatchableError]
+    kad_message_duration_ms.time(labelValues = [$MessageType.getProviders]):
+      ioRes = catch:
+        await stream.writeLp(encoded.buffer)
+        replyBuf = await stream.readLp(MaxMsgSize)
+    if ioRes.isErr:
+      return err(ioRes.error.msg)
 
-  kad_message_bytes_received.inc(
-    replyBuf.len.int64, labelValues = [$MessageType.getProviders]
-  )
+    kad_message_bytes_received.inc(
+      replyBuf.len.int64, labelValues = [$MessageType.getProviders]
+    )
 
-  let reply = Message.decode(replyBuf).valueOr:
-    return err("GetProviders reply decode fail")
+    let reply = Message.decode(replyBuf).valueOr:
+      return err("GetProviders reply decode fail")
 
-  if reply.closerPeers.len > 0:
-    kad_responses_with_closer_peers.inc(labelValues = [$MessageType.getProviders])
+    if reply.closerPeers.len > 0:
+      kad_responses_with_closer_peers.inc(labelValues = [$MessageType.getProviders])
 
-  debug "Received reply for GetProviders", peer = peer, reply = reply
+    debug "Received reply for GetProviders", peer = peer, reply = reply
 
-  stream.observedAddr.withValue(observedAddr):
-    kad.updatePeers(@[PeerInfo(peerId: stream.peerId, addrs: @[observedAddr])])
+    stream.observedAddr.withValue(observedAddr):
+      kad.updatePeers(@[PeerInfo(peerId: stream.peerId, addrs: @[observedAddr])])
 
-  return ok(reply)
+    return ok(reply)
 
 proc getProviders*(
     kad: KadDHT, key: Key

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -107,45 +107,45 @@ proc addProviderRecord(pm: ProviderManager, record: ProviderRecord) =
 proc dispatchAddProvider(
     kad: KadDHT, peer: PeerId, key: Key
 ): Future[Result[AddProviderStatus, string]] {.async: (raises: [CancelledError]).} =
-  withRpcSlot(kad):
-    let streamRes = catch:
-      await kad.switch.dial(peer, kad.switch.peerStore[AddressBook][peer], kad.codec)
-    if streamRes.isErr:
-      return err(streamRes.error.msg)
-    let stream = streamRes.value()
-    defer:
-      await stream.close()
+  withRpcSlot(kad)
+  let streamRes = catch:
+    await kad.switch.dial(peer, kad.switch.peerStore[AddressBook][peer], kad.codec)
+  if streamRes.isErr:
+    return err(streamRes.error.msg)
+  let stream = streamRes.value()
+  defer:
+    await stream.close()
 
-    let msg = Message(
-      msgType: MessageType.addProvider,
-      key: key,
-      providerPeers: @[kad.switch.peerInfo.toPeer()],
-    )
-    let encoded = msg.encode(kad.config.hideConnectionStatus)
-    kad_messages_sent.inc(labelValues = [$MessageType.addProvider])
-    kad_message_bytes_sent.inc(
-      encoded.buffer.len.int64, labelValues = [$MessageType.addProvider]
-    )
-    let writeRes = catch:
-      await stream.writeLp(encoded.buffer)
-    if writeRes.isErr:
-      return err(writeRes.error.msg)
+  let msg = Message(
+    msgType: MessageType.addProvider,
+    key: key,
+    providerPeers: @[kad.switch.peerInfo.toPeer()],
+  )
+  let encoded = msg.encode(kad.config.hideConnectionStatus)
+  kad_messages_sent.inc(labelValues = [$MessageType.addProvider])
+  kad_message_bytes_sent.inc(
+    encoded.buffer.len.int64, labelValues = [$MessageType.addProvider]
+  )
+  let writeRes = catch:
+    await stream.writeLp(encoded.buffer)
+  if writeRes.isErr:
+    return err(writeRes.error.msg)
 
-    if not kad.config.providerRejection:
-      return ok(AddProviderStatus.accepted)
+  if not kad.config.providerRejection:
+    return ok(AddProviderStatus.accepted)
 
-    let readFut = stream.readLp(MaxMsgSize)
-    if not (await readFut.withTimeout(kad.config.timeout)):
-      return ok(AddProviderStatus.accepted)
-    let readRes = catch:
-      await readFut
-    if readRes.isErr:
-      return ok(AddProviderStatus.accepted)
+  let readFut = stream.readLp(MaxMsgSize)
+  if not (await readFut.withTimeout(kad.config.timeout)):
+    return ok(AddProviderStatus.accepted)
+  let readRes = catch:
+    await readFut
+  if readRes.isErr:
+    return ok(AddProviderStatus.accepted)
 
-    let reply = Message.decode(readRes.value).valueOr:
-      return ok(AddProviderStatus.accepted)
+  let reply = Message.decode(readRes.value).valueOr:
+    return ok(AddProviderStatus.accepted)
 
-    return ok(reply.providerStatus.get(AddProviderStatus.accepted))
+  return ok(reply.providerStatus.get(AddProviderStatus.accepted))
 
 proc sendBatch(kad: KadDHT, peers: seq[PeerId], key: Key): auto =
   peers.mapIt(kad.dispatchAddProvider(it, key))
@@ -291,47 +291,47 @@ method handleAddProvider*(
 proc dispatchGetProviders*(
     kad: KadDHT, peer: PeerId, key: Key
 ): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
-  withRpcSlot(kad):
-    let streamRes = catch:
-      await kad.switch.dial(peer, kad.switch.peerStore[AddressBook][peer], kad.codec)
-    if streamRes.isErr:
-      return err(streamRes.error.msg)
-    let stream = streamRes.value()
-    defer:
-      await stream.close()
-    let msg = Message(msgType: MessageType.getProviders, key: key)
-    let encoded = msg.encode(kad.config.hideConnectionStatus)
+  withRpcSlot(kad)
+  let streamRes = catch:
+    await kad.switch.dial(peer, kad.switch.peerStore[AddressBook][peer], kad.codec)
+  if streamRes.isErr:
+    return err(streamRes.error.msg)
+  let stream = streamRes.value()
+  defer:
+    await stream.close()
+  let msg = Message(msgType: MessageType.getProviders, key: key)
+  let encoded = msg.encode(kad.config.hideConnectionStatus)
 
-    kad_messages_sent.inc(labelValues = [$MessageType.getProviders])
-    kad_message_bytes_sent.inc(
-      encoded.buffer.len.int64, labelValues = [$MessageType.getProviders]
-    )
+  kad_messages_sent.inc(labelValues = [$MessageType.getProviders])
+  kad_message_bytes_sent.inc(
+    encoded.buffer.len.int64, labelValues = [$MessageType.getProviders]
+  )
 
-    var replyBuf: seq[byte]
-    var ioRes: Result[void, ref CatchableError]
-    kad_message_duration_ms.time(labelValues = [$MessageType.getProviders]):
-      ioRes = catch:
-        await stream.writeLp(encoded.buffer)
-        replyBuf = await stream.readLp(MaxMsgSize)
-    if ioRes.isErr:
-      return err(ioRes.error.msg)
+  var replyBuf: seq[byte]
+  var ioRes: Result[void, ref CatchableError]
+  kad_message_duration_ms.time(labelValues = [$MessageType.getProviders]):
+    ioRes = catch:
+      await stream.writeLp(encoded.buffer)
+      replyBuf = await stream.readLp(MaxMsgSize)
+  if ioRes.isErr:
+    return err(ioRes.error.msg)
 
-    kad_message_bytes_received.inc(
-      replyBuf.len.int64, labelValues = [$MessageType.getProviders]
-    )
+  kad_message_bytes_received.inc(
+    replyBuf.len.int64, labelValues = [$MessageType.getProviders]
+  )
 
-    let reply = Message.decode(replyBuf).valueOr:
-      return err("GetProviders reply decode fail")
+  let reply = Message.decode(replyBuf).valueOr:
+    return err("GetProviders reply decode fail")
 
-    if reply.closerPeers.len > 0:
-      kad_responses_with_closer_peers.inc(labelValues = [$MessageType.getProviders])
+  if reply.closerPeers.len > 0:
+    kad_responses_with_closer_peers.inc(labelValues = [$MessageType.getProviders])
 
-    debug "Received reply for GetProviders", peer = peer, reply = reply
+  debug "Received reply for GetProviders", peer = peer, reply = reply
 
-    stream.observedAddr.withValue(observedAddr):
-      kad.updatePeers(@[PeerInfo(peerId: stream.peerId, addrs: @[observedAddr])])
+  stream.observedAddr.withValue(observedAddr):
+    kad.updatePeers(@[PeerInfo(peerId: stream.peerId, addrs: @[observedAddr])])
 
-    return ok(reply)
+  return ok(reply)
 
 proc getProviders*(
     kad: KadDHT, key: Key

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -2,7 +2,7 @@
 # Copyright (c) Status Research & Development GmbH
 
 ## Provider record management for the Kademlia DHT.
-## Receivers always enforce ``KadDHTConfig.maxProvidersPerKey``; when
+## Receivers always enforce ``KadDHTConfig.limits.maxProvidersPerKey``; when
 ## ``providerRejection`` is true they additionally reply accepted/rejected on
 ## field 11 so senders can spill over to farther peers. Without
 ## ``providerRejection`` the limit is enforced silently — over-cap
@@ -257,7 +257,7 @@ method handleAddProvider*(
   # Per-key cap is enforced regardless of providerRejection: when rejection is
   # disabled the receiver still drops over-cap providers, just silently.
   var atCap = false
-  kad.config.maxProvidersPerKey.withValue(limit):
+  kad.config.limits.maxProvidersPerKey.withValue(limit):
     let existingProviders =
       kad.providerManager.knownKeys.getOrDefault(msg.key, initHashSet[Provider]())
     let senderIsKnown = existingProviders.anyIt(it.id == peerBytes)

--- a/libp2p/protocols/kademlia/put.nim
+++ b/libp2p/protocols/kademlia/put.nim
@@ -97,10 +97,10 @@ proc dispatchPutVal*(
 proc putValue*(
     kad: KadDHT, key: Key, value: seq[byte]
 ): Future[Result[void, string]] {.async: (raises: [CancelledError]), gcsafe.} =
-  if value.len > kad.config.maxValueSize:
+  if value.len > kad.config.limits.maxValueSize:
     return err(
-      "value exceeds maxValueSize (" & $value.len & " > " & $kad.config.maxValueSize &
-        ")"
+      "value exceeds maxValueSize (" & $value.len & " > " &
+        $kad.config.limits.maxValueSize & ")"
     )
 
   let record = EntryRecord(value: value, time: Timestamp.now())
@@ -136,9 +136,9 @@ proc handlePutValue*(
     error "No value in record", msg = msg, stream = stream
     return
 
-  if value.len > kad.config.maxValueSize:
+  if value.len > kad.config.limits.maxValueSize:
     debug "PUT_VALUE dropped: value exceeds maxValueSize",
-      stream = stream, size = value.len, cap = kad.config.maxValueSize
+      stream = stream, size = value.len, cap = kad.config.limits.maxValueSize
     return
 
   let entryRecord = EntryRecord(value: value, time: Timestamp.now())

--- a/libp2p/protocols/kademlia/put.nim
+++ b/libp2p/protocols/kademlia/put.nim
@@ -50,49 +50,49 @@ proc manageExpiredRecords*(kad: KadDHT) {.async: (raises: [CancelledError]).} =
 proc dispatchPutVal*(
     kad: KadDHT, peer: PeerId, key: Key, value: seq[byte]
 ): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
-  withRpcSlot(kad):
-    let streamRes = catch:
-      await kad.switch.dial(peer, kad.switch.peerStore[AddressBook][peer], kad.codec)
-    if streamRes.isErr:
-      return err(streamRes.error.msg)
-    let stream = streamRes.value()
-    defer:
-      await stream.close()
-    let msg = Message(
-      msgType: MessageType.putValue,
-      key: key,
-      record: Opt.some(Record(key: key, value: Opt.some(value))),
-    )
-    let encoded = msg.encode()
+  withRpcSlot(kad)
+  let streamRes = catch:
+    await kad.switch.dial(peer, kad.switch.peerStore[AddressBook][peer], kad.codec)
+  if streamRes.isErr:
+    return err(streamRes.error.msg)
+  let stream = streamRes.value()
+  defer:
+    await stream.close()
+  let msg = Message(
+    msgType: MessageType.putValue,
+    key: key,
+    record: Opt.some(Record(key: key, value: Opt.some(value))),
+  )
+  let encoded = msg.encode()
 
-    kad_messages_sent.inc(labelValues = [$MessageType.putValue])
-    kad_message_bytes_sent.inc(
-      encoded.buffer.len.int64, labelValues = [$MessageType.putValue]
-    )
+  kad_messages_sent.inc(labelValues = [$MessageType.putValue])
+  kad_message_bytes_sent.inc(
+    encoded.buffer.len.int64, labelValues = [$MessageType.putValue]
+  )
 
-    var replyBuf: seq[byte]
-    var ioRes: Result[void, ref CatchableError]
-    kad_message_duration_ms.time(labelValues = [$MessageType.putValue]):
-      ioRes = catch:
-        await stream.writeLp(encoded.buffer)
-        replyBuf = await stream.readLp(MaxMsgSize)
-    if ioRes.isErr:
-      return err(ioRes.error.msg)
+  var replyBuf: seq[byte]
+  var ioRes: Result[void, ref CatchableError]
+  kad_message_duration_ms.time(labelValues = [$MessageType.putValue]):
+    ioRes = catch:
+      await stream.writeLp(encoded.buffer)
+      replyBuf = await stream.readLp(MaxMsgSize)
+  if ioRes.isErr:
+    return err(ioRes.error.msg)
 
-    kad_message_bytes_received.inc(
-      replyBuf.len.int64, labelValues = [$MessageType.putValue]
-    )
+  kad_message_bytes_received.inc(
+    replyBuf.len.int64, labelValues = [$MessageType.putValue]
+  )
 
-    let reply = Message.decode(replyBuf).valueOr:
-      return err("PutValue reply decode fail")
+  let reply = Message.decode(replyBuf).valueOr:
+    return err("PutValue reply decode fail")
 
-    debug "Got PutValue reply", msg = msg, reply = reply, stream = stream
+  debug "Got PutValue reply", msg = msg, reply = reply, stream = stream
 
-    if reply != msg:
-      error "Unexpected change between msg and reply: ",
-        msg = msg, reply = reply, stream = stream
+  if reply != msg:
+    error "Unexpected change between msg and reply: ",
+      msg = msg, reply = reply, stream = stream
 
-    return ok()
+  return ok()
 
 proc putValue*(
     kad: KadDHT, key: Key, value: seq[byte]

--- a/libp2p/protocols/kademlia/put.nim
+++ b/libp2p/protocols/kademlia/put.nim
@@ -139,6 +139,7 @@ proc handlePutValue*(
   if value.len > kad.config.limits.maxValueSize:
     debug "PUT_VALUE dropped: value exceeds maxValueSize",
       stream = stream, size = value.len, cap = kad.config.limits.maxValueSize
+    await stream.reset()
     return
 
   let entryRecord = EntryRecord(value: value, time: Timestamp.now())

--- a/libp2p/protocols/kademlia/put.nim
+++ b/libp2p/protocols/kademlia/put.nim
@@ -48,54 +48,61 @@ proc manageExpiredRecords*(kad: KadDHT) {.async: (raises: [CancelledError]).} =
       debug "Expired record removed", key = key
 
 proc dispatchPutVal*(
-    switch: Switch, peer: PeerId, key: Key, value: seq[byte], codec: string
+    kad: KadDHT, peer: PeerId, key: Key, value: seq[byte]
 ): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
-  let streamRes = catch:
-    await switch.dial(peer, switch.peerStore[AddressBook][peer], codec)
-  if streamRes.isErr:
-    return err(streamRes.error.msg)
-  let stream = streamRes.value()
-  defer:
-    await stream.close()
-  let msg = Message(
-    msgType: MessageType.putValue,
-    key: key,
-    record: Opt.some(Record(key: key, value: Opt.some(value))),
-  )
-  let encoded = msg.encode()
+  withRpcSlot(kad):
+    let streamRes = catch:
+      await kad.switch.dial(peer, kad.switch.peerStore[AddressBook][peer], kad.codec)
+    if streamRes.isErr:
+      return err(streamRes.error.msg)
+    let stream = streamRes.value()
+    defer:
+      await stream.close()
+    let msg = Message(
+      msgType: MessageType.putValue,
+      key: key,
+      record: Opt.some(Record(key: key, value: Opt.some(value))),
+    )
+    let encoded = msg.encode()
 
-  kad_messages_sent.inc(labelValues = [$MessageType.putValue])
-  kad_message_bytes_sent.inc(
-    encoded.buffer.len.int64, labelValues = [$MessageType.putValue]
-  )
+    kad_messages_sent.inc(labelValues = [$MessageType.putValue])
+    kad_message_bytes_sent.inc(
+      encoded.buffer.len.int64, labelValues = [$MessageType.putValue]
+    )
 
-  var replyBuf: seq[byte]
-  var ioRes: Result[void, ref CatchableError]
-  kad_message_duration_ms.time(labelValues = [$MessageType.putValue]):
-    ioRes = catch:
-      await stream.writeLp(encoded.buffer)
-      replyBuf = await stream.readLp(MaxMsgSize)
-  if ioRes.isErr:
-    return err(ioRes.error.msg)
+    var replyBuf: seq[byte]
+    var ioRes: Result[void, ref CatchableError]
+    kad_message_duration_ms.time(labelValues = [$MessageType.putValue]):
+      ioRes = catch:
+        await stream.writeLp(encoded.buffer)
+        replyBuf = await stream.readLp(MaxMsgSize)
+    if ioRes.isErr:
+      return err(ioRes.error.msg)
 
-  kad_message_bytes_received.inc(
-    replyBuf.len.int64, labelValues = [$MessageType.putValue]
-  )
+    kad_message_bytes_received.inc(
+      replyBuf.len.int64, labelValues = [$MessageType.putValue]
+    )
 
-  let reply = Message.decode(replyBuf).valueOr:
-    return err("PutValue reply decode fail")
+    let reply = Message.decode(replyBuf).valueOr:
+      return err("PutValue reply decode fail")
 
-  debug "Got PutValue reply", msg = msg, reply = reply, stream = stream
+    debug "Got PutValue reply", msg = msg, reply = reply, stream = stream
 
-  if reply != msg:
-    error "Unexpected change between msg and reply: ",
-      msg = msg, reply = reply, stream = stream
+    if reply != msg:
+      error "Unexpected change between msg and reply: ",
+        msg = msg, reply = reply, stream = stream
 
-  return ok()
+    return ok()
 
 proc putValue*(
     kad: KadDHT, key: Key, value: seq[byte]
 ): Future[Result[void, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  if value.len > kad.config.maxValueSize:
+    return err(
+      "value exceeds maxValueSize (" & $value.len & " > " & $kad.config.maxValueSize &
+        ")"
+    )
+
   let record = EntryRecord(value: value, time: Timestamp.now())
 
   if not kad.config.validator.isValid(key, record):
@@ -109,7 +116,7 @@ proc putValue*(
   kad.dataTable.insert(key, value, Timestamp.now())
 
   for chunk in peers.toChunks(kad.config.alpha):
-    let batch = chunk.mapIt(kad.switch.dispatchPutVal(it, key, value, kad.codec))
+    let batch = chunk.mapIt(kad.dispatchPutVal(it, key, value))
     await batch.allFuturesWaitOrTimeout(kad.config.timeout)
 
   ok()
@@ -127,6 +134,11 @@ proc handlePutValue*(
 
   let value = record.value.valueOr:
     error "No value in record", msg = msg, stream = stream
+    return
+
+  if value.len > kad.config.maxValueSize:
+    debug "PUT_VALUE dropped: value exceeds maxValueSize",
+      stream = stream, size = value.len, cap = kad.config.maxValueSize
     return
 
   let entryRecord = EntryRecord(value: value, time: Timestamp.now())

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -30,16 +30,18 @@ const
     # KV entries older than this are considered stale and will be evicted
   DefaultCleanupDataEntriesInterval* = 1.hours # how often to scan for stale KV entries
 
+  MaxMsgSize* = 4096
+
   DefaultMaxProvidersPerKey* = 20 ## upper bound on providers stored per key
   DefaultMaxShortlistSize* = DefaultReplication * 2
     ## upper bound on iterative-lookup shortlist
   DefaultMaxReceivedSize* = DefaultReplication
     ## upper bound on per-query ``ReceivedTable``
-  DefaultMaxValueSize* = 8 * 1024 ## upper bound (bytes) on a stored record value
+  DefaultMaxValueSize* = MaxMsgSize
+    ## upper bound (bytes) on a stored record value; kept equal to MaxMsgSize
+    ## so that accepted values can always be transmitted in a single LP frame
   DefaultMaxConcurrentRpcs* = 100
     ## upper bound on in-flight outbound RPCs across find/get/put/provider
-
-  MaxMsgSize* = 4096
 
 type Key* = seq[byte]
 

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -322,6 +322,32 @@ method select*(
 
   return ok(bestIdx)
 
+type KadDHTLimits* = object
+  maxProvidersPerKey*: Opt[int]
+    ## Maximum number of distinct providers stored per key.
+    ## ``Opt.none`` means unlimited; the default is ``DefaultMaxProvidersPerKey``.
+  maxShortlistSize*: int
+    ## Maximum number of peers retained in an iterative-lookup shortlist.
+    ## When exceeded, farther peers are dropped so the shortlist stays bounded.
+  maxReceivedSize*: int
+    ## Maximum number of per-peer entries retained in a GET_VALUE
+    ## ``ReceivedTable``.
+  maxValueSize*: int
+    ## Maximum size (bytes) of an individual record value. Enforced on
+    ## ``putValue`` and on incoming PUT_VALUE / GET_VALUE records.
+  maxConcurrentRpcs*: int
+    ## Maximum number of in-flight outbound RPCs (find/get/put/provider)
+    ## across the whole node. Excess calls wait on a shared semaphore.
+
+proc new*(T: typedesc[KadDHTLimits]): T {.raises: [].} =
+  T(
+    maxProvidersPerKey: Opt.some(DefaultMaxProvidersPerKey),
+    maxShortlistSize: DefaultMaxShortlistSize,
+    maxReceivedSize: DefaultMaxReceivedSize,
+    maxValueSize: DefaultMaxValueSize,
+    maxConcurrentRpcs: DefaultMaxConcurrentRpcs,
+  )
+
 type KadDHTConfig* = object
   validator*: EntryValidator
   selector*: EntrySelector
@@ -345,24 +371,10 @@ type KadDHTConfig* = object
   providerRejection*: bool
     ## When true, ADD_PROVIDER receivers reply with accepted/rejected on
     ## field 11; the sender spills over to farther peers when a full batch is
-    ## rejected. The per-key cap (``maxProvidersPerKey``) is always enforced
-    ## regardless of this flag — this only controls whether rejections are
-    ## acknowledged on the wire.
-  maxProvidersPerKey*: Opt[int]
-    ## Maximum number of distinct providers stored per key.
-    ## ``Opt.none`` means unlimited; the default is ``DefaultMaxProvidersPerKey``.
-  maxShortlistSize*: int
-    ## Maximum number of peers retained in an iterative-lookup shortlist.
-    ## When exceeded, farther peers are dropped so the shortlist stays bounded.
-  maxReceivedSize*: int
-    ## Maximum number of per-peer entries retained in a GET_VALUE
-    ## ``ReceivedTable``.
-  maxValueSize*: int
-    ## Maximum size (bytes) of an individual record value. Enforced on
-    ## ``putValue`` and on incoming PUT_VALUE / GET_VALUE records.
-  maxConcurrentRpcs*: int
-    ## Maximum number of in-flight outbound RPCs (find/get/put/provider)
-    ## across the whole node. Excess calls wait on a shared semaphore.
+    ## rejected. The per-key cap (``limits.maxProvidersPerKey``) is always
+    ## enforced regardless of this flag — this only controls whether
+    ## rejections are acknowledged on the wire.
+  limits*: KadDHTLimits
 
 proc new*(
     K: typedesc[KadDHTConfig],
@@ -385,18 +397,14 @@ proc new*(
     hideConnectionStatus: bool = true,
     disableBootstrapping: bool = false,
     providerRejection: bool = false,
-    maxProvidersPerKey: Opt[int] = Opt.some(DefaultMaxProvidersPerKey),
-    maxShortlistSize: int = DefaultMaxShortlistSize,
-    maxReceivedSize: int = DefaultMaxReceivedSize,
-    maxValueSize: int = DefaultMaxValueSize,
-    maxConcurrentRpcs: int = DefaultMaxConcurrentRpcs,
+    limits: KadDHTLimits = KadDHTLimits.new(),
 ): K {.raises: [].} =
-  doAssert maxProvidersPerKey.isNone or maxProvidersPerKey.get() > 0,
+  doAssert limits.maxProvidersPerKey.isNone or limits.maxProvidersPerKey.get() > 0,
     "maxProvidersPerKey must be > 0; use Opt.none(int) for unlimited"
-  doAssert maxShortlistSize > 0, "maxShortlistSize must be > 0"
-  doAssert maxReceivedSize > 0, "maxReceivedSize must be > 0"
-  doAssert maxValueSize > 0, "maxValueSize must be > 0"
-  doAssert maxConcurrentRpcs > 0, "maxConcurrentRpcs must be > 0"
+  doAssert limits.maxShortlistSize > 0, "maxShortlistSize must be > 0"
+  doAssert limits.maxReceivedSize > 0, "maxReceivedSize must be > 0"
+  doAssert limits.maxValueSize > 0, "maxValueSize must be > 0"
+  doAssert limits.maxConcurrentRpcs > 0, "maxConcurrentRpcs must be > 0"
   KadDHTConfig(
     validator: validator,
     selector: selector,
@@ -417,11 +425,7 @@ proc new*(
     hideConnectionStatus: hideConnectionStatus,
     disableBootstrapping: disableBootstrapping,
     providerRejection: providerRejection,
-    maxProvidersPerKey: maxProvidersPerKey,
-    maxShortlistSize: maxShortlistSize,
-    maxReceivedSize: maxReceivedSize,
-    maxValueSize: maxValueSize,
-    maxConcurrentRpcs: maxConcurrentRpcs,
+    limits: limits,
   )
 
 type KadDHT* = ref object of LPProtocol
@@ -436,7 +440,7 @@ type KadDHT* = ref object of LPProtocol
   providerManager*: ProviderManager
   config*: KadDHTConfig
   rpcSem*: AsyncSemaphore
-    ## Bounds in-flight outbound RPCs to ``config.maxConcurrentRpcs``.
+    ## Bounds in-flight outbound RPCs to ``config.limits.maxConcurrentRpcs``.
 
 template withRpcSlot*(kad: KadDHT, body: untyped): untyped =
   ## Acquire one ``rpcSem`` slot for the duration of ``body``. The slot is

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -30,6 +30,15 @@ const
     # KV entries older than this are considered stale and will be evicted
   DefaultCleanupDataEntriesInterval* = 1.hours # how often to scan for stale KV entries
 
+  DefaultMaxProvidersPerKey* = 20 ## upper bound on providers stored per key
+  DefaultMaxShortlistSize* = DefaultReplication * 2
+    ## upper bound on iterative-lookup shortlist
+  DefaultMaxReceivedSize* = DefaultReplication
+    ## upper bound on per-query ``ReceivedTable``
+  DefaultMaxValueSize* = 8 * 1024 ## upper bound (bytes) on a stored record value
+  DefaultMaxConcurrentRpcs* = 100
+    ## upper bound on in-flight outbound RPCs across find/get/put/provider
+
   MaxMsgSize* = 4096
 
 type Key* = seq[byte]
@@ -334,13 +343,26 @@ type KadDHTConfig* = object
   hideConnectionStatus*: bool
   disableBootstrapping*: bool
   providerRejection*: bool
-    ## When true, the node enforces ``maxProvidersPerKey`` and replies to
-    ## ADD_PROVIDER with accepted/rejected on field 11; the sender spills over
-    ## to farther peers when a full batch is rejected.
+    ## When true, ADD_PROVIDER receivers reply with accepted/rejected on
+    ## field 11; the sender spills over to farther peers when a full batch is
+    ## rejected. The per-key cap (``maxProvidersPerKey``) is always enforced
+    ## regardless of this flag — this only controls whether rejections are
+    ## acknowledged on the wire.
   maxProvidersPerKey*: Opt[int]
     ## Maximum number of distinct providers stored per key.
-    ## None (default) means unlimited.
-    ## Only enforced when ``providerRejection`` is true.
+    ## ``Opt.none`` means unlimited; the default is ``DefaultMaxProvidersPerKey``.
+  maxShortlistSize*: int
+    ## Maximum number of peers retained in an iterative-lookup shortlist.
+    ## When exceeded, farther peers are dropped so the shortlist stays bounded.
+  maxReceivedSize*: int
+    ## Maximum number of per-peer entries retained in a GET_VALUE
+    ## ``ReceivedTable``.
+  maxValueSize*: int
+    ## Maximum size (bytes) of an individual record value. Enforced on
+    ## ``putValue`` and on incoming PUT_VALUE / GET_VALUE records.
+  maxConcurrentRpcs*: int
+    ## Maximum number of in-flight outbound RPCs (find/get/put/provider)
+    ## across the whole node. Excess calls wait on a shared semaphore.
 
 proc new*(
     K: typedesc[KadDHTConfig],
@@ -363,10 +385,18 @@ proc new*(
     hideConnectionStatus: bool = true,
     disableBootstrapping: bool = false,
     providerRejection: bool = false,
-    maxProvidersPerKey: Opt[int] = Opt.none(int),
+    maxProvidersPerKey: Opt[int] = Opt.some(DefaultMaxProvidersPerKey),
+    maxShortlistSize: int = DefaultMaxShortlistSize,
+    maxReceivedSize: int = DefaultMaxReceivedSize,
+    maxValueSize: int = DefaultMaxValueSize,
+    maxConcurrentRpcs: int = DefaultMaxConcurrentRpcs,
 ): K {.raises: [].} =
   doAssert maxProvidersPerKey.isNone or maxProvidersPerKey.get() > 0,
     "maxProvidersPerKey must be > 0; use Opt.none(int) for unlimited"
+  doAssert maxShortlistSize > 0, "maxShortlistSize must be > 0"
+  doAssert maxReceivedSize > 0, "maxReceivedSize must be > 0"
+  doAssert maxValueSize > 0, "maxValueSize must be > 0"
+  doAssert maxConcurrentRpcs > 0, "maxConcurrentRpcs must be > 0"
   KadDHTConfig(
     validator: validator,
     selector: selector,
@@ -388,6 +418,10 @@ proc new*(
     disableBootstrapping: disableBootstrapping,
     providerRejection: providerRejection,
     maxProvidersPerKey: maxProvidersPerKey,
+    maxShortlistSize: maxShortlistSize,
+    maxReceivedSize: maxReceivedSize,
+    maxValueSize: maxValueSize,
+    maxConcurrentRpcs: maxConcurrentRpcs,
   )
 
 type KadDHT* = ref object of LPProtocol
@@ -401,3 +435,17 @@ type KadDHT* = ref object of LPProtocol
   dataTable*: LocalTable
   providerManager*: ProviderManager
   config*: KadDHTConfig
+  rpcSem*: AsyncSemaphore
+    ## Bounds in-flight outbound RPCs to ``config.maxConcurrentRpcs``.
+
+template withRpcSlot*(kad: KadDHT, body: untyped): untyped =
+  ## Acquire one ``rpcSem`` slot for the duration of ``body``. The slot is
+  ## released whether ``body`` completes normally, raises, or is cancelled.
+  await kad.rpcSem.acquire()
+  try:
+    body
+  finally:
+    try:
+      kad.rpcSem.release()
+    except AsyncSemaphoreError:
+      raiseAssert "rpcSem released without acquire"

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -457,13 +457,11 @@ type KadDHT* = ref object of LPProtocol
   rpcSem*: AsyncSemaphore
     ## Bounds in-flight outbound RPCs to ``config.limits.maxConcurrentRpcs``.
 
-template withRpcSlot*(kad: KadDHT, body: untyped): untyped =
-  ## Acquire one ``rpcSem`` slot for the duration of ``body``. The slot is
-  ## released whether ``body`` completes normally, raises, or is cancelled.
+template withRpcSlot*(kad: KadDHT) =
+  ## Acquire one ``rpcSem`` slot until the enclosing scope exits. The slot is
+  ## released whether the scope exits normally, raises, or is cancelled.
   await kad.rpcSem.acquire()
-  try:
-    body
-  finally:
+  defer:
     try:
       kad.rpcSem.release()
     except AsyncSemaphoreError:

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -37,9 +37,10 @@ const
     ## upper bound on iterative-lookup shortlist
   DefaultMaxReceivedSize* = DefaultReplication
     ## upper bound on per-query ``ReceivedTable``
-  DefaultMaxValueSize* = MaxMsgSize
-    ## upper bound (bytes) on a stored record value; kept equal to MaxMsgSize
-    ## so that accepted values can always be transmitted in a single LP frame
+  DefaultMaxValueSize* = 3072
+    ## upper bound (bytes) on a stored record value. Held below ``MaxMsgSize``
+    ## (4096) to leave headroom for the protobuf overhead from other message
+    ## fields, so an accepted value still fits in a single LP frame.
   DefaultMaxConcurrentRpcs* = 100
     ## upper bound on in-flight outbound RPCs across find/get/put/provider
 
@@ -327,7 +328,8 @@ method select*(
 type KadDHTLimits* = object
   maxProvidersPerKey*: Opt[int]
     ## Maximum number of distinct providers stored per key.
-    ## ``Opt.none`` means unlimited; the default is ``DefaultMaxProvidersPerKey``.
+    ## ``Opt.none`` means unlimited; when limits are derived by the
+    ## ``KadDHTConfig`` constructor this defaults to ``replication``.
   maxShortlistSize*: int
     ## Maximum number of peers retained in an iterative-lookup shortlist.
     ## When exceeded, farther peers are dropped so the shortlist stays bounded.
@@ -341,11 +343,15 @@ type KadDHTLimits* = object
     ## Maximum number of in-flight outbound RPCs (find/get/put/provider)
     ## across the whole node. Excess calls wait on a shared semaphore.
 
-proc new*(T: typedesc[KadDHTLimits]): T {.raises: [].} =
+proc new*(T: typedesc[KadDHTLimits], replication: int, quorum: int): T {.raises: [].} =
+  ## Builds a limits object whose shortlist/received caps and providers-per-key
+  ## are sized off the actual ``replication`` and ``quorum`` so the configuration
+  ## stays internally consistent (e.g. ``maxShortlistSize >= replication``,
+  ## ``maxReceivedSize >= quorum``).
   T(
-    maxProvidersPerKey: Opt.some(DefaultMaxProvidersPerKey),
-    maxShortlistSize: DefaultMaxShortlistSize,
-    maxReceivedSize: DefaultMaxReceivedSize,
+    maxProvidersPerKey: Opt.some(replication),
+    maxShortlistSize: replication * 2,
+    maxReceivedSize: max(replication, quorum),
     maxValueSize: DefaultMaxValueSize,
     maxConcurrentRpcs: DefaultMaxConcurrentRpcs,
   )
@@ -399,14 +405,21 @@ proc new*(
     hideConnectionStatus: bool = true,
     disableBootstrapping: bool = false,
     providerRejection: bool = false,
-    limits: KadDHTLimits = KadDHTLimits.new(),
+    limits: Opt[KadDHTLimits] = Opt.none(KadDHTLimits),
 ): K {.raises: [].} =
-  doAssert limits.maxProvidersPerKey.isNone or limits.maxProvidersPerKey.get() > 0,
+  let actualLimits = limits.valueOr:
+    KadDHTLimits.new(replication, quorum)
+  doAssert actualLimits.maxProvidersPerKey.isNone or
+    actualLimits.maxProvidersPerKey.get() > 0,
     "maxProvidersPerKey must be > 0; use Opt.none(int) for unlimited"
-  doAssert limits.maxShortlistSize > 0, "maxShortlistSize must be > 0"
-  doAssert limits.maxReceivedSize > 0, "maxReceivedSize must be > 0"
-  doAssert limits.maxValueSize > 0, "maxValueSize must be > 0"
-  doAssert limits.maxConcurrentRpcs > 0, "maxConcurrentRpcs must be > 0"
+  doAssert actualLimits.maxShortlistSize > 0, "maxShortlistSize must be > 0"
+  doAssert actualLimits.maxReceivedSize > 0, "maxReceivedSize must be > 0"
+  doAssert actualLimits.maxValueSize > 0, "maxValueSize must be > 0"
+  doAssert actualLimits.maxConcurrentRpcs > 0, "maxConcurrentRpcs must be > 0"
+  doAssert actualLimits.maxShortlistSize >= replication,
+    "maxShortlistSize must be >= replication so the shortlist can hold the target k-bucket"
+  doAssert actualLimits.maxReceivedSize >= quorum,
+    "maxReceivedSize must be >= quorum so getValue can ever satisfy quorum"
   KadDHTConfig(
     validator: validator,
     selector: selector,
@@ -427,7 +440,7 @@ proc new*(
     hideConnectionStatus: hideConnectionStatus,
     disableBootstrapping: disableBootstrapping,
     providerRejection: providerRejection,
-    limits: limits,
+    limits: actualLimits,
   )
 
 type KadDHT* = ref object of LPProtocol

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -77,6 +77,7 @@ proc new*(
     config: config,
     providerManager:
       ProviderManager.new(config.providerRecordCapacity, config.providedKeyCapacity),
+    rpcSem: newAsyncSemaphore(config.limits.maxConcurrentRpcs),
     rtManager: ServiceRoutingTableManager.new(),
     clientMode: client,
     advertiser: Advertiser.new(),

--- a/tests/libp2p/kademlia/test_add_provider.nim
+++ b/tests/libp2p/kademlia/test_add_provider.nim
@@ -412,7 +412,7 @@ suite "KadDHT - ADD_PROVIDER Rejection":
     # kads[0] is sender, kads[1] is receiver with maxProvidersPerKey = 1
     let senderKad = setupKad(testKadConfig(providerRejection = true))
     var receiverConfig = testKadConfig(providerRejection = true)
-    receiverConfig.maxProvidersPerKey = Opt.some(1)
+    receiverConfig.limits.maxProvidersPerKey = Opt.some(1)
     let receiverKad = setupKad(receiverConfig)
 
     startAndDeferStop(@[senderKad, receiverKad])
@@ -444,7 +444,7 @@ suite "KadDHT - ADD_PROVIDER Rejection":
     # so a re-advertisement is not blocked by the per-key limit check.
     let senderKad = setupKad(testKadConfig(providerRejection = true))
     var receiverConfig = testKadConfig(providerRejection = true)
-    receiverConfig.maxProvidersPerKey = Opt.some(1)
+    receiverConfig.limits.maxProvidersPerKey = Opt.some(1)
     let receiverKad = setupKad(receiverConfig)
 
     startAndDeferStop(@[senderKad, receiverKad])
@@ -471,7 +471,7 @@ suite "KadDHT - ADD_PROVIDER Rejection":
     let senderKad = setupKad(testKadConfig(providerRejection = true))
 
     var closeConfig = testKadConfig(providerRejection = true)
-    closeConfig.maxProvidersPerKey = Opt.some(1)
+    closeConfig.limits.maxProvidersPerKey = Opt.some(1)
     let closeKad = setupKad(closeConfig)
 
     let farKad = setupKad(testKadConfig(providerRejection = true))
@@ -541,7 +541,7 @@ suite "KadDHT - ADD_PROVIDER Rejection":
     )
     var receiverConfig =
       testKadConfig(providerRejection = false, providerExpirationInterval = 30.seconds)
-    receiverConfig.maxProvidersPerKey = Opt.some(1)
+    receiverConfig.limits.maxProvidersPerKey = Opt.some(1)
     let receiverKad = setupKad(receiverConfig)
 
     startAndDeferStop(@[senderKad, receiverKad])
@@ -572,7 +572,7 @@ suite "KadDHT - ADD_PROVIDER Rejection":
   asyncTest "providerRejection=true: receiver enforces limit and rejects":
     let senderKad = setupKad(testKadConfig(providerRejection = true))
     var receiverConfig = testKadConfig(providerRejection = true)
-    receiverConfig.maxProvidersPerKey = Opt.some(1)
+    receiverConfig.limits.maxProvidersPerKey = Opt.some(1)
     let receiverKad = setupKad(receiverConfig)
 
     startAndDeferStop(@[senderKad, receiverKad])
@@ -600,7 +600,7 @@ suite "KadDHT - ADD_PROVIDER Rejection":
     # The sender stores the key and moves on regardless.
     let senderKad = setupKad(testKadConfig(providerRejection = false))
     var receiverConfig = testKadConfig(providerRejection = true)
-    receiverConfig.maxProvidersPerKey = Opt.some(1)
+    receiverConfig.limits.maxProvidersPerKey = Opt.some(1)
     let receiverKad = setupKad(receiverConfig)
 
     startAndDeferStop(@[senderKad, receiverKad])

--- a/tests/libp2p/kademlia/test_add_provider.nim
+++ b/tests/libp2p/kademlia/test_add_provider.nim
@@ -532,10 +532,10 @@ suite "KadDHT - ADD_PROVIDER Rejection":
       nodeA.providerManager.providerRecords.len == 1
       nodeB.providerManager.providerRecords.len == 1
 
-  asyncTest "providerRejection=false: receiver never sends rejection replies":
-    # A receiver with providerRejection=false (default) stores everything and
-    # never sends a reply, so the sender always sees accepted.
-    # Use a longer providerExpirationInterval so records survive the reply timeouts.
+  asyncTest "providerRejection=false: receiver enforces limit silently":
+    # The receiver enforces ``maxProvidersPerKey`` even with rejection disabled,
+    # but it does not send a rejection reply, so the sender treats the absence
+    # of a reply as accepted.
     let senderKad = setupKad(
       testKadConfig(providerRejection = true, providerExpirationInterval = 30.seconds)
     )
@@ -552,8 +552,8 @@ suite "KadDHT - ADD_PROVIDER Rejection":
     checkUntilTimeout:
       receiverKad.providerManager.providerRecords.len == 1
 
-    # Second sender: receiver has no rejection enabled, so it stores again and
-    # never replies → sender treats absence of reply as accepted.
+    # Second sender: receiver is at the per-key cap and drops the record
+    # silently (no reply).
     let sender2Kad = setupKad(
       testKadConfig(providerRejection = true, providerExpirationInterval = 30.seconds)
     )
@@ -563,11 +563,11 @@ suite "KadDHT - ADD_PROVIDER Rejection":
     let status =
       await sender2Kad.sendAddProviderAndGetStatus(receiverKad, key.toCid().toKey())
     check status.isOk()
-    # No rejection reply sent by receiver → treated as accepted by sender
+    # No reply sent by receiver → sender treats absence of reply as accepted
     check status.value() == AddProviderStatus.accepted
-    # Both providers stored (maxProvidersPerKey is ignored without rejection)
-    checkUntilTimeout:
-      receiverKad.providerManager.providerRecords.len == 2
+    # Limit enforced silently: still only one record at the receiver
+    await sleepAsync(200.milliseconds)
+    check receiverKad.providerManager.providerRecords.len == 1
 
   asyncTest "providerRejection=true: receiver enforces limit and rejects":
     let senderKad = setupKad(testKadConfig(providerRejection = true))

--- a/tests/libp2p/kademlia/test_add_provider.nim
+++ b/tests/libp2p/kademlia/test_add_provider.nim
@@ -565,8 +565,9 @@ suite "KadDHT - ADD_PROVIDER Rejection":
     check status.isOk()
     # No reply sent by receiver → sender treats absence of reply as accepted
     check status.value() == AddProviderStatus.accepted
-    # Limit enforced silently: still only one record at the receiver
-    await sleepAsync(200.milliseconds)
+    # Limit enforced silently: still only one record at the receiver.
+    # sendAddProviderAndGetStatus already waited for the reply timeout, so the
+    # receiver has finished processing by the time we reach this check.
     check receiverKad.providerManager.providerRecords.len == 1
 
   asyncTest "providerRejection=true: receiver enforces limit and rejects":

--- a/tests/libp2p/kademlia/test_limits.nim
+++ b/tests/libp2p/kademlia/test_limits.nim
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import chronos, chronicles, results, sequtils, sets, tables
+import ../../../libp2p/[protocols/kademlia, switch, builders]
+import ../../tools/[lifecycle, topology, unittest]
+import ./utils.nim
+
+trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
+
+suite "KadDHT - Limits":
+  teardown:
+    checkTrackers()
+
+  test "updateShortlist caps shortlist at maxShortlistSize":
+    let kad = setupKad()
+    kad.config.maxShortlistSize = 5
+
+    let targetKey = randomPeerId().toKey()
+    var state = LookupState.init(kad, targetKey)
+
+    # Generate 20 fresh peers and feed them through updateShortlist.
+    var peers: seq[Peer]
+    for i in 0 ..< 20:
+      peers.add(Peer(id: randomPeerId().toKey(), addrs: @[]))
+
+    let msg = Message(msgType: MessageType.findNode, closerPeers: peers)
+    discard state.updateShortlist(msg)
+
+    check state.shortlist.len <= kad.config.maxShortlistSize
+
+  test "updateShortlist prefers closer peers when over cap":
+    let kad = setupKad()
+    kad.config.maxShortlistSize = 3
+
+    # Use the no-op hasher so XOR distance is a function of the key bytes
+    # directly, making "close" peers easy to construct.
+    kad.rtable.config.hasher = Opt.some(noOpHasher)
+    var target: Key = newSeq[byte](32)
+    var state = LookupState.init(kad, target)
+    # Drop any peers pre-seeded from the routing table.
+    state.shortlist.clear()
+
+    # Insert a far peer first
+    var farId: Key = newSeq[byte](32)
+    farId[0] = 0xFF
+    let farMsg = Message(
+      msgType: MessageType.findNode, closerPeers: @[Peer(id: farId, addrs: @[])]
+    )
+    discard state.updateShortlist(farMsg)
+
+    # Now insert 5 close peers — they should evict the far one
+    var closePeers: seq[Peer]
+    for i in 1 .. 5:
+      var id: Key = newSeq[byte](32)
+      id[31] = byte(i)
+      closePeers.add(Peer(id: id, addrs: @[]))
+    let closeMsg = Message(msgType: MessageType.findNode, closerPeers: closePeers)
+    discard state.updateShortlist(closeMsg)
+
+    check state.shortlist.len == kad.config.maxShortlistSize
+
+  asyncTest "putValue rejects values larger than maxValueSize":
+    let kads = setupKadSwitches(2)
+    startAndDeferStop(kads)
+    await connect(kads[0], kads[1])
+
+    kads[1].config.maxValueSize = 16
+
+    let key = kads[0].rtable.selfId
+    let big = newSeq[byte](32)
+    let res = await kads[1].putValue(key, big)
+
+    check:
+      res.isErr()
+      kads[0].dataTable.len == 0
+      kads[1].dataTable.len == 0
+
+  asyncTest "handlePutValue drops records exceeding maxValueSize":
+    let kads = setupKadSwitches(2)
+    startAndDeferStop(kads)
+    await connect(kads[0], kads[1])
+
+    # Lower the receiver's cap so the sender's normal-size put is rejected
+    # on the wire even though the sender accepts it locally.
+    kads[0].config.maxValueSize = 8
+    kads[1].config.maxValueSize = 1024
+
+    let key = kads[0].rtable.selfId
+    let value = newSeq[byte](64)
+    discard await kads[1].putValue(key, value)
+
+    # Sender stores locally (under its own cap); receiver drops the wire copy.
+    await sleepAsync(200.milliseconds)
+    check:
+      kads[1].containsData(key, value)
+      kads[0].containsNoData(key)
+
+  asyncTest "getValue caps ReceivedTable at maxReceivedSize":
+    let kads = setupKadSwitches(4)
+    startAndDeferStop(kads)
+    await connectStar(kads)
+
+    let key = kads[0].rtable.selfId
+    let value = @[1.byte, 2, 3]
+
+    # Seed every other node with the key/value
+    for i in 1 ..< 4:
+      discard await kads[i].putValue(key, value)
+
+    # Cap kads[0]'s ReceivedTable below the available peers
+    kads[0].config.maxReceivedSize = 1
+    let res = await kads[0].getValue(key, quorumOverride = Opt.some(1))
+
+    check res.isOk()
+    check res.value().value == value
+
+  asyncTest "rpcSem bounds concurrent in-flight RPCs":
+    # With a 1-slot semaphore the second concurrent dispatchFindNode is forced
+    # to wait until the first releases — easy to observe by checking that the
+    # semaphore count never goes negative and reaches 0 mid-flight.
+    let kads = setupKadSwitches(2)
+    startAndDeferStop(kads)
+    await connect(kads[0], kads[1])
+
+    # Replace the semaphore with a 1-slot one; the helper template uses kad.rpcSem.
+    kads[0].rpcSem = newAsyncSemaphore(1)
+
+    let target = kads[1].rtable.selfId
+    let f1 = kads[0].dispatchFindNode(kads[1].switch.peerInfo.peerId, target)
+    let f2 = kads[0].dispatchFindNode(kads[1].switch.peerInfo.peerId, target)
+    await allFutures(f1, f2)
+    check:
+      f1.read().isOk()
+      f2.read().isOk()

--- a/tests/libp2p/kademlia/test_limits.nim
+++ b/tests/libp2p/kademlia/test_limits.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import chronos, chronicles, results, sequtils, sets, tables
+import chronos, chronicles, results, tables
 import ../../../libp2p/[protocols/kademlia, switch, builders]
 import ../../tools/[lifecycle, topology, unittest]
 import ./utils.nim
@@ -16,7 +16,7 @@ suite "KadDHT - Limits":
 
   test "updateShortlist caps shortlist at maxShortlistSize":
     let kad = setupKad()
-    kad.config.maxShortlistSize = 5
+    kad.config.limits.maxShortlistSize = 5
 
     let targetKey = randomPeerId().toKey()
     var state = LookupState.init(kad, targetKey)
@@ -29,11 +29,11 @@ suite "KadDHT - Limits":
     let msg = Message(msgType: MessageType.findNode, closerPeers: peers)
     discard state.updateShortlist(msg)
 
-    check state.shortlist.len <= kad.config.maxShortlistSize
+    check state.shortlist.len <= kad.config.limits.maxShortlistSize
 
   test "updateShortlist prefers closer peers when over cap":
     let kad = setupKad()
-    kad.config.maxShortlistSize = 3
+    kad.config.limits.maxShortlistSize = 3
 
     # Use the no-op hasher so XOR distance is a function of the key bytes
     # directly, making "close" peers easy to construct.
@@ -60,14 +60,14 @@ suite "KadDHT - Limits":
     let closeMsg = Message(msgType: MessageType.findNode, closerPeers: closePeers)
     discard state.updateShortlist(closeMsg)
 
-    check state.shortlist.len == kad.config.maxShortlistSize
+    check state.shortlist.len == kad.config.limits.maxShortlistSize
 
   asyncTest "putValue rejects values larger than maxValueSize":
     let kads = setupKadSwitches(2)
     startAndDeferStop(kads)
     await connect(kads[0], kads[1])
 
-    kads[1].config.maxValueSize = 16
+    kads[1].config.limits.maxValueSize = 16
 
     let key = kads[0].rtable.selfId
     let big = newSeq[byte](32)
@@ -85,8 +85,8 @@ suite "KadDHT - Limits":
 
     # Lower the receiver's cap so the sender's normal-size put is rejected
     # on the wire even though the sender accepts it locally.
-    kads[0].config.maxValueSize = 8
-    kads[1].config.maxValueSize = 1024
+    kads[0].config.limits.maxValueSize = 8
+    kads[1].config.limits.maxValueSize = 1024
 
     let key = kads[0].rtable.selfId
     let value = newSeq[byte](64)
@@ -111,7 +111,7 @@ suite "KadDHT - Limits":
       discard await kads[i].putValue(key, value)
 
     # Cap kads[0]'s ReceivedTable below the available peers
-    kads[0].config.maxReceivedSize = 1
+    kads[0].config.limits.maxReceivedSize = 1
     let res = await kads[0].getValue(key, quorumOverride = Opt.some(1))
 
     check res.isOk()

--- a/tests/libp2p/kademlia/test_limits.nim
+++ b/tests/libp2p/kademlia/test_limits.nim
@@ -8,7 +8,7 @@ import ../../../libp2p/[protocols/kademlia, switch, builders]
 import ../../tools/[lifecycle, topology, unittest]
 import ./utils.nim
 
-trace "chronicles has to be imported to fix Error: undeclared identifier: 'activeChroniclesStream'"
+# chronicles must be imported to avoid "undeclared identifier: 'activeChroniclesStream'"
 
 suite "KadDHT - Limits":
   teardown:
@@ -93,7 +93,8 @@ suite "KadDHT - Limits":
     discard await kads[1].putValue(key, value)
 
     # Sender stores locally (under its own cap); receiver drops the wire copy.
-    await sleepAsync(200.milliseconds)
+    # putValue awaited the full RPC batch, so the receiver has already processed
+    # (and dropped) the message by the time we reach this check.
     check:
       kads[1].containsData(key, value)
       kads[0].containsNoData(key)
@@ -118,9 +119,9 @@ suite "KadDHT - Limits":
     check res.value().value == value
 
   asyncTest "rpcSem bounds concurrent in-flight RPCs":
-    # With a 1-slot semaphore the second concurrent dispatchFindNode is forced
-    # to wait until the first releases — easy to observe by checking that the
-    # semaphore count never goes negative and reaches 0 mid-flight.
+    # With a 1-slot semaphore the second concurrent dispatchFindNode must wait
+    # for the first to release before it can start. We verify this by checking
+    # availableSlots mid-flight (should be 0) and after completion (should be 1).
     let kads = setupKadSwitches(2)
     startAndDeferStop(kads)
     await connect(kads[0], kads[1])
@@ -131,7 +132,12 @@ suite "KadDHT - Limits":
     let target = kads[1].rtable.selfId
     let f1 = kads[0].dispatchFindNode(kads[1].switch.peerInfo.peerId, target)
     let f2 = kads[0].dispatchFindNode(kads[1].switch.peerInfo.peerId, target)
+    # Yield so both coroutines get a chance to start; with a 1-slot semaphore
+    # f1 holds the slot (suspended in dial) while f2 is blocked on acquire.
+    await sleepAsync(0)
+    check kads[0].rpcSem.availableSlots == 0
     await allFutures(f1, f2)
     check:
+      kads[0].rpcSem.availableSlots == 1
       f1.read().isOk()
       f2.read().isOk()


### PR DESCRIPTION
## Summary

Adds configurable upper bounds to several Kademlia DHT data structures that
previously could grow without limit (#1851).

### Bounded Structures

* `provider.nim`

  * Per-key provider sets (`knownKeys[k]`) are now bounded by
    `maxProvidersPerKey` regardless of `providerRejection`.
  * With `providerRejection = true`, the receiver still replies with a status.
  * With `providerRejection = false`, over-cap advertisements are silently
    dropped.

* `find.nim`

  * `LookupState.shortlist` is now bounded by `maxShortlistSize`.
  * When at capacity:

    * the farthest unresponded peer is evicted only if the incoming peer is
      closer
    * responded peers are preserved so their results remain usable

* `get.nim`

  * The per-query `ReceivedTable` stops accepting new peers after reaching
    `maxReceivedSize`.

* `put.nim` / `get.nim`

  * Both the `putValue` API and inbound PUT/GET handlers now reject records
    whose value exceeds `maxValueSize`.

* `kademlia.nim`

  * All outbound RPC dispatchers now share a global
    `AsyncSemaphore` bounded by `maxConcurrentRpcs`.
  * Enforcement is implemented through a new `withRpcSlot` template.

### Dispatcher Changes

The following procedures were changed from `Switch` receivers to `KadDHT`
receivers so they can access the shared semaphore:

* `dispatchPutVal`
* `dispatchAddProvider`

## Affected Areas

* [x] Protocol Logic — Kademlia DHT

  * provider records
  * iterative lookup
  * GET / PUT / ADD_PROVIDER RPCs

## Compatibility & Downstream Validation

This is a pure addition of bounded defaults:

* no wire-format changes
* no new required configuration

All existing tests in `tests/libp2p/kademlia/` pass (125 total).

One test was updated to reflect the new always-enforced provider cap:

```text
providerRejection=false: receiver never sends rejection replies
```

## Impact on Library Users

### API Changes

`KadDHTConfig` gains five new optional configuration fields:

* `maxShortlistSize`
* `maxReceivedSize`
* `maxValueSize`
* `maxConcurrentRpcs`
* `maxProvidersPerKey`

  * existing field
  * default changed from `Opt.none` to `Opt.some(20)`

All new fields have defaults, so callers using:

```nim
KadDHTConfig.new()
```

require no migration.

### Behavioral Changes

With default configuration, nodes now enforce:

* maximum of 20 providers per key
* maximum shortlist size of 40 peers
* maximum `ReceivedTable` size of 20 entries
* maximum record value size of 8 KiB
* maximum of 100 concurrent in-flight RPCs

Additionally:

* `dispatchPutVal`
* `dispatchAddProvider`

now have source-incompatible signatures for any external caller invoking them
directly outside the `kademlia` module (none exist in-tree).

## Risk Assessment

* The new defaults are intentionally generous (at or above replication factor),
  so well-behaved nodes should not hit these limits during normal operation.

* Over-cap inbound RPCs are:

  * silently dropped, or
  * rejected with a status reply when `providerRejection` is enabled

  No on-wire error-code changes are introduced.

* The shared RPC semaphore introduces minor self-throttling during bursty
  lookup activity.

  With:

```text
maxConcurrentRpcs = 100
alpha = 10
```

roughly 10 concurrent lookup operations can proceed without contention.

## References

* Closes #1851
