### PR TITLE
chore(protobuf): decode procs to return result

### DIFF
--- a/libp2p/crypto/crypto.nim
+++ b/libp2p/crypto/crypto.nim
@@ -1039,7 +1039,7 @@ proc readFieldInto*(
     if key.init(data):
       value = key
       return true
-    raise (ref ProtobufValueError)(msg: "Invalid PublicKey")
+    raise newException(ProtobufValueError, "Invalid PublicKey")
 
   false
 
@@ -1075,6 +1075,6 @@ proc readFieldInto*(
     if sig.init(data):
       value = sig
       return true
-    raise (ref ProtobufValueError)(msg: "Invalid Signature")
+    raise newException(ProtobufValueError, "Invalid Signature")
 
   false

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -1379,7 +1379,7 @@ proc readFieldInto*(
 
   if readFieldInto(stream, data, header, pbytes):
     let ma = MultiAddress.init(data).valueOr:
-      return false
+      raise newException(ProtobufValueError, "Invalid protobuf MultiAddress")
 
     value.add(ma)
     true

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -1379,7 +1379,7 @@ proc readFieldInto*(
 
   if readFieldInto(stream, data, header, pbytes):
     let ma = MultiAddress.init(data).valueOr:
-      raise newException(ProtobufValueError, "Invalid protobuf MultiAddress")
+      return false
 
     value.add(ma)
     true

--- a/libp2p/protocols/connectivity/autonat/client.nim
+++ b/libp2p/protocols/connectivity/autonat/client.nim
@@ -33,13 +33,12 @@ method dialMe*(
     base, async: (raises: [AutonatError, AutonatUnreachableError, CancelledError])
 .} =
   proc getResponseOrRaise(
-      autonatMsg: Opt[AutonatMsg]
+      msg: AutonatMsg
   ): AutonatDialResponse {.raises: [AutonatError].} =
-    autonatMsg.withValue(msg):
-      if msg.msgType == MsgType.DialResponse:
-        msg.response.withValue(res):
-          if not (res.status == Ok and res.ma.isNone()):
-            return res
+    if msg.msgType == MsgType.DialResponse:
+      msg.response.withValue(res):
+        if not (res.status == Ok and res.ma.isNone()):
+          return res
     raise newException(AutonatError, "Unexpected response")
 
   let stream =
@@ -86,7 +85,9 @@ method dialMe*(
   except CatchableError as e:
     raise newException(AutonatError, "read Dial response failed: " & e.msg, e)
 
-  let response = getResponseOrRaise(AutonatMsg.decode(move(respBytes)))
+  let msg = AutonatMsg.decode(move(respBytes)).valueOr:
+    raise newException(AutonatError, error)
+  let response = getResponseOrRaise(msg)
 
   return
     case response.status

--- a/libp2p/protocols/connectivity/autonat/server.nim
+++ b/libp2p/protocols/connectivity/autonat/server.nim
@@ -167,7 +167,7 @@ proc new*(
   ) {.async: (raises: [CancelledError]).} =
     try:
       let msg = AutonatMsg.decode(await stream.readLp(1024)).valueOr:
-        raise newException(AutonatError, "Received malformed message")
+        raise newException(AutonatError, error)
       if msg.msgType != MsgType.Dial:
         raise newException(AutonatError, "Message type should be dial")
       await autonat.handleDial(stream, msg)

--- a/libp2p/protocols/connectivity/autonat/types.nim
+++ b/libp2p/protocols/connectivity/autonat/types.nim
@@ -11,7 +11,7 @@ import
   ../../../multiaddress,
   ../../../peerid,
   ../../../errors,
-  ../../../protobuf/utils
+  ../../../utils/protobuf
 
 logScope:
   topics = "libp2p autonat"

--- a/libp2p/protocols/connectivity/dcutr/client.nim
+++ b/libp2p/protocols/connectivity/dcutr/client.nim
@@ -47,7 +47,7 @@ proc startSync*(
     debug "Dcutr initiator has sent a Connect message."
     let rttStart = Moment.now()
     let connectAnswer = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
-      raise newException(DcutrError, "Failed to decode a Connect message answer.")
+      raise newException(DcutrError, error)
 
     peerDialableAddrs = getHolePunchableAddrs(connectAnswer.addrs)
     if peerDialableAddrs.len == 0:

--- a/libp2p/protocols/connectivity/dcutr/core.nim
+++ b/libp2p/protocols/connectivity/dcutr/core.nim
@@ -17,7 +17,7 @@ import
   ../../../errors,
   ../../../muxers/muxer,
   ../../../stream/connection,
-  ../../../protobuf/utils
+  ../../../utils/protobuf
 
 export multiaddress
 

--- a/libp2p/protocols/connectivity/dcutr/server.nim
+++ b/libp2p/protocols/connectivity/dcutr/server.nim
@@ -30,7 +30,7 @@ proc new*(
     var peerDialableAddrs: seq[MultiAddress]
     try:
       let connectMsg = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
-        raise newException(DcutrError, "Failed to decode a Connect message.")
+        raise newException(DcutrError, error)
 
       debug "Dcutr receiver received a Connect message.", connectMsg
 
@@ -56,7 +56,7 @@ proc new*(
         await stream.send(MsgType.Connect, ourAddrs)
         debug "Dcutr receiver has sent a Connect message back."
         let syncMsg = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
-          raise newException(DcutrError, "Failed to decode a Sync message.")
+          raise newException(DcutrError, error)
         debug "Dcutr receiver has received a Sync message.", syncMsg
         debug "Dcutr initiator has no supported dialable addresses to connect to. Aborting Dcutr.",
           addrs = connectMsg.addrs
@@ -79,7 +79,7 @@ proc new*(
       await stream.send(MsgType.Connect, ourAddrs)
       debug "Dcutr receiver has sent a Connect message back."
       let syncMsg = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
-        raise newException(DcutrError, "Failed to decode a Sync message.")
+        raise newException(DcutrError, error)
       debug "Dcutr receiver has received a Sync message.", syncMsg
 
       if peerDialableAddrs.len > maxDialableAddrs:

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -10,7 +10,6 @@ import std/strutils
 import results, chronos, chronicles
 import protobuf_serialization, protobuf_serialization/pkg/results
 import
-  ../protobuf/utils,
   ../peerinfo,
   ../stream/connection,
   ../peerid,
@@ -18,7 +17,7 @@ import
   ../multiaddress,
   ../multicodec,
   ../protocols/protocol,
-  ../utils/opt,
+  ../utils/[opt, protobuf],
   ../errors,
   ../observedaddrmanager
 
@@ -172,7 +171,7 @@ proc identify*(
     raise newException(IdentityInvalidMsgError, "Empty message received")
 
   var identifyMsg = IdentifyMsg.decode(move message).valueOr:
-    raise newException(IdentityInvalidMsgError, "Incorrect message received")
+    raise newException(IdentityInvalidMsgError, error)
 
   debug "identify: info received", stream, identifyMsg
 
@@ -218,7 +217,7 @@ proc init*(p: IdentifyPush) =
         return
 
     let identifyMsg = IdentifyMsg.decode(move message).valueOr:
-      info "failed to decode identify message", stream
+      info "failed to decode identify message", error, stream
       return
 
     debug "identify push: info received", stream, identifyMsg

--- a/libp2p/protocols/rendezvous/protobuf.nim
+++ b/libp2p/protocols/rendezvous/protobuf.nim
@@ -8,7 +8,7 @@ import
   protobuf_serialization,
   protobuf_serialization/pkg/results,
   protobuf_serialization/std/enums,
-  ../../protobuf/utils
+  ../../utils/protobuf
 
 export results
 

--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -292,7 +292,9 @@ proc advertisePeer[E](
       await stream.writeLp(msg)
       let
         buf = await stream.readLp(4096)
-        msgRecv = Message.decode(buf).tryGet()
+        msgRecv = Message.decode(buf).valueOr:
+          debug "failed to decode Message", error = error
+          return
       if msgRecv.msgType != MessageType.RegisterResponse:
         trace "Unexpected register response", peer, msgType = msgRecv.msgType
       elif msgRecv.registerResponse.tryGet().status != ResponseStatus.Ok:
@@ -404,7 +406,7 @@ proc requestPeer[E](
   let
     buf = await stream.readLp(MaximumMessageLen)
     msgRcv = Message.decode(buf).valueOr:
-      debug "Message undecodable"
+      debug "Message undecodable", error = error
       return @[]
   if msgRcv.msgType != MessageType.DiscoverResponse:
     debug "Unexpected discover response", msgType = msgRcv.msgType
@@ -559,7 +561,9 @@ proc new*(
     try:
       let
         buf = await stream.readLp(4096)
-        msg = Message.decode(buf).tryGet()
+        msg = Message.decode(buf).valueOr:
+          debug "failed to decode Message", error = error
+          return
       case msg.msgType
       of MessageType.Register:
         await rdv.register(

--- a/libp2p/utils/protobuf.nim
+++ b/libp2p/utils/protobuf.nim
@@ -17,10 +17,10 @@ macro serializerFor*(_: type Protobuf, Types: untyped): untyped =
       proc `decodeName`(buf2: seq[byte]): `T` {.raises: [SerializationError].} =
         decode(Protobuf, buf2, `T`)
 
-      proc decode*(_: type `T`, buf: seq[byte]): Opt[`T`] =
+      proc decode*(_: type `T`, buf: seq[byte]): Result[`T`, string] =
         try:
-          Opt.some(`decodeName`(buf))
-        except SerializationError:
-          Opt.none(`T`)
+          ok(`decodeName`(buf))
+        except SerializationError as e:
+          err("failed to decode " & $(`T`) & " from protobuf bytes. " & e.msg)
 
   stmts


### PR DESCRIPTION
- `decode*` procs should return result, because details about errors should be logged or propagated
- moved utils to `utils/protobuf`; folder `nim-libp2p/libp2p/protobuf` should eventually disappear 