### PR TITLE
feat(LPProtocol): add metrics

### DIFF
--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -4,11 +4,29 @@
 {.push raises: [].}
 
 import std/[tables]
-import chronos, results
+import chronos, results, metrics
 import ../stream/connection
 import ../utils/opt
 
 export results
+
+declareCounter(
+  libp2p_protocol_stream_cap_rejections_total,
+  "protocol stream budget rejections",
+  labels = ["protocol", "direction", "scope"],
+)
+
+declareGauge(
+  libp2p_protocol_streams_open,
+  "protocol stream instances currently open",
+  labels = ["protocol", "direction"],
+)
+
+export libp2p_protocol_stream_cap_rejections_total, libp2p_protocol_streams_open
+
+const
+  scopeTotal = "total"
+  scopePeerPeer = "per_peer"
 
 type
   LPProtoHandler* = proc(stream: Stream, proto: string): Future[void] {.
@@ -81,36 +99,58 @@ proc new*(
     ),
   )
 
+func budgetReason(p: LPProtocol, peerId: PeerId, dir: Direction): (bool, string) =
+  ## Returns (canAccept, scope) indicating whether a stream can be accepted
+  ## and which scope would reject it.
+  let budget = p.streamBudget
+  if budget.isNil:
+    return (true, "")
+
+  if dir == Direction.In:
+    if p.maxIncomingStreamsPerPeer.isSome and
+        budget.perPeerIncoming.getOrDefault(peerId) >= p.maxIncomingStreamsPerPeer.get:
+      return (false, scopePeerPeer)
+    if p.maxIncomingStreamsTotal.isSome and
+        budget.totalIncoming >= p.maxIncomingStreamsTotal.get:
+      return (false, scopeTotal)
+  else:
+    if p.maxOutgoingStreamsPerPeer.isSome and
+        budget.perPeerOutgoing.getOrDefault(peerId) >= p.maxOutgoingStreamsPerPeer.get:
+      return (false, scopePeerPeer)
+    if p.maxOutgoingStreamsTotal.isSome and
+        budget.totalOutgoing >= p.maxOutgoingStreamsTotal.get:
+      return (false, scopeTotal)
+
+  return (true, "")
+
 func canAcceptIncoming*(p: LPProtocol, peerId: PeerId): bool =
   ## Returns true if an incoming stream from `peerId` is within all configured
   ## inbound budgets. Returns false when any limit would be exceeded.
-  let budget = p.streamBudget
-  if budget.isNil:
-    return true
-  if p.maxIncomingStreamsPerPeer.isSome and
-      budget.perPeerIncoming.getOrDefault(peerId) >= p.maxIncomingStreamsPerPeer.get:
-    return false
-  if p.maxIncomingStreamsTotal.isSome and
-      budget.totalIncoming >= p.maxIncomingStreamsTotal.get:
-    return false
-  return true
+  let (canAccept, _) = p.budgetReason(peerId, Direction.In)
+  canAccept
 
 proc reserveIncoming*(p: LPProtocol, peerId: PeerId): bool =
-  if not p.canAcceptIncoming(peerId):
-    return false
-
   let budget = p.streamBudget
   if budget.isNil:
     return true
+
+  let (canAccept, scope) = p.budgetReason(peerId, Direction.In)
+  if not canAccept:
+    libp2p_protocol_stream_cap_rejections_total.inc(
+      labelValues = [p.codec, "in", scope]
+    )
+    return false
 
   budget.totalIncoming.inc
   budget.perPeerIncoming.inc(peerId)
+  libp2p_protocol_streams_open.inc(labelValues = [p.codec, "in"])
   return true
 
 proc releaseIncoming*(p: LPProtocol, peerId: PeerId) =
   let budget = p.streamBudget
   if budget.isNil:
     return
+
   budget.totalIncoming.dec
   if budget.totalIncoming < 0:
     budget.totalIncoming = 0
@@ -118,39 +158,41 @@ proc releaseIncoming*(p: LPProtocol, peerId: PeerId) =
   if budget.perPeerIncoming[peerId] <= 0:
     budget.perPeerIncoming.del(peerId)
 
+  libp2p_protocol_streams_open.dec(labelValues = [p.codec, "in"])
+
 func canOpenOutgoing*(p: LPProtocol, peerId: PeerId): bool =
   ## Returns true if an outgoing stream to `peerId` is within all configured
   ## outbound budgets. Returns false when any limit would be exceeded.
-  let budget = p.streamBudget
-  if budget.isNil:
-    return true
-  if p.maxOutgoingStreamsPerPeer.isSome and
-      budget.perPeerOutgoing.getOrDefault(peerId) >= p.maxOutgoingStreamsPerPeer.get:
-    return false
-  if p.maxOutgoingStreamsTotal.isSome and
-      budget.totalOutgoing >= p.maxOutgoingStreamsTotal.get:
-    return false
-  return true
+  let (canAccept, _) = p.budgetReason(peerId, Direction.Out)
+  canAccept
 
 proc reserveOutgoing*(p: LPProtocol, peerId: PeerId): bool =
-  if not p.canOpenOutgoing(peerId):
-    return false
-
   let budget = p.streamBudget
   if budget.isNil:
     return true
+
+  let (canAccept, scope) = p.budgetReason(peerId, Direction.Out)
+  if not canAccept:
+    libp2p_protocol_stream_cap_rejections_total.inc(
+      labelValues = [p.codec, "out", scope]
+    )
+    return false
 
   budget.totalOutgoing.inc
   budget.perPeerOutgoing.inc(peerId)
+  libp2p_protocol_streams_open.inc(labelValues = [p.codec, "out"])
   return true
 
 proc releaseOutgoing*(p: LPProtocol, peerId: PeerId) =
   let budget = p.streamBudget
   if budget.isNil:
     return
+
   budget.totalOutgoing.dec
   if budget.totalOutgoing < 0:
     budget.totalOutgoing = 0
   budget.perPeerOutgoing.inc(peerId, -1)
   if budget.perPeerOutgoing[peerId] <= 0:
     budget.perPeerOutgoing.del(peerId)
+
+  libp2p_protocol_streams_open.dec(labelValues = [p.codec, "out"])

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -86,6 +86,7 @@ proc new*(
     maxOutgoingStreamsTotal: Opt[int] | int = Opt.none(int),
     maxOutgoingStreamsPerPeer: Opt[int] | int = Opt.none(int),
 ): T =
+  doAssert(codecs.len > 0, "Codecs sequence must not be empty!")
   T(
     codecs: codecs,
     handlerImpl: handler,

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -26,7 +26,7 @@ export libp2p_protocol_stream_cap_rejections_total, libp2p_protocol_streams_open
 
 const
   scopeTotal = "total"
-  scopePeerPeer = "per_peer"
+  scopePerPeer = "per_peer"
 
 type
   LPProtoHandler* = proc(stream: Stream, proto: string): Future[void] {.
@@ -109,14 +109,14 @@ func budgetReason(p: LPProtocol, peerId: PeerId, dir: Direction): (bool, string)
   if dir == Direction.In:
     if p.maxIncomingStreamsPerPeer.isSome and
         budget.perPeerIncoming.getOrDefault(peerId) >= p.maxIncomingStreamsPerPeer.get:
-      return (false, scopePeerPeer)
+      return (false, scopePerPeer)
     if p.maxIncomingStreamsTotal.isSome and
         budget.totalIncoming >= p.maxIncomingStreamsTotal.get:
       return (false, scopeTotal)
   else:
     if p.maxOutgoingStreamsPerPeer.isSome and
         budget.perPeerOutgoing.getOrDefault(peerId) >= p.maxOutgoingStreamsPerPeer.get:
-      return (false, scopePeerPeer)
+      return (false, scopePerPeer)
     if p.maxOutgoingStreamsTotal.isSome and
         budget.totalOutgoing >= p.maxOutgoingStreamsTotal.get:
       return (false, scopeTotal)

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -132,6 +132,7 @@ func canAcceptIncoming*(p: LPProtocol, peerId: PeerId): bool =
 proc reserveIncoming*(p: LPProtocol, peerId: PeerId): bool =
   let budget = p.streamBudget
   if budget.isNil:
+    libp2p_protocol_streams_open.inc(labelValues = [p.codec, "in"])
     return true
 
   let (canAccept, scope) = p.budgetReason(peerId, Direction.In)
@@ -149,6 +150,7 @@ proc reserveIncoming*(p: LPProtocol, peerId: PeerId): bool =
 proc releaseIncoming*(p: LPProtocol, peerId: PeerId) =
   let budget = p.streamBudget
   if budget.isNil:
+    libp2p_protocol_streams_open.dec(labelValues = [p.codec, "in"])
     return
 
   let pb = budget.perPeerIncoming[peerId]
@@ -171,6 +173,7 @@ func canOpenOutgoing*(p: LPProtocol, peerId: PeerId): bool =
 proc reserveOutgoing*(p: LPProtocol, peerId: PeerId): bool =
   let budget = p.streamBudget
   if budget.isNil:
+    libp2p_protocol_streams_open.inc(labelValues = [p.codec, "out"])
     return true
 
   let (canAccept, scope) = p.budgetReason(peerId, Direction.Out)
@@ -188,6 +191,7 @@ proc reserveOutgoing*(p: LPProtocol, peerId: PeerId): bool =
 proc releaseOutgoing*(p: LPProtocol, peerId: PeerId) =
   let budget = p.streamBudget
   if budget.isNil:
+    libp2p_protocol_streams_open.dec(labelValues = [p.codec, "out"])
     return
 
   let pb = budget.perPeerOutgoing[peerId]

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -151,13 +151,15 @@ proc releaseIncoming*(p: LPProtocol, peerId: PeerId) =
   if budget.isNil:
     return
 
-  budget.totalIncoming.dec
-  if budget.totalIncoming < 0:
-    budget.totalIncoming = 0
-  budget.perPeerIncoming.inc(peerId, -1)
-  if budget.perPeerIncoming[peerId] <= 0:
+  let pb = budget.perPeerIncoming[peerId]
+  if pb == 0:
+    return # there was no reserve for this peer
+  elif pb == 1:
     budget.perPeerIncoming.del(peerId)
+  else:
+    budget.perPeerIncoming.inc(peerId, -1)
 
+  budget.totalIncoming.dec
   libp2p_protocol_streams_open.dec(labelValues = [p.codec, "in"])
 
 func canOpenOutgoing*(p: LPProtocol, peerId: PeerId): bool =
@@ -188,11 +190,13 @@ proc releaseOutgoing*(p: LPProtocol, peerId: PeerId) =
   if budget.isNil:
     return
 
-  budget.totalOutgoing.dec
-  if budget.totalOutgoing < 0:
-    budget.totalOutgoing = 0
-  budget.perPeerOutgoing.inc(peerId, -1)
-  if budget.perPeerOutgoing[peerId] <= 0:
+  let pb = budget.perPeerOutgoing[peerId]
+  if pb == 0:
+    return # there was no reserve for this peer
+  elif pb == 1:
     budget.perPeerOutgoing.del(peerId)
+  else:
+    budget.perPeerOutgoing.inc(peerId, -1)
 
+  budget.totalOutgoing.dec
   libp2p_protocol_streams_open.dec(labelValues = [p.codec, "out"])

--- a/tests/libp2p/test_multistream.nim
+++ b/tests/libp2p/test_multistream.nim
@@ -209,6 +209,7 @@ suite "Multistream select":
       check proto == "/test/proto/1.0.0"
       await stream.close()
 
+    protocol.codec = "/test/proto/1.0.0"
     protocol.handler = testHandler
     ms.addHandler("/test/proto/1.0.0", protocol)
     await ms.handle(stream)
@@ -236,7 +237,9 @@ suite "Multistream select":
       check proto == "/test/proto/1.0.0"
       await stream.close()
 
+    firstProtocol.codec = "/test/proto/1.0.0"
     firstProtocol.handler = firstHandler
+    secondProtocol.codec = "/test/proto/1.0.0"
     secondProtocol.handler = secondHandler
     ms.addHandler("/test/proto/1.0.0", firstProtocol)
     ms.addHandler("/test/proto/1.0.0", secondProtocol)
@@ -261,6 +264,7 @@ suite "Multistream select":
     stream = Connection(newTestLsStream(testLsHandler))
 
     var protocol: LPProtocol = new LPProtocol
+    protocol.codecs = @["/test/proto1/1.0.0", "/test/proto2/1.0.0"]
     protocol.handler = noReachHandler
     ms.addHandler("/test/proto1/1.0.0", protocol)
     ms.addHandler("/test/proto2/1.0.0", protocol)
@@ -300,6 +304,7 @@ suite "Multistream select":
       finally:
         await stream.close()
 
+    protocol.codec = "/test/proto/1.0.0"
     protocol.handler = testHandler
     let msListen = MultistreamSelect.new()
     msListen.addHandler("/test/proto/1.0.0", protocol)
@@ -460,6 +465,7 @@ suite "Multistream select":
       finally:
         await stream.close()
 
+    protocol.codec = "/test/proto/1.0.0"
     protocol.handler = testHandler
     let msListen = MultistreamSelect.new()
     msListen.addHandler("/test/proto/1.0.0", protocol)
@@ -501,6 +507,7 @@ suite "Multistream select":
       finally:
         await stream.close()
 
+    protocol.codecs = @["/test/proto1/1.0.0", "/test/proto2/1.0.0"]
     protocol.handler = testHandler
     let msListen = MultistreamSelect.new()
     msListen.addHandler("/test/proto1/1.0.0", protocol)


### PR DESCRIPTION
adds metrics to LPProtocol for:
- protocol stream budget rejections 
- protocol stream instances currently open

due to issues with metrics library test are in separate pr. this code has been tested with fixed version from local.