### PR TITLE
fix(gossipsub): Partial Messages - fanout regression

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
@@ -233,6 +233,27 @@ proc handleSubscribeRPC(ext: PartialMessageExtension, peerId: PeerId, rpc: SubOp
   else:
     ext.peerTopicOpts.del(key)
 
+proc shouldHandlePartialRPC(
+    ext: PartialMessageExtension, peerId: PeerId, rpc: PartialMessageExtensionRPC
+): bool =
+  let nodeTopicOpts = ext.config.nodeTopicOpts(rpc.topicID)
+  if nodeTopicOpts.requestsPartial:
+    return true
+
+  # We only send parts to a peer that asked for them.
+  if not ext.peerRequestsPartial(peerId, rpc.topicID):
+    return false
+
+  if nodeTopicOpts.supportsSendingPartial:
+    return true
+
+  # An unsubscribed fanout publisher has no topic opts set, but it has published
+  # to this group, so it can still fulfill parts the peer is missing.
+  # Look up without creating state.
+  let groupState =
+    ext.groupState.getOrDefault(TopicGroupKey.new(rpc.topicID, rpc.groupID))
+  groupState != nil and groupState.hasPublished()
+
 proc handlePartialRPC(
     ext: PartialMessageExtension, peerId: PeerId, rpc: PartialMessageExtensionRPC
 ) =
@@ -252,19 +273,7 @@ proc handlePartialRPC(
     peerState.receivedPartsMetadata = Opt.some(rpc.partsMetadata)
     groupState.heartbeatsTillEviction = ext.config.heartbeatsTillEviction
 
-  let nodeTopicOpts = ext.config.nodeTopicOpts(rpc.topicID)
-
-  # An unsubscribed fanout publisher does not advertise topic opts, but it has
-  # published to this group and can still fulfill parts the peer is missing.
-  # Look up without creating state, so an unrelated RPC does not allocate a group.
-  let group = ext.groupState.getOrDefault(TopicGroupKey.new(rpc.topicID, rpc.groupID))
-  let nodeCanSendPartial =
-    nodeTopicOpts.supportsSendingPartial or (group != nil and group.hasPublished())
-
-  let shouldHandlePartialRPC =
-    nodeTopicOpts.requestsPartial or
-    (nodeCanSendPartial and ext.peerRequestsPartial(peerId, rpc.topicID))
-  if shouldHandlePartialRPC:
+  if shouldHandlePartialRPC(ext, peerId, rpc):
     ext.config.onIncomingRPC(peerId, rpc)
 
 method onHandleRPC*(

--- a/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
@@ -246,9 +246,8 @@ proc handlePartialRPC(
     debug "RPC did not pass application validation", msg = validateRes.error
     return
 
-  var groupState = ext.getGroupState(rpc.topicID, rpc.groupID)
-
   if rpc.partsMetadata.len > 0:
+    var groupState = ext.getGroupState(rpc.topicID, rpc.groupID)
     var peerState = groupState.getPeerState(peerId)
     peerState.receivedPartsMetadata = Opt.some(rpc.partsMetadata)
     groupState.heartbeatsTillEviction = ext.config.heartbeatsTillEviction
@@ -257,8 +256,10 @@ proc handlePartialRPC(
 
   # An unsubscribed fanout publisher does not advertise topic opts, but it has
   # published to this group and can still fulfill parts the peer is missing.
+  # Look up without creating state, so an unrelated RPC does not allocate a group.
+  let group = ext.groupState.getOrDefault(TopicGroupKey.new(rpc.topicID, rpc.groupID))
   let nodeCanSendPartial =
-    nodeTopicOpts.supportsSendingPartial or groupState.hasPublished()
+    nodeTopicOpts.supportsSendingPartial or (group != nil and group.hasPublished())
 
   let shouldHandlePartialRPC =
     nodeTopicOpts.requestsPartial or

--- a/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
@@ -139,6 +139,9 @@ template getPeerState(gs: GroupState, peerId: PeerId): PeerGroupState =
 template hasPeer(gs: GroupState, peerId: PeerId): bool =
   gs.peerState.hasKey(peerId)
 
+template hasPublished(gs: GroupState): bool =
+  gs.lastPublishedMetadata.len > 0
+
 proc unionWithSentPartsMetadata(
     ext: PartialMessageExtension,
     peerState: var PeerGroupState,
@@ -175,7 +178,7 @@ proc peersRequestingPartial(ext: PartialMessageExtension, topic: string): seq[Pe
 
 proc gossipPartsMetadata*(ext: PartialMessageExtension) =
   for tgKey, group in ext.groupState.mpairs:
-    if group.lastPublishedMetadata.len == 0:
+    if not group.hasPublished():
       # node has not published anything on this (topic, group)
       continue
 
@@ -243,18 +246,23 @@ proc handlePartialRPC(
     debug "RPC did not pass application validation", msg = validateRes.error
     return
 
+  var groupState = ext.getGroupState(rpc.topicID, rpc.groupID)
+
   if rpc.partsMetadata.len > 0:
-    var groupState = ext.getGroupState(rpc.topicID, rpc.groupID)
     var peerState = groupState.getPeerState(peerId)
     peerState.receivedPartsMetadata = Opt.some(rpc.partsMetadata)
     groupState.heartbeatsTillEviction = ext.config.heartbeatsTillEviction
 
   let nodeTopicOpts = ext.config.nodeTopicOpts(rpc.topicID)
+
+  # An unsubscribed fanout publisher does not advertise topic opts, but it has
+  # published to this group and can still fulfill parts the peer is missing.
+  let nodeCanSendPartial =
+    nodeTopicOpts.supportsSendingPartial or groupState.hasPublished()
+
   let shouldHandlePartialRPC =
-    nodeTopicOpts.requestsPartial or (
-      nodeTopicOpts.supportsSendingPartial and
-      ext.peerRequestsPartial(peerId, rpc.topicID)
-    )
+    nodeTopicOpts.requestsPartial or
+    (nodeCanSendPartial and ext.peerRequestsPartial(peerId, rpc.topicID))
   if shouldHandlePartialRPC:
     ext.config.onIncomingRPC(peerId, rpc)
 

--- a/tests/interop/gossipsub/test_runner.nim
+++ b/tests/interop/gossipsub/test_runner.nim
@@ -265,10 +265,9 @@ suite "GossipSub Interop - Script runner - Component":
       key in runner0.messages
       key in runner1.messages
       runner0.messages[key].isComplete()
-      not runner1.messages[key].isComplete()
-        # will never receive message since it is not subscribed
+      runner1.messages[key].isComplete()
       logStream0.data.contains("All parts received")
-      not logStream1.data.contains("All parts received") # should not receive all parts
+      logStream1.data.contains("All parts received")
 
   asyncTest "received message logs include duplicates once per inbound rpc":
     let sender = createNode(0, TcpAutoAddress)

--- a/tests/libp2p/pubsub/extensions/test_extension_partial_message.nim
+++ b/tests/libp2p/pubsub/extensions/test_extension_partial_message.nim
@@ -233,6 +233,33 @@ suite "GossipSub Extensions :: Partial Message Extension":
     check:
       cr.incomingRPC.len == 0
 
+  test "handleRPC: calls onIncomingRPC for unsubscribed fanout publisher that has published":
+    const topic = "logos-partial"
+    var cr = CallbackRecorder(publishToPeers: @[peerId])
+    var config = cr.config()
+    config.nodeTopicOpts = proc(topic: string): TopicOpts {.gcsafe, raises: [].} =
+      TopicOpts(requestsPartial: false, supportsSendingPartial: false)
+    var ext = PartialMessageExtension.new(config)
+
+    # peer subscribes requesting partials
+    ext.subscribe(peerId, topic, true)
+
+    # node publishes to the group, establishing lastPublishedMetadata
+    let pm = MyPartialMessage(
+      groupId: groupId,
+      data: {1: "one".toBytes, 2: "two".toBytes, 3: "three".toBytes}.toTable,
+    )
+    check ext.publishPartial(topic, pm) == 1
+
+    # peer requests missing parts
+    let pmRPC = PartialMessageExtensionRPC(
+      topicID: topic, groupID: groupId, partsMetadata: MyPartsMetadata.want(@[1, 2])
+    )
+    ext.handlePartialMessage(peerId, pmRPC)
+    check:
+      cr.incomingRPC.len == 1
+      cr.incomingRPC[0] == PeerRPC(peerId: peerId, rpc: pmRPC)
+
   test "handleRPC: adds penalty when groupId or topicId is not set":
     const topic = "logos-partial"
     var cr = CallbackRecorder(publishToPeers: @[peerId])


### PR DESCRIPTION
## Summary

Fixes #2586. After PR #2569, an unsubscribed fanout publisher could no longer fulfill partial message requests. The gating in `handlePartialRPC` only let a node respond if it requested partials or advertised support for sending them. A fanout publisher does neither: it can't declare `supportsSendingPartial` without subscribing to the topic, yet it still holds the full message data consumers are missing. So consumers asking for parts never got them.

The fix adds a third path: if the peer requested partials and we have published to this `(topic, group)`, handle the RPC. Published state is tracked via the new `hasPublished()` helper (`lastPublishedMetadata.len > 0`).

The gating logic moved out of `handlePartialRPC` into a dedicated `shouldHandlePartialRPC` proc, restructured as guard clauses so it reads top to bottom and only does the group lookup on the path that needs it.

## Affected Areas
- [x] Gossipsub

## Impact on Library Users

Behavior change for the partial message extension: unsubscribed fanout publishers now correctly respond to part requests from consumers, restoring the pre-#2569 fulfillment flow. No API changes.

## Risk Assessment

Low. The change only widens when `onIncomingRPC` fires, and only for a peer that explicitly requested partials and a group we have actually published to. The new `getOrDefault` lookup does not allocate group state for unrelated RPCs.

## Reference
- Tested https://github.com/vacp2p/nim-libp2p/pull/2597/commits/6dd17d86f37c0460cc537a93da73358fad77517d against GossipSub Interop tests in https://github.com/rlve/test-plans/pull/10/changes/b3988ba687e950a356f2680d5fd5b7eaeaf1b1af - https://github.com/rlve/test-plans/actions/runs/26888908126/job/79308942071