### PR TITLE
chore(signed-envelope): utilize protobuf-serialization

### DIFF
--- a/libp2p/extended_peer_record.nim
+++ b/libp2p/extended_peer_record.nim
@@ -138,7 +138,7 @@ proc isValid*(xpr: SignedExtendedPeerRecord): bool =
     if not svc.isValid():
       return false
   let encoded = xpr.encode()
-  if encoded.isErr or encoded.get().len == 0 or encoded.get().len > MaxXPRSize:
+  if encoded.len == 0 or encoded.len > MaxXPRSize:
     return false
   true
 

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -84,7 +84,7 @@ proc createReserveResponse(
     rsrv = Reservation(
       expire: Opt.some(expireUnix),
       addrs: r.switch.peerInfo.addrs.mapIt(?it.concat(ma).orErr(CryptoError.KeyError)),
-      svoucher: Opt.some(?sv.encode),
+      svoucher: Opt.some(sv.encode),
     )
     msg = HopMessage(
       msgType: Opt.some(HopMessageType.Status),

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -92,7 +92,7 @@ proc makeIdentifyMsg(
   var spr = Opt.none(seq[byte])
   ## Optionally populate signedPeerRecord field.
   ## See https://github.com/libp2p/go-libp2p/blob/ddf96ce1cfa9e19564feb9bd3e8269958bbc0aba/p2p/protocol/identify/pb/identify.proto for reference.
-  if sign and pi.signedPeerRecord.envelope.publicKey.getBytes().isOk:
+  if sign:
     spr = Opt.some(pi.signedPeerRecord.envelope.encode())
 
   IdentifyMsg(

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -93,8 +93,7 @@ proc makeIdentifyMsg(
   ## Optionally populate signedPeerRecord field.
   ## See https://github.com/libp2p/go-libp2p/blob/ddf96ce1cfa9e19564feb9bd3e8269958bbc0aba/p2p/protocol/identify/pb/identify.proto for reference.
   if sign:
-    pi.signedPeerRecord.envelope.encode().withValue(value):
-      spr = Opt.some(value)
+    spr = Opt.some(pi.signedPeerRecord.envelope.encode())
 
   IdentifyMsg(
     publicKey: Opt.some(pi.publicKey),

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -92,7 +92,7 @@ proc makeIdentifyMsg(
   var spr = Opt.none(seq[byte])
   ## Optionally populate signedPeerRecord field.
   ## See https://github.com/libp2p/go-libp2p/blob/ddf96ce1cfa9e19564feb9bd3e8269958bbc0aba/p2p/protocol/identify/pb/identify.proto for reference.
-  if sign:
+  if sign and pi.signedPeerRecord.envelope.publicKey.getBytes().isOk:
     spr = Opt.some(pi.signedPeerRecord.envelope.encode())
 
   IdentifyMsg(

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -123,7 +123,7 @@ proc peerExchangeList*(g: GossipSub, topic: string): seq[PeerInfoMsg] =
       peerId: x.peerId,
       signedPeerRecord:
         if x.peerId in sprBook:
-          sprBook[x.peerId].encode().get(default(seq[byte]))
+          sprBook[x.peerId].encode()
         else:
           default(seq[byte]),
     )

--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -327,8 +327,7 @@ proc advertise*[E](
     info "Can't create the signed peer record", error = error
     return
 
-  let pBuff = signedPeerRecord.encode().valueOr:
-    raise newException(AdvertiseError, "Wrong Custom Peer Record")
+  let pBuff = signedPeerRecord.encode()
   await rdv.advertise(ns, ttl, peers, Opt.some(pBuff))
 
 proc advertise*[E](

--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -364,8 +364,7 @@ method advertise*(
   if rdv.switch.isNil:
     # I don't like this, but adding this as i don't understand why we have a constructor without switch as arg
     raise newException(AdvertiseError, "Rendezvous not setup with a switch")
-  let sprBuff = rdv.switch.peerInfo.signedPeerRecord.encode().valueOr:
-    raise newException(AdvertiseError, "Wrong Signed Peer Record")
+  let sprBuff = rdv.switch.peerInfo.signedPeerRecord.encode()
   await rdv.advertise(ns, lttl, rdv.peers, sprBuff)
 
 proc requestLocally*[E](rdv: GenericRendezVous[E], ns: string): seq[E] =

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -23,10 +23,7 @@ proc refreshSelfSignedPeerRecord(
     error "Failed to create signed extended peer record", error
     return
 
-  let encodedSR = extPeerRecord.encode().valueOr:
-    error "Failed to encode signed peer record", error
-    return
-
+  let encodedSR = extPeerRecord.encode()
   let key = disco.switch.peerInfo.peerId.toKey()
 
   debug "Publishing Signed XPR", xpr = $extPeerRecord

--- a/libp2p/protocols/service_discovery/advertiser.nim
+++ b/libp2p/protocols/service_discovery/advertiser.nim
@@ -43,10 +43,7 @@ proc getAdvertBytes(disco: ServiceDiscovery, explicit: Opt[seq[byte]]): Opt[seq[
   let extRecord = disco.record().valueOr:
     error "failed to create extended peer record", error
     return Opt.none(seq[byte])
-  let bytes = extRecord.encode().valueOr:
-    error "failed to encode advertisement", error
-    return Opt.none(seq[byte])
-  Opt.some(bytes)
+  Opt.some(extRecord.encode())
 
 proc advertiseToRegistrar*(
   disco: ServiceDiscovery,

--- a/libp2p/protocols/service_discovery/types.nim
+++ b/libp2p/protocols/service_discovery/types.nim
@@ -140,10 +140,7 @@ proc encode*(ads: seq[Advertisement], fReturn: int): seq[seq[byte]] {.raises: []
   for ad in ads:
     if adBytes.len >= fReturn:
       break
-    let encoded = ad.encode().valueOr:
-      error "failed to encode advertisement", error
-      continue
-    adBytes.add(encoded)
+    adBytes.add(ad.encode())
   adBytes
 
 proc hashServiceId*(serviceStr: string): ServiceId =

--- a/libp2p/signed_envelope.nim
+++ b/libp2p/signed_envelope.nim
@@ -99,7 +99,7 @@ proc decode*[T](
     return err(EnvelopeWrongType)
   if not envelope.verify(T.payloadDomain):
     return err(EnvelopeInvalidSignature)
-  
+
   let
     data = ?T.decode(envelope.payload).mapErr(x => EnvelopeInvalidProtobuf)
     signedPayload = SignedPayload[T](envelope: envelope, data: data)

--- a/libp2p/signed_envelope.nim
+++ b/libp2p/signed_envelope.nim
@@ -66,6 +66,12 @@ proc decode*(
     except SerializationError:
       return err(EnvelopeInvalidProtobuf)
 
+  if envelope.publicKey.getBytes().isErr:
+    return err(EnvelopeFieldMissing)
+
+  if envelope.signature.data.len == 0:
+    return err(EnvelopeFieldMissing)
+
   if not envelope.verify(domain):
     return err(EnvelopeInvalidSignature)
 

--- a/libp2p/signed_envelope.nim
+++ b/libp2p/signed_envelope.nim
@@ -7,7 +7,8 @@
 
 import std/sugar
 import pkg/stew/byteutils, pkg/results
-import multicodec, crypto/crypto, protobuf/minprotobuf, vbuffer
+import multicodec, crypto/crypto, vbuffer
+import protobuf_serialization
 
 export crypto
 
@@ -18,45 +19,20 @@ type
     EnvelopeInvalidSignature
     EnvelopeWrongType
 
-  Envelope* = object
-    publicKey*: PublicKey
-    domain*: string
-    payloadType*: seq[byte]
-    payload: seq[byte]
-    signature*: Signature
+  Envelope* {.proto3.} = object
+    publicKey* {.fieldNumber: 1, ext.}: PublicKey
+    payloadType* {.fieldNumber: 2.}: seq[byte]
+    payload {.fieldNumber: 3.}: seq[byte]
+    signature* {.fieldNumber: 5, ext.}: Signature
 
-proc mapProtobufError(e: ProtoError): EnvelopeError =
-  case e
-  of RequiredFieldMissing: EnvelopeFieldMissing
-  else: EnvelopeInvalidProtobuf
-
-proc getSignatureBuffer(e: Envelope): seq[byte] =
+proc getSignatureBuffer(e: Envelope, domain: string): seq[byte] =
   var buffer = initVBuffer()
 
-  let domainBytes = e.domain.toBytes()
-  buffer.writeSeq(domainBytes)
+  buffer.writeSeq(domain.toBytes())
   buffer.writeSeq(e.payloadType)
   buffer.writeSeq(e.payload)
 
   buffer.buffer
-
-proc decode*(
-    T: typedesc[Envelope], buf: sink seq[byte], domain: string
-): Result[Envelope, EnvelopeError] =
-  let pb = initProtoBuffer(move(buf))
-  var envelope = Envelope()
-
-  envelope.domain = domain
-  ?pb.getRequiredField(1, envelope.publicKey).mapErr(mapProtobufError)
-  discard ?pb.getField(2, envelope.payloadType).mapErr(mapProtobufError)
-  ?pb.getRequiredField(3, envelope.payload).mapErr(mapProtobufError)
-  ?pb.getRequiredField(5, envelope.signature).mapErr(mapProtobufError)
-
-  if envelope.signature.verify(envelope.getSignatureBuffer(), envelope.publicKey) ==
-      false:
-    err(EnvelopeInvalidSignature)
-  else:
-    ok(envelope)
 
 proc init*(
     T: typedesc[Envelope],
@@ -67,49 +43,37 @@ proc init*(
 ): Result[Envelope, CryptoError] =
   var envelope = Envelope(
     publicKey: ?privateKey.getPublicKey(),
-    domain: domain,
     payloadType: move(payloadType),
     payload: move(payload),
   )
 
-  envelope.signature = ?privateKey.sign(envelope.getSignatureBuffer())
+  envelope.signature = ?privateKey.sign(envelope.getSignatureBuffer(domain))
 
   ok(envelope)
 
-proc encode*(env: Envelope): Result[seq[byte], CryptoError] =
-  var pb = initProtoBuffer()
+proc verify*(envelope: Envelope, domain: string): bool =
+  envelope.signature.verify(envelope.getSignatureBuffer(domain), envelope.publicKey)
 
-  try:
-    pb.write(1, env.publicKey)
-    pb.write(2, env.payloadType)
-    pb.write(3, env.payload)
-    pb.write(5, env.signature)
-  except ResultError[CryptoError] as exc:
-    return err(exc.error)
+proc encode*(envelope: Envelope): seq[byte] =
+  Protobuf.encode(envelope)
 
-  pb.finish()
-  ok(pb.buffer)
+proc decode*(
+    _: type Envelope, buf: seq[byte], domain: string
+): Result[Envelope, EnvelopeError] =
+  let envelope =
+    try:
+      Protobuf.decode(buf, Envelope)
+    except SerializationError:
+      return err(EnvelopeInvalidProtobuf)
 
-proc payload*(env: Envelope): seq[byte] =
+  if not envelope.verify(domain):
+    return err(EnvelopeInvalidSignature)
+
+  ok(envelope)
+
+proc payload*(envelope: Envelope): seq[byte] =
   # Payload is readonly
-  env.payload
-
-proc getField*(
-    pb: ProtoBuffer, field: int, value: var Envelope, domain: string
-): ProtoResult[bool] =
-  var buffer: seq[byte]
-  let res = ?pb.getField(field, buffer)
-  if not (res):
-    ok(false)
-  else:
-    value = Envelope.decode(move(buffer), domain).valueOr:
-      return err(ProtoError.IncorrectBlob)
-    ok(true)
-
-proc write*(pb: var ProtoBuffer, field: int, env: Envelope): Result[void, CryptoError] =
-  let e = ?env.encode()
-  pb.write(field, e)
-  ok()
+  envelope.payload
 
 type SignedPayload*[T] = object
   # T needs to have .encode(), .decode(), .payloadType(), .payloadDomain()
@@ -126,30 +90,19 @@ proc init*[T](
 
   ok(SignedPayload[T](data: data, envelope: envelope))
 
-proc getField*[T](
-    pb: ProtoBuffer, field: int, value: var SignedPayload[T]
-): ProtoResult[bool] =
-  if not ?getField(pb, field, value.envelope, T.payloadDomain):
-    ok(false)
-  else:
-    mixin decode
-    value.data = ?T.decode(value.envelope.payload).mapErr(x => ProtoError.IncorrectBlob)
-    ok(true)
-
 proc decode*[T](
     _: typedesc[SignedPayload[T]], envelope: Envelope
 ): Result[SignedPayload[T], EnvelopeError] =
   mixin decode
 
-  if envelope.domain != T.payloadDomain:
+  if envelope.payloadType != T.payloadType:
     return err(EnvelopeWrongType)
-
+  if not envelope.verify(T.payloadDomain):
+    return err(EnvelopeInvalidSignature)
+  
   let
     data = ?T.decode(envelope.payload).mapErr(x => EnvelopeInvalidProtobuf)
     signedPayload = SignedPayload[T](envelope: envelope, data: data)
-
-  if envelope.payloadType != T.payloadType:
-    return err(EnvelopeWrongType)
 
   when compiles(?signedPayload.checkValid()):
     ?signedPayload.checkValid()
@@ -162,5 +115,5 @@ proc decode*[T](
   let envelope = ?Envelope.decode(move(buffer), T.payloadDomain)
   SignedPayload[T].decode(envelope)
 
-proc encode*[T](msg: SignedPayload[T]): Result[seq[byte], CryptoError] =
+proc encode*[T](msg: SignedPayload[T]): seq[byte] =
   msg.envelope.encode()

--- a/tests/libp2p/discovery/test_rendezvous.nim
+++ b/tests/libp2p/discovery/test_rendezvous.nim
@@ -113,8 +113,7 @@ proc advertise*(
     rdv.switch.peerInfo.privateKey, customPeerRecord
   ).valueOr:
     raise newException(AdvertiseError, "Failed to sign Custom Peer Record")
-  let sprBuff = se.encode().valueOr:
-    raise newException(AdvertiseError, "Wrong Signed Peer Record")
+  let sprBuff = se.encode()
   await rdv.advertise(namespace, rdv.config.minDuration, rdv.peers, sprBuff)
 
 suite "RendezVous":

--- a/tests/libp2p/discovery/test_rendezvous_errors.nim
+++ b/tests/libp2p/discovery/test_rendezvous_errors.nim
@@ -52,7 +52,7 @@ suite "RendezVous Errors":
       (
         proc(node: RendezVous): Message =
           prepareRegisterMessage(
-            "A".repeat(300), node.switch.peerInfo.signedPeerRecord.encode().get, 2.hours
+            "A".repeat(300), node.switch.peerInfo.signedPeerRecord.encode(), 2.hours
           )
       ),
       ResponseStatus.InvalidNamespace,
@@ -71,7 +71,7 @@ suite "RendezVous Errors":
       (
         proc(node: RendezVous): Message =
           prepareRegisterMessage(
-            "namespace", node.switch.peerInfo.signedPeerRecord.encode().get, 73.hours
+            "namespace", node.switch.peerInfo.signedPeerRecord.encode(), 73.hours
           )
       ),
       ResponseStatus.InvalidTTL,
@@ -134,7 +134,7 @@ suite "RendezVous Errors":
     # Attempt one more registration which should be rejected with NotAuthorized
     let messageBuf = encode(
       prepareRegisterMessage(
-        namespace, peerNodes[0].switch.peerInfo.signedPeerRecord.encode().get, 2.hours
+        namespace, peerNodes[0].switch.peerInfo.signedPeerRecord.encode(), 2.hours
       )
     )
 

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -266,9 +266,10 @@ suite "Identify":
           switch2.peerInfo.protocols
 
       let oldPeerId = switch2.peerInfo.peerId
-      switch2.peerInfo = PeerInfo.new(PrivateKey.random(rng()).get())
+      let wrongPeerInfo = PeerInfo.new(PrivateKey.random(rng()).get())
+      await wrongPeerInfo.update()
 
-      await identifyPush2.push(switch2.peerInfo, stream)
+      await identifyPush2.push(wrongPeerInfo, stream)
 
       # We have no way to know when the message will is received
       # because it will fail validation inside push identify itself
@@ -280,8 +281,8 @@ suite "Identify":
 
       # Wait the very end to be sure that the push has been processed
       check:
-        switch1.peerStore[ProtoBook][oldPeerId] != switch2.peerInfo.protocols
-        switch1.peerStore[AddressBook][oldPeerId] != switch2.peerInfo.addrs
+        switch1.peerStore[ProtoBook][oldPeerId] != wrongPeerInfo.protocols
+        switch1.peerStore[AddressBook][oldPeerId] != wrongPeerInfo.addrs
 
   asyncTest "identify exposes QUIC transport addresses":
     # Server switch with both QUIC and TCP

--- a/tests/libp2p/protocols/test_relay_v2.nim
+++ b/tests/libp2p/protocols/test_relay_v2.nim
@@ -46,7 +46,6 @@ suite "Circuit Relay V2":
         .init(relayKey, Voucher.init(relayPeerId, reservingPeerId, expiration))
         .tryGet()
         .encode()
-        .tryGet()
 
       let missingRelay = SignedVoucher
         .init(
@@ -57,7 +56,6 @@ suite "Circuit Relay V2":
         )
         .tryGet()
         .encode()
-        .tryGet()
 
       let missingPeer = SignedVoucher
         .init(
@@ -66,7 +64,6 @@ suite "Circuit Relay V2":
         )
         .tryGet()
         .encode()
-        .tryGet()
 
       let missingExpiration = SignedVoucher
         .init(
@@ -78,7 +75,6 @@ suite "Circuit Relay V2":
         )
         .tryGet()
         .encode()
-        .tryGet()
 
       check:
         SignedVoucher.decode(valid).isOk

--- a/tests/libp2p/pubsub/test_behavior.nim
+++ b/tests/libp2p/pubsub/test_behavior.nim
@@ -173,9 +173,9 @@ suite "GossipSub Behavior":
       peer2Info = peerInfoList.filterIt(it.peerId == peers[2].peerId)[0]
 
     check:
-      peer0Info.signedPeerRecord == mockRecord0.envelope.encode().get()
+      peer0Info.signedPeerRecord == mockRecord0.envelope.encode()
       peer1Info.signedPeerRecord.len == 0
-      peer2Info.signedPeerRecord == mockRecord2.envelope.encode().get()
+      peer2Info.signedPeerRecord == mockRecord2.envelope.encode()
 
   asyncTest "handleIHave - peers with no budget should not request messages":
     # Given a GossipSub instance with one peer

--- a/tests/libp2p/service_discovery/test_ext_peer_records.nim
+++ b/tests/libp2p/service_discovery/test_ext_peer_records.nim
@@ -59,9 +59,9 @@ suite "Signed Extended Peer Record":
     check signedExtPR.isOk() == true
 
     let encoded = signedExtPR.get().encode()
-    check encoded.isOk() == true
+    check encoded.len > 0
 
-    let decoded = SignedExtendedPeerRecord.decode(encoded.get())
+    let decoded = SignedExtendedPeerRecord.decode(encoded)
     check:
       decoded.isOk() == true
       decoded.get() == signedExtPR.get()
@@ -85,8 +85,8 @@ suite "Signed Extended Peer Record":
     let encoded = signedExtPR.get().encode()
 
     check:
-      encoded.isOk() == true
-      SignedExtendedPeerRecord.decode(encoded.get()).error == EnvelopeInvalidSignature
+      encoded.len > 0
+      SignedExtendedPeerRecord.decode(encoded).error == EnvelopeInvalidSignature
 
   test "Decode doesn't fail if some addresses are invalid":
     let

--- a/tests/libp2p/test_peer_info.nim
+++ b/tests/libp2p/test_peer_info.nim
@@ -44,8 +44,8 @@ suite "PeerInfo":
     # Check envelope fields
     check:
       env.publicKey == peerInfo.publicKey
-      env.domain == ExpectedDomain
       env.payloadType == ExpectedPayloadType
+      env.verify(ExpectedDomain)
 
     # Check payload (routing record)
     check:

--- a/tests/libp2p/test_peer_store.nim
+++ b/tests/libp2p/test_peer_store.nim
@@ -42,7 +42,7 @@ suite "PeerStore":
     SignedPeerRecord.init(privateKey, PeerRecord.init(peerId, addrs, seqNo)).tryGet()
 
   proc storedPeerRecord(peerStore: PeerStore, peerId: PeerId): PeerRecord =
-    let encoded = peerStore[SPRBook][peerId].encode().tryGet()
+    let encoded = peerStore[SPRBook][peerId].encode()
     SignedPeerRecord.decode(encoded).tryGet().data
 
   proc checkStoredPeerRecord(

--- a/tests/libp2p/test_routing_record.nim
+++ b/tests/libp2p/test_routing_record.nim
@@ -55,7 +55,7 @@ suite "Signed Routing Record":
       routingRecord = SignedPeerRecord
         .init(privKey, PeerRecord.init(peerId, multiAddresses, 42))
         .tryGet()
-      buffer = routingRecord.envelope.encode().tryGet()
+      buffer = routingRecord.envelope.encode()
 
       parsedRR = SignedPeerRecord.decode(buffer).tryGet().data
 
@@ -78,7 +78,7 @@ suite "Signed Routing Record":
       routingRecord = SignedPeerRecord
         .init(privKey2, PeerRecord.init(peerId, multiAddresses, 42))
         .tryGet()
-      buffer = routingRecord.envelope.encode().tryGet()
+      buffer = routingRecord.envelope.encode()
 
     check SignedPeerRecord.decode(buffer).error == EnvelopeInvalidSignature
 

--- a/tests/libp2p/test_signed_envelope.nim
+++ b/tests/libp2p/test_signed_envelope.nim
@@ -13,11 +13,11 @@ suite "Signed envelope":
       privKey = PrivateKey.random(rng()).tryGet()
       envelope =
         Envelope.init(privKey, @[byte 12, 0], "payload".toBytes(), "domain").tryGet()
-      buffer = envelope.encode().tryGet()
+      buffer = envelope.encode()
       decodedEnvelope = Envelope.decode(buffer, "domain").tryGet()
       wrongDomain = Envelope.decode(buffer, "wdomain")
 
-      reencodedEnvelope = decodedEnvelope.encode().tryGet()
+      reencodedEnvelope = decodedEnvelope.encode()
       redecodedEnvelope = Envelope.decode(reencodedEnvelope, "domain").tryGet()
 
     check:
@@ -73,7 +73,7 @@ suite "Signed payload":
       privKey = PrivateKey.random(rng()).tryGet()
       dummyPayload = DummyPayload(awesome: 12.byte)
       signed = SignedDummy.init(privKey, dummyPayload).tryGet()
-      encoded = signed.encode().tryGet()
+      encoded = signed.encode()
       decoded = SignedDummy.decode(encoded).tryGet()
 
     check:
@@ -85,7 +85,7 @@ suite "Signed payload":
       privKey = PrivateKey.random(rng()).tryGet()
       dummyPayload = DummyPayload(awesome: 30.byte)
       signed = SignedDummy.init(privKey, dummyPayload).tryGet()
-      encoded = signed.encode().tryGet()
+      encoded = signed.encode()
 
     check SignedDummy.decode(encoded).error == EnvelopeInvalidSignature
 
@@ -96,6 +96,6 @@ suite "Signed payload":
       signed = Envelope
         .init(privKey, @[55.byte], dummyPayload.encode(), DummyPayload.payloadDomain)
         .tryGet()
-      encoded = signed.encode().tryGet()
+      encoded = signed.encode()
 
     check SignedDummy.decode(encoded).error == EnvelopeWrongType


### PR DESCRIPTION
utilizing `protobuf-serialization` for `Envelope` type.

- filed `domain` from `Envelope` type has been removed - it is not there in the spec
  - `domain` field was not really needed/used; but some places did check value of this field. since filed is removed new method `verify(domain)` was added that will check signature with specified domain. when `true` domain is correct, when `false` signature is is not correct (domain is not as expected. payload or key). in places where it was used it doesn't really matter which is not correct 
- `Envelope` proc for protobuf encoding now returns `seq[byte]` instead of ` Result[seq[byte], CryptoError]` 