### PR TITLE
chore: enable XCannotRaiseY warning-as-error

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -16,6 +16,7 @@ switch("warningAsError", "UnusedImport:on")
 switch("warningAsError", "UseBase:on")
 switch("hintAsError", "ConvFromXtoItselfNotNeeded:on")
 switch("hintAsError", "DuplicateModuleImport:on")
+switch("hintAsError", "XCannotRaiseY:on")
 
 --styleCheck:
   usages

--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -198,7 +198,7 @@ proc addressMapper(
     addrs.add(processedMA)
   return addrs
 
-method setup*(self: AutonatService, switch: Switch) {.raises: [ServiceSetupError].} =
+method setup*(self: AutonatService, switch: Switch) {.raises: [].} =
   info "Setting up AutonatService"
 
   self.addressMapper = proc(

--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -240,7 +240,7 @@ proc addressMapper(
       addrs.add(peerStore.guessDialableAddr(listenAddr))
   return addrs
 
-method setup*(self: AutonatV2Service, switch: Switch) {.raises: [ServiceSetupError].} =
+method setup*(self: AutonatV2Service, switch: Switch) {.raises: [].} =
   trace "Setting up AutonatV2Service"
 
   self.addressMapper = proc(

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -623,13 +623,15 @@ method publish*(
 
   return 0
 
+{.push hint[XCannotRaiseY]: off.}
   # Base initPubSub keeps `raises: [InitializationError]` to match overrides.
-
 method initPubSub*(p: PubSub) {.base, raises: [InitializationError].} =
   ## perform pubsub initialization
   p.observers = new(seq[PubSubObserver])
   if p.msgIdProvider == nil:
     p.msgIdProvider = defaultMsgIdProvider
+
+{.pop.}
 
 method addValidator*(
     p: PubSub, topic: varargs[string], hook: ValidatorHandler

--- a/libp2p/services/autorelayservice.nim
+++ b/libp2p/services/autorelayservice.nim
@@ -54,7 +54,7 @@ proc reserveAndUpdate(
         self.onReservation(concat(toSeq(self.relayAddresses.values)))
     await sleepAsync chronos.seconds(ttl - 30)
 
-method setup*(self: AutoRelayService, switch: Switch) {.raises: [ServiceSetupError].} =
+method setup*(self: AutoRelayService, switch: Switch) {.raises: [].} =
   self.addressMapper = proc(
       listenAddrs: seq[MultiAddress]
   ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =

--- a/libp2p/services/natservice.nim
+++ b/libp2p/services/natservice.nim
@@ -430,7 +430,7 @@ proc setupHolePunching(
 
 proc setupAutonatV1(
     self: NATService, switch: Switch, r: ReachabilityConfig
-) {.raises: [ServiceSetupError].} =
+) {.raises: [].} =
   let autonatService =
     AutonatService.new(AutonatClient(), self.rng, scheduleInterval = r.scheduleInterval)
   autonatService.setup(switch)

--- a/libp2p/services/wildcardresolverservice.nim
+++ b/libp2p/services/wildcardresolverservice.nim
@@ -101,9 +101,7 @@ proc expandWildcardAddresses(
           addresses.add(remapped)
   addresses
 
-method setup*(
-    self: WildcardAddressResolverService, switch: Switch
-) {.raises: [ServiceSetupError].} =
+method setup*(self: WildcardAddressResolverService, switch: Switch) {.raises: [].} =
   ## Sets up the `WildcardAddressResolverService`.
   ##
   ## This method adds the address mapper to the peer's list of address mappers.
@@ -113,7 +111,7 @@ method setup*(
   ## - `switch`: The switch context in which the service operates.
   ##
   ## Returns:
-  ## - No value. If setup fails, a `ServiceSetupError` is raised.
+  ## - No value.
   debug "Setting up WildcardAddressResolverService"
 
   self.addressMapper = proc(

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -67,10 +67,14 @@ type
     ## Service is internal component of Switch. Service is automatically started and stopped
     ## when the Switch starts and stops.
 
+{.push hint[XCannotRaiseY]: off.}
+  # Base setup keeps `raises: [ServiceSetupError]` to match overrides.
 method setup*(
     self: Service, switch: Switch
 ) {.base, gcsafe, raises: [ServiceSetupError].} =
   raiseAssert "[Service.setup] abstract method not implemented!"
+
+{.pop.}
 
 method start*(
     self: Service, switch: Switch


### PR DESCRIPTION
## Summary

Enables the `XCannotRaiseY` hint as an error in `config.nims` and fixes all resulting violations.

The hint fires when a routine's `raises:` list declares an exception that the body can never actually raise. The various `Service.setup` overrides (`AutonatService`, `AutonatV2Service`, `AutoRelayService`, `WildcardAddressResolverService`) and `NATService.setupAutonatV1` declared `raises: [ServiceSetupError]` but no longer raise it, so their effect lists are narrowed to `raises: []`.

Two `base` methods must keep a wider `raises:` list to remain compatible with their overrides even though their own bodies don't raise the declared exception:
- `Service.setup` (base) keeps `raises: [ServiceSetupError]`
- `PubSub.initPubSub` (base) keeps `raises: [InitializationError]`

For those, the hint is locally silenced with a scoped `{.push hint[XCannotRaiseY]: off.}` / `{.pop.}`.

## Affected Areas

- [x] Protocol Logic
  <!-- autonat / autonatv2 services, pubsub base init -->
- [x] Build / Tooling
  <!-- new warning-as-error in config.nims -->
- [x] Other
  <!-- NAT / autorelay / wildcard-resolver services -->

## Impact on Library Users

Internal cleanup. The narrowed `raises: []` effect lists on `setup` methods are stricter (fewer declared exceptions), which is compatible for callers. No API or behavior changes.

## Risk Assessment

Low. Changes are limited to exception-effect annotations and a build flag; no runtime logic is modified. Backward compatible.

## Additional Notes

N/A