### PR TITLE
chore(MultistreamSelect): remove codecs from addHandler proc

### DIFF
--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -224,19 +224,11 @@ proc handle*(
   else:
     debug "no handlers", stream, protocol = ms
 
-proc addHandler*(
-    m: MultistreamSelect,
-    codecs: seq[string],
-    protocol: LPProtocol,
-    matcher: Matcher = nil,
-) =
-  trace "registering protocols", protos = codecs
-  m.handlers.add(HandlerHolder(protos: codecs, protocol: protocol, match: matcher))
-
-proc addHandler*(
-    m: MultistreamSelect, codec: string, protocol: LPProtocol, matcher: Matcher = nil
-) =
-  addHandler(m, @[codec], protocol, matcher)
+proc addHandler*(m: MultistreamSelect, protocol: LPProtocol, matcher: Matcher = nil) =
+  trace "registering protocols", protos = protocol.codecs
+  m.handlers.add(
+    HandlerHolder(protos: protocol.codecs, protocol: protocol, match: matcher)
+  )
 
 proc addHandler*[E](
     m: MultistreamSelect,
@@ -248,12 +240,11 @@ proc addHandler*[E](
     matcher: Matcher = nil,
 ) =
   ## helper to allow registering pure handlers
-  trace "registering proto handler", proto = codec
   let protocol = new LPProtocol
   protocol.codec = codec
   protocol.handler = handler
 
-  m.handlers.add(HandlerHolder(protos: @[codec], protocol: protocol, match: matcher))
+  m.addHandler(protocol, matcher)
 
 proc start*(m: MultistreamSelect) {.async: (raises: [CancelledError]).} =
   let futs = m.handlers.mapIt(it.protocol.start())

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -60,12 +60,10 @@ method stop*(p: LPProtocol) {.base, async: (raises: []).} =
   p.started = false
 
 func codec*(p: LPProtocol): string =
-  doAssert(p.codecs.len > 0, "Codecs sequence was empty!")
+  doAssert(p.codecs.len > 0, "codecs sequence must not be empty")
   p.codecs[0]
 
 func `codec=`*(p: LPProtocol, codec: string) =
-  # always insert as first codec
-  # if we use this abstraction
   p.codecs.insert(codec, 0)
 
 template `handler`*(p: LPProtocol): LPProtoHandler =
@@ -86,7 +84,9 @@ proc new*(
     maxOutgoingStreamsTotal: Opt[int] | int = Opt.none(int),
     maxOutgoingStreamsPerPeer: Opt[int] | int = Opt.none(int),
 ): T =
-  doAssert(codecs.len > 0, "Codecs sequence must not be empty!")
+  doAssert(codecs.len > 0, "codecs sequence must not be empty")
+  doAssert(not handler.isNil, "handler must not be set")
+
   var proto = T(
     codecs: codecs,
     handlerImpl: handler,

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -85,7 +85,7 @@ proc new*(
     maxOutgoingStreamsPerPeer: Opt[int] | int = Opt.none(int),
 ): T =
   doAssert(codecs.len > 0, "codecs sequence must not be empty")
-  doAssert(not handler.isNil, "handler must not be set")
+  doAssert(not handler.isNil, "handler must be set")
 
   var proto = T(
     codecs: codecs,

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -199,16 +199,18 @@ proc mount*[T: LPProtocol](
 ) {.gcsafe, raises: [LPError].} =
   ## mount a protocol to the switch
 
-  if isNil(proto.handler):
+  if proto.handler.isNil:
     raise newException(LPError, "Protocol has to define a handle method or proc")
 
   if proto.codec.len == 0:
     raise newException(LPError, "Protocol has to define a codec string")
 
   if s.started and not proto.started:
-    raise newException(LPError, "Protocol not started")
+    raise newException(
+      LPError, "Protocol needs to be started when mounting to started Switch"
+    )
 
-  s.ms.addHandler(proto.codecs, proto, matcher)
+  s.ms.addHandler(proto, matcher)
   s.peerInfo.protocols.add(proto.codec)
   s.peerInfo.notifyObservers()
 

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -74,7 +74,7 @@ suite "Identify":
       await transport2.stop()
 
     asyncTest "default agent version":
-      msListen.addHandler(IdentifyCodec, identifyProto1)
+      msListen.addHandler(identifyProto1)
       proc acceptHandler(): Future[void] {.async.} =
         let c = await transport1.accept()
         await msListen.handle(c)
@@ -95,7 +95,7 @@ suite "Identify":
     asyncTest "custom agent version":
       const customAgentVersion = "MY CUSTOM AGENT STRING"
       remotePeerInfo.agentVersion = customAgentVersion
-      msListen.addHandler(IdentifyCodec, identifyProto1)
+      msListen.addHandler(identifyProto1)
 
       proc acceptHandler(): Future[void] {.async.} =
         let c = await transport1.accept()
@@ -115,7 +115,7 @@ suite "Identify":
       check id.signedPeerRecord.isNone()
 
     asyncTest "handle failed identify":
-      msListen.addHandler(IdentifyCodec, identifyProto1)
+      msListen.addHandler(identifyProto1)
 
       proc acceptHandler() {.async: (raises: [CancelledError]).} =
         var conn: RawConn
@@ -136,7 +136,7 @@ suite "Identify":
         discard await identifyProto2.identify(conn, pi2.peerId)
 
     asyncTest "can send signed peer record":
-      msListen.addHandler(IdentifyCodec, identifyProto1)
+      msListen.addHandler(identifyProto1)
       identifyProto1.sendSignedPeerRecord = true
       proc acceptHandler(): Future[void] {.async.} =
         let c = await transport1.accept()

--- a/tests/libp2p/protocols/test_ping.nim
+++ b/tests/libp2p/protocols/test_ping.nim
@@ -59,7 +59,7 @@ suite "Ping":
     checkTrackers()
 
   asyncTest "simple ping":
-    msListen.addHandler(PingCodec, pingProto1)
+    msListen.addHandler(pingProto1)
     serverFut = transport1.start(@[ma])
     proc acceptHandler(): Future[void] {.async.} =
       let c = await transport1.accept()
@@ -76,7 +76,7 @@ suite "Ping":
     check not second.isZero()
 
   asyncTest "ping callback":
-    msDial.addHandler(PingCodec, pingProto2)
+    msDial.addHandler(pingProto2)
     serverFut = transport1.start(@[ma])
     proc acceptHandler(): Future[void] {.async.} =
       let c = await transport1.accept()
@@ -108,7 +108,7 @@ suite "Ping":
     fakePingProto.codec = PingCodec
     fakePingProto.handler = fakeHandle
 
-    msListen.addHandler(PingCodec, fakePingProto)
+    msListen.addHandler(fakePingProto)
     serverFut = transport1.start(@[ma])
     proc acceptHandler(): Future[void] {.async.} =
       let c = await transport1.accept()

--- a/tests/libp2p/test_multistream.nim
+++ b/tests/libp2p/test_multistream.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import chronos, strformat, stew/byteutils
+import chronos, stew/byteutils
 import
   ../../libp2p/[
     multistream,
@@ -16,9 +16,12 @@ import
     upgrademngrs/upgrade,
     utils/future,
   ]
-import ../tools/[unittest, sync]
+import ../tools/[unittest, sync, multiaddress]
 
 {.push raises: [].}
+
+converter toStringSeq(s: string): seq[string] =
+  @[s]
 
 ## Mock stream for select test
 type TestSelectStream = ref object of Connection
@@ -189,64 +192,49 @@ proc noReachHandler(
   raiseAssert "must not be reached"
 
 suite "Multistream select":
+  const codecs = "/test/proto/1.0.0"
+
   teardown:
     checkTrackers()
 
   asyncTest "test select custom proto":
     let ms = MultistreamSelect.new()
     let stream = newTestSelectStream()
-    check (await ms.select(stream, @["/test/proto/1.0.0"])) == "/test/proto/1.0.0"
+    check (await ms.select(stream, @[codecs])) == codecs
     await stream.close()
 
   asyncTest "test handle custom proto":
     let ms = MultistreamSelect.new()
     let stream = newTestSelectStream()
 
-    var protocol: LPProtocol = new LPProtocol
     proc testHandler(
         stream: Stream, proto: string
     ): Future[void] {.async: (raises: [CancelledError]).} =
-      check proto == "/test/proto/1.0.0"
+      check proto == codecs
       await stream.close()
 
-    protocol.codec = "/test/proto/1.0.0"
-    protocol.handler = testHandler
-    ms.addHandler("/test/proto/1.0.0", protocol)
+    ms.addHandler(LPProtocol.new(codecs, testHandler))
     await ms.handle(stream)
 
   asyncTest "test handle invokes only first matching handler":
     let ms = MultistreamSelect.new()
-    let stream = newTestSelectStream()
-
     var firstCalls = 0
-    var secondCalls = 0
 
-    var firstProtocol: LPProtocol = new LPProtocol
     proc firstHandler(
         stream: Stream, proto: string
     ): Future[void] {.async: (raises: [CancelledError]).} =
       firstCalls += 1
-      check proto == "/test/proto/1.0.0"
+      check proto == codecs
       await stream.close()
 
-    var secondProtocol: LPProtocol = new LPProtocol
-    proc secondHandler(
-        stream: Stream, proto: string
-    ): Future[void] {.async: (raises: [CancelledError]).} =
-      secondCalls += 1
-      check proto == "/test/proto/1.0.0"
-      await stream.close()
+    ms.addHandler(LPProtocol.new(codecs, firstHandler))
+    ms.addHandler(LPProtocol.new(codecs, noReachHandler))
+    ms.addHandler(LPProtocol.new(codecs, noReachHandler))
 
-    firstProtocol.codec = "/test/proto/1.0.0"
-    firstProtocol.handler = firstHandler
-    secondProtocol.codec = "/test/proto/1.0.0"
-    secondProtocol.handler = secondHandler
-    ms.addHandler("/test/proto/1.0.0", firstProtocol)
-    ms.addHandler("/test/proto/1.0.0", secondProtocol)
-    await ms.handle(stream)
+    await ms.handle(newTestSelectStream())
+    await ms.handle(newTestSelectStream())
 
-    check firstCalls == 1
-    check secondCalls == 0
+    check firstCalls == 2
 
   asyncTest "test handle `ls`":
     let ms = MultistreamSelect.new()
@@ -262,14 +250,11 @@ suite "Multistream select":
       done.complete()
 
     stream = Connection(newTestLsStream(testLsHandler))
+    ms.addHandler("/test/proto1/1.0.0", LPProtoHandler(noReachHandler))
+    ms.addHandler("/test/proto2/1.0.0", LPProtoHandler(noReachHandler))
 
-    var protocol: LPProtocol = new LPProtocol
-    protocol.codecs = @["/test/proto1/1.0.0", "/test/proto2/1.0.0"]
-    protocol.handler = noReachHandler
-    ms.addHandler("/test/proto1/1.0.0", protocol)
-    ms.addHandler("/test/proto2/1.0.0", protocol)
     await ms.handle(stream)
-    await done.wait(5.seconds)
+    await done
 
   asyncTest "test handle `na`":
     let ms = MultistreamSelect.new()
@@ -283,20 +268,16 @@ suite "Multistream select":
 
     stream = newTestNaStream(testNaHandler)
 
-    var protocol: LPProtocol = new LPProtocol
-    protocol.handler = noReachHandler
-    ms.addHandler("/unabvailable/proto/1.0.0", protocol)
+    ms.addHandler("/unabvailable/proto1/1.0.0", LPProtoHandler(noReachHandler))
 
     await ms.handle(stream)
 
   asyncTest "e2e - handle":
-    let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
-
     var protocol: LPProtocol = new LPProtocol
     proc testHandler(
         stream: Stream, proto: string
     ): Future[void] {.async: (raises: [CancelledError]).} =
-      check proto == "/test/proto/1.0.0"
+      check proto == codecs
       try:
         await stream.writeLp("Hello!")
       except LPStreamError:
@@ -304,13 +285,11 @@ suite "Multistream select":
       finally:
         await stream.close()
 
-    protocol.codec = "/test/proto/1.0.0"
-    protocol.handler = testHandler
     let msListen = MultistreamSelect.new()
-    msListen.addHandler("/test/proto/1.0.0", protocol)
+    msListen.addHandler(codecs, LPProtoHandler(testHandler))
 
     let transport1 = TcpTransport.new(upgrade = Upgrade())
-    asyncSpawn transport1.start(ma)
+    asyncSpawn transport1.start(@[TcpAutoAddress])
 
     proc acceptHandler(): Future[void] {.async.} =
       let stream = await transport1.accept()
@@ -323,7 +302,7 @@ suite "Multistream select":
     let transport2 = TcpTransport.new(upgrade = Upgrade())
     let stream = await transport2.dial(transport1.addrs[0])
 
-    check (await msDial.select(stream, "/test/proto/1.0.0")) == true
+    check (await msDial.select(stream, codecs)) == true
 
     let hello = string.fromBytes(await stream.readLp(1024))
     check hello == "Hello!"
@@ -335,7 +314,6 @@ suite "Multistream select":
     await handlerWait.wait(30.seconds)
 
   asyncTest "e2e - streams limit":
-    let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
     let blocker = newWaitGroup(1)
 
     # Start 5 streams which are blocked by `blocker`
@@ -352,15 +330,14 @@ suite "Multistream select":
       finally:
         await stream.close()
 
-    var protocol: LPProtocol =
-      LPProtocol.new(@["/test/proto/1.0.0"], testHandler, maxIncomingStreamsPerPeer = 5)
+    let protocol = LPProtocol.new(codecs, testHandler, maxIncomingStreamsPerPeer = 5)
 
     protocol.handler = testHandler
     let msListen = MultistreamSelect.new()
-    msListen.addHandler("/test/proto/1.0.0", protocol)
+    msListen.addHandler(protocol)
 
     let transport1 = TcpTransport.new(upgrade = Upgrade())
-    await transport1.start(ma)
+    await transport1.start(@[TcpAutoAddress])
 
     proc acceptedOne(c: Stream) {.async.} =
       await msListen.handle(c)
@@ -379,7 +356,7 @@ suite "Multistream select":
     proc connector() {.async.} =
       let stream = await transport2.dial(transport1.addrs[0])
       check:
-        (await msDial.select(stream, "/test/proto/1.0.0")) == true
+        (await msDial.select(stream, codecs)) == true
       check:
         string.fromBytes(await stream.readLp(1024)) == "Hello!"
       await stream.close()
@@ -412,16 +389,12 @@ suite "Multistream select":
     await handlerWait.cancelAndWait()
 
   asyncTest "e2e - ls":
-    let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
-
     let msListen = MultistreamSelect.new()
-    var protocol: LPProtocol = new LPProtocol
-    protocol.handler = noReachHandler
-    msListen.addHandler("/test/proto1/1.0.0", protocol)
-    msListen.addHandler("/test/proto2/1.0.0", protocol)
+    msListen.addHandler("/test/proto1/1.0.0", LPProtoHandler(noReachHandler))
+    msListen.addHandler("/test/proto2/1.0.0", LPProtoHandler(noReachHandler))
 
     let transport1: TcpTransport = TcpTransport.new(upgrade = Upgrade())
-    let listenFut = transport1.start(ma)
+    let listenFut = transport1.start(@[TcpAutoAddress])
 
     proc acceptHandler(): Future[void] {.async.} =
       let stream = await transport1.accept()
@@ -451,13 +424,10 @@ suite "Multistream select":
     await listenFut.wait(5.seconds)
 
   asyncTest "e2e - select one from a list with unsupported protos":
-    let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
-
-    var protocol: LPProtocol = new LPProtocol
     proc testHandler(
         stream: Stream, proto: string
     ): Future[void] {.async: (raises: [CancelledError]).} =
-      check proto == "/test/proto/1.0.0"
+      check proto == codecs
       try:
         await stream.writeLp("Hello!")
       except LPStreamError:
@@ -465,13 +435,11 @@ suite "Multistream select":
       finally:
         await stream.close()
 
-    protocol.codec = "/test/proto/1.0.0"
-    protocol.handler = testHandler
     let msListen = MultistreamSelect.new()
-    msListen.addHandler("/test/proto/1.0.0", protocol)
+    msListen.addHandler(LPProtocol.new(codecs, testHandler))
 
     let transport1: TcpTransport = TcpTransport.new(upgrade = Upgrade())
-    asyncSpawn transport1.start(ma)
+    asyncSpawn transport1.start(@[TcpAutoAddress])
 
     proc acceptHandler(): Future[void] {.async.} =
       let stream = await transport1.accept()
@@ -482,8 +450,7 @@ suite "Multistream select":
     let transport2: TcpTransport = TcpTransport.new(upgrade = Upgrade())
     let stream = await transport2.dial(transport1.addrs[0])
 
-    check (await msDial.select(stream, @["/test/proto/1.0.0", "/test/no/proto/1.0.0"])) ==
-      "/test/proto/1.0.0"
+    check (await msDial.select(stream, @["/test/no/proto/1.0.0", codecs])) == codecs
 
     let hello = string.fromBytes(await stream.readLp(1024))
     check hello == "Hello!"
@@ -493,56 +460,15 @@ suite "Multistream select":
     await transport2.stop()
     await transport1.stop()
 
-  asyncTest "e2e - select one with both valid":
-    let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
-
-    var protocol: LPProtocol = new LPProtocol
-    proc testHandler(
-        stream: Stream, proto: string
-    ): Future[void] {.async: (raises: [CancelledError]).} =
-      try:
-        await stream.writeLp(&"Hello from {proto}!")
-      except LPStreamError:
-        raiseAssert "LPStreamError while handling connection"
-      finally:
-        await stream.close()
-
-    protocol.codecs = @["/test/proto1/1.0.0", "/test/proto2/1.0.0"]
-    protocol.handler = testHandler
-    let msListen = MultistreamSelect.new()
-    msListen.addHandler("/test/proto1/1.0.0", protocol)
-    msListen.addHandler("/test/proto2/1.0.0", protocol)
-
-    let transport1: TcpTransport = TcpTransport.new(upgrade = Upgrade())
-    asyncSpawn transport1.start(ma)
-
-    proc acceptHandler(): Future[void] {.async.} =
-      let stream = await transport1.accept()
-      await msListen.handle(stream)
-
-    let acceptFut = acceptHandler()
-    let msDial = MultistreamSelect.new()
-    let transport2: TcpTransport = TcpTransport.new(upgrade = Upgrade())
-    let stream = await transport2.dial(transport1.addrs[0])
-
-    check (await msDial.select(stream, @["/test/proto2/1.0.0", "/test/proto1/1.0.0"])) ==
-      "/test/proto2/1.0.0"
-
-    check string.fromBytes(await stream.readLp(1024)) == "Hello from /test/proto2/1.0.0!"
-
-    await stream.close()
-    await acceptFut
-    await transport2.stop()
-    await transport1.stop()
-
 suite "Multistream :: stream limits":
+  const codecs = "/test/proto-stream-limits/1.0.0"
+
   teardown:
     checkTrackers()
 
-  let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").get()]
   proc acceptHandler(protocol: LPProtocol, transport: Transport) {.async.} =
     let msListen = MultistreamSelect.new()
-    msListen.addHandler(protocol.codecs, protocol)
+    msListen.addHandler(protocol)
 
     proc acceptedOne(c: Stream) {.async.} =
       await msListen.handle(c)
@@ -574,13 +500,11 @@ suite "Multistream :: stream limits":
     const maxTotalStreams = 3
 
     let protocol = LPProtocol.new(
-      @["/test/proto/1.0.0"],
-      makeBlockedHandler(),
-      maxIncomingStreamsTotal = maxTotalStreams,
+      codecs, makeBlockedHandler(), maxIncomingStreamsTotal = maxTotalStreams
     )
 
     let transport1 = TcpTransport.new(upgrade = Upgrade())
-    await transport1.start(ma)
+    await transport1.start(@[TcpAutoAddress])
 
     let handlerWait = acceptHandler(protocol, transport1)
 
@@ -618,7 +542,7 @@ suite "Multistream :: stream limits":
     )
 
     let transport1 = TcpTransport.new(upgrade = Upgrade())
-    await transport1.start(ma)
+    await transport1.start(@[TcpAutoAddress])
 
     let handlerWait = acceptHandler(protocol, transport1)
 
@@ -663,11 +587,10 @@ suite "Multistream :: stream limits":
         if handlerCount == 1:
           handlerResolved.complete()
 
-    let protocol =
-      LPProtocol.new(@["/test/proto/1.0.0"], testHandler, maxIncomingStreamsTotal = 1)
+    let protocol = LPProtocol.new(codecs, testHandler, maxIncomingStreamsTotal = 1)
 
     let transport1 = TcpTransport.new(upgrade = Upgrade())
-    await transport1.start(ma)
+    await transport1.start(@[TcpAutoAddress])
 
     let handlerWait = acceptHandler(protocol, transport1)
 
@@ -695,12 +618,11 @@ suite "Multistream :: stream limits":
     await handlerWait.cancelAndWait()
 
   asyncTest "e2e - inbound per-peer limit":
-    let protocol = LPProtocol.new(
-      @["/test/proto/1.0.0"], makeBlockedHandler(), maxIncomingStreamsPerPeer = 2
-    )
+    let protocol =
+      LPProtocol.new(codecs, makeBlockedHandler(), maxIncomingStreamsPerPeer = 2)
 
     let transport1 = TcpTransport.new(upgrade = Upgrade())
-    await transport1.start(ma)
+    await transport1.start(@[TcpAutoAddress])
 
     let handlerWait = acceptHandler(protocol, transport1)
 


### PR DESCRIPTION
`MultistreamSelect.addHandler` proc had extra codecs argument that was used to register handler. this argument was unnecessary as switch already used `LPProtocol.codecs` as value. this means that `addHandler` can internally get protocol codecs and use that value for registering handlers.

additional effort cosmetics improvements of tests.


closes: #2580 