### PR TITLE
feat(nat): portmapper interface

### DIFF
--- a/libp2p/services/nat/portmapper.nim
+++ b/libp2p/services/nat/portmapper.nim
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.push raises: [].}
+
+import std/[net]
+import chronos, results
+
+type
+  MapProto* = enum
+    mpTcp
+    mpUdp
+
+  PortMapper* = ref object of RootObj
+    ## Abstract base for a NAT port-mapping client (UPnP / NAT-PMP / mock).
+    ## All operations are async because real implementations dispatch the
+    ## underlying sync C calls to a dedicated worker thread.
+
+method discover*(
+    self: PortMapper, timeout: Duration
+): Future[Result[IpAddress, string]] {.base, async: (raises: [CancelledError]), gcsafe.} =
+  raiseAssert "PortMapper.discover not implemented"
+
+method map*(
+    self: PortMapper,
+    internalPort: Port,
+    externalPort: Port,
+    proto: MapProto,
+    lease: uint32,
+): Future[Result[Port, string]] {.base, async: (raises: [CancelledError]), gcsafe.} =
+  raiseAssert "PortMapper.map not implemented"
+
+method unmap*(
+    self: PortMapper, externalPort: Port, proto: MapProto
+): Future[Result[void, string]] {.base, async: (raises: [CancelledError]), gcsafe.} =
+  raiseAssert "PortMapper.unmap not implemented"
+
+method close*(self: PortMapper) {.base, gcsafe, raises: [].} =
+  discard

--- a/libp2p/wire.nim
+++ b/libp2p/wire.nim
@@ -174,3 +174,12 @@ proc isLoopbackMA*(ma: MultiAddress): bool =
     return false
 
   return hostIP.isLoopback()
+
+proc isPrivateMA*(ma: MultiAddress): bool =
+  ## True for addresses on private/non-routable networks: RFC1918, CGNAT
+  ## (RFC6598), link-local. These are the cases where a NAT port mapping is
+  ## actually useful.
+  let hostIP = initTAddress(ma).valueOr:
+    return false
+
+  hostIP.isPrivate() or hostIP.isShared() or hostIP.isLinkLocal()


### PR DESCRIPTION
## Summary
  - Adds `libp2p/services/nat/portmapper.nim`: abstract `PortMapper` ref object
   with async `discover`, `map`, `unmap`, `close` methods
  - Adds `isPrivateMA` to `libp2p/wire.nim`: returns true for
  RFC1918/CGNAT/link-local addresses (the cases where port mapping is useful)

  No concrete implementations yet; depends on Part 1 for the
  `nim-nat-traversal` dep.

  Part 2 of 3 for the UPnP/NAT-PMP port mapping feature.