### PR TITLE
chore(nix): build nat_traversal in cbind derivation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,12 @@
               pkgs.nim-2_2
               pkgs.nimble
               pkgs.makeWrapper
+            ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+              # cbind builds nat_traversal's vendored C libs; miniupnpc's Darwin
+              # Makefile archives with Apple's `libtool` (from cctools), resolved
+              # via `$(shell which libtool)`.
+              pkgs.cctools
+              pkgs.which
             ];
           };
         }

--- a/nix/cbind.nix
+++ b/nix/cbind.nix
@@ -30,6 +30,12 @@ pkgs.stdenv.mkDerivation {
     pkgs.nim-2_2
     pkgs.git
     pkgs.nimble
+  ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+    # miniupnpc's Darwin Makefile archives via `LIBTOOL ?= $(shell which libtool)`.
+    # cctools supplies Apple's `libtool`; `which` lets the lookup resolve it.
+    # Without both, LIBTOOL collapses to empty and no .a is produced.
+    pkgs.cctools
+    pkgs.which
   ];
 
   buildPhase = ''

--- a/nix/cbind.nix
+++ b/nix/cbind.nix
@@ -4,9 +4,12 @@ let
   deps = import ./deps.nix { inherit pkgs; };
   cbindDeps = import ./cbind-deps.nix { inherit pkgs; };
 
+  # nat_traversal is resolved from a writable copy (see buildPhase), not the store.
+  depsWithoutNat = builtins.removeAttrs deps [ "nat_traversal" ];
+
   pathArgs =
     builtins.concatStringsSep " "
-      (map (p: "--path:${p}") (builtins.attrValues deps));
+      (map (p: "--path:${p}") (builtins.attrValues depsWithoutNat));
 
   cbindPathArgs =
     builtins.concatStringsSep " "
@@ -37,39 +40,30 @@ pkgs.stdenv.mkDerivation {
 
     mkdir -p build $NIMCACHE
 
+    echo "== Building nat_traversal vendored C libs =="
+    # nat_traversal emits {.passl: <pkgRoot>/vendor/.../lib*.a.}; the store copy
+    # is read-only, so stage a writable copy and build the .a files in place.
+    NAT_PKG=$TMPDIR/nat_traversal
+    cp -r ${deps.nat_traversal} $NAT_PKG
+    chmod -R +w $NAT_PKG
+    # The vendored Makefiles default to CC=gcc, absent on the Darwin stdenv;
+    # forward $CC (wrapped gcc on Linux, clang on Darwin).
+    make -C $NAT_PKG/vendor/miniupnp/miniupnpc \
+      CC="$CC" CFLAGS="-Os -fPIC" build/libminiupnpc.a
+    make -C $NAT_PKG/vendor/libnatpmp-upstream \
+      CC="$CC" \
+      CFLAGS="-Wall -Os -fPIC -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4" \
+      libnatpmp.a
+
+    commonArgs="--noNimblePath ${cbindPathArgs} ${pathArgs} --path:$NAT_PKG \
+      --threads:on --opt:size --noMain --mm:refc --header --undef:metrics \
+      --nimMainPrefix:libp2p --nimcache:$NIMCACHE"
+
     echo "== Building C bindings (dynamic/shared) =="
-    nim c \
-      --noNimblePath \
-      ${cbindPathArgs} \
-      ${pathArgs} \
-      --out:build/libp2p.${libExt} \
-      --app:lib \
-      --threads:on \
-      --opt:size \
-      --noMain \
-      --mm:refc \
-      --header \
-      --undef:metrics \
-      --nimMainPrefix:libp2p \
-      --nimcache:$NIMCACHE \
-      cbind/libp2p.nim
+    nim c $commonArgs --app:lib --out:build/libp2p.${libExt} cbind/libp2p.nim
 
     echo "== Building C bindings (static) =="
-    nim c \
-      --noNimblePath \
-      ${cbindPathArgs} \
-      ${pathArgs} \
-      --out:build/libp2p.a \
-      --app:staticlib \
-      --threads:on \
-      --opt:size \
-      --noMain \
-      --mm:refc \
-      --header \
-      --undef:metrics \
-      --nimMainPrefix:libp2p \
-      --nimcache:$NIMCACHE \
-      cbind/libp2p.nim
+    nim c $commonArgs --app:staticlib --out:build/libp2p.a cbind/libp2p.nim
   '';
 
   installPhase = ''


### PR DESCRIPTION
## Summary

The `nim-libp2p-cbind` Nix derivation (`nix/cbind.nix`) failed to link because `nat_traversal` was never built. `nim-nat-traversal` vendors **miniupnpc** and **libnatpmp** as C sources and emits `{.passl: <pkgRoot>/vendor/.../lib*.a.}` from its Nim modules — but those `.a` files only exist if the vendored Makefiles are run, and the Nix store copy of the dependency is read-only.

This PR teaches the cbind build to:

- Stage a **writable** copy of the `nat_traversal` package into `$TMPDIR`, since the linker pragmas resolve the `.a` paths relative to the package root that Nim builds the module from.
- Build `libminiupnpc.a` and `libnatpmp.a` from the vendored Makefiles before compiling the bindings.
- Resolve `nat_traversal` from that writable copy (`--path:$NAT_PKG`) while excluding it from the auto-generated dep `--path` list (`depsWithoutNat`), so Nim links against the freshly built libs rather than the read-only store copy.

It also passes the stdenv compiler through to both vendored Makefiles: they default to `CC=gcc`, which has no binary on the macOS Nix stdenv (clang only). Forwarding `CC="$CC"` (wrapped gcc on Linux, clang on Darwin) keeps the build working cross-platform.

## Affected Areas

- [x] Build / Tooling
  <!-- Nix cbind derivation only; no library code changes -->

## Compatibility & Downstream Validation

N/A — Nix build tooling only; no behavioral or API change.

## Impact on Library Users

No impact on library consumers. This only fixes the C-binding (`cbind`) Nix derivation so it links `nat_traversal`'s vendored UPnP/NAT-PMP static libs.

## Risk Assessment

Low. Scoped to `nix/cbind.nix`; no Nim source, runtime, or network behavior changes. The `CC="$CC"` forwarding makes the previously Linux-only path build on macOS as well.

## References

Extracted from the nat-traversal build work on `chore/cbind/metrics` (the `--undef:metrics`→`-d:metrics` flip from that branch is intentionally **not** included here).