### PR TITLE
chore: remove unnecessery transport argument

### DIFF
--- a/tests/libp2p/protocols/test_autonat.nim
+++ b/tests/libp2p/protocols/test_autonat.nim
@@ -14,13 +14,13 @@ import
     nameresolving/nameresolver,
     nameresolving/mockresolver,
   ]
-import ../../tools/[unittest, crypto, switch_builder]
+import ../../tools/[unittest, crypto, switch_builder, multiaddress]
 
 proc makeAutonatSwitch(nameResolver: NameResolver = nil): Switch =
   return SwitchBuilder
     .new()
     .withRng(rng())
-    .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
+    .withAddresses(@[TcpAutoAddress])
     .withTcpTransport()
     .withMplex()
     .withAutonat()
@@ -29,7 +29,7 @@ proc makeAutonatSwitch(nameResolver: NameResolver = nil): Switch =
     .build()
 
 proc makeSwitch(): Switch =
-  return makeStandardSwitch(transport = TransportType.TCP)
+  return makeStandardSwitch(TcpAutoAddress)
 
 proc makeAutonatServicePrivate(): Switch =
   var autonatProtocol = new LPProtocol

--- a/tests/libp2p/protocols/test_autonat_v2.nim
+++ b/tests/libp2p/protocols/test_autonat_v2.nim
@@ -16,21 +16,19 @@ import
     protocols/connectivity/autonatv2/client,
     protocols/connectivity/autonatv2/mockserver,
   ]
-import ../../tools/[unittest, crypto, switch_builder]
+import ../../tools/[unittest, crypto, switch_builder, multiaddress]
 
 proc setupAutonat(
     srcAddrs: seq[MultiAddress] = newSeq[MultiAddress](),
     config: AutonatV2Config = AutonatV2Config.new(),
 ): Future[(Switch, Switch, AutonatV2Client)] {.async.} =
-  var srcBuilder = makeStandardSwitchBuilder(transport = TransportType.TCP)
+  var srcBuilder = makeStandardSwitchBuilder(TcpAutoAddress)
   if srcAddrs.len > 0:
     srcBuilder = srcBuilder.withAddresses(srcAddrs)
 
   let
     src = srcBuilder.build()
-    dst = makeStandardSwitchBuilder(transport = TransportType.TCP)
-      .withAutonatV2Server(config)
-      .build()
+    dst = makeStandardSwitchBuilder(TcpAutoAddress).withAutonatV2Server(config).build()
     client = AutonatV2Client.new(rng())
 
   client.setup(src)

--- a/tests/libp2p/protocols/test_dcutr.nim
+++ b/tests/libp2p/protocols/test_dcutr.nim
@@ -10,10 +10,10 @@ import ../../../libp2p/protocols/connectivity/dcutr/[client, server]
 from ../../../libp2p/protocols/connectivity/autonat/types import NetworkReachability
 import ../../../libp2p/[builders, utils/future]
 import ../../stubs/switchstub
-import ../../tools/[unittest, switch_builder]
+import ../../tools/[unittest, switch_builder, multiaddress]
 
 proc makeSwitch(): Switch =
-  return makeStandardSwitch(transport = TransportType.TCP)
+  return makeStandardSwitch(TcpAutoAddress)
 
 suite "Dcutr":
   teardown:

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -164,7 +164,10 @@ suite "Identify":
       stream {.threadvar.}: Stream
 
     asyncSetup:
-      let ma = @[TcpAutoAddressIP4, TcpAutoAddressIP6]
+      let ma = @[
+        MultiAddress.init("/ip4/0.0.0.0/tcp/0").get(),
+        MultiAddress.init("/ip6/::/tcp/0").get(),
+      ]
       switch1 = makeStandardSwitchBuilder(TcpAutoAddress)
         .withAddresses(ma)
         .withSignedPeerRecord(true)

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -164,10 +164,7 @@ suite "Identify":
       stream {.threadvar.}: Stream
 
     asyncSetup:
-      let ma = @[
-        TcpAutoAddressIP4,
-        TcpAutoAddressIP6,
-      ]
+      let ma = @[TcpAutoAddressIP4, TcpAutoAddressIP6]
       switch1 = makeStandardSwitchBuilder(TcpAutoAddress)
         .withAddresses(ma)
         .withSignedPeerRecord(true)

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -165,14 +165,14 @@ suite "Identify":
 
     asyncSetup:
       let ma = @[
-        MultiAddress.init("/ip4/0.0.0.0/tcp/0").get(),
-        MultiAddress.init("/ip6/::/tcp/0").get(),
+        TcpAutoAddressIP4,
+        TcpAutoAddressIP6,
       ]
-      switch1 = makeStandardSwitchBuilder(transport = TransportType.TCP)
+      switch1 = makeStandardSwitchBuilder(TcpAutoAddress)
         .withAddresses(ma)
         .withSignedPeerRecord(true)
         .build()
-      switch2 = makeStandardSwitchBuilder(transport = TransportType.TCP)
+      switch2 = makeStandardSwitchBuilder(TcpAutoAddress)
         .withAddresses(ma)
         .withSignedPeerRecord(true)
         .build()
@@ -297,7 +297,7 @@ suite "Identify":
         .build()
 
       # Client switch to dial and identify
-      client = makeStandardSwitch(transport = TransportType.TCP)
+      client = makeStandardSwitch(TcpAutoAddress)
 
     await server.start()
     await client.start()

--- a/tests/libp2p/protocols/test_relay_v1.nim
+++ b/tests/libp2p/protocols/test_relay_v1.nim
@@ -257,7 +257,7 @@ suite "Circuit Relay":
     r.maxCircuitPerPeer = tmp
     await stream.close()
 
-    let dst2 = makeStandardSwitch(transport = TransportType.TCP)
+    let dst2 = makeStandardSwitch(TcpAutoAddress)
     await dst2.start()
     await srelay.connect(dst2.peerInfo.peerId, dst2.peerInfo.addrs)
 

--- a/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
@@ -8,7 +8,9 @@ import
   ../../../../libp2p/protocols/pubsub/
     [gossipsub, mcache, peertable, pubsubpeer, timedcache, rpc/message]
 import ../../../../libp2p/utils/future
-import ../../../tools/[lifecycle, topology, unittest, futures, sync, switch_builder, multiaddress]
+import
+  ../../../tools/
+    [lifecycle, topology, unittest, futures, sync, switch_builder, multiaddress]
 import ../utils
 
 const MsgIdSuccess = "msg id gen success"

--- a/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
@@ -8,7 +8,7 @@ import
   ../../../../libp2p/protocols/pubsub/
     [gossipsub, mcache, peertable, pubsubpeer, timedcache, rpc/message]
 import ../../../../libp2p/utils/future
-import ../../../tools/[lifecycle, topology, unittest, futures, sync, switch_builder]
+import ../../../tools/[lifecycle, topology, unittest, futures, sync, switch_builder, multiaddress]
 import ../utils
 
 const MsgIdSuccess = "msg id gen success"
@@ -554,7 +554,7 @@ suite "GossipSub Component - Message Handling":
     let nodes = generateNodes(
         20,
         gossip = true,
-        transport = TransportType.TCP, # use TCP becasue it's more reliable (temporarily)
+        address = TcpAutoAddress, # use TCP becasue it's more reliable (temporarily)
       )
       .toGossipSub()
 

--- a/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
@@ -556,7 +556,7 @@ suite "GossipSub Component - Message Handling":
     let nodes = generateNodes(
         20,
         gossip = true,
-        address = TcpAutoAddress, # use TCP becasue it's more reliable (temporarily)
+        address = TcpAutoAddress, # use TCP because it's more reliable (temporarily)
       )
       .toGossipSub()
 

--- a/tests/libp2p/pubsub/utils.nim
+++ b/tests/libp2p/pubsub/utils.nim
@@ -25,7 +25,8 @@ import
     protocols/pubsub/floodsub,
     protocols/pubsub/rpc/messages,
   ]
-import ../../tools/[unittest, crypto, bufferstream, futures, switch_builder, multiaddress]
+import
+  ../../tools/[unittest, crypto, bufferstream, futures, switch_builder, multiaddress]
 
 export switch
 

--- a/tests/libp2p/pubsub/utils.nim
+++ b/tests/libp2p/pubsub/utils.nim
@@ -25,7 +25,7 @@ import
     protocols/pubsub/floodsub,
     protocols/pubsub/rpc/messages,
   ]
-import ../../tools/[unittest, crypto, bufferstream, futures, switch_builder]
+import ../../tools/[unittest, crypto, bufferstream, futures, switch_builder, multiaddress]
 
 export switch
 
@@ -188,6 +188,7 @@ proc applyDValues*(parameters: var GossipSubParams, dValues: Opt[DValues]) =
 
 proc generateNodes*(
     num: int,
+    address: MultiAddress = QuicAutoAddress,
     msgIdProvider: MsgIdProvider = defaultMsgIdProvider,
     gossip: bool = false,
     triggerSelf: bool = false,
@@ -223,11 +224,10 @@ proc generateNodes*(
       Opt.none(PingPongExtensionConfig),
     preambleExtensionConfig: Opt[PreambleExtensionConfig] =
       Opt.none(PreambleExtensionConfig),
-    transport: TransportType = TransportType.QUIC,
 ): seq[PubSub] =
   var pubsubs: seq[PubSub]
   for i in 0 ..< num:
-    let switch = makeStandardSwitchBuilder(transport = transport)
+    let switch = makeStandardSwitchBuilder(address)
       .withSignedPeerRecord(sendSignedPeerRecord)
       .build()
     let pubsub =

--- a/tests/libp2p/test_switch.nim
+++ b/tests/libp2p/test_switch.nim
@@ -609,9 +609,7 @@ suite "Switch":
 
     # Start first switch
     switches.add(
-      makeStandardSwitchBuilder(transport = TransportType.TCP)
-        .withMaxConnsPerPeer(10)
-        .build()
+      makeStandardSwitchBuilder(TcpAutoAddress).withMaxConnsPerPeer(10).build()
     )
     switches[0].addConnEventHandler(hook, ConnEventKind.Connected)
     switches[0].addConnEventHandler(hook, ConnEventKind.Disconnected)
@@ -620,9 +618,7 @@ suite "Switch":
     # Connect remaining switches sequentially
     for i in 1 .. 5:
       switches.add(
-        makeStandardSwitchBuilder(transport = TransportType.TCP)
-          .withPrivateKey(privateKey)
-          .build()
+        makeStandardSwitchBuilder(TcpAutoAddress).withPrivateKey(privateKey).build()
       )
       switches[i].addConnEventHandler(hook, ConnEventKind.Connected)
       switches[i].addConnEventHandler(hook, ConnEventKind.Disconnected)
@@ -655,7 +651,7 @@ suite "Switch":
       await rawConn.closeWithEOF()
 
     let handlerWait = acceptHandler()
-    let switch = makeStandardSwitch(transport = TransportType.TCP)
+    let switch = makeStandardSwitch(TcpAutoAddress)
 
     await switch.start()
 
@@ -711,7 +707,7 @@ suite "Switch":
     await switch1.stop()
 
   asyncTest "connect to inexistent peer":
-    let switch2 = makeStandardSwitch(transport = TransportType.TCP)
+    let switch2 = makeStandardSwitch(TcpAutoAddress)
     await switch2.start()
     let someAddr = MultiAddress.init("/ip4/127.128.0.99").get()
     let seckey = PrivateKey.random(ECDSA, rng()).get()
@@ -722,7 +718,7 @@ suite "Switch":
 
   asyncTest "e2e total connection limits on incoming connections":
     var switches: seq[Switch]
-    let destSwitch = makeStandardSwitchBuilder(transport = TransportType.TCP)
+    let destSwitch = makeStandardSwitchBuilder(TcpAutoAddress)
       .withConnectionLimits(ConnectionLimits.maxTotal(3))
       .build()
     switches.add(destSwitch)
@@ -730,7 +726,7 @@ suite "Switch":
 
     let destPeerInfo = destSwitch.peerInfo
     for i in 0 ..< 3:
-      let switch = makeStandardSwitch(transport = TransportType.TCP)
+      let switch = makeStandardSwitch(TcpAutoAddress)
       switches.add(switch)
       await switch.start()
 
@@ -738,7 +734,7 @@ suite "Switch":
         1000.millis
       )
 
-    let switchFail = makeStandardSwitch(transport = TransportType.TCP)
+    let switchFail = makeStandardSwitch(TcpAutoAddress)
     switches.add(switchFail)
     await switchFail.start()
 
@@ -753,16 +749,16 @@ suite "Switch":
   asyncTest "e2e total connection limits on incoming connections":
     var switches: seq[Switch]
     for i in 0 ..< 3:
-      switches.add(makeStandardSwitch(transport = TransportType.TCP))
+      switches.add(makeStandardSwitch(TcpAutoAddress))
       await switches[i].start()
 
-    let srcSwitch = makeStandardSwitchBuilder(transport = TransportType.TCP)
+    let srcSwitch = makeStandardSwitchBuilder(TcpAutoAddress)
       .withConnectionLimits(ConnectionLimits.maxTotal(3))
       .build()
     await srcSwitch.start()
     switches.add(srcSwitch)
 
-    let dstSwitch = makeStandardSwitch(transport = TransportType.TCP)
+    let dstSwitch = makeStandardSwitch(TcpAutoAddress)
     await dstSwitch.start()
     switches.add(dstSwitch)
 
@@ -778,7 +774,7 @@ suite "Switch":
 
   asyncTest "e2e max incoming connection limits":
     var switches: seq[Switch]
-    let destSwitch = makeStandardSwitchBuilder(transport = TransportType.TCP)
+    let destSwitch = makeStandardSwitchBuilder(TcpAutoAddress)
       .withConnectionLimits(ConnectionLimits.maxInOut(3, 1))
       .build()
     switches.add(destSwitch)
@@ -786,7 +782,7 @@ suite "Switch":
 
     let destPeerInfo = destSwitch.peerInfo
     for i in 0 ..< 3:
-      let switch = makeStandardSwitch(transport = TransportType.TCP)
+      let switch = makeStandardSwitch(TcpAutoAddress)
       switches.add(switch)
       await switch.start()
 
@@ -794,7 +790,7 @@ suite "Switch":
         1000.millis
       )
 
-    let switchFail = makeStandardSwitch(transport = TransportType.TCP)
+    let switchFail = makeStandardSwitch(TcpAutoAddress)
     switches.add(switchFail)
     await switchFail.start()
 
@@ -809,15 +805,15 @@ suite "Switch":
   asyncTest "e2e max outgoing connection limits":
     var switches: seq[Switch]
     for i in 0 ..< 3:
-      switches.add(makeStandardSwitch(transport = TransportType.TCP))
+      switches.add(makeStandardSwitch(TcpAutoAddress))
       await switches[i].start()
 
-    let srcSwitch = makeStandardSwitchBuilder(transport = TransportType.TCP)
+    let srcSwitch = makeStandardSwitchBuilder(TcpAutoAddress)
       .withConnectionLimits(ConnectionLimits.maxInOut(1, 3))
       .build()
     await srcSwitch.start()
 
-    let dstSwitch = makeStandardSwitch(transport = TransportType.TCP)
+    let dstSwitch = makeStandardSwitch(TcpAutoAddress)
     await dstSwitch.start()
 
     for s in switches:
@@ -850,13 +846,12 @@ suite "Switch":
     testProto.codec = TestCodec
     testProto.handler = handle
 
-    let switch1 = makeStandardSwitch(transport = TransportType.TCP)
+    let switch1 = makeStandardSwitch(TcpAutoAddress)
     switch1.mount(testProto)
     await switch1.start()
 
-    let switch2 = makeStandardSwitchBuilder(transport = TransportType.TCP)
-      .withPeerStore(capacity = 0)
-      .build()
+    let switch2 =
+      makeStandardSwitchBuilder(TcpAutoAddress).withPeerStore(capacity = 0).build()
     await switch2.start()
 
     let stream =
@@ -957,14 +952,13 @@ suite "Switch":
 
       let addrs = @[TcpAutoAddressIP4, TcpAutoAddressIP6]
 
-      let switch1 = makeStandardSwitchBuilder(transport = TransportType.TCP)
-        .withAddresses(addrs)
-        .build()
+      let switch1 =
+        makeStandardSwitchBuilder(TcpAutoAddress).withAddresses(addrs).build()
 
       switch1.mount(testProto)
 
-      let switch2 = makeStandardSwitch(transport = TransportType.TCP)
-      let switch3 = makeStandardSwitch(transport = TransportType.TCP)
+      let switch2 = makeStandardSwitch(TcpAutoAddress)
+      let switch3 = makeStandardSwitch(TcpAutoAddress)
 
       await allFuturesRaising(switch1.start(), switch2.start(), switch3.start())
 
@@ -1004,10 +998,9 @@ suite "Switch":
     resolver.ipResponses[("localhost", true)] = @["::1"]
 
     let
-      srcSwitch = makeStandardSwitchBuilder(transport = TransportType.TCP)
-        .withNameResolver(resolver)
-        .build()
-      destSwitch = makeStandardSwitch(transport = TransportType.TCP)
+      srcSwitch =
+        makeStandardSwitchBuilder(TcpAutoAddress).withNameResolver(resolver).build()
+      destSwitch = makeStandardSwitch(TcpAutoAddress)
 
     await destSwitch.start()
     await srcSwitch.start()
@@ -1068,8 +1061,8 @@ suite "Switch":
 
   asyncTest "e2e quic transport":
     let
-      srcSwitch = makeStandardSwitch(transport = TransportType.QUIC)
-      destSwitch = makeStandardSwitch(transport = TransportType.QUIC)
+      srcSwitch = makeStandardSwitch(QuicAutoAddress)
+      destSwitch = makeStandardSwitch(QuicAutoAddress)
 
     await destSwitch.start()
     await srcSwitch.start()
@@ -1162,7 +1155,7 @@ suite "Switch":
     await handleFinished.wait(5.seconds)
 
   asyncTest "switch failing to start stops properly":
-    let switch = makeStandardSwitchBuilder(transport = TransportType.TCP)
+    let switch = makeStandardSwitchBuilder(TcpAutoAddress)
       .withAddresses(
         @[
           MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet(),
@@ -1211,14 +1204,14 @@ suite "Switch":
     # it when ConcurrentUpgrades (4) were in flight; manifested as 80+ kad nodes
     # getting stuck on bootstrap.
     const NumPeers = 85
-    let server = makeStandardSwitchBuilder(transport = TransportType.TCP)
+    let server = makeStandardSwitchBuilder(TcpAutoAddress)
       .withConnectionLimits(ConnectionLimits.maxTotal(NumPeers))
       .build()
     await server.start()
 
     var clients: seq[Switch]
     for _ in 0 ..< NumPeers:
-      let c = makeStandardSwitch(transport = TransportType.TCP)
+      let c = makeStandardSwitch(TcpAutoAddress)
       await c.start()
       clients.add(c)
     defer:
@@ -1236,12 +1229,8 @@ suite "Switch :: IdentifyPusher Service":
     switch2 {.threadvar.}: Switch
 
   asyncSetup:
-    switch1 = makeStandardSwitchBuilder(transport = TransportType.TCP)
-      .withIdentifyPusher()
-      .build()
-    switch2 = makeStandardSwitchBuilder(transport = TransportType.TCP)
-      .withIdentifyPusher()
-      .build()
+    switch1 = makeStandardSwitchBuilder(TcpAutoAddress).withIdentifyPusher().build()
+    switch2 = makeStandardSwitchBuilder(TcpAutoAddress).withIdentifyPusher().build()
     await switch1.start()
     await switch2.start()
     await switch1.connect(switch2.peerInfo.peerId, switch2.peerInfo.addrs)

--- a/tests/tools/switch_builder.nim
+++ b/tests/tools/switch_builder.nim
@@ -3,8 +3,7 @@
 
 {.used.}
 
-import
-  results, ../../libp2p/[errors, switch, builders, multiaddress, transports/wstransport]
+import ../../libp2p/[switch, builders, multiaddress, transports/wstransport]
 import ./[crypto, multiaddress]
 
 export builders
@@ -26,8 +25,7 @@ proc makeStandardSwitchBuilder*(
     b = b.withTransport(
       proc(transportConfig: TransportConfig): Transport =
         WsTransport.new(transportConfig.upgr, transportConfig.rng)
-    )
-    b = b.withMplex()
+    ).withMplex()
   elif Memory.match(address):
     b = b.withMemoryTransport().withMplex()
   else:

--- a/tests/tools/switch_builder.nim
+++ b/tests/tools/switch_builder.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import ../../libp2p/[switch, builders, multiaddress, transports/wstransport]
+import ../../libp2p/[switch, builders, multiaddress]
 import ./[crypto, multiaddress]
 
 export builders
@@ -11,8 +11,8 @@ export builders
 proc makeStandardSwitchBuilder*(
     address: MultiAddress = QuicAutoAddress
 ): SwitchBuilder =
-  ## Helper that creates Switch with standard configurations.
-  ## Transport is added automatically to match listen `address`.
+  ## Helper that creates a SwitchBuilder with standard configurations.
+  ## Transport is added automatically to match the listen `address`.
 
   var b = SwitchBuilder.new().withRng(rng()).withNoise().withAddress(address)
 
@@ -26,7 +26,7 @@ proc makeStandardSwitchBuilder*(
   elif Memory.match(address):
     b = b.withMemoryTransport().withMplex()
   else:
-    raiseAssert "could not infere transport from address"
+    raiseAssert "could not infer transport from address"
 
   b
 

--- a/tests/tools/switch_builder.nim
+++ b/tests/tools/switch_builder.nim
@@ -9,7 +9,9 @@ import ./[crypto, multiaddress]
 
 export builders
 
-proc makeStandardSwitchBuilder*(address: MultiAddress = QuicAutoAddress): SwitchBuilder =
+proc makeStandardSwitchBuilder*(
+    address: MultiAddress = QuicAutoAddress
+): SwitchBuilder =
   ## Helper that creates Switch with standard configurations.
   ## Transport is added automatically to match listen `address`.
 
@@ -34,6 +36,6 @@ proc makeStandardSwitchBuilder*(address: MultiAddress = QuicAutoAddress): Switch
   b
 
 proc makeStandardSwitch*(
-    address: MultiAddress | string = QuicAutoAddress
+    address: MultiAddress = QuicAutoAddress
 ): Switch {.raises: [LPError].} =
   return makeStandardSwitchBuilder(address).build()

--- a/tests/tools/switch_builder.nim
+++ b/tests/tools/switch_builder.nim
@@ -22,10 +22,7 @@ proc makeStandardSwitchBuilder*(
   elif TCP.match(address):
     b = b.withTcpTransport().withMplex()
   elif WebSockets.match(address):
-    b = b.withTransport(
-      proc(transportConfig: TransportConfig): Transport =
-        WsTransport.new(transportConfig.upgr, transportConfig.rng)
-    ).withMplex()
+    b = b.withWsTransport().withMplex()
   elif Memory.match(address):
     b = b.withMemoryTransport().withMplex()
   else:

--- a/tests/tools/switch_builder.nim
+++ b/tests/tools/switch_builder.nim
@@ -9,54 +9,24 @@ import ./[crypto, multiaddress]
 
 export builders
 
-type TransportType* {.pure.} = enum
-  QUIC
-  TCP
-  Websocket
-  Memory
+proc makeStandardSwitchBuilder*(address: MultiAddress = QuicAutoAddress): SwitchBuilder =
+  ## Helper that creates Switch with standard configurations.
+  ## Transport is added automatically to match listen `address`.
 
-proc makeStandardSwitchBuilder*(
-    address: MultiAddress | string = "", transport: TransportType = TransportType.QUIC
-): SwitchBuilder =
-  ## Helper for common switch configurations.
-  ## When address is specified builder will create transport matching address. 
-  ## If address is not specified transport with default address is created.
-
-  var b = SwitchBuilder.new().withRng(rng()).withNoise()
-
-  let addrs =
-    when address is MultiAddress:
-      address
-    else:
-      if address.len > 0:
-        MultiAddress.init(address).valueOr:
-          raise newException(LPError, error)
-      else:
-        case transport
-        of TransportType.QUIC:
-          QuicAutoAddress
-        of TransportType.TCP:
-          TcpAutoAddress
-        of TransportType.Websocket:
-          WsAutoAddress
-        of TransportType.Memory:
-          MultiAddress.init(MemoryAutoAddress).valueOr:
-            raise newException(LPError, error)
-
-  b = b.withAddress(addrs)
+  var b = SwitchBuilder.new().withRng(rng()).withNoise().withAddress(address)
 
   # address will decide which transport to use
-  if QUIC_V1.match(addrs):
+  if QUIC_V1.match(address):
     b = b.withQuicTransport()
-  elif TCP.match(addrs):
+  elif TCP.match(address):
     b = b.withTcpTransport().withMplex()
-  elif WebSockets.match(addrs):
+  elif WebSockets.match(address):
     b = b.withTransport(
       proc(transportConfig: TransportConfig): Transport =
         WsTransport.new(transportConfig.upgr, transportConfig.rng)
     )
     b = b.withMplex()
-  elif Memory.match(addrs):
+  elif Memory.match(address):
     b = b.withMemoryTransport().withMplex()
   else:
     raiseAssert "could not infere transport from address"
@@ -64,6 +34,6 @@ proc makeStandardSwitchBuilder*(
   b
 
 proc makeStandardSwitch*(
-    address: MultiAddress | string = "", transport: TransportType = TransportType.QUIC
+    address: MultiAddress | string = QuicAutoAddress
 ): Switch {.raises: [LPError].} =
-  return makeStandardSwitchBuilder(address, transport).build()
+  return makeStandardSwitchBuilder(address).build()


### PR DESCRIPTION
`makeStandardSwitchBuilder` never really needed `transport: TransportType` argument. when user creates switch, transport should be added by default to match listen address.