### PR TITLE
refactor(Identify): remove peerId argument form IdentifyPushHandler

### DIFF
--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -70,8 +70,7 @@ type
     sendSignedPeerRecord*: bool
     observedAddrManager*: ObservedAddrManager
 
-  IdentifyPushHandler* =
-    proc(peer: PeerId, newInfo: IdentifyInfo): Future[void] {.gcsafe, raises: [].}
+  IdentifyPushHandler* = proc(newInfo: IdentifyInfo): Future[void] {.gcsafe, raises: [].}
 
   IdentifyPush* = ref object of LPProtocol
     identifyHandler: IdentifyPushHandler
@@ -239,7 +238,7 @@ proc init*(p: IdentifyPush) =
     if not handler.isNil:
       trace "triggering peer event", peerInfo = stream.peerId
       try:
-        await handler(stream.peerId, makeIdentifyInfo(peerId, identifyMsg))
+        await handler(makeIdentifyInfo(peerId, identifyMsg))
       except CancelledError as e:
         raise e
       except CatchableError as e:

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -70,7 +70,8 @@ type
     sendSignedPeerRecord*: bool
     observedAddrManager*: ObservedAddrManager
 
-  IdentifyPushHandler* = proc(newInfo: IdentifyInfo): Future[void] {.gcsafe, raises: [].}
+  IdentifyPushHandler* =
+    proc(newInfo: IdentifyInfo): Future[void] {.gcsafe, raises: [].}
 
   IdentifyPush* = ref object of LPProtocol
     identifyHandler: IdentifyPushHandler

--- a/libp2p/services/identify_pusher.nim
+++ b/libp2p/services/identify_pusher.nim
@@ -118,15 +118,15 @@ method setup*(p: IdentifyPusher, switch: Switch) {.raises: [ServiceSetupError].}
   p.connManager = switch.connManager
   p.peerInfo = switch.peerInfo
 
-  proc onIncomingPush(peerId: PeerId, info: IdentifyInfo) {.async.} =
+  proc onIncomingPush(info: IdentifyInfo) {.async.} =
     if not p.started:
       return
 
     p.peerStore.updatePeerInfo(info)
     if IdentifyPushCodec in info.protos:
-      p.pushPeers.incl(peerId)
+      p.pushPeers.incl(info.peerId)
     else:
-      p.pushPeers.excl(peerId)
+      p.pushPeers.excl(info.peerId)
 
   p.identifyPush = IdentifyPush.new(onIncomingPush)
 

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -177,10 +177,10 @@ suite "Identify":
         .withSignedPeerRecord(true)
         .build()
 
-      proc updateStore1(peerId: PeerId, info: IdentifyInfo) {.async.} =
+      proc updateStore1(info: IdentifyInfo) {.async.} =
         switch1.peerStore.updatePeerInfo(info)
 
-      proc updateStore2(peerId: PeerId, info: IdentifyInfo) {.async.} =
+      proc updateStore2(info: IdentifyInfo) {.async.} =
         switch2.peerStore.updatePeerInfo(info)
 
       identifyPush1 = IdentifyPush.new(updateStore1)


### PR DESCRIPTION
as it was unnecessary due to it already being available via `IdentifyInfo`