### PR TITLE
fix(hpservice): stop autorelay with hole punching service

### DIFF
--- a/libp2p/services/hpservice.nim
+++ b/libp2p/services/hpservice.nim
@@ -137,6 +137,8 @@ method start*(self: HPService, switch: Switch) {.async: (raises: [CancelledError
 
 method stop*(self: HPService, switch: Switch) {.async: (raises: [CancelledError]).} =
   await self.autonatService.stop(switch)
+  if self.autoRelayService.isRunning():
+    await self.autoRelayService.stop(switch)
   if not isNil(self.newConnectedPeerHandler):
     switch.connManager.removePeerEventHandler(
       self.newConnectedPeerHandler, PeerEventKind.Joined


### PR DESCRIPTION
## Summary
Ensures HPService stops AutoRelay when hole punching is stopped.

HPService starts AutoRelay from the AutoNAT reachability callback when the node is not reachable. Since AutoRelay is owned and managed through HPService in the hole punching setup, HPService should also stop it during service shutdown.

## Affected Areas
- [x] Peer Management / Discovery
- [x] Protocol Logic

## Impact on Library Users
No API changes. Stopping HPService now also stops any AutoRelay runner and address mapper started by HPService.

## Risk Assessment
Low risk. The stop path checks whether AutoRelay is running before stopping it, and AutoRelay's stop operation is already idempotent.
