### PR TITLE
chore(yamux): fix send window integer bounds

### DIFF
--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -19,6 +19,7 @@ const
   YamuxDefaultWindowSize* = 256000
   MaxSendQueueSize = 256000
   MaxChannelCount* = 256
+  MaxSendWindow = int64(high(uint32))
 
 when defined(libp2p_yamux_metrics):
   declareGauge libp2p_yamux_channels, "yamux channels", labels = ["initiator", "peer"]
@@ -140,7 +141,7 @@ type
   YamuxChannel* = ref object of Connection
     id: uint32
     recvWindow: int
-    sendWindow: int
+    sendWindow: int64
     maxRecvWindow: int
     maxSendQueueSize: int
     conn: RawConn
@@ -342,7 +343,7 @@ proc sendLoop(channel: YamuxChannel) {.async: (raises: []).} =
   while channel.sendQueue.len > 0:
     channel.sendQueue.keepItIf(not it.fut.finished())
 
-    if channel.sendWindow == 0:
+    if channel.sendWindow <= 0:
       trace "trying to send while the sendWindow is empty"
       if channel.lengthSendQueueWithLimit() > channel.maxSendQueueSize:
         trace "channel send queue too big, resetting",
@@ -353,7 +354,7 @@ proc sendLoop(channel: YamuxChannel) {.async: (raises: []).} =
 
     let
       bytesAvailable = channel.lengthSendQueue()
-      numBytesToSend = min(channel.sendWindow, bytesAvailable)
+      numBytesToSend = min(channel.sendWindow, bytesAvailable.int64).int
     var
       sendBuffer = newSeqUninit[byte](NumBytesHeader + numBytesToSend)
       header = YamuxHeader.data(channel.id, numBytesToSend.uint32)
@@ -655,7 +656,8 @@ method handle*(m: Yamux) {.async: (raises: []).} =
             )
 
         if header.msgType == WindowUpdate:
-          channel.sendWindow += int(header.length)
+          channel.sendWindow =
+            min(channel.sendWindow + int64(header.length), MaxSendWindow)
           asyncSpawn channel.sendLoop()
         else:
           if header.length.int > channel.recvWindow.int:

--- a/tests/libp2p/muxers/test_yamux.nim
+++ b/tests/libp2p/muxers/test_yamux.nim
@@ -12,6 +12,16 @@ include ../../../libp2p/muxers/yamux/yamux
 proc newBlockerFut(): Future[void] {.async: (raises: [], raw: true).} =
   newFuture[void]()
 
+proc blockedThenClose(
+    blocker: Future[void].Raising([])
+): proc(stream: MuxedStream) {.async: (raises: []).} =
+  proc(stream: MuxedStream) {.async: (raises: []).} =
+    await blocker
+    try:
+      await stream.close()
+    except CancelledError, LPStreamError:
+      return
+
 suite "Yamux":
   teardown:
     checkTrackers()
@@ -291,6 +301,56 @@ suite "Yamux":
       readerBlocker2.complete()
       await wait(thirdWriter, 1.seconds)
       await streamA.close()
+
+  suite "Send window bounds":
+    const streamId = 5'u32
+
+    asyncTest "WindowUpdate is clamped to the maximum":
+      mSetup(startHandlera = false)
+      let blocker = newBlockerFut()
+      yamuxb.streamHandler = blockedThenClose(blocker)
+
+      await conna.write(YamuxHeader.windowUpdate(streamId, delta = 0, {Syn}))
+      checkUntilTimeoutCustom(1.seconds, 10.milliseconds):
+        yamuxb.channels.hasKey(streamId)
+
+      await conna.write(YamuxHeader.windowUpdate(streamId, delta = high(uint32)))
+      checkUntilTimeoutCustom(1.seconds, 10.milliseconds):
+        yamuxb.channels[streamId].sendWindow == MaxSendWindow
+
+      blocker.complete()
+
+    asyncTest "Cumulative WindowUpdates saturate without overflow":
+      mSetup(startHandlera = false)
+      let blocker = newBlockerFut()
+      yamuxb.streamHandler = blockedThenClose(blocker)
+
+      await conna.write(YamuxHeader.windowUpdate(streamId, delta = 0, {Syn}))
+      checkUntilTimeoutCustom(1.seconds, 10.milliseconds):
+        yamuxb.channels.hasKey(streamId)
+
+      for _ in 0 ..< 8:
+        await conna.write(YamuxHeader.windowUpdate(streamId, delta = high(uint32)))
+
+      checkUntilTimeoutCustom(1.seconds, 10.milliseconds):
+        yamuxb.channels[streamId].sendWindow == MaxSendWindow
+
+      blocker.complete()
+
+    asyncTest "Send path tolerates a non-positive sendWindow":
+      mSetup(startHandlera = false, startHandlerb = false)
+      let channel =
+        yamuxb.createStream(streamId, false, YamuxDefaultWindowSize, MaxSendQueueSize)
+      channel.sendWindow = -100000
+
+      let writer = channel.write(newSeq[byte](10))
+      await sleepAsync(50.milliseconds)
+      check:
+        not writer.finished()
+
+      await channel.reset()
+      expect(LPStreamError):
+        await writer
 
   suite "Timeout testing":
     asyncTest "Check if InTimeout close both streams correctly":


### PR DESCRIPTION
Widens the Yamux channel send window to `int64` and clamps window updates to `high(uint32)` so accumulated updates can't wrap. The send loop now treats any non-positive window as empty (`<= 0` instead of `== 0`), and byte-count math is done in `int64` before narrowing.

Includes tests for window-update bounds and send behaviour at the limit.