### PR TITLE
chore(LPProtocol): fast path when there are no limits

### DIFF
--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -36,8 +36,8 @@ type
   StreamBudgetState = ref object
     totalIncoming: int
     totalOutgoing: int
-    perPeerIncoming: CountTable[PeerId] = initCountTable[PeerId]()
-    perPeerOutgoing: CountTable[PeerId] = initCountTable[PeerId]()
+    perPeerIncoming: CountTable[PeerId]
+    perPeerOutgoing: CountTable[PeerId]
 
   LPProtocol* = ref object of RootObj
     started*: bool

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -36,8 +36,8 @@ type
   StreamBudgetState = ref object
     totalIncoming: int
     totalOutgoing: int
-    perPeerIncoming: CountTable[PeerId]
-    perPeerOutgoing: CountTable[PeerId]
+    perPeerIncoming: CountTable[PeerId] = initCountTable[PeerId]()
+    perPeerOutgoing: CountTable[PeerId] = initCountTable[PeerId]()
 
   LPProtocol* = ref object of RootObj
     started*: bool
@@ -87,18 +87,22 @@ proc new*(
     maxOutgoingStreamsPerPeer: Opt[int] | int = Opt.none(int),
 ): T =
   doAssert(codecs.len > 0, "Codecs sequence must not be empty!")
-  T(
+  var proto = T(
     codecs: codecs,
     handlerImpl: handler,
     maxIncomingStreamsTotal: toOpt(maxIncomingStreamsTotal),
     maxIncomingStreamsPerPeer: toOpt(maxIncomingStreamsPerPeer),
     maxOutgoingStreamsTotal: toOpt(maxOutgoingStreamsTotal),
     maxOutgoingStreamsPerPeer: toOpt(maxOutgoingStreamsPerPeer),
-    streamBudget: StreamBudgetState(
-      perPeerIncoming: initCountTable[PeerId](),
-      perPeerOutgoing: initCountTable[PeerId](),
-    ),
   )
+
+  # initialize streamBudget only when there is some limit used.
+  # keeping streamBudget uninitialized makes `reserve` and `release` return early (fast path).
+  if proto.maxIncomingStreamsTotal.isSome or proto.maxIncomingStreamsPerPeer.isSome or
+      proto.maxOutgoingStreamsTotal.isSome or proto.maxOutgoingStreamsPerPeer.isSome:
+    proto.streamBudget = StreamBudgetState()
+
+  proto
 
 func budgetReason(p: LPProtocol, peerId: PeerId, dir: Direction): (bool, string) =
   ## Returns (canAccept, scope) indicating whether a stream can be accepted

--- a/tests/libp2p/test_protocol.nim
+++ b/tests/libp2p/test_protocol.nim
@@ -61,6 +61,11 @@ suite "LPProtocol stream budget":
     )
     assertNoLimits(p)
 
+  test "LPProtocol with no limits (created with new keword)":
+    let p = new LPProtocol
+    p.codecs = codecs
+    assertNoLimits(p)
+
   test "reserveIncoming and releaseIncoming with per-peer limit":
     let p = LPProtocol.new(
       codecs,

--- a/tests/libp2p/test_protocol.nim
+++ b/tests/libp2p/test_protocol.nim
@@ -67,7 +67,7 @@ suite "LPProtocol stream budget":
     )
     assertNoLimits(p)
 
-  test "LPProtocol with no limits (created with new keword)":
+  test "LPProtocol with no limits (created with new keyword)": 
     let p = new LPProtocol
     p.codecs = codecs
     assertNoLimits(p)

--- a/tests/libp2p/test_protocol.nim
+++ b/tests/libp2p/test_protocol.nim
@@ -15,7 +15,7 @@ proc handler(
 template assertNoLimits(p: LPProtocol) =
   # when there are no limits reserve and release will always succeed
 
-  # this for is here to drive over any limits (default of explicit)
+  # this for is here to drive over any limits (default or explicit)
   for i in 0 .. 1000:
     check:
       p.reserveIncoming(peerId1)

--- a/tests/libp2p/test_protocol.nim
+++ b/tests/libp2p/test_protocol.nim
@@ -16,7 +16,7 @@ template assertNoLimits(p: LPProtocol) =
   # when there are no limits reserve and release will always succeed
 
   # this for is here to drive over any limits (default or explicit)
-  for i in 0 .. 1000:
+  for _ in 0 .. 1000:
     check:
       p.reserveIncoming(peerId1)
       p.reserveOutgoing(peerId1)

--- a/tests/libp2p/test_protocol.nim
+++ b/tests/libp2p/test_protocol.nim
@@ -12,6 +12,33 @@ proc handler(
 ): Future[void] {.async: (raises: [CancelledError]).} =
   discard
 
+template assertNoLimits(p: LPProtocol) =
+  # when there are no limits reserve and release will always succeed
+
+  check: # incoming
+    p.canAcceptIncoming(peerId1)
+    p.canAcceptIncoming(peerId2)
+    p.reserveIncoming(peerId1)
+    p.reserveIncoming(peerId1)
+    p.reserveIncoming(peerId2)
+    p.canAcceptIncoming(peerId1)
+    p.canAcceptIncoming(peerId2)
+
+  p.releaseIncoming(peerId1)
+  p.releaseIncoming(peerId2)
+
+  check: # outgoing
+    p.canOpenOutgoing(peerId1)
+    p.canOpenOutgoing(peerId2)
+    p.reserveOutgoing(peerId1)
+    p.reserveOutgoing(peerId1)
+    p.reserveOutgoing(peerId2)
+    p.canOpenOutgoing(peerId1)
+    p.canOpenOutgoing(peerId2)
+
+  p.releaseOutgoing(peerId1)
+  p.releaseOutgoing(peerId2)
+
 suite "LPProtocol stream budget":
   const codecs = @["/test/1.0.0"]
   let
@@ -19,7 +46,11 @@ suite "LPProtocol stream budget":
     peerId2 = PeerId.random(rng()).get()
     peerId3 = PeerId.random(rng()).get()
 
-  test "canAcceptIncoming returns true with no limits":
+  test "LPProtocol with no limits (default values)":
+    let p = LPProtocol.new(codecs, handler)
+    assertNoLimits(p)
+
+  test "LPProtocol with no limits (explicit values)":
     let p = LPProtocol.new(
       codecs,
       handler,
@@ -28,24 +59,7 @@ suite "LPProtocol stream budget":
       maxOutgoingStreamsTotal = Opt.none(int),
       maxOutgoingStreamsPerPeer = Opt.none(int),
     )
-
-    check:
-      p.canAcceptIncoming(peerId1)
-      p.canAcceptIncoming(peerId2)
-
-  test "canOpenOutgoing returns true with no limits":
-    let p = LPProtocol.new(
-      codecs,
-      handler,
-      maxIncomingStreamsTotal = Opt.none(int),
-      maxIncomingStreamsPerPeer = Opt.none(int),
-      maxOutgoingStreamsTotal = Opt.none(int),
-      maxOutgoingStreamsPerPeer = Opt.none(int),
-    )
-
-    check:
-      p.canOpenOutgoing(peerId1)
-      p.canOpenOutgoing(peerId2)
+    assertNoLimits(p)
 
   test "reserveIncoming and releaseIncoming with per-peer limit":
     let p = LPProtocol.new(

--- a/tests/libp2p/test_protocol.nim
+++ b/tests/libp2p/test_protocol.nim
@@ -67,7 +67,7 @@ suite "LPProtocol stream budget":
     )
     assertNoLimits(p)
 
-  test "LPProtocol with no limits (created with new keyword)": 
+  test "LPProtocol with no limits (created with new keyword)":
     let p = new LPProtocol
     p.codecs = codecs
     assertNoLimits(p)

--- a/tests/libp2p/test_protocol.nim
+++ b/tests/libp2p/test_protocol.nim
@@ -15,6 +15,12 @@ proc handler(
 template assertNoLimits(p: LPProtocol) =
   # when there are no limits reserve and release will always succeed
 
+  # this for is here to drive over any limits (default of explicit)
+  for i in 0 .. 1000:
+    check:
+      p.reserveIncoming(peerId1)
+      p.reserveOutgoing(peerId1)
+
   check: # incoming
     p.canAcceptIncoming(peerId1)
     p.canAcceptIncoming(peerId2)


### PR DESCRIPTION
this pr enables fast path for `LPProtocol` procs like `reserve` and `release` in case when there are no limits. 