### PR TITLE
fix(autonatv2): include observed addresses in dial request candidates

### DIFF
--- a/libp2p/protocols/connectivity/autonatv2/mockclient.nim
+++ b/libp2p/protocols/connectivity/autonatv2/mockclient.nim
@@ -12,6 +12,7 @@ type AutonatV2ClientMock* = ref object of AutonatV2Client
   dials*: int
   expectedDials: int
   finished*: Future[void]
+  allTestAddrs*: seq[seq[MultiAddress]]
 
 proc new*(
     T: typedesc[AutonatV2ClientMock], response: AutonatV2Response, expectedDials: int
@@ -29,6 +30,7 @@ method sendDialRequest*(
     async: (raises: [AutonatV2Error, CancelledError, DialFailedError, LPStreamError])
 .} =
   self.dials += 1
+  self.allTestAddrs.add(testAddrs)
   if self.dials == self.expectedDials:
     self.finished.complete()
 

--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -161,18 +161,19 @@ proc askPeer(
 
   var reqAddrs = switch.peerInfo.addrs
   if self.config.enableDialableCandidates:
-    # Until the node is confirmed reachable, the address mapper leaves only
-    # listen addresses in peerInfo.addrs, so a node behind NAT would never
-    # submit a dialable candidate (chicken-and-egg).
-    # Add first the guessDialableAddr that uses the listen port
-    # and the observed address as a fallback.
-    var observedCandidates =
-      switch.peerInfo.listenAddrs.mapIt(switch.peerStore.guessDialableAddr(it))
+    # A node behind NAT only has listen addresses until it is confirmed
+    # reachable, so derive extra candidates from the observed addresses to break
+    # the chicken-and-egg.
+    var observedCandidates: seq[MultiAddress]
+    for listenAddr in switch.peerInfo.listenAddrs:
+      let guessed = switch.peerStore.guessDialableAddr(listenAddr)
+      if guessed != listenAddr:
+        observedCandidates.add(guessed)
     observedCandidates &= switch.peerStore.getMostObservedProtosAndPorts()
 
-    # Combine observed candidates with the node's current addresses to form the
-    # candidate list
-    reqAddrs = deduplicate(reqAddrs & observedCandidates)
+    reqAddrs = deduplicate(reqAddrs & observedCandidates).filterIt(
+        switch.peerInfo.addressPolicy(it)
+      )
     if reqAddrs.len == 0:
       debug "No candidate addresses to test, not asking peer"
       return Unknown

--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -158,13 +158,12 @@ proc askPeer(
 
   # Until the node is confirmed reachable, the address mapper leaves only
   # listen addresses in peerInfo.addrs, so a node behind NAT would never
-  # submit a dialable candidate (chicken-and-egg). Add the addresses
-  # observed by other peers via identify as additional candidates.
-  var observedCandidates = switch.peerStore.getMostObservedProtosAndPorts()
-  if observedCandidates.len == 0:
-    # Fallback to guessDialableAddr if no observed candidates are available
-    observedCandidates =
-      switch.peerInfo.listenAddrs.mapIt(switch.peerStore.guessDialableAddr(it))
+  # submit a dialable candidate (chicken-and-egg).
+  # Add first the guessDialableAddr that uses the listen port
+  # and the observed address as a fallback.
+  var observedCandidates =
+    switch.peerInfo.listenAddrs.mapIt(switch.peerStore.guessDialableAddr(it))
+  observedCandidates &= switch.peerStore.getMostObservedProtosAndPorts()
 
   # Combine observed candidates with the node's current addresses to form the
   # candidate list

--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -38,6 +38,7 @@ type
     maxQueueSize: int
     minConfidence: float
     enableAddressMapper: bool
+    enableDialableCandidates: bool
 
   AutonatV2Service* = ref object of Service
     config*: AutonatV2ServiceConfig
@@ -65,6 +66,7 @@ proc new*(
     maxQueueSize: int = 10,
     minConfidence: float = 0.3,
     enableAddressMapper = true,
+    enableDialableCandidates = false,
 ): T =
   return T(
     scheduleInterval: scheduleInterval,
@@ -73,6 +75,7 @@ proc new*(
     maxQueueSize: maxQueueSize,
     minConfidence: minConfidence,
     enableAddressMapper: enableAddressMapper,
+    enableDialableCandidates: enableDialableCandidates,
   )
 
 proc new*(
@@ -156,21 +159,23 @@ proc askPeer(
 
   trace "Asking peer for reachability"
 
-  # Until the node is confirmed reachable, the address mapper leaves only
-  # listen addresses in peerInfo.addrs, so a node behind NAT would never
-  # submit a dialable candidate (chicken-and-egg).
-  # Add first the guessDialableAddr that uses the listen port
-  # and the observed address as a fallback.
-  var observedCandidates =
-    switch.peerInfo.listenAddrs.mapIt(switch.peerStore.guessDialableAddr(it))
-  observedCandidates &= switch.peerStore.getMostObservedProtosAndPorts()
+  var reqAddrs = switch.peerInfo.addrs
+  if self.config.enableDialableCandidates:
+    # Until the node is confirmed reachable, the address mapper leaves only
+    # listen addresses in peerInfo.addrs, so a node behind NAT would never
+    # submit a dialable candidate (chicken-and-egg).
+    # Add first the guessDialableAddr that uses the listen port
+    # and the observed address as a fallback.
+    var observedCandidates =
+      switch.peerInfo.listenAddrs.mapIt(switch.peerStore.guessDialableAddr(it))
+    observedCandidates &= switch.peerStore.getMostObservedProtosAndPorts()
 
-  # Combine observed candidates with the node's current addresses to form the
-  # candidate list
-  let reqAddrs = deduplicate(switch.peerInfo.addrs & observedCandidates)
-  if reqAddrs.len == 0:
-    debug "No candidate addresses to test, not asking peer"
-    return Unknown
+    # Combine observed candidates with the node's current addresses to form the
+    # candidate list
+    reqAddrs = deduplicate(reqAddrs & observedCandidates)
+    if reqAddrs.len == 0:
+      debug "No candidate addresses to test, not asking peer"
+      return Unknown
 
   var dialBackAddr = Opt.none(MultiAddress)
   let ans =

--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -171,12 +171,13 @@ proc askPeer(
         observedCandidates.add(guessed)
     observedCandidates &= switch.peerStore.getMostObservedProtosAndPorts()
 
-    reqAddrs = deduplicate(reqAddrs & observedCandidates).filterIt(
+    reqAddrs = deduplicate(observedCandidates & reqAddrs).filterIt(
         switch.peerInfo.addressPolicy(it)
       )
-    if reqAddrs.len == 0:
-      debug "No candidate addresses to test, not asking peer"
-      return Unknown
+
+  if reqAddrs.len == 0:
+    debug "No candidate addresses to test, not asking peer"
+    return Unknown
 
   var dialBackAddr = Opt.none(MultiAddress)
   let ans =

--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -155,10 +155,27 @@ proc askPeer(
     return Unknown
 
   trace "Asking peer for reachability"
+
+  # Until the node is confirmed reachable, the address mapper leaves only
+  # listen addresses in peerInfo.addrs, so a node behind NAT would never
+  # submit a dialable candidate (chicken-and-egg). Add the addresses
+  # observed by other peers via identify as additional candidates.
+  var observedCandidates = switch.peerStore.getMostObservedProtosAndPorts()
+  if observedCandidates.len == 0:
+    # Fallback to guessDialableAddr if no observed candidates are available
+    observedCandidates =
+      switch.peerInfo.listenAddrs.mapIt(switch.peerStore.guessDialableAddr(it))
+
+  # Combine observed candidates with the node's current addresses to form the
+  # candidate list
+  let reqAddrs = deduplicate(switch.peerInfo.addrs & observedCandidates)
+  if reqAddrs.len == 0:
+    debug "No candidate addresses to test, not asking peer"
+    return Unknown
+
   var dialBackAddr = Opt.none(MultiAddress)
   let ans =
     try:
-      let reqAddrs = switch.peerInfo.addrs
       let autonatV2Resp = await self.client.sendDialRequest(peerId, reqAddrs)
       debug "AutonatV2Response", autonatV2Resp = autonatV2Resp
       dialBackAddr = autonatV2Resp.addrs

--- a/tests/libp2p/protocols/test_autonat_v2_service.nim
+++ b/tests/libp2p/protocols/test_autonat_v2_service.nim
@@ -604,7 +604,16 @@ suite "AutonatV2 Service":
     await switch.startAndConnect(switches)
     await client.finished
 
+    let tcpPart = switch.peerInfo.listenAddrs[0][1].tryGet()
+    let guessed = concat(MultiAddress.init("/ip4/8.8.8.8").tryGet(), tcpPart).tryGet()
+    check guessed in client.allTestAddrs[0]
+    # Ensure that the guessed IP is preferred over the observed IP when both are dialable.
+    check client.allTestAddrs[0].find(guessed) <
+      client.allTestAddrs[0].find(observedAddr)
+
+    # Observed address is kept as a fallback
     check observedAddr in client.allTestAddrs[0]
+
     for ma in switch.peerInfo.addrs:
       check ma in client.allTestAddrs[0]
 

--- a/tests/libp2p/protocols/test_autonat_v2_service.nim
+++ b/tests/libp2p/protocols/test_autonat_v2_service.nim
@@ -593,7 +593,11 @@ suite "AutonatV2 Service":
 
   asyncTest "Observed addresses must be included in dial request candidates":
     let
-      (service, client) = newService(NetworkReachability.Reachable, expectedDials = 1)
+      (service, client) = newService(
+        NetworkReachability.Reachable,
+        expectedDials = 1,
+        config = AutonatV2ServiceConfig.new(enableDialableCandidates = true),
+      )
       switch = createSwitch(Opt.some(service))
       switches = @[createSwitch()]
 
@@ -633,7 +637,9 @@ suite "AutonatV2 Service":
       (service, client) = newService(
         NetworkReachability.Reachable,
         expectedDials = ObservedAddrQuorum + 1,
-        config = AutonatV2ServiceConfig.new(minConfidence = 0.9),
+        config = AutonatV2ServiceConfig.new(
+          minConfidence = 0.9, enableDialableCandidates = true
+        ),
       )
       switch = createSwitch(Opt.some(service))
       switches = createSwitches(ObservedAddrQuorum + 1)
@@ -655,6 +661,31 @@ suite "AutonatV2 Service":
 
     # Make sure the guessed dialable address is not in the peer's listen addresses
     check expected notin switch.peerInfo.addrs
+
+    await switch.stop()
+    await switches.stopAll()
+
+  asyncTest "Dialable candidates are not added when disabled":
+    # Same setup as the mirror test above (node kept Unknown via high
+    # minConfidence, so the address mapper stays inactive), but with
+    # enableDialableCandidates left to its default of false. The node then
+    # advertises only its listen addresses, so every dial request must be
+    # exactly the listen addresses: no guessed or observed candidate is added,
+    # even after the observed IP reaches quorum.
+    let
+      (service, client) = newService(
+        NetworkReachability.Reachable,
+        expectedDials = ObservedAddrQuorum + 1,
+        config = AutonatV2ServiceConfig.new(minConfidence = 0.9),
+      )
+      switch = createSwitch(Opt.some(service))
+      switches = createSwitches(ObservedAddrQuorum + 1)
+
+    await switch.startAndConnect(switches)
+    await client.finished
+
+    for reqAddrs in client.allTestAddrs:
+      check reqAddrs == switch.peerInfo.listenAddrs
 
     await switch.stop()
     await switches.stopAll()

--- a/tests/libp2p/protocols/test_autonat_v2_service.nim
+++ b/tests/libp2p/protocols/test_autonat_v2_service.nim
@@ -8,6 +8,7 @@ import
   ../../../libp2p/[
     builders,
     switch,
+    observedaddrmanager,
     protocols/connectivity/autonatv2/types,
     protocols/connectivity/autonatv2/service,
     protocols/connectivity/autonatv2/mockclient,
@@ -584,6 +585,66 @@ suite "AutonatV2 Service":
     check service.networkReachability == NetworkReachability.NotReachable
     check capturedAddr.isSome()
     check capturedAddr.get() == switch.peerInfo.addrs[0]
+
+    await switch.stop()
+    await switches.stopAll()
+
+  asyncTest "Observed addresses must be included in dial request candidates":
+    let
+      (service, client) = newService(NetworkReachability.Reachable, expectedDials = 1)
+      switch = createSwitch(Opt.some(service))
+      switches = @[createSwitch()]
+
+    # Simulate identify reports from other peers: the same public address
+    # must be observed at least minCount (3) times to become a candidate.
+    let observedAddr = MultiAddress.init("/ip4/8.8.8.8/tcp/4040").tryGet()
+    for _ in 0 ..< 3:
+      discard switch.peerStore.identify.observedAddrManager.addObservation(observedAddr)
+
+    await switch.startAndConnect(switches)
+    await client.finished
+
+    check observedAddr in client.allTestAddrs[0]
+    for ma in switch.peerInfo.addrs:
+      check ma in client.allTestAddrs[0]
+
+    await switch.stop()
+    await switches.stopAll()
+
+  asyncTest "Dial request must fall back to the guessed dialable address when the observed IP reaches quorum but the port does not":
+    # High minConfidence keeps the node Unknown for the whole test, so the
+    # address mapper stays inactive: candidates can only come from the
+    # observed addresses.
+    # Each connection triggers identify: after 3 of them the observed IP
+    # reaches quorum (ports are ephemeral, only the IP is stable), so the
+    # ask triggered by the 4th connection must include the guessed
+    # dialable address (observed IP + listen port).
+    let
+      (service, client) = newService(
+        NetworkReachability.Reachable,
+        expectedDials = 4,
+        config = AutonatV2ServiceConfig.new(minConfidence = 0.9),
+      )
+      switch = createSwitch(Opt.some(service))
+      switches = createSwitches(4)
+
+    await switch.startAndConnect(switches)
+    await client.finished
+
+    let tcpPart = switch.peerInfo.listenAddrs[0][1].tryGet()
+    let expected =
+      concat(MultiAddress.init("/ip4/127.0.0.1").tryGet(), tcpPart).tryGet()
+
+    # Before the quorum (first 3 asks), only the listen addresses are sent.
+    for reqAddrs in client.allTestAddrs[0 ..< 3]:
+      check reqAddrs == switch.peerInfo.listenAddrs
+
+    # The 4th ask is the first one with the quorum reached: it must contain
+    # the guessed dialable address.
+    check expected in client.allTestAddrs[3]
+
+    # Make sure the guessed dialable address is not in the peer's listen addresses
+    check expected notin switch.peerInfo.addrs
 
     await switch.stop()
     await switches.stopAll()

--- a/tests/libp2p/protocols/test_autonat_v2_service.nim
+++ b/tests/libp2p/protocols/test_autonat_v2_service.nim
@@ -111,6 +111,8 @@ proc newService(
       )
   (AutonatV2Service.new(rng(), client = client, config = config), client)
 
+const ObservedAddrQuorum = 3
+
 const AutonatV2ReachabilityConfidenceMetric =
   "libp2p_autonat_v2_reachability_confidence"
 
@@ -596,9 +598,9 @@ suite "AutonatV2 Service":
       switches = @[createSwitch()]
 
     # Simulate identify reports from other peers: the same public address
-    # must be observed at least minCount (3) times to become a candidate.
+    # must be observed at least quorum times to become a candidate.
     let observedAddr = MultiAddress.init("/ip4/8.8.8.8/tcp/4040").tryGet()
-    for _ in 0 ..< 3:
+    for _ in 0 ..< ObservedAddrQuorum:
       discard switch.peerStore.identify.observedAddrManager.addObservation(observedAddr)
 
     await switch.startAndConnect(switches)
@@ -624,18 +626,17 @@ suite "AutonatV2 Service":
     # High minConfidence keeps the node Unknown for the whole test, so the
     # address mapper stays inactive: candidates can only come from the
     # observed addresses.
-    # Each connection triggers identify: after 3 of them the observed IP
-    # reaches quorum (ports are ephemeral, only the IP is stable), so the
-    # ask triggered by the 4th connection must include the guessed
-    # dialable address (observed IP + listen port).
+    # Each connection triggers identify: after quorum of them the observed IP
+    # reaches quorum (ports are ephemeral, only the IP is stable), so the next
+    # ask must include the guessed dialable address (observed IP + listen port).
     let
       (service, client) = newService(
         NetworkReachability.Reachable,
-        expectedDials = 4,
+        expectedDials = ObservedAddrQuorum + 1,
         config = AutonatV2ServiceConfig.new(minConfidence = 0.9),
       )
       switch = createSwitch(Opt.some(service))
-      switches = createSwitches(4)
+      switches = createSwitches(ObservedAddrQuorum + 1)
 
     await switch.startAndConnect(switches)
     await client.finished
@@ -644,13 +645,13 @@ suite "AutonatV2 Service":
     let expected =
       concat(MultiAddress.init("/ip4/127.0.0.1").tryGet(), tcpPart).tryGet()
 
-    # Before the quorum (first 3 asks), only the listen addresses are sent.
-    for reqAddrs in client.allTestAddrs[0 ..< 3]:
+    # Before the quorum (first quorum asks), only the listen addresses are sent.
+    for reqAddrs in client.allTestAddrs[0 ..< ObservedAddrQuorum]:
       check reqAddrs == switch.peerInfo.listenAddrs
 
-    # The 4th ask is the first one with the quorum reached: it must contain
-    # the guessed dialable address.
-    check expected in client.allTestAddrs[3]
+    # The first ask after the quorum is reached must contain the guessed
+    # dialable address.
+    check expected in client.allTestAddrs[ObservedAddrQuorum]
 
     # Make sure the guessed dialable address is not in the peer's listen addresses
     check expected notin switch.peerInfo.addrs


### PR DESCRIPTION
## Summary

The AutonatV2 service sent only `peerInfo.addrs` as dial-request candidates. Until the node is confirmed reachable, the address mapper leaves only listen addresses there, so a node behind NAT never submits a dialable candidate: its reachability can never be confirmed (chicken-and-egg).

This PR lets the service add the addresses observed by other peers via identify as additional candidates, behind a new opt-in config flag `enableDialableCandidates` (default `false`, so behavior is unchanged unless explicitly enabled).

When enabled, `askPeer` builds the candidate list as:

- `guessDialableAddr(listenAddr)` for each listen address, kept only when an observed-IP quorum actually changed it (so we never submit a raw / private / wildcard address)
- plus `getMostObservedProtosAndPorts()` when a full IP+port observation reached quorum
- merged with `peerInfo.addrs`, deduplicated, then filtered through `peerInfo.addressPolicy`

It also guards against an empty candidate list: `askPeer` returns `Unknown` without dialing instead of sending an empty dial request.

## Affected Areas

- [ ] Gossipsub
- [ ] Transports
- [ ] Peer Management / Discovery
- [x] Protocol Logic
  <!-- autonatv2 service: dial-request candidate selection -->
- [ ] Build / Tooling
- [ ] Other

## Compatibility & Downstream Validation

Additive, opt-in config field. Off by default, so no behavior change for existing consumers.

- **Nimbus:** N/A
- **Waku:** N/A
- **Codex:** N/A

## Impact on Library Users

Off by default: existing consumers see no change. Consumers that opt in via `AutonatV2ServiceConfig.new(enableDialableCandidates = true)` get richer dial-request candidates derived from observed addresses (useful for nodes that change networks, e.g. mobile). The new field is additive: no breaking change, no migration needed. The `peerInfo.addressPolicy` and explicit announced addresses are still respected.

## Risk Assessment

Low. Disabled by default. When enabled, only a few extra candidates are added for dial-back testing.
## References

<!-- Link related issue here if any -->