### PR TITLE
chore(deps): bump protobuf_serialization to v0.5.0

### DIFF
--- a/.pinned
+++ b/.pinned
@@ -16,6 +16,6 @@ testutils;https://github.com/status-im/nim-testutils@#e85cb6ff9c328a6e12441e81ff
 unittest2;https://github.com/status-im/nim-unittest2@#26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189
 websock;https://github.com/status-im/nim-websock@#387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d
 zlib;https://github.com/status-im/nim-zlib@#e680f269fb01af2c34a2ba879ff281795a5258fe
-protobuf_serialization;https://github.com/status-im/nim-protobuf-serialization@#63a13aa8dd8840eaf4d65090afbb93293fa426f5
+protobuf_serialization;https://github.com/status-im/nim-protobuf-serialization@#f45476a3c1f4e7bff73845e6450d686be040ddeb
 nat_traversal;https://github.com/status-im/nim-nat-traversal@#860e18c37667b5dd005b94c63264560c35d88004
 npeg;https://github.com/zevv/npeg@#409f6796d0e880b3f0222c964d1da7de6e450811

--- a/.pinned
+++ b/.pinned
@@ -16,6 +16,6 @@ testutils;https://github.com/status-im/nim-testutils@#e85cb6ff9c328a6e12441e81ff
 unittest2;https://github.com/status-im/nim-unittest2@#26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189
 websock;https://github.com/status-im/nim-websock@#387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d
 zlib;https://github.com/status-im/nim-zlib@#e680f269fb01af2c34a2ba879ff281795a5258fe
-protobuf_serialization;https://github.com/status-im/nim-protobuf-serialization@#38d24eb3bd93e605fb88199da71d36b1ec0ad60d
+protobuf_serialization;https://github.com/status-im/nim-protobuf-serialization@#63a13aa8dd8840eaf4d65090afbb93293fa426f5
 nat_traversal;https://github.com/status-im/nim-nat-traversal@#860e18c37667b5dd005b94c63264560c35d88004
 npeg;https://github.com/zevv/npeg@#409f6796d0e880b3f0222c964d1da7de6e450811

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -12,7 +12,7 @@ requires "nim >= 2.2.4",
   "nimcrypto >= 0.6.0", "bearssl >= 0.2.7",
   "https://github.com/vacp2p/nim-boringssl >= 0.0.8", "chronicles >= 0.11.0",
   "chronos >= 4.2.2", "metrics >= 0.2.2", "secp256k1", "stew >= 0.4.2", "unittest2",
-  "results", "serialization", "lsquic >= 0.5.1", "protobuf_serialization >= 0.4.0",
+  "results", "serialization", "lsquic >= 0.5.1", "protobuf_serialization >= 0.5.0",
   "https://github.com/status-im/nim-websock >= 0.4.0",
   "https://github.com/status-im/nim-nat-traversal >= 0.0.1"
 

--- a/libp2p/crypto/crypto.nim
+++ b/libp2p/crypto/crypto.nim
@@ -1007,8 +1007,7 @@ proc getField*(pb: ProtoBuffer, field: int, value: var Signature): ProtoResult[b
 
 ## protobuf_serialization extension
 
-func supportsPacked*(T: type PublicKey, ProtoType: type ProtobufExt): bool =
-  false
+Protobuf.extensionDefaults(PublicKey, packed = false)
 
 func computeFieldSize*(
     field: int, value: PublicKey, ProtoType: type ProtobufExt, skipDefault: static bool
@@ -1043,8 +1042,7 @@ proc readFieldInto*(
 
   false
 
-func supportsPacked*(T: type Signature, ProtoType: type ProtobufExt): bool =
-  false
+Protobuf.extensionDefaults(Signature, packed = false)
 
 func computeFieldSize*(
     field: int, value: Signature, ProtoType: type ProtobufExt, skipDefault: static bool

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -1332,10 +1332,7 @@ func shortLog*(addrs: seq[MultiAddress], maxAddrs: int): string =
 
 ## protobuf_serialization extension
 
-func supportsPacked*(T: type MultiAddress, ProtoType: type ProtobufExt): bool =
-  false
-func supportsPacked*(T: type seq[MultiAddress], ProtoType: type ProtobufExt): bool =
-  false
+Protobuf.extensionDefaults(MultiAddress, defaultWriteSeq = true, packed = false)
 
 func computeFieldSize*(
     field: int,

--- a/libp2p/peerid.nim
+++ b/libp2p/peerid.nim
@@ -287,10 +287,7 @@ func getField*(pb: ProtoBuffer, field: int, pid: var PeerId): ProtoResult[bool] 
 
 ## protobuf_serialization extension
 
-func supportsPacked*(T: type PeerId, ProtoType: type ProtobufExt): bool =
-  false
-func supportsPacked*(T: type seq[PeerId], ProtoType: type ProtobufExt): bool =
-  false
+Protobuf.extensionDefaults(PeerId, defaultSeq = true, packed = false)
 
 func computeFieldSize*(
     field: int, value: PeerId, ProtoType: type ProtobufExt, skipDefault: static bool

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -103,8 +103,8 @@
 
   protobuf_serialization = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-protobuf-serialization";
-    rev = "38d24eb3bd93e605fb88199da71d36b1ec0ad60d";
-    sha256 = "0jr0a41b4r444si6xfa7bclw8mjsk6id10lrdvbxzp99750zspb9";
+    rev = "f45476a3c1f4e7bff73845e6450d686be040ddeb";
+    sha256 = "1b4cnlkqlmnhx5gd4smiz4xwaj2zmyccc2q20r26gcqfiyp9na0v";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
Bumps protobuf to v0.5:

- Adds oneof support needed for autonat v2
- Adds results.Opt proto3 support needed for circuit v2