### PR TITLE
feat(nat): upnp, nat-pmp build infra

### DIFF
--- a/.github/workflows/cbindings.yml
+++ b/.github/workflows/cbindings.yml
@@ -45,7 +45,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: nimbledeps
-          key: nimbledeps-${{ hashFiles('.pinned') }}
+          # Keep this in sync with ci.yml's cache key so entries are
+          # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
+          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: nimbledeps
-          key: nimbledeps-${{ hashFiles('.pinned') }}
+          key: nimbledeps-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ hashFiles('.pinned') }}
 
       - name: Restore llvm-mingw (Windows) from cache
         if: runner.os == 'Windows' && matrix.platform.cc == 'clang'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,14 @@ jobs:
         uses: actions/cache@v5
         with:
           path: nimbledeps
-          key: nimbledeps-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ hashFiles('.pinned') }}
+          # Scope by os/cpu/cc: nimbledeps contains pre-built .a files for
+          # nim-nat-traversal's vendored miniupnpc/libnatpmp, rebuilt by
+          # `make nat_libs` against the host toolchain. Sharing the cache
+          # across mismatched toolchains (linux<->windows, gcc<->clang)
+          # produced broken artifacts last time. Keep this key in sync
+          # with the other workflows that cache nimbledeps so cache
+          # entries are reusable across them.
+          key: nimbledeps-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ hashFiles('.pinned') }}
 
       - name: Restore llvm-mingw (Windows) from cache
         if: runner.os == 'Windows' && matrix.platform.cc == 'clang'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -38,7 +38,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: nimbledeps
-          key: nimbledeps-${{ hashFiles('.pinned') }}
+          # Keep this in sync with ci.yml's cache key so entries are
+          # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
+          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/daily_runnable_examples.yml
+++ b/.github/workflows/daily_runnable_examples.yml
@@ -36,7 +36,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: nimbledeps
-          key: nimbledeps-${{ hashFiles('.pinned') }}
+          # Keep this in sync with ci.yml's cache key so entries are
+          # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
+          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/daily_tests_no_flags.yml
+++ b/.github/workflows/daily_tests_no_flags.yml
@@ -36,7 +36,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: nimbledeps
-          key: nimbledeps-${{ hashFiles('.pinned') }}
+          # Keep this in sync with ci.yml's cache key so entries are
+          # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
+          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -45,7 +45,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: nimbledeps
-          key: nimbledeps-${{ hashFiles('.pinned') }}
+          # Keep this in sync with ci.yml's cache key so entries are
+          # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
+          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.pinned
+++ b/.pinned
@@ -17,3 +17,4 @@ unittest2;https://github.com/status-im/nim-unittest2@#26f2ef3ae0ec72a2a75bfe557e
 websock;https://github.com/status-im/nim-websock@#387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d
 zlib;https://github.com/status-im/nim-zlib@#e680f269fb01af2c34a2ba879ff281795a5258fe
 protobuf_serialization;https://github.com/status-im/nim-protobuf-serialization@#38d24eb3bd93e605fb88199da71d36b1ec0ad60d
+nat_traversal;https://github.com/status-im/nim-nat-traversal@#860e18c37667b5dd005b94c63264560c35d88004

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: all build deps cbind clean test _test_all test_multiformat_exts test_integration \
-        install_pinned pin unpin gen_multicodec format clean-nim
+        install_pinned pin unpin gen_multicodec format clean-nim nat_libs nat_pkg_dir_check
 
 NIM_VERSION  ?= 2.2.10
 NPH_VERSION  ?= 0.7.0
@@ -79,7 +79,50 @@ nimble.paths: $(wildcard nimbledeps/pkgs2/*/*.nimble) $(wildcard nimbledeps/pkgs
 	  done; \
 	done
 
-test: nimble.paths
+# nim-nat-traversal vendors miniupnpc and libnatpmp as C sources. The package's
+# `before install` hook builds them, but the resulting .a files are not always
+# preserved alongside the package dir (cross-OS cache reuse, different gcc
+# versions). Rebuild them up-front against the host's toolchain.
+NAT_PKG_DIR := $(firstword $(wildcard nimbledeps/pkgs2/nat_traversal-*))
+NAT_PMP_LIB := $(NAT_PKG_DIR)/vendor/libnatpmp-upstream/libnatpmp.a
+
+# Use gcc rather than `cc` so the linux-i386 wrapper (external/bin/gcc, which
+# injects -m32) is picked up. On macOS and llvm-mingw, `gcc` is a clang
+# compatibility shim, so this stays ABI-compatible with nim's choice.
+NAT_CC ?= gcc
+
+# miniupnpc's unix Makefile drops the .a under `build/`, but its Windows
+# Makefile.mingw drops it at the package root. Match each one.
+ifeq ($(OS),Windows_NT)
+  NAT_UPNP_LIB := $(NAT_PKG_DIR)/vendor/miniupnp/miniupnpc/libminiupnpc.a
+  NAT_UPNP_MAKE_ARGS := -f Makefile.mingw CC=$(NAT_CC) libminiupnpc.a
+  NAT_PMP_CFLAGS := -Wall -Os -fPIC -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4 -DWIN32 -DNATPMP_STATICLIB
+else
+  NAT_UPNP_LIB := $(NAT_PKG_DIR)/vendor/miniupnp/miniupnpc/build/libminiupnpc.a
+  NAT_UPNP_MAKE_ARGS := CC=$(NAT_CC) CFLAGS="-Os -fPIC" build/libminiupnpc.a
+  NAT_PMP_CFLAGS := -Wall -Os -fPIC -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4
+endif
+
+# Stamp-based rebuild: the stamp records "the .a files in this package dir were
+# built by our recipe with the right compiler". Re-running install_pinned wipes
+# the package dir (and thus the stamp), forcing a rebuild.
+NAT_LIBS_STAMP := $(NAT_PKG_DIR)/.libp2p-nat-libs.stamp
+
+nat_libs: $(NAT_LIBS_STAMP)
+
+nat_pkg_dir_check:
+	@test -n "$(NAT_PKG_DIR)" || \
+	  (echo "Error: nat_traversal package not found under nimbledeps/pkgs2/. Run 'nimble install_pinned' first." && exit 1)
+
+$(NAT_LIBS_STAMP): | nat_pkg_dir_check
+	rm -f "$(NAT_UPNP_LIB)" "$(NAT_PMP_LIB)"
+	-$(MAKE) -C "$(NAT_PKG_DIR)/vendor/miniupnp/miniupnpc" clean
+	-$(MAKE) -C "$(NAT_PKG_DIR)/vendor/libnatpmp-upstream" clean
+	$(MAKE) -C "$(NAT_PKG_DIR)/vendor/miniupnp/miniupnpc" $(NAT_UPNP_MAKE_ARGS)
+	$(MAKE) -C "$(NAT_PKG_DIR)/vendor/libnatpmp-upstream" CC=$(NAT_CC) CFLAGS="$(NAT_PMP_CFLAGS)" libnatpmp.a
+	touch "$@"
+
+test: nimble.paths nat_libs
 ifeq ($(TEST_PATH),)
 	$(MAKE) _test_all
 	$(MAKE) test_multiformat_exts
@@ -91,13 +134,13 @@ else
 	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
 endif
 
-_test_all: nimble.paths
+_test_all: nimble.paths nat_libs
 	$(NIMC) c $(NIM_FLAGS) \
 	  $(if $(CICOV),--nimcache:nimcache/test_all,) \
 	  tests/test_all.nim
 	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
 
-test_multiformat_exts: nimble.paths
+test_multiformat_exts: nimble.paths nat_libs
 	$(NIMC) c $(NIM_FLAGS) \
 	  $(if $(CICOV),--nimcache:nimcache/test_all_multiformat,) \
 	  -d:libp2p_multicodec_exts=../tests/libp2p/multiformat_exts/multicodec_exts.nim \
@@ -109,7 +152,7 @@ test_multiformat_exts: nimble.paths
 	  tests/test_all.nim
 	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all_multiformat.xml
 
-test_integration: nimble.paths
+test_integration: nimble.paths nat_libs
 	$(NIMC) c $(NIM_FLAGS) \
 	  $(if $(CICOV),--nimcache:nimcache/integration,) \
 	  tests/integration/test_all.nim

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ nimble.paths: $(wildcard nimbledeps/pkgs2/*/*.nimble) $(wildcard nimbledeps/pkgs
 # `before install` hook builds them, but the resulting .a files are not always
 # preserved alongside the package dir (cross-OS cache reuse, different gcc
 # versions). Rebuild them up-front against the host's toolchain.
-NAT_PKG_DIR := $(firstword $(wildcard nimbledeps/pkgs2/nat_traversal-*))
+NAT_PKG_DIR := $(firstword $(wildcard nimbledeps/pkgs2/nat_traversal-*) $(wildcard nimbledeps/pkgs/nat_traversal-*))
 NAT_PMP_LIB := $(NAT_PKG_DIR)/vendor/libnatpmp-upstream/libnatpmp.a
 
 # Use gcc rather than `cc` so the linux-i386 wrapper (external/bin/gcc, which
@@ -111,7 +111,7 @@ nat_libs: $(NAT_LIBS_STAMP)
 
 nat_pkg_dir_check:
 	@test -n "$(NAT_PKG_DIR)" || \
-	  (echo "Error: nat_traversal package not found under nimbledeps/pkgs2/. Run 'nimble install_pinned' first." && exit 1)
+	  (echo "Error: nat_traversal package not found under nimbledeps/pkgs2/ or nimbledeps/pkgs/. Run 'nimble install_pinned' first." && exit 1)
 
 $(NAT_LIBS_STAMP): | nat_pkg_dir_check
 	rm -f "$(NAT_UPNP_LIB)" "$(NAT_PMP_LIB)"

--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -6,6 +6,8 @@ author = "Status Research & Development GmbH"
 description = "C bindings for LibP2P implementation"
 license = "MIT"
 
+import os, strutils
+
 # The rest of dependencies is inherited from parent libp2p.nimble via nimble.paths
 requires "taskpools >= 0.1.0"
 
@@ -43,14 +45,32 @@ task libDynamic, "Generate dynamic bindings":
 task libStatic, "Generate static bindings":
   buildCBindings "static", ""
 
+proc findNatPkgDir(): string =
+  # Match the top-level Makefile: nimble installs deps under pkgs2 on newer
+  # versions and pkgs on older ones; resolve from either.
+  for base in ["../nimbledeps/pkgs2", "../nimbledeps/pkgs"]:
+    if dirExists(base):
+      for d in listDirs(base):
+        if d.extractFilename().startsWith("nat_traversal-"):
+          return d
+  quit "nat_traversal package not found under ../nimbledeps/pkgs2 or " &
+    "../nimbledeps/pkgs; run 'nimble install_pinned' first"
+
 task examples, "Build and run C bindings examples":
   buildCBindings "static", ""
   # libp2p.a transitively references miniupnpc and libnatpmp via nat_traversal.
   # Build the vendored .a's via the parent Makefile and link them in.
   exec "make -C .. nat_libs"
-  let natLibs =
-    "../nimbledeps/pkgs2/nat_traversal-*/vendor/miniupnp/miniupnpc/build/libminiupnpc.a " &
-    "../nimbledeps/pkgs2/nat_traversal-*/vendor/libnatpmp-upstream/libnatpmp.a"
+  let natPkg = findNatPkgDir()
+  # miniupnpc's unix Makefile drops the .a under build/, but its Makefile.mingw
+  # drops it at the package root. Match the parent Makefile's per-OS choice.
+  let upnpA =
+    when defined(windows):
+      natPkg / "vendor/miniupnp/miniupnpc/libminiupnpc.a"
+    else:
+      natPkg / "vendor/miniupnp/miniupnpc/build/libminiupnpc.a"
+  let pmpA = natPkg / "vendor/libnatpmp-upstream/libnatpmp.a"
+  let natLibs = upnpA & " " & pmpA
   exec "g++ -I. -o ../build/cbindings ./examples/cbindings.c ../build/libp2p.a " &
     natLibs & " -pthread"
   exec "g++ -I. -o ../build/echo ./examples/echo.c ../build/libp2p.a " & natLibs &

--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -45,7 +45,15 @@ task libStatic, "Generate static bindings":
 
 task examples, "Build and run C bindings examples":
   buildCBindings "static", ""
-  exec "g++ -I. -o ../build/cbindings ./examples/cbindings.c ../build/libp2p.a -pthread"
-  exec "g++ -I. -o ../build/echo ./examples/echo.c ../build/libp2p.a -pthread"
+  # libp2p.a transitively references miniupnpc and libnatpmp via nat_traversal.
+  # Build the vendored .a's via the parent Makefile and link them in.
+  exec "make -C .. nat_libs"
+  let natLibs =
+    "../nimbledeps/pkgs2/nat_traversal-*/vendor/miniupnp/miniupnpc/build/libminiupnpc.a " &
+    "../nimbledeps/pkgs2/nat_traversal-*/vendor/libnatpmp-upstream/libnatpmp.a"
+  exec "g++ -I. -o ../build/cbindings ./examples/cbindings.c ../build/libp2p.a " &
+    natLibs & " -pthread"
+  exec "g++ -I. -o ../build/echo ./examples/echo.c ../build/libp2p.a " & natLibs &
+    " -pthread"
   exec "../build/cbindings"
   exec "../build/echo"

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -13,7 +13,8 @@ requires "nim >= 2.2.4",
   "https://github.com/vacp2p/nim-boringssl >= 0.0.4", "chronicles >= 0.11.0",
   "chronos >= 4.2.2", "metrics", "secp256k1", "stew >= 0.4.2", "unittest2", "results",
   "serialization", "lsquic >= 0.4.1", "protobuf_serialization >= 0.4.0",
-  "https://github.com/status-im/nim-websock >= 0.4.0"
+  "https://github.com/status-im/nim-websock >= 0.4.0",
+  "https://github.com/status-im/nim-nat-traversal >= 0.0.1"
 
 import os, sequtils, strutils
 

--- a/libp2p/services/nat/portmapper.nim
+++ b/libp2p/services/nat/portmapper.nim
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.push raises: [].}
+
+import std/[net]
+import chronos, results
+
+type
+  MapProto* = enum
+    mpTcp
+    mpUdp
+
+  PortMapper* = ref object of RootObj
+    ## Abstract base for a NAT port-mapping client (UPnP / NAT-PMP / mock).
+    ## All operations are async because real implementations dispatch the
+    ## underlying sync C calls to a dedicated worker thread.
+
+method discover*(
+    self: PortMapper, timeout: Duration
+): Future[Result[IpAddress, string]] {.base, async: (raises: [CancelledError]), gcsafe.} =
+  raiseAssert "PortMapper.discover not implemented"
+
+method map*(
+    self: PortMapper,
+    internalPort: Port,
+    externalPort: Port,
+    proto: MapProto,
+    lease: uint32,
+): Future[Result[Port, string]] {.base, async: (raises: [CancelledError]), gcsafe.} =
+  raiseAssert "PortMapper.map not implemented"
+
+method unmap*(
+    self: PortMapper, externalPort: Port, proto: MapProto
+): Future[Result[void, string]] {.base, async: (raises: [CancelledError]), gcsafe.} =
+  raiseAssert "PortMapper.unmap not implemented"
+
+method close*(self: PortMapper) {.base, gcsafe, raises: [].} =
+  discard

--- a/libp2p/wire.nim
+++ b/libp2p/wire.nim
@@ -174,3 +174,12 @@ proc isLoopbackMA*(ma: MultiAddress): bool =
     return false
 
   return hostIP.isLoopback()
+
+proc isPrivateMA*(ma: MultiAddress): bool =
+  ## True for addresses on private/non-routable networks: RFC1918, CGNAT
+  ## (RFC6598), link-local. These are the cases where a NAT port mapping is
+  ## actually useful.
+  let hostIP = initTAddress(ma).valueOr:
+    return false
+
+  hostIP.isPrivate() or hostIP.isShared() or hostIP.isLinkLocal()


### PR DESCRIPTION
## Summary
  - Pins `nim-nat-traversal` in `.pinned` and adds it to `libp2p.nimble`
  - Adds `nat_libs` Makefile target that rebuilds the vendored
  miniupnpc/libnatpmp C libraries against the host toolchain (stamp-based,
  survives `install_pinned` re-runs, Windows-aware)
  - Scopes the CI nimbledeps cache key per `os`/`cpu` so the `.a` files can't
  be reused across platforms
  - Updates `cbind/cbind.nimble` to link the two `.a`s alongside `libp2p.a`

  Part 1 of 3 for the UPnP/NAT-PMP port mapping feature.