### PR TITLE
fix(tests): shard test_all to fix i386+orc OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,19 +160,6 @@ jobs:
         run: |
           nimble install_pinned
 
-      # Nim's semantic phase OOMs on linux-i386 + orc when compiling
-      # tests/test_all.nim (one TU pulling in ~150 test files; orc injects
-      # lifetime hooks at every value site, blowing past the runner's RAM).
-      # Refc fits; orc needs the spill.
-      - name: Increase swap (linux-i386 + orc)
-        if: matrix.platform.os == 'linux' && matrix.platform.cpu == 'i386' && matrix.nim.memory_management == 'orc'
-        run: |
-          sudo fallocate -l 8G /swapfile_extra
-          sudo chmod 600 /swapfile_extra
-          sudo mkswap /swapfile_extra
-          sudo swapon /swapfile_extra
-          free -h
-
       - name: Run tests
         id: run-tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,19 @@ jobs:
         run: |
           nimble install_pinned
 
+      # Nim's semantic phase OOMs on linux-i386 + orc when compiling
+      # tests/test_all.nim (one TU pulling in ~150 test files; orc injects
+      # lifetime hooks at every value site, blowing past the runner's RAM).
+      # Refc fits; orc needs the spill.
+      - name: Increase swap (linux-i386 + orc)
+        if: matrix.platform.os == 'linux' && matrix.platform.cpu == 'i386' && matrix.nim.memory_management == 'orc'
+        run: |
+          sudo fallocate -l 8G /swapfile_extra
+          sudo chmod 600 /swapfile_extra
+          sudo mkswap /swapfile_extra
+          sudo swapon /swapfile_extra
+          free -h
+
       - name: Run tests
         id: run-tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
-.PHONY: all build deps cbind clean test _test_all test_multiformat_exts test_integration \
+# test_all is compiled in `TEST_ALL_SLICES` translation units. Each slice
+# imports a deterministic 1/N subset of the test files (see tests/imports.nim).
+# On 32-bit targets the Nim compiler is itself a 32-bit process capped at ~3 GB
+# of address space; the unsharded TU overran that on orc. Two slices halve the
+# memory footprint enough to fit, and the overhead is small on 64-bit targets.
+TEST_ALL_SLICES ?= 2
+TEST_ALL_SLICE_IDS := $(shell seq 0 $$(( $(TEST_ALL_SLICES) - 1 )))
+TEST_ALL_SLICE_TARGETS := $(addprefix _test_all_slice_,$(TEST_ALL_SLICE_IDS))
+
+.PHONY: all build deps cbind clean test _test_all $(TEST_ALL_SLICE_TARGETS) \
+        test_multiformat_exts test_integration \
         install_pinned pin unpin gen_multicodec format clean-nim nat_libs nat_pkg_dir_check
 
 NIM_VERSION  ?= 2.2.10
@@ -139,11 +149,16 @@ else
 	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
 endif
 
-_test_all: nimble.paths nat_libs
+_test_all: $(TEST_ALL_SLICE_TARGETS)
+
+$(TEST_ALL_SLICE_TARGETS): _test_all_slice_%: nimble.paths nat_libs
 	$(NIMC) c $(NIM_FLAGS) \
-	  $(if $(CICOV),--nimcache:nimcache/test_all,) \
+	  $(if $(CICOV),--nimcache:nimcache/test_all_$*,) \
+	  -d:sliceTotal=$(TEST_ALL_SLICES) \
+	  -d:sliceIdx=$* \
+	  -o:tests/test_all_$* \
 	  tests/test_all.nim
-	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
+	./tests/test_all_$* $(RUNNER_FLAGS) --xml:tests/results_test_all_$*.xml
 
 test_multiformat_exts: nimble.paths nat_libs
 	$(NIMC) c $(NIM_FLAGS) \

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -3,8 +3,15 @@
 { pkgs }:
 
 {
+  nim = pkgs.fetchgit {
+    url = "https://github.com/nim-lang/Nim.git";
+    rev = "9fe2137fa2f3f66cf5a44f357d461829ac9e20c4";
+    sha256 = "1d2d9pv3x3i7im1cbnbj3qg9rvqg34f320pzjb1xriay89d30kr7";
+    fetchSubmodules = true;
+  };
+
   unittest2 = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-unittest2";
+    url = "https://github.com/status-im/nim-unittest2.git";
     rev = "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189";
     sha256 = "1n8n36kad50m97b64y7bzzknz9n7szffxhp0bqpk3g2v7zpda8sw";
     fetchSubmodules = true;
@@ -17,10 +24,17 @@
     fetchSubmodules = true;
   };
 
-  boringssl = pkgs.fetchgit {
-    url = "https://github.com/vacp2p/nim-boringssl";
-    rev = "03bd48b54bc2bdc12d8c1bd9c95a32951f2c5962";
-    sha256 = "0idisahaqbl88lccsdngpvaliah6dj3gnm76k83jnjv1gjnih2dj";
+  testutils = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-testutils";
+    rev = "6ce5e5e2301ccbc04b09d27ff78741ff4d352b4d";
+    sha256 = "1vbkr6i5yxhc2ai3b7rbglhmyc98f99x874fqdp6a152a6kqgwxy";
+    fetchSubmodules = true;
+  };
+
+  npeg = pkgs.fetchgit {
+    url = "https://github.com/zevv/npeg";
+    rev = "409f6796d0e880b3f0222c964d1da7de6e450811";
+    sha256 = "1h2f5znbpa3svk7wsw2axn8f7f59d23xq85z148kiv6fqh0ffwbm";
     fetchSubmodules = true;
   };
 
@@ -31,6 +45,13 @@
     fetchSubmodules = true;
   };
 
+  nat_traversal = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-nat-traversal";
+    rev = "860e18c37667b5dd005b94c63264560c35d88004";
+    sha256 = "0319k5bbl468phwfnvlrh7725sc80rnf7m9gyj0i3cb5hb9q78bs";
+    fetchSubmodules = true;
+  };
+
   stew = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-stew";
     rev = "4382b18f04b3c43c8409bfcd6b62063773b2bbaa";
@@ -38,38 +59,10 @@
     fetchSubmodules = true;
   };
 
-  faststreams = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-faststreams";
-    rev = "50889cd16ec8771106cdd0eeea460039e8571e06";
-    sha256 = "1hd4bhvw5lzwg924i8dif5mi61h0ayiplq38djvrdbfsjdhw2zvw";
-    fetchSubmodules = true;
-  };
-
-  serialization = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-serialization";
-    rev = "b0f2fa32960ea532a184394b0f27be37bd80248b";
-    sha256 = "0wip1fjx7ka39ck1g1xvmyarzq1p5dlngpqil6zff8k8z5skiz27";
-    fetchSubmodules = true;
-  };
-
-  json_serialization = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-json-serialization";
-    rev = "a6dcf03e04e179127a5fcb7e495d19a821d56c17";
-    sha256 = "0nn1kllp5khsmy4a412w425pycdsn1x7gfhjl9wmlvvsvjvkw7rm";
-    fetchSubmodules = true;
-  };
-
-  testutils = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-testutils";
-    rev = "e85cb6ff9c328a6e12441e81ff632ef8b3af62b3";
-    sha256 = "0pbnb78cqiim8xr66kmbyydkag108j7v7yda2j4rl5s9xaz21m9a";
-    fetchSubmodules = true;
-  };
-
-  chronicles = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-chronicles";
-    rev = "27ec507429a4eb81edc20f28292ee8ec420be05b";
-    sha256 = "1xx9fcfwgcaizq3s7i3s03mclz253r5j8va38l9ycl19fcbc96z9";
+  zlib = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-zlib";
+    rev = "190246aa0bb6569781370964fa2faa474203d6dd";
+    sha256 = "0x5l55gwzb1ay3k9inmi1g25jiv7flry247fcwd8rw3zw9pgchfv";
     fetchSubmodules = true;
   };
 
@@ -87,27 +80,6 @@
     fetchSubmodules = true;
   };
 
-  zlib = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-zlib";
-    rev = "c9e64574438e69f3dd9b64da048f9fffc89e2809";
-    sha256 = "1yj9d3z96pyad0dnb1a1cbl4rwgrzqmbjk8wc7ynh4sbh7nwxh4q";
-    fetchSubmodules = true;
-  };
-
-  nimcrypto = pkgs.fetchgit {
-    url = "https://github.com/cheatfate/nimcrypto";
-    rev = "721fb99ee099b632eb86dfad1f0d96ee87583774";
-    sha256 = "178vzb3q8wzjq295ik2pd25rrqf32w381ck76hm5x2d8qnzfmkkc";
-    fetchSubmodules = true;
-  };
-
-  lsquic = pkgs.fetchgit {
-    url = "https://github.com/vacp2p/nim-lsquic";
-    rev = "00e4b7dfaa197cd120267aa897b33b0914166b45";
-    sha256 = "0kfkcscafiz82amj7skn5hspqhs6ixdz09hy64cfhsxyd6mi48nq";
-    fetchSubmodules = true;
-  };
-
   metrics = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-metrics";
     rev = "a1296caf3ebb5f30f51a5feae7749a30df2824c2";
@@ -115,10 +87,17 @@
     fetchSubmodules = true;
   };
 
-  npeg = pkgs.fetchgit {
-    url = "https://github.com/zevv/npeg";
-    rev = "409f6796d0e880b3f0222c964d1da7de6e450811";
-    sha256 = "1h2f5znbpa3svk7wsw2axn8f7f59d23xq85z148kiv6fqh0ffwbm";
+  faststreams = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-faststreams";
+    rev = "50889cd16ec8771106cdd0eeea460039e8571e06";
+    sha256 = "1hd4bhvw5lzwg924i8dif5mi61h0ayiplq38djvrdbfsjdhw2zvw";
+    fetchSubmodules = true;
+  };
+
+  serialization = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-serialization";
+    rev = "b0f2fa32960ea532a184394b0f27be37bd80248b";
+    sha256 = "0wip1fjx7ka39ck1g1xvmyarzq1p5dlngpqil6zff8k8z5skiz27";
     fetchSubmodules = true;
   };
 
@@ -129,10 +108,24 @@
     fetchSubmodules = true;
   };
 
-  secp256k1 = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-secp256k1";
-    rev = "d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15";
-    sha256 = "1qjrmwbngb73f6r1fznvig53nyal7wj41d1cmqfksrmivk2sgrn2";
+  json_serialization = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-json-serialization";
+    rev = "c343b0e243d9e17e2c40f3a8a24340f7c4a71d44";
+    sha256 = "0i8sq51nqj8lshf6bfixaz9a7sq0ahsbvq3chkxdvv4khsqvam91";
+    fetchSubmodules = true;
+  };
+
+  chronicles = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-chronicles";
+    rev = "27ec507429a4eb81edc20f28292ee8ec420be05b";
+    sha256 = "1xx9fcfwgcaizq3s7i3s03mclz253r5j8va38l9ycl19fcbc96z9";
+    fetchSubmodules = true;
+  };
+
+  nimcrypto = pkgs.fetchgit {
+    url = "https://github.com/cheatfate/nimcrypto";
+    rev = "b3dbc9c4d08e58c5b7bfad6dc7ef2ee52f2f4c08";
+    sha256 = "1v4rz42lwcazs6isi3kmjylkisr84mh0kgmlqycx4i885dn3g0l4";
     fetchSubmodules = true;
   };
 
@@ -140,6 +133,27 @@
     url = "https://github.com/status-im/nim-websock";
     rev = "387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d";
     sha256 = "1v0m3x96fbp9jdzsys6mbxxc2xw3k3dqiv7wksfla89gc6z8w377";
+    fetchSubmodules = true;
+  };
+
+  secp256k1 = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-secp256k1";
+    rev = "d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15";
+    sha256 = "1qjrmwbngb73f6r1fznvig53nyal7wj41d1cmqfksrmivk2sgrn2";
+    fetchSubmodules = true;
+  };
+
+  boringssl = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/nim-boringssl";
+    rev = "e77caabae78fbc9aa5b78a0a521181b077c82571";
+    sha256 = "15k4dqh1hlcpq9zm30lpr728h7apdmgm22xzqhdm3clq9kia6fr8";
+    fetchSubmodules = true;
+  };
+
+  lsquic = pkgs.fetchgit {
+    url = "https://github.com/vacp2p/nim-lsquic";
+    rev = "3813b849d70edbef24dac3926b32949029721fdc";
+    sha256 = "016r3i7xj5mriaf199xr91j1f8312s89zgp66fiy9bj1j1i22yp7";
     fetchSubmodules = true;
   };
 

--- a/tests/imports.nim
+++ b/tests/imports.nim
@@ -73,6 +73,7 @@ macro importTests*(
       cmp(a.replace('\\', '/'), b.replace('\\', '/')),
   )
 
+  var importedFiles: seq[string] = @[]
   for i, file in matchingFiles:
     if i mod sliceTotal == sliceIdx:
       imports.add(newNimNode(nnkImportStmt).add(newLit(file)))

--- a/tests/imports.nim
+++ b/tests/imports.nim
@@ -67,9 +67,9 @@ macro importTests*(
 
   # Deterministic order so a given (sliceIdx, sliceTotal) always selects the
   # same set across runs and platforms.
-  sort(matchingFiles)
+  sort(matchingFiles, proc(a, b: string): int =
+    cmp(a.replace('\\', '/'), b.replace('\\', '/')))
 
-  var importedFiles: seq[string] = @[]
   for i, file in matchingFiles:
     if i mod sliceTotal == sliceIdx:
       imports.add(newNimNode(nnkImportStmt).add(newLit(file)))

--- a/tests/imports.nim
+++ b/tests/imports.nim
@@ -1,16 +1,30 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
+import std/algorithm
 import std/macros
 import std/os
 import std/strutils
 import std/sequtils
 
+# Split the test corpus across `sliceTotal` translation units; each invocation
+# of test_all.nim compiles only the files whose sorted index is `sliceIdx` mod
+# `sliceTotal`. On 32-bit targets the Nim compiler is itself a 32-bit process
+# and is capped at ~3 GB of address space, which the unsharded TU overran on
+# orc. Slicing keeps each compile under that ceiling and is a no-op when
+# sliceTotal == 1.
+const sliceTotal* {.intdefine.}: int = 1
+const sliceIdx* {.intdefine.}: int = 0
+static:
+  doAssert sliceTotal >= 1, "sliceTotal must be >= 1"
+  doAssert sliceIdx >= 0 and sliceIdx < sliceTotal,
+    "sliceIdx must be in [0, sliceTotal)"
+
 proc printImportSummary(importedFiles: seq[string], baseDir: string) =
   ## Prints a summary of imported test files at compile time
   echo "\n"
   echo "=================================="
-  echo "Dynamic test import"
+  echo "Dynamic test import (slice ", sliceIdx, "/", sliceTotal, ")"
   echo "Imported ", importedFiles.len, " files."
   echo ""
   for file in importedFiles:
@@ -36,15 +50,28 @@ macro importTests*(
   ##
   ## Example: `importTests("tests", @[], "quic")` imports only QUIC-related tests
   let imports = newStmtList()
-  var importedFiles: seq[string] = @[]
+  var matchingFiles: seq[string] = @[]
 
   for file in walkDirRec(dir):
     let (path, name, ext) = splitFile(file)
     let isTestFile = name.startsWith("test_") and name != "test_all" and ext == ".nim"
     let isIgnored = ignorePaths.len > 0 and ignorePaths.anyIt(path.contains(it))
-    let isMatched = matchPath.len == 0 or file.contains(matchPath)
+    # walkDirRec uses the host's path separator; normalize so callers can pass
+    # forward-slash matchPath values that work on Windows too.
+    let normFile = file.replace('\\', '/')
+    let normMatch = matchPath.replace('\\', '/')
+    let isMatched = normMatch.len == 0 or normFile.contains(normMatch)
 
     if isTestFile and not isIgnored and isMatched:
+      matchingFiles.add(file)
+
+  # Deterministic order so a given (sliceIdx, sliceTotal) always selects the
+  # same set across runs and platforms.
+  sort(matchingFiles)
+
+  var importedFiles: seq[string] = @[]
+  for i, file in matchingFiles:
+    if i mod sliceTotal == sliceIdx:
       imports.add(newNimNode(nnkImportStmt).add(newLit(file)))
       importedFiles.add(file)
 

--- a/tests/imports.nim
+++ b/tests/imports.nim
@@ -67,8 +67,11 @@ macro importTests*(
 
   # Deterministic order so a given (sliceIdx, sliceTotal) always selects the
   # same set across runs and platforms.
-  sort(matchingFiles, proc(a, b: string): int =
-    cmp(a.replace('\\', '/'), b.replace('\\', '/')))
+  sort(
+    matchingFiles,
+    proc(a, b: string): int =
+      cmp(a.replace('\\', '/'), b.replace('\\', '/')),
+  )
 
   for i, file in matchingFiles:
     if i mod sliceTotal == sliceIdx:


### PR DESCRIPTION
## Summary

The `linux-i386 + Nim 2.2.10 + orc` matrix cell has been failing across PRs with `out of memory` during Nim compilation of `tests/test_all.nim` (e.g. [run 26834331161](https://github.com/vacp2p/nim-libp2p/actions/runs/26834331161/job/79129481198?pr=2590), and most recently [run 26844174056](https://github.com/vacp2p/nim-libp2p/actions/runs/26844174056/job/79159069912?pr=2575) from a PR pointing at this branch).

**Root cause:** on i386 jobs the Nim compiler itself is built and run as a 32-bit ELF — see `.github/actions/install_nim/action.yml`, which puts a `gcc -m32` wrapper on PATH and passes `ARCH_OVERRIDE=x86` to `build_nim.sh`. A 32-bit process on x86 Linux is hard-capped at ~3 GB of address space regardless of how much RAM (or swap) the host has. `tests/test_all.nim` is a single TU that pulls in ~150 test files via `importTests`; with `--mm:orc --opt:speed` the semantic phase injects lifetime hooks (`=destroy`, `=copy`, `=sink`) at every value site and pushes the Nim process past that cap. The error string (`out of memory`) is Nim's own `raiseOutOfMem`, printed when `malloc` returns NULL.

**Previous attempt** (in this PR's first commit) added an 8 GB swapfile to the failing cell. It got slightly further but still OOMed — host swap cannot extend a single process's address space, so the swap was treating the wrong constraint.

**Fix:** shard `tests/test_all.nim` into `TEST_ALL_SLICES` translation units (default 2). Each slice imports a deterministic 1/N subset of the test files (sorted by path, distributed round-robin) and writes its own JUnit XML. Slicing is implemented in `tests/imports.nim` via `-d:sliceTotal=N -d:sliceIdx=I` and is a no-op when `sliceTotal == 1`. The Makefile drives the per-slice compile-and-run via a `_test_all_slice_%` pattern rule. The CI swap step is dropped — it was load-bearing for the wrong reason.

Halving the per-TU file count brings each Nim compile well under the 3 GB ceiling. Slicing is applied universally (not i386-only) so the same code path runs on every matrix cell; the overhead on 64-bit cells is one additional Nim compiler bootstrap, and the per-slice compile is correspondingly smaller.

## Affected Areas

- [x] Build / Tooling

  Test harness sharding (`tests/imports.nim`, `Makefile`) and CI step removal (`.github/workflows/ci.yml`).

## Impact on Library Users

None — test infrastructure only. Library code, public API, and runtime behaviour are unchanged.

## Risk Assessment

Low.

- Slicing is universal, so the same code path runs on every cell — no platform-specific drift risk.
- Each slice runs `finalCheckTrackers()` independently, which is strictly stronger leak-checking than the previous single-TU run (a tracker leaked by a test in slice 0 can no longer be silently mopped up by a test in slice 1).
- Each slice produces its own `tests/results_test_all_<i>.xml`; the existing `tests/results_*.xml` glob in the test-reporter step picks them all up unchanged.
- `TEST_ALL_SLICES` is `?= 2` so it can be bumped (or pinned to 1 to reproduce the old behaviour) without further code changes.

## References

- Previous quick-fix commit on this branch: `5124f95` (`fix(ci): i386 OOM on ORC tests`) — now reverted in favour of the proper fix.
- Failing job log used to diagnose the per-process VM cap: [run 26844174056 / linux-i386 (Nim v2.2.10 / gcc) orc](https://github.com/vacp2p/nim-libp2p/actions/runs/26844174056/job/79159069912?pr=2575).