### PR TITLE
feat(nat): upnp

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -40,7 +40,9 @@ import
 export
   switch, peerid, peerinfo, peeraddrpolicy, connection, multiaddress, crypto, errors,
   TLSPrivateKey, TLSCertificate, TLSFlags, ServerFlags, connmanager.ConnectionLimits,
-  connmanager.maxTotal, connmanager.maxInOut, natservice.NATConfig
+  connmanager.maxTotal, connmanager.maxInOut, natservice.NATConfig, natservice.NATMode,
+  natservice.PortMapperFactory, natservice.upnpConfig, natservice.natPmpConfig,
+  natservice.NATService
 
 const MemoryAutoAddress* = memorytransport.MemoryAutoAddress
 
@@ -91,6 +93,7 @@ type
     autonatV2Client: AutonatV2Client
     holePunchingConfig: Opt[HolePunchingConfig]
     natConfig: Opt[NATConfig]
+    natPortMapperFactory: PortMapperFactory
     autotlsConfig: Opt[AutotlsConfig]
     circuitRelay: Opt[Relay]
     rdvConfig: Opt[RendezVousConfig]
@@ -357,10 +360,15 @@ proc withAutonatV2*(
   b.autonatV2Config = Opt.some(serviceConfig)
   b
 
-proc withNAT*(b: SwitchBuilder, config: NATConfig): SwitchBuilder =
+proc withNAT*(
+    b: SwitchBuilder, config: NATConfig, portMapperFactory: PortMapperFactory = nil
+): SwitchBuilder =
   ## Enable a NAT traversal service.
   ## TODO: wire in autonat / hole-punching.
+  ## ``portMapperFactory`` is intended for tests; when ``nil``, NATService picks
+  ## the production UPnP / NAT-PMP backend matching ``config.mode``.
   b.natConfig = Opt.some(config)
+  b.natPortMapperFactory = portMapperFactory
   b
 
 proc withHolePunching*(
@@ -543,7 +551,12 @@ proc setupServices(b: SwitchBuilder, switch: Switch) {.raises: [LPError].} =
     switch.services.add(HPService.new(autonatService, autoRelayService))
 
   b.natConfig.withValue(natCfg):
-    switch.services.add(NATService.new(natCfg))
+    let svc =
+      if b.natPortMapperFactory.isNil:
+        NATService.new(natCfg)
+      else:
+        NATService.new(natCfg, b.natPortMapperFactory)
+    switch.services.add(svc)
 
   if b.identifyPusherEnabled:
     switch.services.add(IdentifyPusher.new())

--- a/libp2p/services/nat/natpmp_mapper.nim
+++ b/libp2p/services/nat/natpmp_mapper.nim
@@ -1,0 +1,290 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## NAT-PMP port mapper. Mirrors the worker-thread structure of upnp_mapper.nim
+## around the `nat_traversal/natpmp` sync bindings.
+
+{.push raises: [].}
+
+import std/[atomics, net]
+import chronos, chronos/threadsync, chronicles, results
+import nat_traversal/natpmp
+import ./portmapper
+
+logScope:
+  topics = "libp2p natservice natpmp"
+
+const
+  ErrBufLen = 256
+  IpBufLen = 16
+
+type
+  NatPmpReqKind = enum
+    nrDiscover
+    nrMap
+    nrUnmap
+    nrShutdown
+
+  NatPmpRequest = object
+    case kind: NatPmpReqKind
+    of nrDiscover:
+      discard
+    of nrMap:
+      mapInternal: uint16
+      mapExternal: uint16
+      mapProto: MapProto
+      mapLease: uint32
+    of nrUnmap:
+      unmapExternal: uint16
+      unmapProto: MapProto
+    of nrShutdown:
+      discard
+
+  NatPmpResponse = object
+    success: bool
+    errorLen: int
+    errorBuf: array[ErrBufLen, char]
+    ipFamily: int
+    ipBuf: array[IpBufLen, byte]
+    externalPort: uint16
+
+  NatPmpWorkerCtx = object
+    reqSignal: ThreadSignalPtr
+    respSignal: ThreadSignalPtr
+    request: NatPmpRequest
+    response: NatPmpResponse
+
+  NatPmpMapper* = ref object of PortMapper
+    ctx: ptr NatPmpWorkerCtx
+    thread: Thread[ptr NatPmpWorkerCtx]
+    closed: Atomic[bool]
+
+proc setError(resp: var NatPmpResponse, msg: string) =
+  resp.success = false
+  resp.ipFamily = 0
+  resp.externalPort = 0
+  let n = min(msg.len, ErrBufLen)
+  for i in 0 ..< n:
+    resp.errorBuf[i] = msg[i]
+  resp.errorLen = n
+
+proc getError(resp: NatPmpResponse): string =
+  result = newString(resp.errorLen)
+  for i in 0 ..< resp.errorLen:
+    result[i] = resp.errorBuf[i]
+
+proc setIp(resp: var NatPmpResponse, ip: IpAddress) =
+  case ip.family
+  of IpAddressFamily.IPv4:
+    resp.ipFamily = 4
+    for i in 0 .. 3:
+      resp.ipBuf[i] = ip.address_v4[i]
+  of IpAddressFamily.IPv6:
+    resp.ipFamily = 6
+    for i in 0 .. 15:
+      resp.ipBuf[i] = ip.address_v6[i]
+
+proc getIp(resp: NatPmpResponse): Opt[IpAddress] =
+  case resp.ipFamily
+  of 4:
+    var ip = IpAddress(family: IpAddressFamily.IPv4)
+    for i in 0 .. 3:
+      ip.address_v4[i] = resp.ipBuf[i]
+    Opt.some(ip)
+  of 6:
+    var ip = IpAddress(family: IpAddressFamily.IPv6)
+    for i in 0 .. 15:
+      ip.address_v6[i] = resp.ipBuf[i]
+    Opt.some(ip)
+  else:
+    Opt.none(IpAddress)
+
+proc toPmpProto(p: MapProto): NatPmpProtocol =
+  case p
+  of mpTcp: NatPmpProtocol.TCP
+  of mpUdp: NatPmpProtocol.UDP
+
+proc ensureInit(pmp: var NatPmp, resp: var NatPmpResponse): bool =
+  if pmp != nil:
+    return true
+
+  pmp = newNatPmp()
+  let r = pmp.init()
+  if r.isErr:
+    resp.setError("natpmp init: " & $r.error)
+    pmp = nil
+    return false
+  true
+
+proc handleDiscover(pmp: var NatPmp, resp: var NatPmpResponse) =
+  if not ensureInit(pmp, resp):
+    return
+
+  let r = pmp.externalIPAddress()
+  if r.isErr:
+    resp.setError("natpmp externalIPAddress: " & $r.error)
+    return
+
+  try:
+    let ip = parseIpAddress($r.get())
+    resp.success = true
+    resp.setIp(ip)
+  except ValueError as exc:
+    resp.setError("natpmp parseIpAddress: " & exc.msg)
+
+proc handleMap(pmp: var NatPmp, req: NatPmpRequest, resp: var NatPmpResponse) =
+  if not ensureInit(pmp, resp):
+    return
+
+  let r = pmp.addPortMapping(
+    eport = cushort(req.mapExternal),
+    iport = cushort(req.mapInternal),
+    protocol = toPmpProto(req.mapProto),
+    lifetime = culong(req.mapLease),
+  )
+  if r.isErr:
+    resp.setError("natpmp addPortMapping: " & $r.error)
+    return
+
+  resp.success = true
+  resp.externalPort = uint16(r.get())
+
+proc handleUnmap(pmp: var NatPmp, req: NatPmpRequest, resp: var NatPmpResponse) =
+  if not ensureInit(pmp, resp):
+    return
+
+  let r = pmp.deletePortMapping(
+    eport = cushort(req.unmapExternal),
+    iport = cushort(req.unmapExternal),
+    protocol = toPmpProto(req.unmapProto),
+  )
+  if r.isErr:
+    resp.setError("natpmp deletePortMapping: " & $r.error)
+    return
+
+  resp.success = true
+
+proc natpmpWorker(ctx: ptr NatPmpWorkerCtx) {.thread.} =
+  var pmp: NatPmp = nil
+
+  while true:
+    let w = ctx.reqSignal.waitSync()
+    if w.isErr:
+      break
+
+    ctx.response = NatPmpResponse()
+
+    case ctx.request.kind
+    of nrDiscover:
+      handleDiscover(pmp, ctx.response)
+    of nrMap:
+      handleMap(pmp, ctx.request, ctx.response)
+    of nrUnmap:
+      handleUnmap(pmp, ctx.request, ctx.response)
+    of nrShutdown:
+      if pmp != nil:
+        pmp.close()
+        pmp = nil
+      discard ctx.respSignal.fireSync()
+      break
+
+    discard ctx.respSignal.fireSync()
+
+proc dispatch(
+    self: NatPmpMapper, req: sink NatPmpRequest
+): Future[void] {.async: (raises: [CancelledError]).} =
+  if self.closed.load:
+    raise newException(CancelledError, "NatPmpMapper closed")
+
+  self.ctx.request = req
+  let fr = self.ctx.reqSignal.fireSync()
+  if fr.isErr or not fr.get():
+    raise newException(CancelledError, "NatPmpMapper signal fire failed")
+
+  try:
+    await self.ctx.respSignal.wait()
+  except AsyncError as exc:
+    raise newException(CancelledError, "NatPmpMapper wait: " & exc.msg)
+
+proc newNatPmpMapper*(): NatPmpMapper {.raises: [ResourceExhaustedError].} =
+  let ctx = createShared(NatPmpWorkerCtx, 1)
+  ctx.reqSignal = ThreadSignalPtr.new().valueOr:
+    freeShared(ctx)
+    raise newException(ResourceExhaustedError, "NatPmpMapper reqSignal: " & error)
+  ctx.respSignal = ThreadSignalPtr.new().valueOr:
+    discard ctx.reqSignal.close()
+    freeShared(ctx)
+    raise newException(ResourceExhaustedError, "NatPmpMapper respSignal: " & error)
+
+  result = NatPmpMapper(ctx: ctx)
+
+  try:
+    createThread(result.thread, natpmpWorker, ctx)
+  except ValueError, ResourceExhaustedError:
+    discard ctx.reqSignal.close()
+    discard ctx.respSignal.close()
+    freeShared(ctx)
+    raise newException(ResourceExhaustedError, "NatPmpMapper thread create failed")
+
+method discover*(
+    self: NatPmpMapper, timeout: Duration
+): Future[Result[IpAddress, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  await self.dispatch(NatPmpRequest(kind: nrDiscover))
+
+  if not self.ctx.response.success:
+    return Result[IpAddress, string].err(self.ctx.response.getError())
+  let ipOpt = self.ctx.response.getIp()
+  if ipOpt.isNone:
+    return Result[IpAddress, string].err("natpmp discover: missing IP in response")
+  Result[IpAddress, string].ok(ipOpt.get())
+
+method map*(
+    self: NatPmpMapper,
+    internalPort: Port,
+    externalPort: Port,
+    proto: MapProto,
+    lease: uint32,
+): Future[Result[Port, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  await self.dispatch(
+    NatPmpRequest(
+      kind: nrMap,
+      mapInternal: uint16(internalPort),
+      mapExternal: uint16(externalPort),
+      mapProto: proto,
+      mapLease: lease,
+    )
+  )
+
+  if self.ctx.response.success:
+    return Result[Port, string].ok(Port(self.ctx.response.externalPort))
+  Result[Port, string].err(self.ctx.response.getError())
+
+method unmap*(
+    self: NatPmpMapper, externalPort: Port, proto: MapProto
+): Future[Result[void, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  await self.dispatch(
+    NatPmpRequest(kind: nrUnmap, unmapExternal: uint16(externalPort), unmapProto: proto)
+  )
+
+  if self.ctx.response.success:
+    return Result[void, string].ok()
+  Result[void, string].err(self.ctx.response.getError())
+
+method close*(self: NatPmpMapper) {.gcsafe, raises: [].} =
+  if self.closed.exchange(true):
+    return
+
+  self.ctx.request = NatPmpRequest(kind: nrShutdown)
+  let fr = self.ctx.reqSignal.fireSync()
+  if fr.isErr or not fr.get():
+    warn "NatPmpMapper shutdown signal failed",
+      err = (if fr.isErr: fr.error else: "timeout")
+
+  try:
+    joinThread(self.thread)
+  except Exception as exc:
+    warn "NatPmpMapper joinThread failed", err = exc.msg
+
+  discard self.ctx.reqSignal.close()
+  discard self.ctx.respSignal.close()
+  freeShared(self.ctx)

--- a/libp2p/services/nat/upnp_mapper.nim
+++ b/libp2p/services/nat/upnp_mapper.nim
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## UPnP-IGD port mapper. The underlying `nat_traversal/miniupnpc` API is
+## synchronous (blocking C calls into miniupnpc), so this module owns a
+## dedicated worker thread that holds the `Miniupnp` instance for the lifetime
+## of the mapper. The async API on top dispatches one request at a time to the
+## worker via two `ThreadSignalPtr`s, with all transferred data laid out as
+## fixed-size POD so no Nim GC heap crosses the thread boundary.
+
+{.push raises: [].}
+
+import std/[atomics, net]
+import chronos, chronos/threadsync, chronicles, results
+import nat_traversal/miniupnpc
+import ./portmapper
+
+logScope:
+  topics = "libp2p natservice upnp"
+
+const
+  ErrBufLen = 256
+  IpBufLen = 16
+
+type
+  UpnpReqKind = enum
+    urDiscover
+    urMap
+    urUnmap
+    urShutdown
+
+  UpnpRequest = object
+    case kind: UpnpReqKind
+    of urDiscover:
+      discoverDelayMs: cint
+    of urMap:
+      mapInternal: uint16
+      mapExternal: uint16
+      mapProto: MapProto
+      mapLease: uint32
+    of urUnmap:
+      unmapExternal: uint16
+      unmapProto: MapProto
+    of urShutdown:
+      discard
+
+  UpnpResponse = object
+    success: bool
+    errorLen: int
+    errorBuf: array[ErrBufLen, char]
+    ipFamily: int # 0 = unset, 4 = IPv4, 6 = IPv6
+    ipBuf: array[IpBufLen, byte]
+    externalPort: uint16
+
+  UpnpWorkerCtx = object
+    reqSignal: ThreadSignalPtr
+    respSignal: ThreadSignalPtr
+    request: UpnpRequest
+    response: UpnpResponse
+
+  UpnpMapper* = ref object of PortMapper
+    ctx: ptr UpnpWorkerCtx
+    thread: Thread[ptr UpnpWorkerCtx]
+    closed: Atomic[bool]
+
+# ----------------------------------------------------------------------------
+# Response buffer helpers (called from both threads; only touch POD fields)
+# ----------------------------------------------------------------------------
+
+proc setError(resp: var UpnpResponse, msg: string) =
+  resp.success = false
+  resp.ipFamily = 0
+  resp.externalPort = 0
+  let n = min(msg.len, ErrBufLen)
+  for i in 0 ..< n:
+    resp.errorBuf[i] = msg[i]
+  resp.errorLen = n
+
+proc getError(resp: UpnpResponse): string =
+  result = newString(resp.errorLen)
+  for i in 0 ..< resp.errorLen:
+    result[i] = resp.errorBuf[i]
+
+proc setIp(resp: var UpnpResponse, ip: IpAddress) =
+  case ip.family
+  of IpAddressFamily.IPv4:
+    resp.ipFamily = 4
+    for i in 0 .. 3:
+      resp.ipBuf[i] = ip.address_v4[i]
+  of IpAddressFamily.IPv6:
+    resp.ipFamily = 6
+    for i in 0 .. 15:
+      resp.ipBuf[i] = ip.address_v6[i]
+
+proc getIp(resp: UpnpResponse): Opt[IpAddress] =
+  case resp.ipFamily
+  of 4:
+    var ip = IpAddress(family: IpAddressFamily.IPv4)
+    for i in 0 .. 3:
+      ip.address_v4[i] = resp.ipBuf[i]
+    Opt.some(ip)
+  of 6:
+    var ip = IpAddress(family: IpAddressFamily.IPv6)
+    for i in 0 .. 15:
+      ip.address_v6[i] = resp.ipBuf[i]
+    Opt.some(ip)
+  else:
+    Opt.none(IpAddress)
+
+# ----------------------------------------------------------------------------
+# Worker thread body
+# ----------------------------------------------------------------------------
+
+proc toUpnpProto(p: MapProto): UPNPProtocol =
+  case p
+  of mpTcp: UPNPProtocol.TCP
+  of mpUdp: UPNPProtocol.UDP
+
+proc handleDiscover(upnp: var Miniupnp, req: UpnpRequest, resp: var UpnpResponse) =
+  if upnp == nil:
+    upnp = newMiniupnp()
+  upnp.discoverDelay = req.discoverDelayMs
+
+  let dr = upnp.discover()
+  if dr.isErr:
+    resp.setError("upnp discover: " & $dr.error)
+    return
+
+  let igd = upnp.selectIGD()
+  if igd != IGDFound:
+    resp.setError("upnp selectIGD: " & $igd)
+    return
+
+  let ipr = upnp.externalIPAddress()
+  if ipr.isErr:
+    resp.setError("upnp externalIPAddress: " & $ipr.error)
+    return
+
+  try:
+    let ip = parseIpAddress(ipr.get())
+    resp.success = true
+    resp.setIp(ip)
+  except ValueError as exc:
+    resp.setError("upnp parseIpAddress: " & exc.msg)
+
+proc handleMap(upnp: Miniupnp, req: UpnpRequest, resp: var UpnpResponse) =
+  if upnp == nil:
+    resp.setError("upnp map: not discovered")
+    return
+
+  let r = upnp.addPortMapping(
+    externalPort = $req.mapExternal,
+    protocol = toUpnpProto(req.mapProto),
+    internalHost = upnp.lanAddr,
+    internalPort = $req.mapInternal,
+    desc = "nim-libp2p",
+    leaseDuration = int(req.mapLease),
+  )
+  if r.isErr:
+    resp.setError("upnp addPortMapping: " & $r.error)
+    return
+
+  resp.success = true
+  resp.externalPort = req.mapExternal # IGD:1 returns the requested port
+
+proc handleUnmap(upnp: Miniupnp, req: UpnpRequest, resp: var UpnpResponse) =
+  if upnp == nil:
+    resp.setError("upnp unmap: not discovered")
+    return
+
+  let r = upnp.deletePortMapping(
+    externalPort = $req.unmapExternal, protocol = toUpnpProto(req.unmapProto)
+  )
+  if r.isErr:
+    resp.setError("upnp deletePortMapping: " & $r.error)
+    return
+
+  resp.success = true
+
+proc upnpWorker(ctx: ptr UpnpWorkerCtx) {.thread.} =
+  var upnp: Miniupnp = nil
+
+  while true:
+    let w = ctx.reqSignal.waitSync()
+    if w.isErr:
+      # signal closed or fatal — bail out
+      break
+
+    ctx.response = UpnpResponse()
+
+    case ctx.request.kind
+    of urDiscover:
+      handleDiscover(upnp, ctx.request, ctx.response)
+    of urMap:
+      handleMap(upnp, ctx.request, ctx.response)
+    of urUnmap:
+      handleUnmap(upnp, ctx.request, ctx.response)
+    of urShutdown:
+      if upnp != nil:
+        upnp.close()
+        upnp = nil
+      discard ctx.respSignal.fireSync()
+      break
+
+    discard ctx.respSignal.fireSync()
+
+# ----------------------------------------------------------------------------
+# Main-thread async dispatch
+# ----------------------------------------------------------------------------
+
+proc dispatch(
+    self: UpnpMapper, req: sink UpnpRequest
+): Future[void] {.async: (raises: [CancelledError]).} =
+  if self.closed.load:
+    raise newException(CancelledError, "UpnpMapper closed")
+
+  self.ctx.request = req
+  let fr = self.ctx.reqSignal.fireSync()
+  if fr.isErr or not fr.get():
+    raise newException(CancelledError, "UpnpMapper signal fire failed")
+
+  try:
+    await self.ctx.respSignal.wait()
+  except AsyncError as exc:
+    raise newException(CancelledError, "UpnpMapper wait: " & exc.msg)
+
+proc newUpnpMapper*(): UpnpMapper {.raises: [ResourceExhaustedError].} =
+  let ctx = createShared(UpnpWorkerCtx, 1)
+  ctx.reqSignal = ThreadSignalPtr.new().valueOr:
+    freeShared(ctx)
+    raise newException(ResourceExhaustedError, "UpnpMapper reqSignal: " & error)
+  ctx.respSignal = ThreadSignalPtr.new().valueOr:
+    discard ctx.reqSignal.close()
+    freeShared(ctx)
+    raise newException(ResourceExhaustedError, "UpnpMapper respSignal: " & error)
+
+  result = UpnpMapper(ctx: ctx)
+
+  try:
+    createThread(result.thread, upnpWorker, ctx)
+  except ValueError, ResourceExhaustedError:
+    discard ctx.reqSignal.close()
+    discard ctx.respSignal.close()
+    freeShared(ctx)
+    raise newException(ResourceExhaustedError, "UpnpMapper thread create failed")
+
+method discover*(
+    self: UpnpMapper, timeout: Duration
+): Future[Result[IpAddress, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  await self.dispatch(
+    UpnpRequest(kind: urDiscover, discoverDelayMs: cint(timeout.milliseconds))
+  )
+
+  if not self.ctx.response.success:
+    return Result[IpAddress, string].err(self.ctx.response.getError())
+  let ipOpt = self.ctx.response.getIp()
+  if ipOpt.isNone:
+    return Result[IpAddress, string].err("upnp discover: missing IP in response")
+  Result[IpAddress, string].ok(ipOpt.get())
+
+method map*(
+    self: UpnpMapper,
+    internalPort: Port,
+    externalPort: Port,
+    proto: MapProto,
+    lease: uint32,
+): Future[Result[Port, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  await self.dispatch(
+    UpnpRequest(
+      kind: urMap,
+      mapInternal: uint16(internalPort),
+      mapExternal: uint16(externalPort),
+      mapProto: proto,
+      mapLease: lease,
+    )
+  )
+
+  if self.ctx.response.success:
+    return Result[Port, string].ok(Port(self.ctx.response.externalPort))
+  Result[Port, string].err(self.ctx.response.getError())
+
+method unmap*(
+    self: UpnpMapper, externalPort: Port, proto: MapProto
+): Future[Result[void, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  await self.dispatch(
+    UpnpRequest(kind: urUnmap, unmapExternal: uint16(externalPort), unmapProto: proto)
+  )
+
+  if self.ctx.response.success:
+    return Result[void, string].ok()
+  Result[void, string].err(self.ctx.response.getError())
+
+method close*(self: UpnpMapper) {.gcsafe, raises: [].} =
+  if self.closed.exchange(true):
+    return
+
+  self.ctx.request = UpnpRequest(kind: urShutdown)
+  let fr = self.ctx.reqSignal.fireSync()
+  if fr.isErr or not fr.get():
+    warn "UpnpMapper shutdown signal failed",
+      err = (if fr.isErr: fr.error else: "timeout")
+
+  try:
+    joinThread(self.thread)
+  except Exception as exc:
+    warn "UpnpMapper joinThread failed", err = exc.msg
+
+  discard self.ctx.reqSignal.close()
+  discard self.ctx.respSignal.close()
+  freeShared(self.ctx)

--- a/libp2p/services/natservice.nim
+++ b/libp2p/services/natservice.nim
@@ -3,10 +3,13 @@
 
 {.push raises: [].}
 
-import std/[net, sequtils]
+import std/[net, sequtils, strutils]
 import chronos, chronicles, results
-import ../[multiaddress]
+import ../[multiaddress, multicodec, wire]
 import ../switch
+import ./nat/[portmapper, upnp_mapper, natpmp_mapper]
+
+export portmapper
 
 logScope:
   topics = "libp2p natservice"
@@ -15,11 +18,17 @@ type
   NATMode* = enum
     natModeAuto
       ## Use libp2p-native mechanisms (autonat / hole-punching). No port-mapping
-      ## is performed.
-      ## TODO: In this skeleton it is a no-op;
+      ## is performed here.
+      ## TODO: In this skeleton it is a no-op; folded in by piece 3a.
     natModeExplicitIp
       ## Static external IP, no probing. The configured ``explicitIp`` is combined
       ## with the bound listen addresses to produce the announced address set.
+    natModeUpnp
+      ## Discover an IGD via UPnP, request port mappings for each private
+      ## listen address, and surface the public ``(extIp, extPort)`` multiaddrs
+      ## through the peerInfo addressMappers chain. Mappings are refreshed
+      ## periodically.
+    natModeNatPmp ## Same as ``natModeUpnp`` but using the NAT-PMP protocol.
 
   NATConfig* = object
     case mode*: NATMode
@@ -27,13 +36,70 @@ type
       explicitIp*: IpAddress
     of natModeAuto:
       discard
+    of natModeUpnp, natModeNatPmp:
+      refreshInterval*: Duration
+      discoveryTimeout*: Duration
+      leaseDuration*: uint32
+
+  PortMapperFactory* = proc(mode: NATMode): PortMapper {.gcsafe, raises: [].}
 
   NATService* = ref object of Service
     config: NATConfig
     addressMapper: AddressMapper
+    portMapperFactory: PortMapperFactory
+    mapper: PortMapper
+    refreshLoopFut: Future[void]
+    mappedPorts: seq[(Port, MapProto)]
+    externalIp*: Opt[IpAddress]
 
-proc new*(T: typedesc[NATService], config: NATConfig): T =
-  T(config: config)
+const
+  DefaultUpnpRefreshInterval* = 30.minutes
+  DefaultUpnpDiscoveryTimeout* = 10.seconds
+  DefaultUpnpLeaseDuration*: uint32 = 3600
+
+proc upnpConfig*(
+    refreshInterval = DefaultUpnpRefreshInterval,
+    discoveryTimeout = DefaultUpnpDiscoveryTimeout,
+    leaseDuration = DefaultUpnpLeaseDuration,
+): NATConfig =
+  NATConfig(
+    mode: natModeUpnp,
+    refreshInterval: refreshInterval,
+    discoveryTimeout: discoveryTimeout,
+    leaseDuration: leaseDuration,
+  )
+
+proc natPmpConfig*(
+    refreshInterval = DefaultUpnpRefreshInterval,
+    discoveryTimeout = DefaultUpnpDiscoveryTimeout,
+    leaseDuration = DefaultUpnpLeaseDuration,
+): NATConfig =
+  NATConfig(
+    mode: natModeNatPmp,
+    refreshInterval: refreshInterval,
+    discoveryTimeout: discoveryTimeout,
+    leaseDuration: leaseDuration,
+  )
+
+proc defaultPortMapperFactory(mode: NATMode): PortMapper {.gcsafe, raises: [].} =
+  try:
+    case mode
+    of natModeUpnp:
+      newUpnpMapper()
+    of natModeNatPmp:
+      newNatPmpMapper()
+    else:
+      nil
+  except ResourceExhaustedError as exc:
+    error "Failed to construct port mapper", mode, err = exc.msg
+    nil
+
+proc new*(
+    T: typedesc[NATService],
+    config: NATConfig,
+    portMapperFactory: PortMapperFactory = defaultPortMapperFactory,
+): T =
+  T(config: config, portMapperFactory: portMapperFactory)
 
 proc explicitIpMapped*(
     listenAddrs: seq[MultiAddress], explicitIp: IpAddress
@@ -56,6 +122,152 @@ proc explicitIpMapped*(
         addrs.add(remapped)
   addrs
 
+# --------------------------------------------------------------------------
+# UPnP / NAT-PMP helpers
+# --------------------------------------------------------------------------
+
+type ListenPort = tuple[port: Port, proto: MapProto, multiAddr: MultiAddress]
+
+proc extractListenPort(ma: MultiAddress): Opt[ListenPort] =
+  ## Pulls (port, transport protocol) out of a listen multiaddress. Returns
+  ## ``none`` if ``ma`` lacks an IP4/IP6 part or a TCP/UDP part. Only IPv4 is
+  ## considered — UPnP and NAT-PMP are IPv4 protocols.
+  if ma.getIp().isNone:
+    return Opt.none(ListenPort)
+
+  let tcpPart = ma[multiCodec("tcp")]
+  if tcpPart.isOk:
+    let ta = initTAddress(ma).valueOr:
+      return Opt.none(ListenPort)
+    return Opt.some((port: ta.port, proto: mpTcp, multiAddr: ma))
+
+  let udpPart = ma[multiCodec("udp")]
+  if udpPart.isOk:
+    let ta = initTAddress(ma).valueOr:
+      return Opt.none(ListenPort)
+    return Opt.some((port: ta.port, proto: mpUdp, multiAddr: ma))
+
+  Opt.none(ListenPort)
+
+proc buildAnnouncedAddr(
+    listenAddr: MultiAddress, externalIp: IpAddress, externalPort: Port
+): Opt[MultiAddress] =
+  ## Take a private listen multiaddress and return the announced equivalent
+  ## with ``externalIp``/``externalPort`` substituted in, preserving transport
+  ## and any suffix.
+  if externalIp.family != IpAddressFamily.IPv4:
+    return Opt.none(MultiAddress)
+
+  let replaced = listenAddr.replaceIp(externalIp).valueOr:
+    return Opt.none(MultiAddress)
+
+  # If the source listen port differs from the mapped external port, we have
+  # to overwrite the port component too. Build by string for simplicity.
+  let srcTa = initTAddress(listenAddr).valueOr:
+    return Opt.some(replaced)
+  if srcTa.port == externalPort:
+    return Opt.some(replaced)
+
+  # Rebuild via string substitution: replace "/tcp/<srcPort>" or "/udp/<srcPort>".
+  let s = $replaced
+  let srcPortStr = "/" & $srcTa.port
+  let srcTcp = "/tcp" & srcPortStr
+  let srcUdp = "/udp" & srcPortStr
+  let dstTcp = "/tcp/" & $externalPort
+  let dstUdp = "/udp/" & $externalPort
+
+  let rebuilt =
+    if srcTcp in s:
+      s.replace(srcTcp, dstTcp)
+    elif srcUdp in s:
+      s.replace(srcUdp, dstUdp)
+    else:
+      return Opt.some(replaced)
+
+  let m = MultiAddress.init(rebuilt).valueOr:
+    return Opt.some(replaced)
+  Opt.some(m)
+
+proc unmapAll(self: NATService) {.async: (raises: [CancelledError]).} =
+  ## Tear down any port mappings we created. Best-effort — failures are logged
+  ## but don't propagate.
+  for (port, proto) in self.mappedPorts:
+    let r = await self.mapper.unmap(port, proto)
+    if r.isErr:
+      warn "Failed to unmap port", port, proto, err = r.error
+  self.mappedPorts.setLen(0)
+
+proc setupMappings*(
+    self: NATService, listenAddrs: seq[MultiAddress]
+): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
+  ## Discover the IGD if not already done, request a mapping for every private
+  ## listen address, and return the resulting announced multiaddr set. Updates
+  ## ``self.externalIp`` and ``self.mappedPorts`` as a side-effect. Exposed for
+  ## tests; the production caller is the addressMapper closure installed in
+  ## ``setup``.
+  let listenPorts: seq[ListenPort] = listenAddrs
+    .filterIt(it.isPrivateMA)
+    .mapIt(extractListenPort(it))
+    .filterIt(it.isSome)
+    .mapIt(it.get())
+
+  if listenPorts.len == 0:
+    debug "No private listen addresses to map; skipping NAT port mapping"
+    return @[]
+
+  if self.mapper.isNil:
+    debug "No port mapper available; skipping NAT port mapping"
+    return @[]
+
+  if self.externalIp.isNone:
+    let discoverRes = await self.mapper.discover(self.config.discoveryTimeout)
+    if discoverRes.isErr:
+      warn "NAT discovery failed; not announcing mapped addresses",
+        err = discoverRes.error
+      return @[]
+    self.externalIp = Opt.some(discoverRes.get())
+    info "NAT discovery succeeded", externalIp = self.externalIp.get()
+
+  let externalIp = self.externalIp.get()
+
+  var announced: seq[MultiAddress]
+  for lp in listenPorts:
+    let mapRes =
+      await self.mapper.map(lp.port, lp.port, lp.proto, self.config.leaseDuration)
+    if mapRes.isErr:
+      warn "NAT port mapping failed",
+        port = lp.port, proto = lp.proto, err = mapRes.error
+      continue
+
+    let extPort = mapRes.get()
+    let entry = (extPort, lp.proto)
+    if entry notin self.mappedPorts:
+      self.mappedPorts.add(entry)
+
+    buildAnnouncedAddr(lp.multiAddr, externalIp, extPort).withValue(annAddr):
+      if annAddr notin announced:
+        announced.add(annAddr)
+
+  announced
+
+proc refreshLoop(self: NATService, switch: Switch) {.async: (raises: []).} =
+  ## Re-issue the mapping requests before the lease expires by triggering a
+  ## ``peerInfo.update()``, which re-invokes our addressMapper.
+  while true:
+    try:
+      await sleepAsync(self.config.refreshInterval)
+    except CancelledError:
+      return
+
+    try:
+      await switch.peerInfo.update()
+    except CancelledError:
+      return
+
+# --------------------------------------------------------------------------
+# Service lifecycle
+# --------------------------------------------------------------------------
+
 method setup*(self: NATService, switch: Switch) {.raises: [ServiceSetupError].} =
   debug "Setting up NATService", mode = self.config.mode
 
@@ -68,19 +280,63 @@ method setup*(self: NATService, switch: Switch) {.raises: [ServiceSetupError].} 
         listenAddrs: seq[MultiAddress]
     ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
       return explicitIpMapped(listenAddrs, self.config.explicitIp)
+  of natModeUpnp, natModeNatPmp:
+    if self.portMapperFactory.isNil:
+      raise newException(
+        ServiceSetupError, "NATService: portMapperFactory must be set for UPnP/NAT-PMP"
+      )
+    self.mapper = self.portMapperFactory(self.config.mode)
+    if self.mapper.isNil:
+      raise newException(
+        ServiceSetupError,
+        "NATService: portMapperFactory returned nil for " & $self.config.mode,
+      )
+    self.addressMapper = proc(
+        listenAddrs: seq[MultiAddress]
+    ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
+      let announced = await self.setupMappings(listenAddrs)
+      # If we got nothing back (e.g. discovery failed, no private listenAddrs)
+      # fall back to passing the listenAddrs through unchanged so the next
+      # mapper in the chain has something to work with.
+      if announced.len == 0:
+        return listenAddrs
+      return announced
 
 method start*(self: NATService, switch: Switch) {.async: (raises: [CancelledError]).} =
   trace "Starting NATService", mode = self.config.mode
+
   if self.addressMapper != nil:
     switch.peerInfo.addressMappers.add(self.addressMapper)
-  # peerInfo.update is invoked by Switch.start once transports have bound,
-  # at which point the mapper runs against the resolved listenAddrs.
+  # peerInfo.update is invoked by Switch.start once transports have bound, at
+  # which point the mapper runs against the resolved listenAddrs.
+
+  case self.config.mode
+  of natModeUpnp, natModeNatPmp:
+    self.refreshLoopFut = self.refreshLoop(switch)
+  else:
+    discard
 
 method stop*(self: NATService, switch: Switch) {.async: (raises: [CancelledError]).} =
   trace "Stopping NATService"
-  if self.addressMapper != nil:
-    switch.peerInfo.addressMappers.keepItIf(it != self.addressMapper)
-  # Do not touch peerInfo.announcedAddrs here: those may have been set by the
-  # user via withAnnouncedAddresses, and triggering peerInfo.update during
-  # shutdown can cause observers (e.g. IdentifyPusher) to broadcast while the
-  # switch is tearing down.
+
+  case self.config.mode
+  of natModeAuto:
+    discard
+  of natModeExplicitIp:
+    if self.addressMapper != nil:
+      switch.peerInfo.addressMappers.keepItIf(it != self.addressMapper)
+    # Do not touch peerInfo.announcedAddrs here: those may have been set by the
+    # user via withAnnouncedAddresses, and triggering peerInfo.update during
+    # shutdown can cause observers (e.g. IdentifyPusher) to broadcast while the
+    # switch is tearing down.
+  of natModeUpnp, natModeNatPmp:
+    if self.refreshLoopFut != nil and not self.refreshLoopFut.finished:
+      await self.refreshLoopFut.cancelAndWait()
+    if self.addressMapper != nil:
+      switch.peerInfo.addressMappers.keepItIf(it != self.addressMapper)
+    if self.mapper != nil:
+      await self.unmapAll()
+      self.mapper.close()
+      self.mapper = nil
+    # Mirror the explicitIp path: deliberately do not call peerInfo.update()
+    # during shutdown.

--- a/tests/libp2p/services/test_natservice.nim
+++ b/tests/libp2p/services/test_natservice.nim
@@ -4,13 +4,16 @@
 {.used.}
 
 import std/net
-import chronos
-import ../../../libp2p/[builders, switch, multiaddress, multicodec]
+import chronos, results
+import ../../../libp2p/[builders, switch, multiaddress, multicodec, peerinfo, wire]
 import ../../../libp2p/services/natservice
+import ../../../libp2p/services/nat/portmapper
 import ../../tools/[unittest, crypto, multiaddress]
 
 proc makeSwitch(
-    config: NATConfig, listenAddrs: seq[MultiAddress]
+    config: NATConfig,
+    listenAddrs: seq[MultiAddress],
+    portMapperFactory: PortMapperFactory = nil,
 ): Switch {.raises: [LPError].} =
   SwitchBuilder
     .new()
@@ -19,7 +22,7 @@ proc makeSwitch(
     .withTcpTransport()
     .withMplex()
     .withNoise()
-    .withNAT(config)
+    .withNAT(config, portMapperFactory)
     .build()
 
 suite "NATService":
@@ -86,3 +89,234 @@ suite "NATService":
     check switch.peerInfo.announcedAddrs.len == 0
     # addrs falls back to mapper-chain output (which here is just listenAddrs).
     check switch.peerInfo.addrs == switch.peerInfo.listenAddrs
+
+# ---------------------------------------------------------------------------
+# Mock port mapper
+# ---------------------------------------------------------------------------
+
+type MockPortMapper = ref object of PortMapper
+  externalIp: IpAddress
+  discoverResult: Result[IpAddress, string]
+  mapResult: Result[Port, string]
+  unmapResult: Result[void, string]
+  discoverCalls: int
+  mapCalls: seq[tuple[internal, external: Port, proto: MapProto, lease: uint32]]
+  unmapCalls: seq[tuple[external: Port, proto: MapProto]]
+  closed: bool
+  mapEvent: AsyncEvent
+
+method discover*(
+    self: MockPortMapper, timeout: Duration
+): Future[Result[IpAddress, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  inc self.discoverCalls
+  self.discoverResult
+
+method map*(
+    self: MockPortMapper,
+    internalPort: Port,
+    externalPort: Port,
+    proto: MapProto,
+    lease: uint32,
+): Future[Result[Port, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  self.mapCalls.add((internalPort, externalPort, proto, lease))
+  if self.mapEvent != nil:
+    self.mapEvent.fire()
+  if self.mapResult.isErr:
+    self.mapResult
+  else:
+    Result[Port, string].ok(externalPort)
+
+method unmap*(
+    self: MockPortMapper, externalPort: Port, proto: MapProto
+): Future[Result[void, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  self.unmapCalls.add((externalPort, proto))
+  self.unmapResult
+
+method close*(self: MockPortMapper) {.gcsafe, raises: [].} =
+  self.closed = true
+
+proc newMockOk(externalIp: IpAddress): MockPortMapper =
+  MockPortMapper(
+    externalIp: externalIp,
+    discoverResult: Result[IpAddress, string].ok(externalIp),
+    mapResult: Result[Port, string].ok(Port(0)), # actual port set per call
+    unmapResult: Result[void, string].ok(),
+  )
+
+proc mockFactoryFail(): PortMapperFactory =
+  let mapper = MockPortMapper(
+    discoverResult: Result[IpAddress, string].err("mock no IGD"),
+    mapResult: Result[Port, string].err("not discovered"),
+    unmapResult: Result[void, string].ok(),
+  )
+  return proc(mode: NATMode): PortMapper {.gcsafe, raises: [].} =
+    mapper
+
+proc findNatService(switch: Switch): NATService =
+  for s in switch.services:
+    if s of NATService:
+      return NATService(s)
+  raiseAssert "NATService not found in switch.services"
+
+proc loopbackAddr(): MultiAddress =
+  MultiAddress.init("/ip4/127.0.0.1/tcp/0").get()
+
+proc privateAddr(port: int = 9000): MultiAddress =
+  MultiAddress.init("/ip4/192.168.1.5/tcp/" & $port).get()
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+asyncTest "natModeUpnp announces external IP after successful mapping":
+  let
+    externalIp = parseIpAddress("203.0.113.42")
+    mapper = newMockOk(externalIp)
+    factory = proc(mode: NATMode): PortMapper {.gcsafe, raises: [].} =
+      mapper
+    cfg = upnpConfig(refreshInterval = 1.hours)
+    switch = makeSwitch(cfg, @[loopbackAddr()], factory)
+    svc = findNatService(switch)
+
+  await switch.start()
+  defer:
+    await switch.stop()
+
+  # Loopback isn't "private" — the mapper sits idle until we feed it a
+  # private listen address. Drive setupMappings directly with one.
+  let announced = await svc.setupMappings(@[privateAddr(9000)])
+  check announced.len == 1
+  check svc.externalIp.isSome
+  check svc.externalIp.get() == externalIp
+  let annTa = initTAddress(announced[0]).tryGet()
+  check annTa.address_v4 == externalIp.address_v4
+  check annTa.port == Port(9000)
+
+asyncTest "natModeUpnp discovery failure leaves announced empty":
+  let
+    cfg = upnpConfig(refreshInterval = 1.hours)
+    switch = makeSwitch(cfg, @[loopbackAddr()], mockFactoryFail())
+    svc = findNatService(switch)
+
+  await switch.start()
+  defer:
+    await switch.stop()
+
+  let announced = await svc.setupMappings(@[privateAddr(9000)])
+  check announced.len == 0
+  check svc.externalIp.isNone
+
+asyncTest "natModeUpnp refresh loop reissues map calls":
+  let
+    externalIp = parseIpAddress("203.0.113.55")
+    mapper = newMockOk(externalIp)
+  mapper.mapEvent = newAsyncEvent()
+
+  let
+    factory = proc(mode: NATMode): PortMapper {.gcsafe, raises: [].} =
+      mapper
+    cfg = upnpConfig(refreshInterval = 50.milliseconds)
+    switch = makeSwitch(cfg, @[loopbackAddr()], factory)
+
+  await switch.start()
+  defer:
+    await switch.stop()
+
+  # Override the bound listenAddrs with a private one so the addressMapper
+  # actually runs the mapper. The refresh loop calls peerInfo.update(), which
+  # re-invokes the addressMapper.
+  switch.peerInfo.listenAddrs = @[privateAddr(9000)]
+  await switch.peerInfo.update()
+  let firstCalls = mapper.mapCalls.len
+  check firstCalls >= 1
+
+  mapper.mapEvent.clear()
+  await mapper.mapEvent.wait()
+  check mapper.mapCalls.len > firstCalls
+
+asyncTest "natModeUpnp stop unmaps all created mappings":
+  let
+    externalIp = parseIpAddress("203.0.113.7")
+    mapper = newMockOk(externalIp)
+    factory = proc(mode: NATMode): PortMapper {.gcsafe, raises: [].} =
+      mapper
+    cfg = upnpConfig(refreshInterval = 1.hours)
+    switch = makeSwitch(cfg, @[loopbackAddr()], factory)
+    svc = findNatService(switch)
+
+  await switch.start()
+
+  discard await svc.setupMappings(@[privateAddr(9000)])
+  let mapsBefore = mapper.mapCalls.len
+
+  await switch.stop()
+
+  check mapsBefore >= 1
+  check mapper.unmapCalls.len == mapsBefore
+  check mapper.closed
+
+asyncTest "natModeNatPmp announces external IP after successful mapping":
+  let
+    externalIp = parseIpAddress("203.0.113.99")
+    mapper = newMockOk(externalIp)
+    factory = proc(mode: NATMode): PortMapper {.gcsafe, raises: [].} =
+      mapper
+    cfg = natPmpConfig(refreshInterval = 1.hours)
+    switch = makeSwitch(cfg, @[loopbackAddr()], factory)
+    svc = findNatService(switch)
+
+  await switch.start()
+  defer:
+    await switch.stop()
+
+  let announced = await svc.setupMappings(@[privateAddr(9000)])
+  check announced.len == 1
+  check svc.externalIp.isSome
+  check svc.externalIp.get() == externalIp
+
+asyncTest "non-private listen addresses are skipped":
+  let
+    externalIp = parseIpAddress("203.0.113.1")
+    mapper = newMockOk(externalIp)
+    factory = proc(mode: NATMode): PortMapper {.gcsafe, raises: [].} =
+      mapper
+    cfg = upnpConfig(refreshInterval = 1.hours)
+    switch = makeSwitch(cfg, @[loopbackAddr()], factory)
+    svc = findNatService(switch)
+
+  await switch.start()
+  defer:
+    await switch.stop()
+
+  # Public + loopback addresses only → discover never runs, no mappings made.
+  let announced = await svc.setupMappings(
+    @[
+      MultiAddress.init("/ip4/8.8.8.8/tcp/9000").tryGet(),
+      MultiAddress.init("/ip4/127.0.0.1/tcp/9001").tryGet(),
+    ]
+  )
+
+  check mapper.discoverCalls == 0
+  check mapper.mapCalls.len == 0
+  check announced.len == 0
+
+asyncTest "user-set announcedAddrs are not overwritten":
+  let
+    externalIp = parseIpAddress("203.0.113.111")
+    userAddr = MultiAddress.init("/ip4/198.51.100.7/tcp/4242").tryGet()
+    mapper = newMockOk(externalIp)
+    factory = proc(mode: NATMode): PortMapper {.gcsafe, raises: [].} =
+      mapper
+    cfg = upnpConfig(refreshInterval = 1.hours)
+    switch = makeSwitch(cfg, @[loopbackAddr()], factory)
+
+  switch.peerInfo.announcedAddrs = @[userAddr]
+
+  await switch.start()
+  defer:
+    await switch.stop()
+
+  check switch.peerInfo.announcedAddrs == @[userAddr]
+  # expandAddrs uses announcedAddrs directly when set, bypassing the
+  # addressMapper chain — so the mapper should never have been consulted.
+  check mapper.discoverCalls == 0


### PR DESCRIPTION
## Summary
  - Adds `libp2p/services/nat/upnp_mapper.nim`: worker-thread-based async
  wrapper around the blocking miniupnpc C API
  - Holds a `Miniupnp` instance for the worker's lifetime; main-thread async
  dispatches one request at a time via two `ThreadSignalPtr`s
  - All cross-thread data is fixed-size POD — no Nim GC heap crosses the thread
   boundary

  Part 3 of 6. Not yet wired into NATService — that comes in part 5.