### PR TITLE
chore(autonatv2): normalize response address selection

### DIFF
--- a/libp2p/protocols/connectivity/autonatv2/utils.nim
+++ b/libp2p/protocols/connectivity/autonatv2/utils.nim
@@ -37,8 +37,16 @@ proc asAutonatV2Response*(
       dialResp: self,
       addrs: Opt.none(MultiAddress),
     )
+
+  if uint64(addrIdx) >= uint64(testAddrs.len):
+    return AutonatV2Response(
+      reachability: self.asNetworkReachability(),
+      dialResp: self,
+      addrs: Opt.none(MultiAddress),
+    )
+
   AutonatV2Response(
     reachability: self.asNetworkReachability(),
     dialResp: self,
-    addrs: Opt.some(testAddrs[addrIdx]),
+    addrs: Opt.some(testAddrs[int(addrIdx)]),
   )

--- a/libp2p/protocols/connectivity/autonatv2/utils.nim
+++ b/libp2p/protocols/connectivity/autonatv2/utils.nim
@@ -38,7 +38,7 @@ proc asAutonatV2Response*(
       addrs: Opt.none(MultiAddress),
     )
 
-  if uint64(addrIdx) >= uint64(testAddrs.len):
+  if addrIdx.uint64 >= testAddrs.len.uint64:
     return AutonatV2Response(
       reachability: self.asNetworkReachability(),
       dialResp: self,
@@ -48,5 +48,5 @@ proc asAutonatV2Response*(
   AutonatV2Response(
     reachability: self.asNetworkReachability(),
     dialResp: self,
-    addrs: Opt.some(testAddrs[int(addrIdx)]),
+    addrs: Opt.some(testAddrs[addrIdx.int]),
   )

--- a/tests/libp2p/protocols/test_autonat_v2.nim
+++ b/tests/libp2p/protocols/test_autonat_v2.nim
@@ -179,6 +179,18 @@ suite "AutonatV2":
         reachability: Reachable, dialResp: correctDialResp, addrs: Opt.some(addrs[0])
       )
 
+    let missingAddrDialResp = DialResponse(
+      status: ResponseStatus.Ok,
+      addrIdx: Opt.some(1.AddrIdx),
+      dialStatus: Opt.none(DialStatus),
+    )
+    check asAutonatV2Response(missingAddrDialResp, addrs) ==
+      AutonatV2Response(
+        reachability: Unknown,
+        dialResp: missingAddrDialResp,
+        addrs: Opt.none(MultiAddress),
+      )
+
   asyncTest "Instantiate server":
     let serverSwitch = makeStandardSwitchBuilder().withAutonatV2Server().build()
     await serverSwitch.start()


### PR DESCRIPTION
keep the reachability result and return no selected address for addresses not part of the original request