### PR TITLE
fix(service-disco): multi service ads caching

### DIFF
--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -55,6 +55,19 @@ proc removeAd*(ipTree: IpTree, ad: Advertisement) {.raises: [].} =
 proc isExpired(now, ts: Moment, expiry: Duration): bool {.inline.} =
   now - ts > expiry
 
+proc hasAdReference(
+    registrar: Registrar, key: AdvertisementKey, excludeSid: ServiceId = default(ServiceId)
+): bool {.raises: [].} =
+  ## Returns true if the ad key is still present in any service's cache list
+  ## (optionally ignoring one service, e.g. the one currently being pruned).
+  for sid, sads in registrar.cache:
+    if sid == excludeSid:
+      continue
+    for a in sads:
+      if a.toAdvertisementKey() == key:
+        return true
+  false
+
 proc pruneAdsForService(
     registrar: Registrar,
     serviceId: ServiceId,
@@ -67,14 +80,22 @@ proc pruneAdsForService(
   while i < ads.len:
     let ad = ads[i]
     let key = ad.toAdvertisementKey()
+    var doDelete = false
     registrar.cacheTimestamps.withValue(key, ts):
       if isExpired(now, ts[], advertExpiry):
+        doDelete = true
+    do:
+      # key not present -> orphan, delete from list
+      doDelete = true
+    if doDelete:
+      ads.delete(i)
+      if not hasAdReference(registrar, key, excludeSid = serviceId):
         registrar.ipTree.removeAd(ad)
-        registrar.cacheTimestamps.del(key)
-        ads.delete(i)
+        if key in registrar.cacheTimestamps:
+          registrar.cacheTimestamps.del(key)
         inc(expiredCount)
-      else:
-        inc(i)
+    else:
+      inc(i)
 
 proc pruneEmptyServices(registrar: Registrar) =
   var toRemove: seq[ServiceId] = @[]
@@ -312,30 +333,50 @@ proc findOldestKey(disco: ServiceDiscovery): Opt[AdvertisementKey] =
 proc evictOldestAd*(
     disco: ServiceDiscovery, serviceId: ServiceId, ads: var seq[Advertisement]
 ) =
+  ## Evict the globally oldest advertisement. Removes it from *all* service
+  ## caches that reference it (supporting multi-service ads), then drops global
+  ## ts/ip tracking.
   let oldestKey = disco.findOldestKey().valueOr:
     return
 
-  var emptiedSid: ServiceId
-  var sidBecameEmpty = false
+  # Capture the ad object before mutating lists
+  var oldestAd: Advertisement
+  var found = false
+  for sads in disco.registrar.cache.values:
+    for a in sads:
+      if a.toAdvertisementKey() == oldestKey:
+        oldestAd = a
+        found = true
+        break
+    if found:
+      break
+  if not found:
+    # Stale ts entry with no list refs; just drop it
+    disco.registrar.cacheTimestamps.del(oldestKey)
+    return
 
-  block search:
-    for sid, sads in disco.registrar.cache.mpairs:
-      for i in 0 ..< sads.len:
-        if sads[i].toAdvertisementKey() == oldestKey:
-          disco.registrar.ipTree.removeAd(sads[i])
-          disco.registrar.cacheTimestamps.del(oldestKey)
-          sads.delete(i)
+  # Remove from every service list that has it
+  var emptiedSids: seq[ServiceId] = @[]
+  for sid, sads in disco.registrar.cache.mpairs:
+    var i = 0
+    var removedHere = false
+    while i < sads.len:
+      if sads[i].toAdvertisementKey() == oldestKey:
+        sads.delete(i)
+        removedHere = true
+      else:
+        inc(i)
+    if removedHere and sads.len == 0:
+      emptiedSids.add(sid)
+    if sid == serviceId and removedHere:
+      ads = sads
 
-          if sid == serviceId:
-            ads = sads
-          elif sads.len == 0:
-            emptiedSid = sid
-            sidBecameEmpty = true
+  for sid in emptiedSids:
+    disco.registrar.cache.del(sid)
 
-          break search
-
-  if sidBecameEmpty:
-    disco.registrar.cache.del(emptiedSid)
+  # Global cleanup (once)
+  disco.registrar.ipTree.removeAd(oldestAd)
+  disco.registrar.cacheTimestamps.del(oldestKey)
 
 proc updateExistingAd*(
     registrar: Registrar,
@@ -381,25 +422,77 @@ proc insertNewAd*(
   return true
 
 proc acceptAdvertisement*(
-    disco: ServiceDiscovery, now: Moment, serviceId: ServiceId, ad: Advertisement
+    disco: ServiceDiscovery, now: Moment, ad: Advertisement
 ) =
-  discard disco.rtManager.addService(
-    serviceId, disco.rtable, disco.config.replication, disco.discoConfig.bucketsCount,
-    Interest,
-  )
-  disco.rtManager.insertPeer(serviceId, ad.data.peerId.toKey())
+  let claimedServices = ad.advertisedServices()
 
-  var ads = disco.registrar.cache.getOrDefault(serviceId)
+  # Ensure routing tables + peer presence for every service the ad claims
+  for sid in claimedServices:
+    discard disco.rtManager.addService(
+      sid, disco.rtable, disco.config.replication, disco.discoConfig.bucketsCount,
+      Interest,
+    )
+    disco.rtManager.insertPeer(sid, ad.data.peerId.toKey())
 
-  var shouldUpdateMetrics: bool
-  let idxOpt = findAdIdx(ads, ad.data.peerId)
-  shouldUpdateMetrics =
+  # If this is a newer seqNo for the peer, drop all older versions of its ads
+  # (from any services) so the new ad can be attached cleanly under its claimed services.
+  var shouldUpdateMetrics = false
+  let peerId = ad.data.peerId
+  block removeOlder:
+    for sid, sads in disco.registrar.cache.mpairs:
+      var i = 0
+      while i < sads.len:
+        let ex = sads[i]
+        if ex.data.peerId == peerId and ex.data.seqNo < ad.data.seqNo:
+          let exKey = ex.toAdvertisementKey()
+          sads.delete(i)
+          if exKey in disco.registrar.cacheTimestamps:
+            disco.registrar.ipTree.removeAd(ex)
+            disco.registrar.cacheTimestamps.del(exKey)
+          shouldUpdateMetrics = true
+        else:
+          inc(i)
+
+  if shouldUpdateMetrics:
+    pruneEmptyServices(disco.registrar)
+
+  # Now attach (or refresh) this ad under all services it claims.
+  # The global ts/ip is created only once; additional services just get a reference.
+  let adKey = ad.toAdvertisementKey()
+  for sid in claimedServices:
+    var ads = disco.registrar.cache.getOrDefault(sid)
+    let idxOpt = findAdIdx(ads, peerId)
+
     if idxOpt.isSome():
-      disco.registrar.updateExistingAd(ads, idxOpt.get(), ad, now)
+      let existing = ads[idxOpt.get()]
+      if existing.data.seqNo == ad.data.seqNo:
+        disco.registrar.cacheTimestamps[adKey] = now
+      elif ad.data.seqNo > existing.data.seqNo:
+        # Higher arrived after pre-clean (e.g. concurrent); replace here
+        disco.registrar.ipTree.removeAd(existing)
+        disco.registrar.cacheTimestamps.del(existing.toAdvertisementKey())
+        ads[idxOpt.get()] = ad
+        disco.registrar.cacheTimestamps[adKey] = now
+        disco.registrar.ipTree.insertAd(ad)
+        shouldUpdateMetrics = true
+      # lower or equal handled; stale ignored
+      disco.registrar.cache[sid] = ads
     else:
-      disco.insertNewAd(serviceId, ads, ad, now)
-
-  disco.registrar.cache[serviceId] = ads
+      if adKey in disco.registrar.cacheTimestamps:
+        # Already live under other service(s) - just reference it here too
+        ads.add(ad)
+        disco.registrar.cache[sid] = ads
+        disco.registrar.cacheTimestamps[adKey] = now
+        shouldUpdateMetrics = true
+      else:
+        # Brand new advertisement
+        if disco.registrar.cacheTimestamps.len.uint64 >= disco.discoConfig.advertCacheCap:
+          evictOldestAd(disco, sid, ads)
+        ads.add(ad)
+        disco.registrar.cacheTimestamps[adKey] = now
+        disco.registrar.ipTree.insertAd(ad)
+        disco.registrar.cache[sid] = ads
+        shouldUpdateMetrics = true
 
   if shouldUpdateMetrics:
     disco.registrar.updateRegistrarMetrics()
@@ -467,7 +560,7 @@ proc registration*(disco: ServiceDiscovery, peerId: PeerId, inMsg: Message): Mes
   tWait = disco.processRetryTicket(regMsg, ad, tWait)
 
   if tWait <= ZeroDuration:
-    disco.acceptAdvertisement(now, serviceId, ad)
+    disco.acceptAdvertisement(now, ad)
 
     msg.register.get().status.get() = kademlia_protobuf.RegistrationStatus.Confirmed
 

--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -78,26 +78,27 @@ proc pruneAdsForService(
     advertExpiry: Duration,
     expiredCount: var int,
 ) =
-  var i = 0
-  while i < ads.len:
-    let ad = ads[i]
-    let key = ad.toAdvertisementKey()
-    var doDelete = false
+  var writeIdx = 0
+  for readIdx in 0 ..< ads.len:
+    let
+      ad = ads[readIdx]
+      key = ad.toAdvertisementKey()
+
+    # Absent key counts as an orphan, so default to expired.
+    var expired = true
     registrar.cacheTimestamps.withValue(key, ts):
-      if isExpired(now, ts[], advertExpiry):
-        doDelete = true
-    do:
-      # key not present -> orphan, delete from list
-      doDelete = true
-    if doDelete:
-      ads.delete(i)
+      expired = isExpired(now, ts[], advertExpiry)
+
+    if expired:
       if not hasAdReference(registrar, key, excludeSid = serviceId):
         registrar.ipTree.removeAd(ad)
-        if key in registrar.cacheTimestamps:
-          registrar.cacheTimestamps.del(key)
-        inc(expiredCount)
+        registrar.cacheTimestamps.del(key)
+        inc expiredCount
     else:
-      inc(i)
+      ads[writeIdx] = ad
+      inc writeIdx
+
+  ads.setLen(writeIdx)
 
 proc pruneEmptyServices(registrar: Registrar) =
   var toRemove: seq[ServiceId] = @[]
@@ -332,51 +333,47 @@ proc findOldestKey(disco: ServiceDiscovery): Opt[AdvertisementKey] =
 
   return Opt.some(oldestKey)
 
+func findAd(registrar: Registrar, key: AdvertisementKey): Opt[Advertisement] =
+  for sads in registrar.cache.values:
+    for a in sads:
+      if a.toAdvertisementKey() == key:
+        return Opt.some(a)
+  Opt.none(Advertisement)
+
+proc removeAdFromLists(registrar: Registrar, key: AdvertisementKey): seq[ServiceId] =
+  var emptiedSids: seq[ServiceId]
+  for sid, sads in registrar.cache.mpairs:
+    var
+      writeIdx = 0
+      removedHere = false
+    for readIdx in 0 ..< sads.len:
+      if sads[readIdx].toAdvertisementKey() == key:
+        removedHere = true
+      else:
+        sads[writeIdx] = sads[readIdx]
+        inc writeIdx
+    if removedHere:
+      sads.setLen(writeIdx)
+      if sads.len == 0:
+        emptiedSids.add(sid)
+  emptiedSids
+
 proc evictOldestAd*(
     disco: ServiceDiscovery, serviceId: ServiceId, ads: var seq[Advertisement]
 ) =
-  ## Evict the globally oldest advertisement. Removes it from *all* service
-  ## caches that reference it (supporting multi-service ads), then drops global
-  ## ts/ip tracking.
   let oldestKey = disco.findOldestKey().valueOr:
     return
 
-  # Capture the ad object before mutating lists
-  var oldestAd: Advertisement
-  var found = false
-  for sads in disco.registrar.cache.values:
-    for a in sads:
-      if a.toAdvertisementKey() == oldestKey:
-        oldestAd = a
-        found = true
-        break
-    if found:
-      break
-  if not found:
+  let oldestAd = disco.registrar.findAd(oldestKey).valueOr:
     # Stale ts entry with no list refs; just drop it
     disco.registrar.cacheTimestamps.del(oldestKey)
     return
 
-  # Remove from every service list that has it
-  var emptiedSids: seq[ServiceId] = @[]
-  for sid, sads in disco.registrar.cache.mpairs:
-    var i = 0
-    var removedHere = false
-    while i < sads.len:
-      if sads[i].toAdvertisementKey() == oldestKey:
-        sads.delete(i)
-        removedHere = true
-      else:
-        inc(i)
-    if removedHere and sads.len == 0:
-      emptiedSids.add(sid)
-    if sid == serviceId and removedHere:
-      ads = sads
+  let emptiedSids = disco.registrar.removeAdFromLists(oldestKey)
 
   for sid in emptiedSids:
     disco.registrar.cache.del(sid)
 
-  # Global cleanup (once)
   disco.registrar.ipTree.removeAd(oldestAd)
   disco.registrar.cacheTimestamps.del(oldestKey)
 
@@ -387,11 +384,6 @@ proc updateExistingAd*(
     ad: Advertisement,
     now: Moment,
 ): bool =
-  ## Update an advertisement that already exists in the cache for this peer.
-  ## - Same seqNo: refreshes the timestamp (no structural change).
-  ## - Higher seqNo: replaces the old entry in the cache and IP tree.
-  ## - Lower seqNo: stale update, ignored.
-  ## Returns true when the cache changed and metrics should be refreshed.
   let existing = ads[idx]
   if existing.data.seqNo == ad.data.seqNo:
     registrar.cacheTimestamps[existing.toAdvertisementKey()] = now
@@ -413,9 +405,6 @@ proc insertNewAd*(
     ad: Advertisement,
     now: Moment,
 ): bool =
-  ## Insert a brand-new advertisement into the cache.
-  ## Evicts the globally oldest entry first if the cache is at capacity.
-  ## Returns true (a new insertion always warrants a metrics update).
   if disco.registrar.cacheTimestamps.len.uint64 >= disco.discoConfig.advertCacheCap:
     evictOldestAd(disco, serviceId, ads)
   ads.add(ad)
@@ -423,10 +412,84 @@ proc insertNewAd*(
   disco.registrar.ipTree.insertAd(ad)
   return true
 
+proc removeOlderAdsForPeer(
+    registrar: Registrar, peerId: PeerId, newSeqNo: uint64
+): bool {.raises: [].} =
+  var removedAny = false
+  for sid, sads in registrar.cache.mpairs:
+    var i = 0
+    while i < sads.len:
+      let ex = sads[i]
+      if ex.data.peerId == peerId and ex.data.seqNo < newSeqNo:
+        let exKey = ex.toAdvertisementKey()
+        sads.delete(i)
+        if exKey in registrar.cacheTimestamps:
+          registrar.ipTree.removeAd(ex)
+          registrar.cacheTimestamps.del(exKey)
+        removedAny = true
+      else:
+        inc(i)
+  removedAny
+
+proc upsertAdvertisementForService(
+    disco: ServiceDiscovery,
+    serviceId: ServiceId,
+    ad: Advertisement,
+    now: Moment,
+    adKey: AdvertisementKey,
+    peerId: PeerId,
+    shouldUpdateMetrics: var bool,
+) {.raises: [].} =
+  var ads = disco.registrar.cache.getOrDefault(serviceId)
+  let idxOpt = findAdIdx(ads, peerId)
+
+  if idxOpt.isSome():
+    let existing = ads[idxOpt.get()]
+    if existing.data.seqNo == ad.data.seqNo:
+      var replaced = false
+      if ad.data.services.len > existing.data.services.len:
+        ads[idxOpt.get()] = ad
+        replaced = true
+      elif ad.data.services.len == existing.data.services.len and
+          ad.data.services != existing.data.services:
+        ads[idxOpt.get()] = ad
+        replaced = true
+      if replaced:
+        disco.registrar.cache[serviceId] = ads
+      disco.registrar.cacheTimestamps[adKey] = now
+    elif ad.data.seqNo > existing.data.seqNo:
+      # Higher seqNo wins for this service.
+      disco.registrar.ipTree.removeAd(existing)
+      disco.registrar.cacheTimestamps.del(existing.toAdvertisementKey())
+      ads[idxOpt.get()] = ad
+      disco.registrar.cacheTimestamps[adKey] = now
+      disco.registrar.ipTree.insertAd(ad)
+      disco.registrar.cache[serviceId] = ads
+      shouldUpdateMetrics = true
+    else:
+      # Stale (lower seqNo). Keep whatever we already have.
+      disco.registrar.cache[serviceId] = ads
+  else:
+    if adKey in disco.registrar.cacheTimestamps:
+      # This ad (by key) is already live under some other service(s).
+      # Just add a reference for this service as well.
+      ads.add(ad)
+      disco.registrar.cache[serviceId] = ads
+      disco.registrar.cacheTimestamps[adKey] = now
+      shouldUpdateMetrics = true
+    else:
+      # Truly new advertisement globally.
+      if disco.registrar.cacheTimestamps.len.uint64 >= disco.discoConfig.advertCacheCap:
+        evictOldestAd(disco, serviceId, ads)
+      ads.add(ad)
+      disco.registrar.cacheTimestamps[adKey] = now
+      disco.registrar.ipTree.insertAd(ad)
+      disco.registrar.cache[serviceId] = ads
+      shouldUpdateMetrics = true
+
 proc acceptAdvertisement*(disco: ServiceDiscovery, now: Moment, ad: Advertisement) =
   let claimedServices = ad.advertisedServices()
 
-  # Ensure routing tables + peer presence for every service the ad claims
   for sid in claimedServices:
     discard disco.rtManager.addService(
       sid, disco.rtable, disco.config.replication, disco.discoConfig.bucketsCount,
@@ -434,65 +497,18 @@ proc acceptAdvertisement*(disco: ServiceDiscovery, now: Moment, ad: Advertisemen
     )
     disco.rtManager.insertPeer(sid, ad.data.peerId.toKey())
 
-  # If this is a newer seqNo for the peer, drop all older versions of its ads
-  # (from any services) so the new ad can be attached cleanly under its claimed services.
   var shouldUpdateMetrics = false
   let peerId = ad.data.peerId
-  block removeOlder:
-    for sid, sads in disco.registrar.cache.mpairs:
-      var i = 0
-      while i < sads.len:
-        let ex = sads[i]
-        if ex.data.peerId == peerId and ex.data.seqNo < ad.data.seqNo:
-          let exKey = ex.toAdvertisementKey()
-          sads.delete(i)
-          if exKey in disco.registrar.cacheTimestamps:
-            disco.registrar.ipTree.removeAd(ex)
-            disco.registrar.cacheTimestamps.del(exKey)
-          shouldUpdateMetrics = true
-        else:
-          inc(i)
 
-  if shouldUpdateMetrics:
+  if removeOlderAdsForPeer(disco.registrar, peerId, ad.data.seqNo):
     pruneEmptyServices(disco.registrar)
+    shouldUpdateMetrics = true
 
-  # Now attach (or refresh) this ad under all services it claims.
-  # The global ts/ip is created only once; additional services just get a reference.
   let adKey = ad.toAdvertisementKey()
   for sid in claimedServices:
-    var ads = disco.registrar.cache.getOrDefault(sid)
-    let idxOpt = findAdIdx(ads, peerId)
-
-    if idxOpt.isSome():
-      let existing = ads[idxOpt.get()]
-      if existing.data.seqNo == ad.data.seqNo:
-        disco.registrar.cacheTimestamps[adKey] = now
-      elif ad.data.seqNo > existing.data.seqNo:
-        # Higher arrived after pre-clean (e.g. concurrent); replace here
-        disco.registrar.ipTree.removeAd(existing)
-        disco.registrar.cacheTimestamps.del(existing.toAdvertisementKey())
-        ads[idxOpt.get()] = ad
-        disco.registrar.cacheTimestamps[adKey] = now
-        disco.registrar.ipTree.insertAd(ad)
-        shouldUpdateMetrics = true
-      # lower or equal handled; stale ignored
-      disco.registrar.cache[sid] = ads
-    else:
-      if adKey in disco.registrar.cacheTimestamps:
-        # Already live under other service(s) - just reference it here too
-        ads.add(ad)
-        disco.registrar.cache[sid] = ads
-        disco.registrar.cacheTimestamps[adKey] = now
-        shouldUpdateMetrics = true
-      else:
-        # Brand new advertisement
-        if disco.registrar.cacheTimestamps.len.uint64 >= disco.discoConfig.advertCacheCap:
-          evictOldestAd(disco, sid, ads)
-        ads.add(ad)
-        disco.registrar.cacheTimestamps[adKey] = now
-        disco.registrar.ipTree.insertAd(ad)
-        disco.registrar.cache[sid] = ads
-        shouldUpdateMetrics = true
+    upsertAdvertisementForService(
+      disco, sid, ad, now, adKey, peerId, shouldUpdateMetrics
+    )
 
   if shouldUpdateMetrics:
     disco.registrar.updateRegistrarMetrics()

--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -56,7 +56,9 @@ proc isExpired(now, ts: Moment, expiry: Duration): bool {.inline.} =
   now - ts > expiry
 
 proc hasAdReference(
-    registrar: Registrar, key: AdvertisementKey, excludeSid: ServiceId = default(ServiceId)
+    registrar: Registrar,
+    key: AdvertisementKey,
+    excludeSid: ServiceId = default(ServiceId),
 ): bool {.raises: [].} =
   ## Returns true if the ad key is still present in any service's cache list
   ## (optionally ignoring one service, e.g. the one currently being pruned).
@@ -421,9 +423,7 @@ proc insertNewAd*(
   disco.registrar.ipTree.insertAd(ad)
   return true
 
-proc acceptAdvertisement*(
-    disco: ServiceDiscovery, now: Moment, ad: Advertisement
-) =
+proc acceptAdvertisement*(disco: ServiceDiscovery, now: Moment, ad: Advertisement) =
   let claimedServices = ad.advertisedServices()
 
   # Ensure routing tables + peer presence for every service the ad claims

--- a/libp2p/protocols/service_discovery/types.nim
+++ b/libp2p/protocols/service_discovery/types.nim
@@ -153,6 +153,10 @@ proc advertisesService*(ad: Advertisement, serviceId: ServiceId): bool =
       return true
   false
 
+proc advertisedServices*(ad: Advertisement): seq[ServiceId] {.raises: [].} =
+  ## Return all service IDs advertised by this advertisement.
+  ad.data.services.mapIt(hashServiceId(it.id))
+
 proc new*(T: typedesc[Registrar]): T =
   T(
     cache: initOrderedTable[ServiceId, seq[Advertisement]](),

--- a/tests/libp2p/service_discovery/component/test_advertise_discover.nim
+++ b/tests/libp2p/service_discovery/component/test_advertise_discover.nim
@@ -112,42 +112,6 @@ suite "Service Discovery Component - Advertise Discover":
         found.get().len == 2 and found.containsPeer(advertiserA) and
           found.containsPeer(advertiserB)
 
-  asyncTest "one advertiser provides two services - both discoverable":
-    # TODO: vacp2p/nim-libp2p#2430 service-disco: missing API for multi-service registration
-    let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0, ipSimCoefficient = 0.0)
-    let registrarNode = setupServiceDiscoveryNode(discoConfig = conf)
-    let advertiserNode = setupServiceDiscoveryNode(discoConfig = conf)
-    let discovererNode = setupServiceDiscoveryNode(discoConfig = conf)
-    startAndDeferStop(@[registrarNode, advertiserNode, discovererNode])
-
-    await connectHub(registrarNode, @[advertiserNode, discovererNode])
-
-    let svcA = makeServiceInfo("service-A")
-    let svcB = makeServiceInfo("service-B")
-    let svcAId = svcA.id.hashServiceId()
-    let svcBId = svcB.id.hashServiceId()
-
-    advertiserNode.addProvidedService(svcA)
-
-    checkUntilTimeout:
-      registrarNode.countAdsInCache(svcAId) == 1
-
-    advertiserNode.addProvidedService(svcB)
-
-    checkUntilTimeout:
-      registrarNode.countAdsInCache(svcBId) == 1
-
-    checkUntilTimeout:
-      block:
-        let foundA = await discovererNode.lookup(svcAId)
-        foundA.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId) and
-          foundA.get().len == 1
-      block:
-        let foundB = await discovererNode.lookup(svcBId)
-        foundB.get().anyIt(it.data.peerId == advertiserNode.switch.peerInfo.peerId) and
-          foundB.get().len == 1
-          # Regression for vacp2p/nim-libp2p#2431: this lookup previously returned a duplicate.
-
   asyncTest "lookup dedups byte-identical adverts but keeps same (peerId, seqNo) variants":
     let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0)
     let registrar1 = setupServiceDiscoveryNode(discoConfig = conf)
@@ -328,9 +292,7 @@ suite "Service Discovery Component - Advertise Discover":
     check advertiserNode.countAdsInCache(serviceId) == 0
 
   asyncTest "auto-advertise on start":
-    # Using ipSimCoefficient = 0.0 to not trigger sybil protection when advertising multiple services
-    # TODO: vacp2p/nim-libp2p#2430 service-disco: missing API for multi-service registration
-    let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0, ipSimCoefficient = 0.0)
+    let conf = ServiceDiscoveryConfig.new()
     let registrarNode = setupServiceDiscoveryNode(discoConfig = conf)
     let discovererNode = setupServiceDiscoveryNode(discoConfig = conf)
 

--- a/tests/libp2p/service_discovery/component/test_lookup_get_ads.nim
+++ b/tests/libp2p/service_discovery/component/test_lookup_get_ads.nim
@@ -125,7 +125,7 @@ suite "Service Discovery Component - Lookup Get Ads":
     for _ in 0 ..< 4:
       let ad = makeAdvertisement(serviceName)
       let now = Moment.now()
-      registrarNode.acceptAdvertisement(now, serviceId, ad)
+      registrarNode.acceptAdvertisement(now, ad)
 
     let found = await discovererNode.lookup(serviceId)
     check found.isOk()

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -1094,7 +1094,10 @@ suite "Service Discovery Registrar - acceptAdvertisement seqNo handling":
       .init(
         privateKey,
         ExtendedPeerRecord(
-          peerId: peerId, seqNo: 1, addresses: @[], services: @[makeServiceInfo(svc)]
+          peerId: peerId,
+          seqNo: 1,
+          addresses: @[],
+          services: @[makeServiceInfo(svc), makeServiceInfo(svc & "-2")],
         ),
       )
       .get()
@@ -1103,7 +1106,10 @@ suite "Service Discovery Registrar - acceptAdvertisement seqNo handling":
       .init(
         privateKey,
         ExtendedPeerRecord(
-          peerId: peerId, seqNo: 2, addresses: @[], services: @[makeServiceInfo(svc)]
+          peerId: peerId,
+          seqNo: 2,
+          addresses: @[],
+          services: @[makeServiceInfo(svc), makeServiceInfo(svc & "-2")],
         ),
       )
       .get()
@@ -1129,7 +1135,10 @@ suite "Service Discovery Registrar - acceptAdvertisement seqNo handling":
       .init(
         privateKey,
         ExtendedPeerRecord(
-          peerId: peerId, seqNo: 10, addresses: @[], services: @[makeServiceInfo(svc)]
+          peerId: peerId,
+          seqNo: 10,
+          addresses: @[],
+          services: @[makeServiceInfo(svc), makeServiceInfo(svc & "-2")],
         ),
       )
       .get()
@@ -1138,7 +1147,10 @@ suite "Service Discovery Registrar - acceptAdvertisement seqNo handling":
       .init(
         privateKey,
         ExtendedPeerRecord(
-          peerId: peerId, seqNo: 5, addresses: @[], services: @[makeServiceInfo(svc)]
+          peerId: peerId,
+          seqNo: 5,
+          addresses: @[],
+          services: @[makeServiceInfo(svc), makeServiceInfo(svc & "-2")],
         ),
       )
       .get()
@@ -1179,7 +1191,7 @@ suite "Service Discovery Registrar - acceptAdvertisement seqNo handling":
           peerId: peerId,
           seqNo: 1,
           addresses: @[AddressInfo(address: makeMultiAddress("10.0.0.1"))],
-          services: @[makeServiceInfo(svc)],
+          services: @[makeServiceInfo(svc), makeServiceInfo(svc & "-2")],
         ),
       )
       .get()
@@ -1191,7 +1203,7 @@ suite "Service Discovery Registrar - acceptAdvertisement seqNo handling":
           peerId: peerId,
           seqNo: 2,
           addresses: @[AddressInfo(address: makeMultiAddress("10.0.0.2"))],
-          services: @[makeServiceInfo(svc)],
+          services: @[makeServiceInfo(svc), makeServiceInfo(svc & "-2")],
         ),
       )
       .get()

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -1061,11 +1061,12 @@ suite "Service Discovery Registrar - acceptAdvertisement seqNo handling":
     let serviceId = makeServiceId()
     let ad = makeAdvertisement($serviceId)
     let now = Moment.now()
+    let svcKey = ad.advertisedServices()[0]
 
-    disco.acceptAdvertisement(now, serviceId, ad)
+    disco.acceptAdvertisement(now, ad)
 
-    check disco.registrar.cache.getOrDefault(serviceId).len == 1
-    check disco.registrar.cache[serviceId][0].data.peerId == ad.data.peerId
+    check disco.registrar.cache.getOrDefault(svcKey).len == 1
+    check disco.registrar.cache[svcKey][0].data.peerId == ad.data.peerId
 
   test "same peer same seqNo is treated as duplicate and not added again":
     let disco =
@@ -1073,69 +1074,72 @@ suite "Service Discovery Registrar - acceptAdvertisement seqNo handling":
     let serviceId = makeServiceId()
     let ad = makeAdvertisement($serviceId)
     let now = Moment.now()
+    let svcKey = ad.advertisedServices()[0]
 
-    disco.acceptAdvertisement(now, serviceId, ad)
-    disco.acceptAdvertisement(now, serviceId, ad)
+    disco.acceptAdvertisement(now, ad)
+    disco.acceptAdvertisement(now, ad)
 
-    check disco.registrar.cache[serviceId].len == 1
+    check disco.registrar.cache[svcKey].len == 1
 
   test "same peer higher seqNo replaces existing ad":
     let disco =
       setupServiceDiscoveryNode(discoConfig = ServiceDiscoveryConfig.new(fReturn = 3))
-    let serviceId = makeServiceId()
     let privateKey = PrivateKey.random(rng()).get()
     let peerId = PeerId.init(privateKey).get()
     let now = Moment.now()
+    let svc = "seqno-higher-svc"
+    let svcKey = svc.hashServiceId()
 
     let oldAd = SignedExtendedPeerRecord
       .init(
         privateKey,
-        ExtendedPeerRecord(peerId: peerId, seqNo: 1, addresses: @[], services: @[]),
+        ExtendedPeerRecord(peerId: peerId, seqNo: 1, addresses: @[], services: @[makeServiceInfo(svc)]),
       )
       .get()
 
     let newAd = SignedExtendedPeerRecord
       .init(
         privateKey,
-        ExtendedPeerRecord(peerId: peerId, seqNo: 2, addresses: @[], services: @[]),
+        ExtendedPeerRecord(peerId: peerId, seqNo: 2, addresses: @[], services: @[makeServiceInfo(svc)]),
       )
       .get()
 
-    disco.acceptAdvertisement(now, serviceId, oldAd)
-    check disco.registrar.cache[serviceId][0].data.seqNo == 1
+    disco.acceptAdvertisement(now, oldAd)
+    check disco.registrar.cache[svcKey][0].data.seqNo == 1
 
-    disco.acceptAdvertisement(now, serviceId, newAd)
+    disco.acceptAdvertisement(now, newAd)
 
-    check disco.registrar.cache[serviceId].len == 1
-    check disco.registrar.cache[serviceId][0].data.seqNo == 2
+    check disco.registrar.cache[svcKey].len == 1
+    check disco.registrar.cache[svcKey][0].data.seqNo == 2
 
   test "same peer lower seqNo is silently dropped":
     let disco =
       setupServiceDiscoveryNode(discoConfig = ServiceDiscoveryConfig.new(fReturn = 3))
-    let serviceId = makeServiceId()
     let privateKey = PrivateKey.random(rng()).get()
     let peerId = PeerId.init(privateKey).get()
     let now = Moment.now()
+    let svc = "seqno-lower-svc"
+    let svcKey = svc.hashServiceId()
 
     let newerAd = SignedExtendedPeerRecord
       .init(
         privateKey,
-        ExtendedPeerRecord(peerId: peerId, seqNo: 10, addresses: @[], services: @[]),
+        ExtendedPeerRecord(peerId: peerId, seqNo: 10, addresses: @[], services: @[makeServiceInfo(svc)]),
       )
       .get()
 
     let olderAd = SignedExtendedPeerRecord
       .init(
         privateKey,
-        ExtendedPeerRecord(peerId: peerId, seqNo: 5, addresses: @[], services: @[]),
+        ExtendedPeerRecord(peerId: peerId, seqNo: 5, addresses: @[], services: @[makeServiceInfo(svc)]),
       )
       .get()
 
-    disco.acceptAdvertisement(now, serviceId, newerAd)
-    disco.acceptAdvertisement(now, serviceId, olderAd)
+    disco.acceptAdvertisement(now, newerAd)
+    disco.acceptAdvertisement(now, olderAd)
 
-    check disco.registrar.cache[serviceId].len == 1
-    check disco.registrar.cache[serviceId][0].data.seqNo == 10
+    check disco.registrar.cache[svcKey].len == 1
+    check disco.registrar.cache[svcKey][0].data.seqNo == 10
 
   test "different peers each store their own ad":
     let disco =
@@ -1144,19 +1148,21 @@ suite "Service Discovery Registrar - acceptAdvertisement seqNo handling":
     let ad1 = makeAdvertisement($serviceId)
     let ad2 = makeAdvertisement($serviceId)
     let now = Moment.now()
+    let svcKey = ad1.advertisedServices()[0]
 
-    disco.acceptAdvertisement(now, serviceId, ad1)
-    disco.acceptAdvertisement(now, serviceId, ad2)
+    disco.acceptAdvertisement(now, ad1)
+    disco.acceptAdvertisement(now, ad2)
 
-    check disco.registrar.cache[serviceId].len == 2
+    check disco.registrar.cache[svcKey].len == 2
 
   test "seqNo replacement updates IP tree correctly":
     let disco =
       setupServiceDiscoveryNode(discoConfig = ServiceDiscoveryConfig.new(fReturn = 3))
-    let serviceId = makeServiceId()
     let privateKey = PrivateKey.random(rng()).get()
     let peerId = PeerId.init(privateKey).get()
     let now = Moment.now()
+    let svc = "seqno-ip2-svc"
+    let svcKey = svc.hashServiceId()
 
     let oldAd = SignedExtendedPeerRecord
       .init(
@@ -1165,7 +1171,7 @@ suite "Service Discovery Registrar - acceptAdvertisement seqNo handling":
           peerId: peerId,
           seqNo: 1,
           addresses: @[AddressInfo(address: makeMultiAddress("10.0.0.1"))],
-          services: @[],
+          services: @[makeServiceInfo(svc)],
         ),
       )
       .get()
@@ -1177,19 +1183,19 @@ suite "Service Discovery Registrar - acceptAdvertisement seqNo handling":
           peerId: peerId,
           seqNo: 2,
           addresses: @[AddressInfo(address: makeMultiAddress("10.0.0.2"))],
-          services: @[],
+          services: @[makeServiceInfo(svc)],
         ),
       )
       .get()
 
-    disco.acceptAdvertisement(now, serviceId, oldAd)
+    disco.acceptAdvertisement(now, oldAd)
     let counterAfterFirst = disco.registrar.ipTree.root.counter
     check counterAfterFirst > 0
 
-    disco.acceptAdvertisement(now, serviceId, newAd)
+    disco.acceptAdvertisement(now, newAd)
 
-    check disco.registrar.cache[serviceId].len == 1
-    check disco.registrar.cache[serviceId][0].data.seqNo == 2
+    check disco.registrar.cache[svcKey].len == 1
+    check disco.registrar.cache[svcKey][0].data.seqNo == 2
     check disco.registrar.ipTree.root.counter == counterAfterFirst
 
 suite "Service Discovery Registrar - waitingTime never negative":
@@ -1232,11 +1238,12 @@ suite "Service Discovery Registrar - concurrent same-peer registration":
     let serviceId = makeServiceId()
     let ad = makeAdvertisement($serviceId)
     let now = Moment.now()
+    let svcKey = ad.advertisedServices()[0]
 
-    disco.acceptAdvertisement(now, serviceId, ad)
-    disco.acceptAdvertisement(now, serviceId, ad)
+    disco.acceptAdvertisement(now, ad)
+    disco.acceptAdvertisement(now, ad)
 
-    check disco.registrar.cache[serviceId].len == 1
+    check disco.registrar.cache[svcKey].len == 1
 
 suite "Service Discovery Registrar - updateExistingAd":
   test "same seqNo refreshes timestamp and returns false":

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -1093,14 +1093,18 @@ suite "Service Discovery Registrar - acceptAdvertisement seqNo handling":
     let oldAd = SignedExtendedPeerRecord
       .init(
         privateKey,
-        ExtendedPeerRecord(peerId: peerId, seqNo: 1, addresses: @[], services: @[makeServiceInfo(svc)]),
+        ExtendedPeerRecord(
+          peerId: peerId, seqNo: 1, addresses: @[], services: @[makeServiceInfo(svc)]
+        ),
       )
       .get()
 
     let newAd = SignedExtendedPeerRecord
       .init(
         privateKey,
-        ExtendedPeerRecord(peerId: peerId, seqNo: 2, addresses: @[], services: @[makeServiceInfo(svc)]),
+        ExtendedPeerRecord(
+          peerId: peerId, seqNo: 2, addresses: @[], services: @[makeServiceInfo(svc)]
+        ),
       )
       .get()
 
@@ -1124,14 +1128,18 @@ suite "Service Discovery Registrar - acceptAdvertisement seqNo handling":
     let newerAd = SignedExtendedPeerRecord
       .init(
         privateKey,
-        ExtendedPeerRecord(peerId: peerId, seqNo: 10, addresses: @[], services: @[makeServiceInfo(svc)]),
+        ExtendedPeerRecord(
+          peerId: peerId, seqNo: 10, addresses: @[], services: @[makeServiceInfo(svc)]
+        ),
       )
       .get()
 
     let olderAd = SignedExtendedPeerRecord
       .init(
         privateKey,
-        ExtendedPeerRecord(peerId: peerId, seqNo: 5, addresses: @[], services: @[makeServiceInfo(svc)]),
+        ExtendedPeerRecord(
+          peerId: peerId, seqNo: 5, addresses: @[], services: @[makeServiceInfo(svc)]
+        ),
       )
       .get()
 

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -67,7 +67,7 @@ proc makeAdvertisement*(
     peerId: peerId,
     seqNo: seqNo,
     addresses: addrs.mapIt(AddressInfo(address: it)),
-    services: @[makeServiceInfo(serviceId)],
+    services: @[makeServiceInfo(serviceId), makeServiceInfo(serviceId & "-secondary")],
   )
   SignedExtendedPeerRecord.init(privateKey, extRecord).get()
 


### PR DESCRIPTION
I noticed that when a registrar accept an advert it was not cached under ALL the services it contained, this is now the case.