### PR TITLE
fix(hpservice): replace delay with identified event

### DIFF
--- a/libp2p/services/hpservice.nim
+++ b/libp2p/services/hpservice.nim
@@ -42,7 +42,6 @@ proc tryStartingDirectConn(
     debug "Direct connection created."
     return true
 
-  await sleepAsync(500.milliseconds) # wait for AddressBook to be populated
   for address in switch.peerStore[AddressBook][peerId]:
     try:
       let isRelayed = address.contains(multiCodec("p2p-circuit"))
@@ -113,7 +112,7 @@ method setup*(self: HPService, switch: Switch) {.raises: [ServiceSetupError].} =
     await newConnectedPeerHandler(self, switch, peerId, event)
 
   switch.connManager.addPeerEventHandler(
-    self.newConnectedPeerHandler, PeerEventKind.Joined
+    self.newConnectedPeerHandler, PeerEventKind.Identified
   )
 
   self.onNewStatusHandler = proc(
@@ -139,5 +138,5 @@ method stop*(self: HPService, switch: Switch) {.async: (raises: [CancelledError]
   await self.autonatService.stop(switch)
   if not isNil(self.newConnectedPeerHandler):
     switch.connManager.removePeerEventHandler(
-      self.newConnectedPeerHandler, PeerEventKind.Joined
+      self.newConnectedPeerHandler, PeerEventKind.Identified
     )


### PR DESCRIPTION
## Summary
Replaces HPService's fixed `500ms` AddressBook wait with the connection manager's `Identified` peer event.

This makes HPService attempt direct-dial upgrades after the identify phase has run, avoiding a timing guess for peers whose dialable addresses are learned from Identify.

## Affected Areas
- [x] Peer Management / Discovery
- [x] Protocol Logic

## Impact on Library Users
No API changes. Hole punching now reacts to the peer identification event before checking stored peer addresses for direct-dial upgrades.

## Risk Assessment
Low behavioral risk. Peers that do not provide usable Identify addresses, or whose addresses are filtered out, can still leave the AddressBook empty; this change removes the fixed delay but does not guarantee address availability.
