### PR TITLE
test(conn-manager): watermark/scoring component 2

### DIFF
--- a/tests/libp2p/test_conn_manager_component.nim
+++ b/tests/libp2p/test_conn_manager_component.nim
@@ -215,3 +215,237 @@ suite "Connection Manager Watermark/Scoring Component":
       node.peerCount == lowWater
 
     check node.isConnected(peers[0].peerInfo.peerId)
+
+  asyncTest "unprotect re-exposes a peer to trimming":
+    # peers[0] is the oldest peer, the first to be trimmed.
+    # protection keeps it through the first trim.
+    # once unprotected the second trim drops it.
+    const
+      lowWater = 2
+      highWater = 3
+    let node = newWatermarkSwitch(lowWater, highWater)
+    # twice highWater peers so a second batch can trigger a second trim
+    let peers = newSwitches(2 * highWater)
+    let all = @[node] & peers
+
+    startAndDeferStop(all)
+
+    for peer in peers[0 ..< highWater]:
+      await connect(peer, node)
+
+    # protect peers[0] before the trim-triggering dial
+    node.connManager.protect(peers[0].peerInfo.peerId, "keep")
+
+    await connect(peers[highWater], node)
+
+    # the first trim settles at lowWater with protected peers[0] still connected
+    checkUntilTimeout:
+      node.peerCount == lowWater
+    check node.isConnected(peers[0].peerInfo.peerId)
+
+    # remove the protection, then drive a second trim with the remaining peers
+    check node.connManager.unprotect(peers[0].peerInfo.peerId, "keep") == false
+    for peer in peers[highWater + 1 ..< peers.len]:
+      await connect(peer, node)
+
+    # the second trim prunes peers[0] now that it is unprotected
+    checkUntilTimeout:
+      node.peerCount == lowWater
+
+    check not node.isConnected(peers[0].peerInfo.peerId)
+
+  asyncTest "multi-tag protection holds until all tags are removed":
+    # peers[0] is the oldest peer, the first to be trimmed.
+    # two protection tags keep it through the first trim.
+    # the second trim drops it only once both tags are removed.
+    const
+      lowWater = 2
+      highWater = 3
+      tagA = "tag-a"
+      tagB = "tag-b"
+    let node = newWatermarkSwitch(lowWater, highWater)
+    let peers = newSwitches(2 * highWater)
+    let all = @[node] & peers
+
+    startAndDeferStop(all)
+
+    for peer in peers[0 ..< highWater]:
+      await connect(peer, node)
+
+    let protectedId = peers[0].peerInfo.peerId
+    node.connManager.protect(protectedId, tagA)
+    node.connManager.protect(protectedId, tagB)
+
+    # removing one of two tags leaves the peer protected
+    check:
+      node.connManager.unprotect(protectedId, tagA) == true
+      node.connManager.isProtected(protectedId)
+
+    await connect(peers[highWater], node)
+
+    # the first trim settles at lowWater with protected peers[0] still connected
+    checkUntilTimeout:
+      node.peerCount == lowWater
+
+    check node.isConnected(protectedId)
+
+    # removing the last tag clears protection
+    check:
+      node.connManager.unprotect(protectedId, tagB) == false
+      not node.connManager.isProtected(protectedId)
+
+    for peer in peers[highWater + 1 ..< peers.len]:
+      await connect(peer, node)
+
+    # the second trim prunes peers[0] now that it is unprotected
+    checkUntilTimeout:
+      node.peerCount == lowWater
+
+    check not node.isConnected(protectedId)
+
+  asyncTest "decaying tag keeps a peer until it decays":
+    # peers[0] is the oldest peer, the first to be trimmed.
+    # a decaying tag keeps it through the first trim.
+    # once the tag value decays to zero the second trim drops it.
+    const
+      lowWater = 2
+      highWater = 3
+    let node = newWatermarkSwitch(lowWater, highWater, decayResolution = 100.millis)
+    let peers = newSwitches(2 * highWater)
+    let all = @[node] & peers
+
+    startAndDeferStop(all)
+
+    for peer in peers[0 ..< highWater]:
+      await connect(peer, node)
+
+    # the tag value decays by 20 every 100ms
+    let taggedId = peers[0].peerInfo.peerId
+    node.connManager.tagPeerDecaying(taggedId, "boost", 100, 100.millis, decayFixed(20))
+
+    await connect(peers[highWater], node)
+
+    # the first trim settles at lowWater with the tagged peers[0] still connected
+    checkUntilTimeout:
+      node.peerCount == lowWater
+
+    check node.isConnected(taggedId)
+
+    # wait for the tag value to decay to zero
+    checkUntilTimeout:
+      node.connManager.peerScore(taggedId) == 0
+
+    for peer in peers[highWater + 1 ..< peers.len]:
+      await connect(peer, node)
+
+    # the second trim prunes peers[0] now that the tag has decayed away
+    checkUntilTimeout:
+      node.peerCount == lowWater
+
+    check not node.isConnected(taggedId)
+
+  asyncTest "trim stops when more than lowWater peers are protected":
+    # protecting more than lowWater peers leaves the trim unable to reach lowWater.
+    # it drops every unprotected peer and then stops.
+    const
+      lowWater = 2
+      highWater = 4
+    let node = newWatermarkSwitch(lowWater, highWater)
+    let peers = newSwitches(highWater + 1)
+    let all = @[node] & peers
+
+    startAndDeferStop(all)
+
+    # peers[2 .. ^1] are protected, which is more than lowWater
+    # protect before connecting so the trigger-dial peers are already exempt when the trim runs
+    let protectedPeers = peers[2 .. ^1]
+    for peer in protectedPeers:
+      node.connManager.protect(peer.peerInfo.peerId, "keep")
+
+    for peer in peers:
+      await connect(peer, node)
+
+    # the trim drops both unprotected peers but cannot pass the protected ones
+    # so it settles at the protected count, above lowWater
+    checkUntilTimeout:
+      node.peerCount == protectedPeers.len
+
+    for peer in protectedPeers:
+      check node.isConnected(peer.peerInfo.peerId)
+
+  asyncTest "hard cap and watermark run together":
+    # the semaphore caps total connections while the watermark trims toward lowWater.
+    # dropping peers below the cap releases their slots, freeing inbound slots again.
+    const
+      lowWater = 2
+      highWater = 4
+      maxConnections = 6
+    let node = newWatermarkSwitch(lowWater, highWater, maxConnections = maxConnections)
+    let peers = newSwitches(highWater + 1)
+    let all = @[node] & peers
+
+    startAndDeferStop(all)
+
+    for peer in peers:
+      await connect(peer, node)
+
+    # both guards run at once: the watermark trims to lowWater, the semaphore tracks the cap
+    # the trimmed connections release their slots back to the semaphore
+    # the accept loop keeps one slot pre-acquired for the next incoming dial
+    # so the available inbound slots settle at cap - lowWater - 1
+    checkUntilTimeout:
+      node.peerCount == lowWater
+      node.connManager.availableSlots(Direction.In) == maxConnections - lowWater - 1
+
+  asyncTest "hard cap rejects new connections when the trim cannot free slots":
+    # every peer is protected, so the trim has nothing to prune
+    # the cap stays full at maxConnections
+    # the semaphore then rejects further connections: an inbound slot blocks, an outbound slot raises
+    const
+      lowWater = 2
+      highWater = 3
+      maxConnections = 4
+    let node = newWatermarkSwitch(lowWater, highWater, maxConnections = maxConnections)
+    let peers = newSwitches(maxConnections)
+    let all = @[node] & peers
+
+    startAndDeferStop(all)
+
+    # protect every peer so the trim has no candidates to prune
+    for peer in peers:
+      node.connManager.protect(peer.peerInfo.peerId, "keep")
+    for peer in peers:
+      await connect(peer, node)
+
+    # more peers than highWater are connected, but the trim can drop none of them
+    # so the cap stays full at maxConnections with no inbound slots left
+    checkUntilTimeout:
+      node.peerCount == maxConnections
+      node.connManager.availableSlots(Direction.In) == 0
+
+    # with the cap full the semaphore rejects new connections
+    check not (await node.connManager.getIncomingSlot().withTimeout(100.millis))
+    expect TooManyConnectionsError:
+      discard node.connManager.getOutgoingSlot()
+
+  asyncTest "dial fails when the trim prunes the new connection":
+    # reaching lowWater can force the trim to drop the dialing peer's own freshly stored connection
+    # the dial then fails with DialFailedError instead of connecting and being trimmed cleanly later
+    const
+      lowWater = 1
+      highWater = 2
+    let node = newWatermarkSwitch(lowWater, highWater)
+    let peers = newSwitches(highWater + 1)
+    let all = @[node] & peers
+
+    startAndDeferStop(all)
+
+    # protect peers[0] so it is the only peer the trim is allowed to keep
+    await connect(peers[0], node)
+    await connect(peers[1], node)
+    node.connManager.protect(peers[0].peerInfo.peerId, "keep")
+
+    # peers[2] triggers the trim, but reaching lowWater forces it to drop both unprotected peers
+    # that includes peers[2]'s own just-stored connection
+    expect DialFailedError:
+      await connect(peers[2], node)


### PR DESCRIPTION
## Summary

Extends the connection-manager component suite with cases for protection lifecycle, decaying scores, and the interaction between the watermark trim and the hard connection cap.

New cases:
- `unprotect` re-exposes a peer so a later trim can prune it
- Multi-tag protection holds until every tag is removed (`isProtected` flips only on the last `unprotect`)
- A decaying tag (`tagPeerDecaying` + `decayFixed`) keeps a peer until its score decays to zero, then the next trim drops it
- Trim stops short of `lowWater` when more than `lowWater` peers are protected, settling at the protected count
- Hard cap and watermark running together: trimmed connections release their semaphore slots, and available inbound slots settle at `cap - lowWater - 1` (accept loop keeps one slot pre-acquired)
- Hard cap rejects new connections when the trim has no prunable candidates: inbound `getIncomingSlot` blocks, outbound `getOutgoingSlot` raises `TooManyConnectionsError`
- Dial fails with `DialFailedError` when reaching `lowWater` forces the trim to drop the dialing peer's own freshly stored connection

## Affected Areas

- [x] Tests

## Impact on Library Users

None.

## Risk Assessment

None.