### PR TITLE
fix(service-disco): misc fixes

### DIFF
--- a/libp2p/extended_peer_record.nim
+++ b/libp2p/extended_peer_record.nim
@@ -138,7 +138,7 @@ proc isValid*(xpr: SignedExtendedPeerRecord): bool =
     if not svc.isValid():
       return false
   let encoded = xpr.encode()
-  if encoded.isErr or encoded.get().len > MaxXPRSize:
+  if encoded.isErr or encoded.get().len == 0 or encoded.get().len > MaxXPRSize:
     return false
   true
 

--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -159,7 +159,7 @@ proc waitingTime*(
   # Bound & Quantize W
   w = max(0.0, w)
   w = min(w, float64(uint32.high))
-  w = ceil(w)
+  w = round(w)
 
   var waitDuration = w.int64.secs
 
@@ -218,85 +218,50 @@ proc updateLowerBounds*(
       registrar.boundIp[ipKey] = now + waitDuration
       registrar.timestampIp[ipKey] = now
 
-proc validateRegisterMessage*(
+proc isValidAdvertisement*(
     regMsg: RegisterMessage, serviceId: ServiceId
-): Opt[Advertisement] =
-  ## Validate a REGISTER message and decode/verify the advertisement.
-  ## Returns Opt.none if the message is invalid.
-  if regMsg.advertisement.len == 0 or regMsg.advertisement.len > MaxXPRSize:
-    if regMsg.advertisement.len > 0:
-      error "advertisement exceeds maximum encoded XPR size",
-        len = regMsg.advertisement.len, max = MaxXPRSize
-    return Opt.none(Advertisement)
-
+): Result[Advertisement, string] =
   let ad = Advertisement.decode(regMsg.advertisement).valueOr:
-    error "invalid advertisement received", error
-    return Opt.none(Advertisement)
-
-  if not ad.advertisesService(serviceId):
-    error "advertisement does not advertise the requested service", serviceId
-    return Opt.none(Advertisement)
+    return err("cannot decode advertisement " & $error)
 
   if not ad.isValid():
-    error "advertisement violates XPR or ServiceInfo size limits"
-    return Opt.none(Advertisement)
+    return err("invalid oversized advertisement")
 
-  return Opt.some(ad)
+  if not ad.advertisesService(serviceId):
+    return err("advertisement & message service mismatch")
 
-proc processRetryTicket*(
-    disco: ServiceDiscovery,
-    regMsg: RegisterMessage,
-    ad: Advertisement,
-    t_wait: Duration,
-    now: Moment,
-): Duration {.raises: [].} =
-  let ticketMsg = regMsg.ticket.valueOr:
-    return t_wait
+  return ok(ad)
 
-  if ticketMsg.advertisement != regMsg.advertisement:
-    return t_wait
-
-  let registrarPubKey = disco.switch.peerInfo.privateKey.getPublicKey().valueOr:
-    error "Failed to get registrar public key", error
-    return t_wait
-
-  if not ticketMsg.verify(registrarPubKey):
-    return t_wait
-
-  let
-    windowStart = ticketMsg.tMod + ticketMsg.tWaitFor
-    windowEnd = windowStart + disco.discoConfig.registrationWindow
-
-  if now in windowStart .. windowEnd:
-    let totalWaitSoFar = now - ticketMsg.tInit
-    return t_wait - totalWaitSoFar
-
-  return t_wait
+proc updateWaitAfterRetry*(
+    disco: ServiceDiscovery, ticketOpt: Opt[Ticket], now: Moment, wait: var Duration
+) =
+  ticketOpt.withValue(ticket):
+    let totalWaitSoFar = now - ticket.tInit
+    wait -= totalWaitSoFar
 
 proc isValidTicket(
     disco: ServiceDiscovery, regMsg: RegisterMessage, now: Moment
-): Opt[bool] {.raises: [].} =
+): Result[Opt[Ticket], string] {.raises: [].} =
   let ticket = regMsg.ticket.valueOr:
-    return Opt.none(bool)
+    return ok(Opt.none(Ticket))
 
   if ticket.advertisement != regMsg.advertisement:
-    return Opt.some(false)
+    return err("message & ticket advertisement mismatch")
 
   let registrarPubKey = disco.switch.peerInfo.privateKey.getPublicKey().valueOr:
-    error "Failed to get registrar public key", error
-    return Opt.some(false)
+    return err("failed to get registrar public key")
 
   if not ticket.verify(registrarPubKey):
-    return Opt.some(false)
+    return err("ticket fails verification")
 
   let
     windowStart = ticket.tMod + ticket.tWaitFor
     windowEnd = windowStart + disco.discoConfig.registrationWindow
 
   if now notin windowStart .. windowEnd:
-    return Opt.some(false)
+    return err("ticket outside valid time window")
 
-  return Opt.some(true)
+  return ok(Opt.some(ticket))
 
 proc sendRegisterResponse*(
     stream: Stream,
@@ -474,8 +439,8 @@ proc registration*(disco: ServiceDiscovery, peerId: PeerId, inMsg: Message): Mes
 
     return msg
 
-  let ad = validateRegisterMessage(regMsg, serviceId).valueOr:
-    error "invalid register message"
+  let ad = isValidAdvertisement(regMsg, serviceId).valueOr:
+    error "invalid advertisement", error
 
     cd_register_requests.inc(
       labelValues = [$kademlia_protobuf.RegistrationStatus.Rejected]
@@ -485,21 +450,20 @@ proc registration*(disco: ServiceDiscovery, peerId: PeerId, inMsg: Message): Mes
 
   let now = Moment.now()
 
-  disco.isValidTicket(regMsg, now).withValue(valid):
-    if not valid:
-      error "invalid ticket in register message"
+  let ticketOpt = disco.isValidTicket(regMsg, now).valueOr:
+    error "invalid ticket", error
 
-      cd_register_requests.inc(
-        labelValues = [$kademlia_protobuf.RegistrationStatus.Rejected]
-      )
+    cd_register_requests.inc(
+      labelValues = [$kademlia_protobuf.RegistrationStatus.Rejected]
+    )
 
-      return msg
+    return msg
 
   var tWait = disco.registrar.waitingTime(
     disco.discoConfig, ad, disco.discoConfig.advertCacheCap, serviceId, now
   )
 
-  tWait = disco.processRetryTicket(regMsg, ad, tWait, now)
+  disco.updateWaitAfterRetry(ticketOpt, now, tWait)
 
   if tWait <= ZeroDuration:
     disco.acceptAdvertisement(now, serviceId, ad)

--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -221,14 +221,18 @@ proc updateLowerBounds*(
 proc isValidAdvertisement*(
     regMsg: RegisterMessage, serviceId: ServiceId
 ): Result[Advertisement, string] =
-  let ad = Advertisement.decode(regMsg.advertisement).valueOr:
-    return err("cannot decode advertisement " & $error)
+  if regMsg.advertisement.len > MaxXPRSize:
+    return err("oversized")
 
-  if not ad.isValid():
-    return err("invalid oversized advertisement")
+  let ad = Advertisement.decode(regMsg.advertisement).valueOr:
+    return err("cannot decode: " & $error)
+
+  for svc in ad.data.services:
+    if not svc.isValid():
+      return err("oversized service data")
 
   if not ad.advertisesService(serviceId):
-    return err("advertisement & message service mismatch")
+    return err("message & advertisement service mismatch")
 
   return ok(ad)
 

--- a/libp2p/protocols/service_discovery/types.nim
+++ b/libp2p/protocols/service_discovery/types.nim
@@ -152,10 +152,7 @@ proc hashServiceId*(serviceStr: string): ServiceId =
   @(digest.data)
 
 proc advertisesService*(ad: Advertisement, serviceId: ServiceId): bool =
-  for service in ad.data.services:
-    if hashServiceId(service.id) == serviceId:
-      return true
-  false
+  ad.data.services.anyIt(hashServiceId(it.id) == serviceId)
 
 proc new*(T: typedesc[Registrar]): T =
   T(

--- a/tests/libp2p/service_discovery/component/test_register.nim
+++ b/tests/libp2p/service_discovery/component/test_register.nim
@@ -14,7 +14,7 @@ suite "Service Discovery Component - Register":
   teardown:
     checkTrackers()
 
-  asyncTest "first REGISTER with no ticket returns Wait":
+  asyncTest "first REGISTER with no ticket returns Confirm":
     let registrarNode = setupServiceDiscoveryNode()
     let advertiserNode = setupServiceDiscoveryNode()
     startAndDeferStop(@[registrarNode, advertiserNode])
@@ -28,8 +28,7 @@ suite "Service Discovery Component - Register":
       registrarNode.switch.peerInfo.peerId, serviceId, adBytes
     )
     check regResp.isOk()
-    check regResp.get().status == kad_protobuf.RegistrationStatus.Wait
-    check regResp.get().ticket.isSome()
+    check regResp.get().status == kad_protobuf.RegistrationStatus.Confirmed
 
   asyncTest "REGISTER with out-of-window ticket ignores ticket and returns Rejected":
     let registrarNode = setupServiceDiscoveryNode()
@@ -61,23 +60,6 @@ suite "Service Discovery Component - Register":
     check regResp.isOk()
     check regResp.get().status == kad_protobuf.RegistrationStatus.Rejected
 
-  asyncTest "REGISTER with safetyParam=0 returns Confirmed on first attempt":
-    let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0)
-    let registrarNode = setupServiceDiscoveryNode(discoConfig = conf)
-    let advertiserNode = setupServiceDiscoveryNode(discoConfig = conf)
-    startAndDeferStop(@[registrarNode, advertiserNode])
-    await connect(registrarNode, advertiserNode)
-
-    let serviceName = "test-confirm-service"
-    let serviceId = serviceName.hashServiceId()
-    let adBytes = makeAdvertisement(serviceName).encode().get()
-
-    let regResp = await advertiserNode.sendRegister(
-      registrarNode.switch.peerInfo.peerId, serviceId, adBytes
-    )
-    check regResp.isOk()
-    check regResp.get().status == kad_protobuf.RegistrationStatus.Confirmed
-
   asyncTest "back-to-back REGISTERs return identical waits":
     # Anti-grinding: tMod + tWaitFor (eligibility moment) must never move earlier across retries.
     let registrarNode = setupServiceDiscoveryNode()
@@ -94,6 +76,10 @@ suite "Service Discovery Component - Register":
       .get()
     let registrarPeerId = registrarNode.switch.peerInfo.peerId
 
+    let response: RegistrationResponse =
+      (await advertiserNode.sendRegister(registrarPeerId, serviceId, adBytes)).get()
+    check response.status == kad_protobuf.RegistrationStatus.Confirmed
+
     proc requestTicket(): Future[Ticket] {.async.} =
       let response: RegistrationResponse =
         (await advertiserNode.sendRegister(registrarPeerId, serviceId, adBytes)).get()
@@ -101,11 +87,11 @@ suite "Service Discovery Component - Register":
       check response.ticket.isSome()
       return response.ticket.get()
 
-    let first = await requestTicket()
     let second = await requestTicket()
+    let third = await requestTicket()
     check:
-      second.tWaitFor == first.tWaitFor
-      second.tMod >= first.tMod
+      third.tWaitFor == second.tWaitFor
+      third.tMod >= second.tMod
 
   asyncTest "REGISTER preserves registrar cache seqNo semantics":
     # Use a non-zero subsecond expiry: the waiting-time formula rounds it down
@@ -227,7 +213,7 @@ suite "Service Discovery Component - Register":
     let maloryResp =
       await maloryNode.sendRegister(registrarPeerId, serviceId, maloryAdBytes)
     check maloryResp.isOk()
-    check maloryResp.get().status == kad_protobuf.RegistrationStatus.Wait
+    check maloryResp.get().status == kad_protobuf.RegistrationStatus.Confirmed
 
     let legitimateResp =
       await legitimateNode.sendRegister(registrarPeerId, serviceId, legitimateAdBytes)

--- a/tests/libp2p/service_discovery/test_advertiser.nim
+++ b/tests/libp2p/service_discovery/test_advertiser.nim
@@ -121,6 +121,7 @@ suite "Advertiser - removeProvidedService":
     disco.addProvidedService(s2)
 
     await disco.removeProvidedService(s1.id)
+    disco.unregisterInterest(s1.id) # local registrar has interest too
 
     check:
       not disco.rtManager.hasService(sid1)
@@ -144,6 +145,7 @@ suite "Advertiser - removeProvidedService":
     disco.addProvidedService(s2)
 
     await disco.removeProvidedService(s1.id)
+    disco.unregisterInterest(s1.id) # local registrar has interest too
 
     check not disco.rtManager.hasService(s1.id.hashServiceId())
     check disco.rtManager.hasService(s2.id.hashServiceId())

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -54,7 +54,7 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
     # With empty cache: c = 0, occupancy = 1.0, c_s = 0, ipSim = 0
     # w = advertExpiry * 1.0 * (0 + 0 + safetyParam)
     let expected =
-      ceil(discoConfig.advertExpiry.seconds.float64 * discoConfig.safetyParam)
+      round(discoConfig.advertExpiry.seconds.float64 * discoConfig.safetyParam)
 
     check abs(w.inFloatSecs - expected) < 0.001
 
@@ -67,33 +67,50 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
     let ad2 = makeAdvertisement($serviceId2)
     let now = Moment.now()
 
+    registrar.cache[serviceId1] = @[ad1]
     registrar.cacheTimestamps[ad1.toAdvertisementKey()] = now
+    let w1 = registrar.waitingTime(discoConfig, ad1, 100, serviceId1, now)
+
+    registrar.cache[serviceId2] = @[ad2]
     registrar.cacheTimestamps[ad2.toAdvertisementKey()] = now
+    let w2 = registrar.waitingTime(discoConfig, ad2, 100, serviceId2, now)
 
-    let w1 = registrar.waitingTime(discoConfig, ad1, 1000, serviceId1, now)
-    let w2 = registrar.waitingTime(discoConfig, ad2, 1000, serviceId2, now)
-
-    # With non-zero cache, occupancy > 1.0
-    check w1 > ZeroDuration or w2 > ZeroDuration
+    check w1 < w2
 
   test "waitingTime increases with service similarity":
     let registrar = Registrar.new()
     let discoConfig = ServiceDiscoveryConfig.new()
-    let serviceId = makeServiceId()
-    let ad1 = makeAdvertisement($serviceId)
-    let ad2 = makeAdvertisement($serviceId)
-    let ad3 = makeAdvertisement($serviceId)
+    let serviceId1 = makeServiceId(1)
+    let serviceId2 = makeServiceId(2)
+    let serviceId3 = makeServiceId(3)
+    let serviceId4 = makeServiceId(4)
+    let ad1 = makeAdvertisement($serviceId1)
+    let ad2 = makeAdvertisement($serviceId2)
+    let ad3 = makeAdvertisement($serviceId3)
+    let ad4 = makeAdvertisement($serviceId4)
+    let ad5 = makeAdvertisement($serviceId4)
+    let ad6 = makeAdvertisement($serviceId4)
     let now = Moment.now()
 
-    registrar.cache[serviceId] = @[ad1, ad2, ad3]
+    registrar.cache[serviceId1] = @[ad1]
+    registrar.cache[serviceId2] = @[ad2]
+    registrar.cache[serviceId3] = @[ad3]
     registrar.cacheTimestamps[ad1.toAdvertisementKey()] = now
     registrar.cacheTimestamps[ad2.toAdvertisementKey()] = now
     registrar.cacheTimestamps[ad3.toAdvertisementKey()] = now
 
-    let w = registrar.waitingTime(discoConfig, ad1, 1000, serviceId, now)
+    let w1 = registrar.waitingTime(discoConfig, ad1, 100, serviceId1, now)
 
-    # c_s = 3, serviceSim = 3/1000 contributes to wait time
-    check w > ZeroDuration
+    registrar.cache.clear()
+    registrar.cacheTimestamps.clear()
+
+    registrar.cache[serviceId4] = @[ad4, ad5, ad6]
+    registrar.cacheTimestamps[ad4.toAdvertisementKey()] = now
+    registrar.cacheTimestamps[ad5.toAdvertisementKey()] = now
+    registrar.cacheTimestamps[ad6.toAdvertisementKey()] = now
+    let w2 = registrar.waitingTime(discoConfig, ad4, 100, serviceId4, now)
+
+    check w1 < w2
 
   test "waitingTime returns 0.0 IP similarity for IPs not in tree":
     let registrar = Registrar.new()
@@ -109,7 +126,7 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w > ZeroDuration
+    check w == ZeroDuration
 
   test "waitingTime uses maximum IP score across multiple addresses":
     let registrar = Registrar.new()
@@ -153,7 +170,7 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
     # At capacity, occupancy = 100.0
     # Allow 1 ns tolerance: float->ns truncation can lose a sub-nanosecond fraction
     let expectedSecs =
-      ceil(discoConfig.advertExpiry.seconds.float64 * 100.0 * discoConfig.safetyParam)
+      round(discoConfig.advertExpiry.seconds.float64 * 100.0 * discoConfig.safetyParam)
     check w.inFloatSecs >= expectedSecs - 1e-9
 
   test "waitingTime formula includes safety parameter":
@@ -224,21 +241,6 @@ suite "Service Discovery Registrar - Lower Bound Enforcement":
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
     check w >= 500.secs
-
-  test "waitingTime service lower bound decreases with elapsed time":
-    let registrar = Registrar.new()
-    let discoConfig = ServiceDiscoveryConfig.new()
-    let serviceId = makeServiceId()
-    let ad = makeAdvertisement($serviceId)
-    let now = initMoment(2000)
-
-    registrar.boundService[serviceId] = initMoment(500)
-    registrar.timestampService[serviceId] = initMoment(1000)
-
-    let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
-
-    check w >= 1.secs
-    check w < 1000.secs
 
   test "waitingTime enforces IP lower bound when exists":
     let registrar = Registrar.new()
@@ -733,25 +735,25 @@ suite "Service Discovery Registrar - Configuration Variations":
     check w >= ZeroDuration
 
 suite "Service Discovery Registrar - Register Message Validation":
-  test "validateRegisterMessage rejects empty advertisement":
+  test "isValidAdvertisement rejects empty advertisement":
     let regMsg = kadprotobuf.RegisterMessage(
       advertisement: @[],
       status: Opt.none(kadprotobuf.RegistrationStatus),
       ticket: Opt.none(Ticket),
     )
 
-    check validateRegisterMessage(regMsg, makeServiceId()).isNone()
+    check isValidAdvertisement(regMsg, makeServiceId()).isErr()
 
-  test "validateRegisterMessage rejects malformed advertisement bytes":
+  test "isValidAdvertisement rejects malformed advertisement bytes":
     let regMsg = kadprotobuf.RegisterMessage(
       advertisement: @[1'u8, 2, 3, 4],
       status: Opt.none(kadprotobuf.RegistrationStatus),
       ticket: Opt.none(Ticket),
     )
 
-    check validateRegisterMessage(regMsg, makeServiceId()).isNone()
+    check isValidAdvertisement(regMsg, makeServiceId()).isErr()
 
-  test "validateRegisterMessage accepts decodable advertisement":
+  test "isValidAdvertisement accepts decodable advertisement":
     let serviceStr = $1
     let serviceId = hashServiceId(serviceStr)
     let ad = makeAdvertisement(serviceStr, addrs = @[makeMultiAddress("10.0.0.1")])
@@ -763,13 +765,13 @@ suite "Service Discovery Registrar - Register Message Validation":
       ticket: Opt.none(Ticket),
     )
 
-    let decoded = validateRegisterMessage(regMsg, serviceId)
+    let decoded = isValidAdvertisement(regMsg, serviceId)
 
-    check decoded.isSome()
+    check decoded.isOk()
     check decoded.get().data.peerId == ad.data.peerId
     check decoded.get().data.seqNo == ad.data.seqNo
 
-  test "validateRegisterMessage rejects advertisement for different service":
+  test "isValidAdvertisement rejects advertisement for different service":
     let serviceId = "service".hashServiceId()
     let ad = makeAdvertisement("other-service")
     let adBuf = ad.encode().get()
@@ -779,9 +781,9 @@ suite "Service Discovery Registrar - Register Message Validation":
       ticket: Opt.none(Ticket),
     )
 
-    check validateRegisterMessage(regMsg, serviceId).isNone()
+    check isValidAdvertisement(regMsg, serviceId).isErr()
 
-  test "validateRegisterMessage rejects advertisement with no services":
+  test "isValidAdvertisement rejects advertisement with no services":
     let serviceId = "service".hashServiceId()
     let ad = makeAdvertisementWithServices(@[])
     let adBuf = ad.encode().get()
@@ -791,9 +793,9 @@ suite "Service Discovery Registrar - Register Message Validation":
       ticket: Opt.none(Ticket),
     )
 
-    check validateRegisterMessage(regMsg, serviceId).isNone()
+    check isValidAdvertisement(regMsg, serviceId).isErr()
 
-  test "validateRegisterMessage accepts multi-service advertisement":
+  test "isValidAdvertisement accepts multi-service advertisement":
     let services = @[
       makeServiceInfo("service-a"),
       makeServiceInfo("service-b"),
@@ -808,227 +810,15 @@ suite "Service Discovery Registrar - Register Message Validation":
       ticket: Opt.none(Ticket),
     )
 
-    let decoded = validateRegisterMessage(regMsg, serviceId)
+    let decoded = isValidAdvertisement(regMsg, serviceId)
 
     check:
-      decoded.isSome()
+      decoded.isOk()
       decoded.get().data.peerId == ad.data.peerId
       decoded.get().data.services.len == 3
 
 suite "Service Discovery Registrar - Retry Ticket Processing":
-  test "processRetryTicket returns original wait time when no ticket is present":
-    let disco = setupServiceDiscoveryNode()
-    let ad = makeAdvertisement(addrs = @[makeMultiAddress("10.0.0.1")])
-    let adBuf = ad.encode().get()
-    let now = Moment.now()
-
-    let regMsg = kadprotobuf.RegisterMessage(
-      advertisement: adBuf,
-      status: Opt.none(kadprotobuf.RegistrationStatus),
-      ticket: Opt.none(Ticket),
-    )
-    let tWait = 300.secs
-
-    let tRemaining = disco.processRetryTicket(regMsg, ad, tWait, now)
-
-    check tRemaining == tWait
-
-  test "processRetryTicket returns original wait time for mismatched ticket advertisement":
-    let disco = setupServiceDiscoveryNode()
-    let ad = makeAdvertisement(addrs = @[makeMultiAddress("10.0.0.1")])
-    let adBuf = ad.encode().get()
-    let now = Moment.now()
-
-    let otherAd = makeAdvertisement(addrs = @[makeMultiAddress("10.0.0.2")])
-    let otherAdBuf = otherAd.encode().get()
-
-    var ticket = Ticket(
-      advertisement: otherAdBuf,
-      tInit: Moment.init(1_000, Second),
-      tMod: Moment.init(1_100, Second),
-      tWaitFor: 50.secs,
-      signature: @[],
-    )
-    check ticket.sign(disco.switch.peerInfo.privateKey).isOk()
-
-    let regMsg = kadprotobuf.RegisterMessage(
-      advertisement: adBuf,
-      status: Opt.none(kadprotobuf.RegistrationStatus),
-      ticket: Opt.some(ticket),
-    )
-    let tWait = 300.secs
-
-    let tRemaining = disco.processRetryTicket(regMsg, ad, tWait, now)
-
-    check tRemaining == tWait
-
-  test "processRetryTicket returns original wait time for invalid ticket signature":
-    let disco = setupServiceDiscoveryNode()
-    let otherDisco = setupServiceDiscoveryNode()
-    let ad = makeAdvertisement(addrs = @[makeMultiAddress("10.0.0.1")])
-    let adBuf = ad.encode().get()
-    let now = Moment.now()
-
-    var ticket = Ticket(
-      advertisement: adBuf,
-      tInit: Moment.init(1_000, Second),
-      tMod: Moment.init(1_100, Second),
-      tWaitFor: 50.secs,
-      signature: @[],
-    )
-    check ticket.sign(otherDisco.switch.peerInfo.privateKey).isOk()
-
-    let regMsg = kadprotobuf.RegisterMessage(
-      advertisement: adBuf,
-      status: Opt.none(kadprotobuf.RegistrationStatus),
-      ticket: Opt.some(ticket),
-    )
-    let tWait = 300.secs
-
-    let tRemaining = disco.processRetryTicket(regMsg, ad, tWait, now)
-
-    check tRemaining == tWait
-
-  test "processRetryTicket returns original wait time when retry window is far in the past":
-    let disco = setupServiceDiscoveryNode()
-    let ad = makeAdvertisement(addrs = @[makeMultiAddress("10.0.0.1")])
-    let adBuf = ad.encode().get()
-
-    let now = Moment.now()
-    var ticket = Ticket(
-      advertisement: adBuf,
-      tInit: Moment.init(1_000, Second),
-      tMod: now - 100_000.secs,
-      tWaitFor: 0.secs,
-      signature: @[],
-    )
-    check ticket.sign(disco.switch.peerInfo.privateKey).isOk()
-
-    let regMsg = kadprotobuf.RegisterMessage(
-      advertisement: adBuf,
-      status: Opt.none(kadprotobuf.RegistrationStatus),
-      ticket: Opt.some(ticket),
-    )
-    let tWait = 300.secs
-
-    let tRemaining = disco.processRetryTicket(regMsg, ad, tWait, now)
-
-    check tRemaining == tWait
-
-  test "processRetryTicket returns original wait time when retry is too early":
-    let disco = setupServiceDiscoveryNode()
-    let ad = makeAdvertisement(addrs = @[makeMultiAddress("10.0.0.1")])
-    let adBuf = ad.encode().get()
-
-    # Set tMod = now, tWaitFor = 100 → windowStart = now + 100 (in the future)
-    let now = Moment.now()
-    var ticket = Ticket(
-      advertisement: adBuf,
-      tInit: now - 1000.secs,
-      tMod: now,
-      tWaitFor: 100.secs,
-      signature: @[],
-    )
-    check ticket.sign(disco.switch.peerInfo.privateKey).isOk()
-
-    let regMsg = kadprotobuf.RegisterMessage(
-      advertisement: adBuf,
-      status: Opt.none(kadprotobuf.RegistrationStatus),
-      ticket: Opt.some(ticket),
-    )
-    let tWait = 300.secs
-
-    let tRemaining = disco.processRetryTicket(regMsg, ad, tWait, now)
-
-    check tRemaining == tWait
-
-  test "processRetryTicket returns original wait time when retry is outside registration window":
-    let disco = setupServiceDiscoveryNode()
-    let ad = makeAdvertisement(addrs = @[makeMultiAddress("10.0.0.1")])
-    let adBuf = ad.encode().get()
-
-    # Set tMod = now - 100, tWaitFor = 50 → windowStart = now - 50
-    # delta = 1s → windowEnd = now - 49; now > windowEnd → outside
-    let now = Moment.now()
-    var ticket = Ticket(
-      advertisement: adBuf,
-      tInit: now - 1000.secs,
-      tMod: now - 100.secs,
-      tWaitFor: 50.secs,
-      signature: @[],
-    )
-    check ticket.sign(disco.switch.peerInfo.privateKey).isOk()
-
-    let regMsg = kadprotobuf.RegisterMessage(
-      advertisement: adBuf,
-      status: Opt.none(kadprotobuf.RegistrationStatus),
-      ticket: Opt.some(ticket),
-    )
-    let tWait = 300.secs
-
-    let tRemaining = disco.processRetryTicket(regMsg, ad, tWait, now)
-
-    check tRemaining == tWait
-
-  test "processRetryTicket subtracts accumulated wait at windowEnd boundary":
-    let disco = setupServiceDiscoveryNode()
-    let ad = makeAdvertisement(addrs = @[makeMultiAddress("10.0.0.1")])
-    let adBuf = ad.encode().get()
-
-    # Set tMod = now, tWaitFor = 0 → windowStart = now
-    # delta = 1s → windowEnd = now + 1; now is within window
-    # totalWaitSoFar = now - (now - 151) = 151 ± 1
-    let now = Moment.now()
-    var ticket = Ticket(
-      advertisement: adBuf,
-      tInit: now - 151.secs,
-      tMod: now,
-      tWaitFor: 0.secs,
-      signature: @[],
-    )
-    check ticket.sign(disco.switch.peerInfo.privateKey).isOk()
-
-    let regMsg = kadprotobuf.RegisterMessage(
-      advertisement: adBuf,
-      status: Opt.none(kadprotobuf.RegistrationStatus),
-      ticket: Opt.some(ticket),
-    )
-    let tWait = 300.secs
-
-    let tRemaining = disco.processRetryTicket(regMsg, ad, tWait, now)
-
-    # totalWaitSoFar = 151 ± 1; tRemaining = 149 ± 1
-    check abs(tRemaining.secs - 149) <= 1
-
-  test "processRetryTicket returns non-positive remaining when accumulated wait exceeds tWait":
-    let disco = setupServiceDiscoveryNode()
-    let ad = makeAdvertisement(addrs = @[makeMultiAddress("10.0.0.1")])
-    let adBuf = ad.encode().get()
-
-    # Set tMod = now, tWaitFor = 0 → windowStart = now (within window)
-    # totalWaitSoFar = now - (now - 150) = 150 ± 1; tWait = 100 → negative
-    let now = Moment.now()
-    var ticket = Ticket(
-      advertisement: adBuf,
-      tInit: now - 150.secs,
-      tMod: now,
-      tWaitFor: 0.secs,
-      signature: @[],
-    )
-    check ticket.sign(disco.switch.peerInfo.privateKey).isOk()
-
-    let regMsg = kadprotobuf.RegisterMessage(
-      advertisement: adBuf,
-      status: Opt.none(kadprotobuf.RegistrationStatus),
-      ticket: Opt.some(ticket),
-    )
-    let tWait = 100.secs
-
-    let tRemaining = disco.processRetryTicket(regMsg, ad, tWait, now)
-
-    check tRemaining <= ZeroDuration
-
-  test "processRetryTicket subtracts accumulated wait for valid retry in window":
+  test "subtracts accumulated wait for retry":
     let disco = setupServiceDiscoveryNode()
     let ad = makeAdvertisement(addrs = @[makeMultiAddress("10.0.0.1")])
     let adBuf = ad.encode().get()
@@ -1050,12 +840,12 @@ suite "Service Discovery Registrar - Retry Ticket Processing":
       status: Opt.none(kadprotobuf.RegistrationStatus),
       ticket: Opt.some(ticket),
     )
-    let tWait = 300.secs
+    var tWait = 300.secs
 
-    let tRemaining = disco.processRetryTicket(regMsg, ad, tWait, now)
+    disco.updateWaitAfterRetry(regMsg.ticket, now, tWait)
 
     # totalWaitSoFar = 150 ± 1; tRemaining = 150 ± 1
-    check abs(tRemaining.secs - 150) <= 1
+    check abs(tWait.secs - 150) <= 1
 
 suite "Service Discovery Registrar - registration rejects invalid tickets":
   # These tests exercise the full registration() path (not just the helper).
@@ -1458,16 +1248,23 @@ suite "Service Discovery Registrar - insertNewAd":
 
 suite "Service Discovery Registrar - registration response":
   test "wait response records the wait time and does not cache the ad":
-    let disco = setupServiceDiscoveryNode()
-    let serviceName = "service"
-    let serviceId = serviceName.hashServiceId()
-    let ad = makeAdvertisement(serviceName)
-    let adBytes = ad.encode().get()
-    let advertiserId = ad.data.peerId
+    let config = ServiceDiscoveryConfig.new(safetyParam = 1.0)
+    let disco = setupServiceDiscoveryNode(discoConfig = config)
+    let serviceId1 = makeServiceId(1)
+    let serviceIdName = "service"
+    let serviceId2 = serviceIdName.hashServiceId()
+    let ad1 = makeAdvertisement($serviceId1)
+    let ad2 = makeAdvertisement(serviceIdName)
+    let adBytes = ad2.encode().get()
+    let advertiserId = ad2.data.peerId
+    let now = Moment.now()
+
+    disco.registrar.cache[serviceId1] = @[ad1]
+    disco.registrar.cacheTimestamps[ad1.toAdvertisementKey()] = now
 
     let inMsg = kadprotobuf.Message(
       msgType: kadprotobuf.MessageType.register,
-      key: serviceId,
+      key: serviceId2,
       register: Opt.some(
         kadprotobuf.RegisterMessage(
           advertisement: adBytes,
@@ -1482,9 +1279,9 @@ suite "Service Discovery Registrar - registration response":
     check:
       reply.status.get() == kadprotobuf.RegistrationStatus.Wait
       reply.ticket.isSome()
-      disco.countAdsInCache(serviceId) == 0
-      serviceId in disco.registrar.boundService
-      serviceId in disco.registrar.timestampService
+      disco.countAdsInCache(serviceId2) == 0
+      serviceId2 in disco.registrar.boundService
+      serviceId2 in disco.registrar.timestampService
 
     let ticket = reply.ticket.get()
     let registrarPubKey = disco.switch.peerInfo.privateKey.getPublicKey().get()


### PR DESCRIPTION
Minor refactor and fixes

Most notable is the change to the waiting time formula.

Before an advertiser could never not wait. One second was the fastest wait time. Now we avoid some communication round trips because some wait time can be 0 and thus advert are accepted instantly by registrars.

N.B. All the deleted tests were redundant or made no sense