### PR TITLE
fix(relay): restore v2 presence validation

### DIFF
--- a/libp2p/protocols/connectivity/relay/client.nim
+++ b/libp2p/protocols/connectivity/relay/client.nim
@@ -59,7 +59,10 @@ proc handleRelayedConnect(
   let
     # TODO: check the go version to see in which way this could fail
     # it's unclear in the spec
-    src = msg.peer.valueOr:
+    srcPeer = msg.peer.valueOr:
+      await sendStopError(stream, MalformedMessage)
+      return
+    src = srcPeer.peerId.valueOr:
       await sendStopError(stream, MalformedMessage)
       return
     limitDuration = msg.limit.get(Limit()).duration
@@ -117,7 +120,9 @@ proc reserve*(
   reservation.svoucher.withValue(sv):
     let svoucher = SignedVoucher.decode(sv).valueOr:
       raise newException(ReservationError, "Invalid voucher")
-    if svoucher.data.relayPeerId != peerId:
+    let relayPeerId = svoucher.data.relayPeerId.valueOr:
+      raise newException(ReservationError, "Invalid voucher PeerId")
+    if relayPeerId != peerId:
       raise newException(ReservationError, "Invalid voucher PeerId")
     rsvp.voucher = Opt.some(svoucher.data)
 

--- a/libp2p/protocols/connectivity/relay/client.nim
+++ b/libp2p/protocols/connectivity/relay/client.nim
@@ -13,7 +13,8 @@ import
   ../../../peerinfo,
   ../../../switch,
   ../../../multiaddress,
-  ../../../stream/connection
+  ../../../stream/connection,
+  ../../../signed_envelope
 
 logScope:
   topics = "libp2p relay relay-client"
@@ -119,11 +120,13 @@ proc reserve*(
 
   reservation.svoucher.withValue(sv):
     let svoucher = SignedVoucher.decode(sv).valueOr:
+      if error == EnvelopeFieldMissing:
+        raise newException(ReservationError, "Missing voucher field")
       raise newException(ReservationError, "Invalid voucher")
     let relayPeerId = svoucher.data.relayPeerId.valueOr:
-      raise newException(ReservationError, "Invalid voucher PeerId")
+      raise newException(ReservationError, "Missing voucher relay PeerId")
     if relayPeerId != peerId:
-      raise newException(ReservationError, "Invalid voucher PeerId")
+      raise newException(ReservationError, "Voucher relay PeerId mismatch")
     rsvp.voucher = Opt.some(svoucher.data)
 
   rsvp.limitDuration = msg.limit.get(Limit()).duration

--- a/libp2p/protocols/connectivity/relay/messages.nim
+++ b/libp2p/protocols/connectivity/relay/messages.nim
@@ -55,9 +55,9 @@ Protobuf.serializerFor([RelayPeer, RelayMessage])
 
 type
   Voucher* {.proto3.} = object
-    relayPeerId* {.fieldNumber: 1, ext.}: PeerId
-    reservingPeerId* {.fieldNumber: 2, ext.}: PeerId
-    expiration* {.fieldNumber: 3, pint.}: uint64
+    relayPeerId* {.fieldNumber: 1, ext.}: Opt[PeerId]
+    reservingPeerId* {.fieldNumber: 2, ext.}: Opt[PeerId]
+    expiration* {.fieldNumber: 3, pint.}: Opt[uint64]
 
   Peer* {.proto3.} = object
     peerId* {.fieldNumber: 1, ext.}: Opt[PeerId]
@@ -73,7 +73,7 @@ type
     data* {.fieldNumber: 2, pint.}: uint64
 
   StatusV2* = enum
-    uset = 0 # needed for protobuf
+    Unused = 0 # needed for protobuf
     Ok = 100
     ReservationRefused = 200
     ResourceLimitExceeded = 201
@@ -113,7 +113,11 @@ proc init*(
     reservingPeerId: PeerId,
     expiration: uint64,
 ): T =
-  T(relayPeerId: relayPeerId, reservingPeerId: reservingPeerId, expiration: expiration)
+  T(
+    relayPeerId: Opt.some(relayPeerId),
+    reservingPeerId: Opt.some(reservingPeerId),
+    expiration: Opt.some(expiration),
+  )
 
 type SignedVoucher* = SignedPayload[Voucher]
 
@@ -124,7 +128,12 @@ proc payloadType*(_: typedesc[Voucher]): seq[byte] =
   @[(byte) 0x03, (byte) 0x02]
 
 proc checkValid*(spr: SignedVoucher): Result[void, EnvelopeError] =
-  if not spr.data.relayPeerId.match(spr.envelope.publicKey):
+  let relayPeerId = spr.data.relayPeerId.valueOr:
+    return err(EnvelopeFieldMissing)
+  if spr.data.reservingPeerId.isNone or spr.data.expiration.isNone:
+    return err(EnvelopeFieldMissing)
+
+  if not relayPeerId.match(spr.envelope.publicKey):
     err(EnvelopeInvalidSignature)
   else:
     ok()

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -77,9 +77,9 @@ proc createReserveResponse(
   let
     expireUnix = expire.toTime.toUnix.uint64
     v = Voucher(
-      relayPeerId: r.switch.peerInfo.peerId,
-      reservingPeerId: pid,
-      expiration: expireUnix,
+      relayPeerId: Opt.some(r.switch.peerInfo.peerId),
+      reservingPeerId: Opt.some(pid),
+      expiration: Opt.some(expireUnix),
     )
     sv = ?SignedVoucher.init(r.switch.peerInfo.privateKey, v)
     ma = ?MultiAddress.init("/p2p/" & $r.switch.peerInfo.peerId).orErr(

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -76,11 +76,7 @@ proc createReserveResponse(
 ): Result[HopMessage, CryptoError] =
   let
     expireUnix = expire.toTime.toUnix.uint64
-    v = Voucher(
-      relayPeerId: Opt.some(r.switch.peerInfo.peerId),
-      reservingPeerId: Opt.some(pid),
-      expiration: Opt.some(expireUnix),
-    )
+    v = Voucher.init(r.switch.peerInfo.peerId, pid, expireUnix)
     sv = ?SignedVoucher.init(r.switch.peerInfo.privateKey, v)
     ma = ?MultiAddress.init("/p2p/" & $r.switch.peerInfo.peerId).orErr(
       CryptoError.KeyError

--- a/tests/libp2p/protocols/test_relay_v2.nim
+++ b/tests/libp2p/protocols/test_relay_v2.nim
@@ -12,6 +12,8 @@ import
     protocols/connectivity/relay/messages,
     protocols/connectivity/relay/utils,
     protocols/connectivity/relay/client,
+    signed_envelope,
+    peerid,
   ]
 import ../../tools/[unittest, crypto]
 
@@ -32,6 +34,58 @@ proc createSwitch(r: Relay = nil, useYamux: bool = false): Switch =
   return builder.build()
 
 suite "Circuit Relay V2":
+  suite "Voucher":
+    test "Reject signed vouchers with missing required fields":
+      let
+        relayKey = PrivateKey.random(rng()).tryGet()
+        relayPeerId = PeerId.init(relayKey).tryGet()
+        reservingPeerId = PeerId.init(PrivateKey.random(rng()).tryGet()).tryGet()
+        expiration = 123'u64
+
+      let valid = SignedVoucher
+        .init(relayKey, Voucher.init(relayPeerId, reservingPeerId, expiration))
+        .tryGet()
+        .encode()
+        .tryGet()
+
+      let missingRelay = SignedVoucher
+        .init(
+          relayKey,
+          Voucher(
+            reservingPeerId: Opt.some(reservingPeerId), expiration: Opt.some(expiration)
+          ),
+        )
+        .tryGet()
+        .encode()
+        .tryGet()
+
+      let missingPeer = SignedVoucher
+        .init(
+          relayKey,
+          Voucher(relayPeerId: Opt.some(relayPeerId), expiration: Opt.some(expiration)),
+        )
+        .tryGet()
+        .encode()
+        .tryGet()
+
+      let missingExpiration = SignedVoucher
+        .init(
+          relayKey,
+          Voucher(
+            relayPeerId: Opt.some(relayPeerId),
+            reservingPeerId: Opt.some(reservingPeerId),
+          ),
+        )
+        .tryGet()
+        .encode()
+        .tryGet()
+
+      check:
+        SignedVoucher.decode(valid).isOk
+        SignedVoucher.decode(missingRelay).error == EnvelopeFieldMissing
+        SignedVoucher.decode(missingPeer).error == EnvelopeFieldMissing
+        SignedVoucher.decode(missingExpiration).error == EnvelopeFieldMissing
+
   suite "Reservation":
     asyncTeardown:
       await allFutures(src1.stop(), src2.stop(), rel.stop())


### PR DESCRIPTION
Restore relay v2 presence validation for Stop peer IDs and signed voucher fields, rejecting malformed messages instead of accepting empty defaults.




For the voucher, note the fields are optional, but should be set:
```proto3
message Voucher {
  // These fields are marked optional for backwards compatibility with proto2.
  // Users should make sure to always set these.
  optional bytes relay = 1;  <-----------
  optional bytes peer = 2;  <------------
  optional uint64 expiration = 3; <---
}
```

For the stop peerId, notice that the peer is `optional`, but if it exist, the id should be set (for a StopMessage of type CONNECT, the peer is required in protocol logic tho)
```

message StopMessage {
  ...
  optional Peer peer = 2;
  ...
}

message Peer {
  // This field is marked optional for backwards compatibility with proto2.
  // Users should make sure to always set this.
  optional bytes id = 1;   <-------------
  ...
}
```