### PR TITLE
fix: autonatv2 failed dial not reachable

### DIFF
--- a/libp2p/protocols/connectivity/autonatv2/server.nim
+++ b/libp2p/protocols/connectivity/autonatv2/server.nim
@@ -197,7 +197,11 @@ proc chooseDialAddr(
       let (mux, stream) =
         try:
           (await (self.forceNewConnection(pid, @[ma]).wait(self.config.dialTimeout))).valueOr:
-            return (Opt.none((Muxer, Stream)), Opt.none(AddrIdx))
+            # canDial is true, which means the dial was attempted but failed.
+            # Opt.some(i.AddrIdx) is returned so the response is EDialError, which
+            # triggers NotReachable, and not EDialRefused, which triggers Unknown
+            # and would never be updated.
+            return (Opt.none((Muxer, Stream)), Opt.some(AddrIdx))
         except AsyncTimeoutError:
           trace "Dial timed out"
           return (Opt.none((Muxer, Stream)), Opt.some(i.AddrIdx))

--- a/libp2p/protocols/connectivity/autonatv2/server.nim
+++ b/libp2p/protocols/connectivity/autonatv2/server.nim
@@ -201,7 +201,7 @@ proc chooseDialAddr(
             # Opt.some(i.AddrIdx) is returned so the response is EDialError, which
             # triggers NotReachable, and not EDialRefused, which triggers Unknown
             # and would never be updated.
-            return (Opt.none((Muxer, Stream)), Opt.some(AddrIdx))
+            return (Opt.none((Muxer, Stream)), Opt.some(i.AddrIdx))
         except AsyncTimeoutError:
           trace "Dial timed out"
           return (Opt.none((Muxer, Stream)), Opt.some(i.AddrIdx))


### PR DESCRIPTION
## Summary

When AutonatV2 server attempts a dial-back to verify a peer's address but the dial fails (after `canDial` returned true), it previously returned `EDialRefused`. On the client side `EDialRefused` maps to `Unknown` reachability, which is never updated afterwards. As a result a peer whose address is not dialable would stay stuck in `Unknown` instead of being correctly marked `NotReachable`.

This PR makes `chooseDialAddr` return `Opt.some(addrIdx)` when the dial was attempted (`canDial` is true) but failed. This produces an `EDialError` response, which the client maps to `NotReachable`, the correct outcome for an address that cannot be reached.

## Affected Areas

- [ ] Gossipsub  
- [ ] Transports  
- [ ] Peer Management / Discovery
- [x] Protocol Logic  
  AutonatV2 server dial-address selection: failed dials now report `EDialError` (NotReachable) instead of `EDialRefused` (Unknown).
- [ ] Build / Tooling
- [ ] Other  

## Compatibility & Downstream Validation

Reference PRs / branches / commits demonstrating successful integration:

- **Nimbus:**  
  <!-- Link PR or branch -->
- **Waku:**  
  <!-- Link PR or branch -->
- **Codex:**  
  <!-- Link PR or branch -->

## Impact on Library Users

Behavior change only, no API change. AutonatV2 clients now receive accurate reachability results: addresses that fail to dial are reported as `NotReachable` instead of `Unknown`. 

## Risk Assessment

- Backward compatible: only the response status for a failed dial changes (`EDialRefused` → `EDialError`)
- Network behavior: peers that were previously left in `Unknown` will now be marked `NotReachable`
- No performance impact.
- No security implications: amplification attack prevention path is unchanged.


## References

<!-- Link related issues / specs / discussions -->