### PR TITLE
chore: add autonat v1 protobuf serialization powered by nim-protobuf-serialization

### DIFF
--- a/libp2p/protocols/connectivity/autonat/client.nim
+++ b/libp2p/protocols/connectivity/autonat/client.nim
@@ -16,10 +16,13 @@ type AutonatClient* = ref object of RootObj
 proc sendDial(
     stream: Stream, pid: PeerId, addrs: seq[MultiAddress]
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
-  let pb = AutonatDial(
-    peerInfo: Opt.some(AutonatPeerInfo(id: Opt.some(pid), addrs: addrs))
+  let pb = AutonatMsg(
+    msgType: MsgType.Dial,
+    dial: Opt.some(AutonatDial(
+      peerInfo: Opt.some(AutonatPeerInfo(id: Opt.some(pid), addrs: addrs))
+    ))
   ).encode()
-  await stream.writeLp(pb.buffer)
+  await stream.writeLp(pb)
 
 method dialMe*(
     self: AutonatClient,
@@ -33,7 +36,7 @@ method dialMe*(
       autonatMsg: Opt[AutonatMsg]
   ): AutonatDialResponse {.raises: [AutonatError].} =
     autonatMsg.withValue(msg):
-      if msg.msgType == DialResponse:
+      if msg.msgType == MsgType.DialResponse:
         msg.response.withValue(res):
           if not (res.status == Ok and res.ma.isNone()):
             return res

--- a/libp2p/protocols/connectivity/autonat/client.nim
+++ b/libp2p/protocols/connectivity/autonat/client.nim
@@ -18,9 +18,9 @@ proc sendDial(
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
   let pb = AutonatMsg(
     msgType: MsgType.Dial,
-    dial: Opt.some(AutonatDial(
-      peerInfo: Opt.some(AutonatPeerInfo(id: Opt.some(pid), addrs: addrs))
-    ))
+    dial: Opt.some(
+      AutonatDial(peerInfo: Opt.some(AutonatPeerInfo(id: Opt.some(pid), addrs: addrs)))
+    ),
   ).encode()
   await stream.writeLp(pb)
 

--- a/libp2p/protocols/connectivity/autonat/server.nim
+++ b/libp2p/protocols/connectivity/autonat/server.nim
@@ -31,15 +31,17 @@ proc sendResponseError(
 ) {.async: (raises: [CancelledError]).} =
   let pb = AutonatMsg(
     msgType: MsgType.DialResponse,
-    response: Opt.some(AutonatDialResponse(
-      status: status,
-      text:
-        if text == "":
-          Opt.none(string)
-        else:
-          Opt.some(text),
-      ma: Opt.none(MultiAddress),
-    ))
+    response: Opt.some(
+      AutonatDialResponse(
+        status: status,
+        text:
+          if text == "":
+            Opt.none(string)
+          else:
+            Opt.some(text),
+        ma: Opt.none(MultiAddress),
+      )
+    ),
   ).encode()
   try:
     await stream.writeLp(pb)
@@ -51,9 +53,11 @@ proc sendResponseOk(
 ) {.async: (raises: [CancelledError]).} =
   let pb = AutonatMsg(
     msgType: MsgType.DialResponse,
-    response: Opt.some(AutonatDialResponse(
-      status: ResponseStatus.Ok, text: Opt.some("Ok"), ma: Opt.some(ma)
-    ))
+    response: Opt.some(
+      AutonatDialResponse(
+        status: ResponseStatus.Ok, text: Opt.some("Ok"), ma: Opt.some(ma)
+      )
+    ),
   ).encode()
   try:
     await stream.writeLp(pb)

--- a/libp2p/protocols/connectivity/autonat/server.nim
+++ b/libp2p/protocols/connectivity/autonat/server.nim
@@ -29,28 +29,34 @@ type Autonat* = ref object of LPProtocol
 proc sendResponseError(
     stream: Stream, status: ResponseStatus, text: string = ""
 ) {.async: (raises: [CancelledError]).} =
-  let pb = AutonatDialResponse(
-    status: status,
-    text:
-      if text == "":
-        Opt.none(string)
-      else:
-        Opt.some(text),
-    ma: Opt.none(MultiAddress),
+  let pb = AutonatMsg(
+    msgType: MsgType.DialResponse,
+    response: Opt.some(AutonatDialResponse(
+      status: status,
+      text:
+        if text == "":
+          Opt.none(string)
+        else:
+          Opt.some(text),
+      ma: Opt.none(MultiAddress),
+    ))
   ).encode()
   try:
-    await stream.writeLp(pb.buffer)
+    await stream.writeLp(pb)
   except LPStreamError as exc:
     trace "autonat failed to send response error", description = exc.msg, stream
 
 proc sendResponseOk(
     stream: Stream, ma: MultiAddress
 ) {.async: (raises: [CancelledError]).} =
-  let pb = AutonatDialResponse(
-    status: ResponseStatus.Ok, text: Opt.some("Ok"), ma: Opt.some(ma)
+  let pb = AutonatMsg(
+    msgType: MsgType.DialResponse,
+    response: Opt.some(AutonatDialResponse(
+      status: ResponseStatus.Ok, text: Opt.some("Ok"), ma: Opt.some(ma)
+    ))
   ).encode()
   try:
-    await stream.writeLp(pb.buffer)
+    await stream.writeLp(pb)
   except LPStreamError as exc:
     trace "autonat failed to send response ok", description = exc.msg, stream
 

--- a/libp2p/protocols/connectivity/autonat/types.nim
+++ b/libp2p/protocols/connectivity/autonat/types.nim
@@ -60,6 +60,4 @@ type
 proc isReachable*(self: NetworkReachability): bool =
   self == NetworkReachability.Reachable
 
-Protobuf.serializerFor(
-  [AutonatPeerInfo, AutonatDial, AutonatDialResponse, AutonatMsg]
-)
+Protobuf.serializerFor([AutonatPeerInfo, AutonatDial, AutonatDialResponse, AutonatMsg])

--- a/libp2p/protocols/connectivity/autonat/types.nim
+++ b/libp2p/protocols/connectivity/autonat/types.nim
@@ -3,10 +3,15 @@
 
 {.push raises: [].}
 
-import stew/objects
 import results, chronos, chronicles
-import ../../../multiaddress, ../../../peerid, ../../../errors
-import ../../../protobuf/minprotobuf
+import
+  protobuf_serialization,
+  protobuf_serialization/pkg/results,
+  protobuf_serialization/std/enums,
+  ../../../multiaddress,
+  ../../../peerid,
+  ../../../errors,
+  ../../../protobuf/utils
 
 logScope:
   topics = "libp2p autonat"
@@ -19,7 +24,7 @@ type
   AutonatError* = object of LPError
   AutonatUnreachableError* = object of LPError
 
-  MsgType* = enum
+  MsgType* {.pure.} = enum
     Dial = 0
     DialResponse = 1
 
@@ -30,22 +35,22 @@ type
     BadRequest = 200
     InternalError = 300
 
-  AutonatPeerInfo* = object
-    id*: Opt[PeerId]
-    addrs*: seq[MultiAddress]
+  AutonatPeerInfo* {.proto2.} = object
+    id* {.fieldNumber: 1, ext.}: Opt[PeerId]
+    addrs* {.fieldNumber: 2, ext.}: seq[MultiAddress]
 
-  AutonatDial* = object
-    peerInfo*: Opt[AutonatPeerInfo]
+  AutonatDial* {.proto2.} = object
+    peerInfo* {.fieldNumber: 1.}: Opt[AutonatPeerInfo]
 
-  AutonatDialResponse* = object
-    status*: ResponseStatus
-    text*: Opt[string]
-    ma*: Opt[MultiAddress]
+  AutonatDialResponse* {.proto2.} = object
+    status* {.fieldNumber: 1, required, ext.}: ResponseStatus
+    text* {.fieldNumber: 2.}: Opt[string]
+    ma* {.fieldNumber: 3, ext.}: Opt[MultiAddress]
 
-  AutonatMsg* = object
-    msgType*: MsgType
-    dial*: Opt[AutonatDial]
-    response*: Opt[AutonatDialResponse]
+  AutonatMsg* {.proto2.} = object
+    msgType* {.fieldNumber: 1, required, ext.}: MsgType
+    dial* {.fieldNumber: 2.}: Opt[AutonatDial]
+    response* {.fieldNumber: 3.}: Opt[AutonatDialResponse]
 
   NetworkReachability* {.pure.} = enum
     Unknown
@@ -55,87 +60,6 @@ type
 proc isReachable*(self: NetworkReachability): bool =
   self == NetworkReachability.Reachable
 
-proc encode(p: AutonatPeerInfo): ProtoBuffer =
-  var pb = initProtoBuffer()
-  p.id.withValue(id):
-    pb.write(1, id)
-  for ma in p.addrs:
-    pb.write(2, ma.data.buffer)
-  pb.finish()
-  pb
-
-proc encode*(d: AutonatDial): ProtoBuffer =
-  var pb = initProtoBuffer()
-  pb.write(1, MsgType.Dial.uint)
-  var dial = initProtoBuffer()
-  d.peerInfo.withValue(pinfo):
-    dial.write(1, encode(pinfo))
-  dial.finish()
-  pb.write(2, dial.buffer)
-  pb.finish()
-  pb
-
-proc encode*(r: AutonatDialResponse): ProtoBuffer =
-  var pb = initProtoBuffer()
-  pb.write(1, MsgType.DialResponse.uint)
-  var bufferResponse = initProtoBuffer()
-  bufferResponse.write(1, r.status.uint)
-  r.text.withValue(text):
-    bufferResponse.write(2, text)
-  r.ma.withValue(ma):
-    bufferResponse.write(3, ma)
-  bufferResponse.finish()
-  pb.write(3, bufferResponse.buffer)
-  pb.finish()
-  pb
-
-proc encode*(msg: AutonatMsg): ProtoBuffer =
-  msg.dial.withValue(dial):
-    return encode(dial)
-  msg.response.withValue(res):
-    return encode(res)
-
-proc decode*(_: typedesc[AutonatMsg], buf: sink seq[byte]): Opt[AutonatMsg] =
-  var
-    msgTypeOrd: uint32
-    pbDial: ProtoBuffer
-    pbResponse: ProtoBuffer
-    msg: AutonatMsg
-
-  let pb = initProtoBuffer(move(buf))
-
-  if ?pb.getField(1, msgTypeOrd).toOpt() and
-      not checkedEnumAssign(msg.msgType, msgTypeOrd):
-    return Opt.none(AutonatMsg)
-  if ?pb.getField(2, pbDial).toOpt():
-    var
-      pbPeerInfo: ProtoBuffer
-      dial: AutonatDial
-    let r4 = ?pbDial.getField(1, pbPeerInfo).toOpt()
-
-    var peerInfo: AutonatPeerInfo
-    if r4:
-      var pid: PeerId
-      let r5 = ?pbPeerInfo.getField(1, pid).toOpt()
-      discard ?pbPeerInfo.getRepeatedField(2, peerInfo.addrs).toOpt()
-      if r5:
-        peerInfo.id = Opt.some(pid)
-      dial.peerInfo = Opt.some(peerInfo)
-    msg.dial = Opt.some(dial)
-
-  if ?pb.getField(3, pbResponse).toOpt():
-    var
-      statusOrd: uint
-      text: string
-      ma: MultiAddress
-      response: AutonatDialResponse
-
-    if ?pbResponse.getField(1, statusOrd).optValue():
-      if not checkedEnumAssign(response.status, statusOrd):
-        return Opt.none(AutonatMsg)
-    if ?pbResponse.getField(2, text).optValue():
-      response.text = Opt.some(text)
-    if ?pbResponse.getField(3, ma).optValue():
-      response.ma = Opt.some(ma)
-    msg.response = Opt.some(response)
-  return Opt.some(msg)
+Protobuf.serializerFor(
+  [AutonatPeerInfo, AutonatDial, AutonatDialResponse, AutonatMsg]
+)

--- a/tests/libp2p/protocols/test_autonat.nim
+++ b/tests/libp2p/protocols/test_autonat.nim
@@ -41,9 +41,13 @@ proc makeAutonatServicePrivate(): Switch =
       await stream.writeLp(
         AutonatMsg(
           msgType: MsgType.DialResponse,
-          response: Opt.some(AutonatDialResponse(
-            status: DialError, text: Opt.some("dial failed"), ma: Opt.none(MultiAddress)
-          ))
+          response: Opt.some(
+            AutonatDialResponse(
+              status: DialError,
+              text: Opt.some("dial failed"),
+              ma: Opt.none(MultiAddress),
+            )
+          ),
         ).encode()
       )
     except LPStreamError:
@@ -102,15 +106,17 @@ suite "Autonat":
     let stream = await src.dial(dst.peerInfo.peerId, @[AutonatCodec])
     let buffer = AutonatMsg(
       msgType: MsgType.Dial,
-      dial: Opt.some(AutonatDial(
-        peerInfo: Opt.some(
-          AutonatPeerInfo(
-            id: Opt.some(src.peerInfo.peerId),
-            # we ask to be dialed in the does nothing listener instead
-            addrs: doesNothingListener.addrs,
+      dial: Opt.some(
+        AutonatDial(
+          peerInfo: Opt.some(
+            AutonatPeerInfo(
+              id: Opt.some(src.peerInfo.peerId),
+              # we ask to be dialed in the does nothing listener instead
+              addrs: doesNothingListener.addrs,
+            )
           )
         )
-      ))
+      ),
     ).encode()
     await stream.writeLp(buffer)
     let response = AutonatMsg.decode(await stream.readLp(1024)).get().response.get()

--- a/tests/libp2p/protocols/test_autonat.nim
+++ b/tests/libp2p/protocols/test_autonat.nim
@@ -39,9 +39,12 @@ proc makeAutonatServicePrivate(): Switch =
     try:
       discard await stream.readLp(1024)
       await stream.writeLp(
-        AutonatDialResponse(
-          status: DialError, text: Opt.some("dial failed"), ma: Opt.none(MultiAddress)
-        ).encode().buffer
+        AutonatMsg(
+          msgType: MsgType.DialResponse,
+          response: Opt.some(AutonatDialResponse(
+            status: DialError, text: Opt.some("dial failed"), ma: Opt.none(MultiAddress)
+          ))
+        ).encode()
       )
     except LPStreamError:
       raiseAssert "Unexpected LPStreamError in autonat private service handler"
@@ -97,15 +100,18 @@ suite "Autonat":
 
     await src.connect(dst.peerInfo.peerId, dst.peerInfo.addrs)
     let stream = await src.dial(dst.peerInfo.peerId, @[AutonatCodec])
-    let buffer = AutonatDial(
-      peerInfo: Opt.some(
-        AutonatPeerInfo(
-          id: Opt.some(src.peerInfo.peerId),
-          # we ask to be dialed in the does nothing listener instead
-          addrs: doesNothingListener.addrs,
+    let buffer = AutonatMsg(
+      msgType: MsgType.Dial,
+      dial: Opt.some(AutonatDial(
+        peerInfo: Opt.some(
+          AutonatPeerInfo(
+            id: Opt.some(src.peerInfo.peerId),
+            # we ask to be dialed in the does nothing listener instead
+            addrs: doesNothingListener.addrs,
+          )
         )
-      )
-    ).encode().buffer
+      ))
+    ).encode()
     await stream.writeLp(buffer)
     let response = AutonatMsg.decode(await stream.readLp(1024)).get().response.get()
     check:


### PR DESCRIPTION
## Summary

This PR replaces minprotobuf-based serialization for autonat v1 protocol with nim-protobuf-serialization-based one.

## Affected Areas
- autonat v1 type definitions
- autonat v1 client
- autonat v1 server
- autonat v1 tests