### PR TITLE
test(conn-manager): event ordering issue

### DIFF
--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -555,6 +555,7 @@ suite "Connection Manager Watermark":
     await connMngr.close()
 
   asyncTest "lifecycle events are emitted not in order when the trim prunes the new connection":
+    # TODO nim-libp2p#2621 conn-manager: trim of the just-stored connection emits Left before Joined
     # storeMuxer triggers the trim before emitting Connected and Joined for the stored peer.
     # the trim can prune the just-stored connection, emitting Left and Disconnected first.
     # consumers assume the order: Connected, Joined, Left, Disconnected.
@@ -599,6 +600,7 @@ suite "Connection Manager Watermark":
     check events == @["Left", "Disconnected", "Connected", "Joined"]
 
   asyncTest "ready state is not cleared when the trim prunes the new connection":
+    # TODO nim-libp2p#2621 conn-manager: trim of the just-stored connection emits Left before Joined
     # the trim drops the stored peer and clears its ready state mid-storeMuxer.
     # storeMuxer then re-adds the dropped peer to readyPeers.
     # a pruned peer must not be reported ready.

--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -554,6 +554,73 @@ suite "Connection Manager Watermark":
 
     await connMngr.close()
 
+  asyncTest "lifecycle events are emitted not in order when the trim prunes the new connection":
+    # storeMuxer triggers the trim before emitting Connected and Joined for the stored peer.
+    # the trim can prune the just-stored connection, emitting Left and Disconnected first.
+    # consumers assume the order: Connected, Joined, Left, Disconnected.
+    let connMngr = newWatermark(1, 2)
+    defer:
+      await connMngr.close()
+
+    let peers = PeerId.random(3, rng()).tryGet()
+    let prunedPeer = peers[2]
+
+    var events: seq[string]
+    proc connHandler(kind: string): ConnEventHandler =
+      return proc(
+          peerId: PeerId, event: ConnEvent
+      ) {.async: (raises: [CancelledError]).} =
+        if peerId == prunedPeer:
+          events.add(kind)
+
+    proc peerHandler(kind: string): PeerEventHandler =
+      return proc(
+          peerId: PeerId, event: PeerEvent
+      ) {.async: (raises: [CancelledError]).} =
+        if peerId == prunedPeer:
+          events.add(kind)
+
+    connMngr.addConnEventHandler(connHandler("Connected"), ConnEventKind.Connected)
+    connMngr.addConnEventHandler(
+      connHandler("Disconnected"), ConnEventKind.Disconnected
+    )
+    connMngr.addPeerEventHandler(peerHandler("Joined"), PeerEventKind.Joined)
+    connMngr.addPeerEventHandler(peerHandler("Left"), PeerEventKind.Left)
+
+    await connMngr.storeMuxer(makeMuxer(peers[0]))
+    await connMngr.storeMuxer(makeMuxer(peers[1]))
+    # protecting peers[0] leaves peers[1] and prunedPeer as the only trim candidates.
+    # reaching lowWater then forces the trim to prune prunedPeer's just-stored connection.
+    connMngr.protect(peers[0], "keep")
+    await connMngr.storeMuxer(makeMuxer(prunedPeer))
+
+    checkUntilTimeout:
+      events.len == 4
+    check events == @["Left", "Disconnected", "Connected", "Joined"]
+
+  asyncTest "ready state is not cleared when the trim prunes the new connection":
+    # the trim drops the stored peer and clears its ready state mid-storeMuxer.
+    # storeMuxer then re-adds the dropped peer to readyPeers.
+    # a pruned peer must not be reported ready.
+    let connMngr = newWatermark(1, 2)
+    defer:
+      await connMngr.close()
+
+    let peers = PeerId.random(3, rng()).tryGet()
+    let prunedPeer = peers[2]
+
+    await connMngr.storeMuxer(makeMuxer(peers[0]))
+    await connMngr.storeMuxer(makeMuxer(peers[1]))
+    # protecting peers[0] forces the trim to prune prunedPeer's just-stored connection
+    connMngr.protect(peers[0], "keep")
+    await connMngr.storeMuxer(makeMuxer(prunedPeer))
+
+    checkUntilTimeout:
+      prunedPeer notin connMngr
+
+    let readyState = await connMngr.waitForPeerReady(prunedPeer, 50.millis)
+    check readyState
+
 suite "Connection Manager Scoring":
   teardown:
     checkTrackers()

--- a/tests/libp2p/test_conn_manager_component.nim
+++ b/tests/libp2p/test_conn_manager_component.nim
@@ -459,6 +459,7 @@ suite "Connection Manager Watermark/Scoring Component":
       await connect(peers[2], node)
 
   asyncTest "Left is emitted before Joined when the trim prunes the new connection":
+    # TODO nim-libp2p#2621 conn-manager: trim of the just-stored connection emits Left before Joined
     # gossipsub unsubscribes on Left as a no-op, then the late Joined subscribes the pruned peer.
     # the wrong order needs a Connected handler that awaits I/O, which delays Joined past the prune.
     const

--- a/tests/libp2p/test_conn_manager_component.nim
+++ b/tests/libp2p/test_conn_manager_component.nim
@@ -4,8 +4,16 @@
 {.used.}
 
 import chronos, std/[sequtils, tables]
-import ../../libp2p/[switch, connmanager, peerinfo, stream/connection]
-import ../tools/[lifecycle, unittest, switch_builder]
+import
+  ../../libp2p/[
+    switch,
+    connmanager,
+    peerinfo,
+    stream/connection,
+    protocols/pubsub/gossipsub,
+    protocols/pubsub/pubsub,
+  ]
+import ../tools/[lifecycle, unittest, switch_builder, crypto, multiaddress]
 
 proc newWatermarkSwitch(
     lowWater: int,
@@ -449,3 +457,43 @@ suite "Connection Manager Watermark/Scoring Component":
     # that includes peers[2]'s own just-stored connection
     expect DialFailedError:
       await connect(peers[2], node)
+
+  asyncTest "Left is emitted before Joined when the trim prunes the new connection":
+    # gossipsub unsubscribes on Left as a no-op, then the late Joined subscribes the pruned peer.
+    # the wrong order needs a Connected handler that awaits I/O, which delays Joined past the prune.
+    const
+      lowWater = 1
+      highWater = 2
+      connectedHandlerDelay = 200.millis
+    let node = newWatermarkSwitch(lowWater, highWater)
+    let gossip =
+      GossipSub.init(switch = node, rng = rng(), parameters = GossipSubParams.init())
+    node.mount(gossip)
+    let peers = newSwitches(highWater + 1)
+    let prunedId = peers[2].peerInfo.peerId
+    let all = @[node] & peers
+
+    startAndDeferStop(all)
+
+    proc connectedHandler(
+        peerId: PeerId, event: ConnEvent
+    ) {.async: (raises: [CancelledError]).} =
+      # simulates a Connected handler with I/O operation, delaying Joined for the pruned peer
+      if peerId == prunedId:
+        await sleepAsync(connectedHandlerDelay)
+
+    node.connManager.addConnEventHandler(connectedHandler, ConnEventKind.Connected)
+
+    # protect peers[0] so it is the only peer the trim is allowed to keep
+    await connect(peers[0], node)
+    await connect(peers[1], node)
+    node.connManager.protect(peers[0].peerInfo.peerId, "keep")
+
+    # peers[2] triggers the trim, which prunes its own just-stored connection
+    expect DialFailedError:
+      await connect(peers[2], node)
+
+    # Joined event arrives late and subscribes
+    checkUntilTimeout:
+      prunedId in gossip.peers
+      not node.isConnected(prunedId)


### PR DESCRIPTION
## Summary

Adds tests documenting an event ordering bug in the connection manager watermark trim. #2621

When a new connection pushes the peer count over `highWater`, `storeMuxer` triggers the trim before emitting `Connected` and `Joined`. With `gracePeriod` at zero and enough protected peers, the trim can prune the just-stored connection itself. The pruned peer's lifecycle events then come out in the wrong order and its ready state survives the disconnect.

The tests assert the current wrong behaviour:
- unit: events for the pruned peer are emitted as `Left, Disconnected, Connected, Joined` instead of `Connected, Joined, Left, Disconnected`
- unit: `waitForPeerReady` returns true for the pruned peer, because `notifyPeerReady` runs after the trim already cleared the ready state
- component: gossipsub unsubscribes on `Left` as a no-op, then the late `Joined` subscribes the pruned peer. The node ends up with a gossipsub subscription for a disconnected peer

In the component test the inversion only shows up when a `Connected` handler takes longer to complete than the connection close. `storeMuxer` emits `Joined` after all `Connected` handlers complete, so a handler that awaits I/O lets the prune finish first. For example that is current downstream usage: nimbus-eth2's `onConnEvent` awaits `performProtocolHandshakes` on every connection. The component test models it with a delaying handler.

  ## Affected Areas
  - [x] Tests

  ## Impact on Library Users

  None.

  ## Risk Assessment

  None