### PR TITLE
chore(gossipsub): cap partial-message group state

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import tables, sets, sequtils, chronicles, results, metrics
+import tables, sets, sequtils, algorithm, chronicles, results, metrics
 import ../../../utils/tablekey
 import ../../../[peerid]
 import ../rpc/messages
@@ -63,9 +63,8 @@ type
       # needs to be implemented by application.
     heartbeatsTillEviction*: int
       # number of heartbeats for which metadata will be retained before eviction
-    maxPartialGroups*: int = 1000
-      # upper bound on (topic, group) entries; new groups are rejected at the limit
-    maxPartialGroupsPerPeer*: int = 100 # upper bound on groups a single peer can create
+    maxPartialGroups*: int = 1000 # global cap; excess trimmed LRU each heartbeat
+    maxPartialGroupsPerPeer*: int = 100
 
   PeerGroupState = ref object
     receivedPartsMetadata: Opt[PartsMetadata] # parts metadata peer sent to this node
@@ -146,6 +145,7 @@ proc evictGroup(ext: PartialMessageExtension, key: TopicGroupKey) =
   group.creator.withValue(creator):
     ext.releasePeerGroup(creator)
   ext.groupState.del(key)
+  ext.updateGroupCountMetric()
 
 proc reduceHeartbeatsTillEviction(ext: PartialMessageExtension) =
   var toRemove: seq[TopicGroupKey] = @[]
@@ -155,38 +155,53 @@ proc reduceHeartbeatsTillEviction(ext: PartialMessageExtension) =
       toRemove.add(key)
   for key in toRemove:
     ext.evictGroup(key)
-  ext.updateGroupCountMetric()
 
 template getGroupState(
     ext: PartialMessageExtension, topic: string, groupId: GroupId
 ): GroupState =
   ext.groupState.mgetOrPut(TopicGroupKey.new(topic, groupId), GroupState())
 
+proc trimToMaxGroups(ext: PartialMessageExtension) =
+  ## Evicts least-recently-used groups down to maxPartialGroups, ranking by
+  ## heartbeatsTillEviction (refreshed whenever a group sees new metadata).
+  let excess = ext.groupState.len - ext.config.maxPartialGroups
+  if excess <= 0:
+    return
+  var groups = ext.groupState.pairs.toSeq()
+  groups.sort do(a, b: (TopicGroupKey, GroupState)) -> int:
+    cmp(a[1].heartbeatsTillEviction, b[1].heartbeatsTillEviction)
+  for (key, _) in groups[0 ..< excess]:
+    ext.evictGroup(key)
+    libp2p_gossipsub_partial_message_groups_dropped.inc()
+
 proc acquireGroupState(
     ext: PartialMessageExtension, peerId: PeerId, topic: string, groupId: GroupId
 ): GroupState =
-  ## Returns the existing group for (topic, groupId), or allocates one for peerId.
-  ## Returns nil when a new group would exceed the global or per-peer limit.
+  ## Returns the group for (topic, groupId), allocating one for peerId if absent.
+  ## Returns nil when allocating would exceed the per-peer limit.
   let key = TopicGroupKey.new(topic, groupId)
   let existing = ext.groupState.getOrDefault(key)
   if not existing.isNil():
     return existing
 
-  if ext.groupState.len >= ext.config.maxPartialGroups or
-      ext.peerGroupCount.getOrDefault(peerId) >= ext.config.maxPartialGroupsPerPeer:
+  if ext.peerGroupCount.getOrDefault(peerId) >= ext.config.maxPartialGroupsPerPeer:
     libp2p_gossipsub_partial_message_groups_dropped.inc()
     return nil
 
   let group = GroupState(creator: Opt.some(peerId))
   ext.groupState[key] = group
   ext.peerGroupCount.inc(peerId)
+  ext.updateGroupCountMetric()
   group
 
 proc trackedGroups(ext: PartialMessageExtension): int =
   ext.groupState.len
 
+proc hasGroup(ext: PartialMessageExtension, topic: string, groupId: GroupId): bool =
+  ext.groupState.hasKey(TopicGroupKey.new(topic, groupId))
+
 when defined(libp2p_testing):
-  export trackedGroups
+  export trackedGroups, hasGroup
 
 template getPeerState(gs: GroupState, peerId: PeerId): PeerGroupState =
   gs.peerState.mgetOrPut(peerId, PeerGroupState())
@@ -196,6 +211,12 @@ template hasPeer(gs: GroupState, peerId: PeerId): bool =
 
 template hasPublished(gs: GroupState): bool =
   gs.lastPublishedMetadata.len > 0
+
+template createdBy(gs: GroupState, peerId: PeerId): bool =
+  gs.creator == Opt.some(peerId)
+
+template isReclaimable(gs: GroupState): bool =
+  gs.peerState.len == 0 and not gs.hasPublished()
 
 proc unionWithSentPartsMetadata(
     ext: PartialMessageExtension,
@@ -249,6 +270,7 @@ proc gossipPartsMetadata*(ext: PartialMessageExtension) =
 
 method onHeartbeat*(ext: PartialMessageExtension) {.gcsafe, raises: [].} =
   ext.reduceHeartbeatsTillEviction()
+  ext.trimToMaxGroups()
   ext.gossipPartsMetadata()
 
 method onNegotiated*(
@@ -259,12 +281,17 @@ method onNegotiated*(
 method onRemovePeer*(
     ext: PartialMessageExtension, peerId: PeerId
 ) {.gcsafe, raises: [].} =
-  # remove peer data from _groupState_
+  var toEvict: seq[TopicGroupKey] = @[]
   for key, group in ext.groupState:
     group.peerState.del(peerId)
-    group.creator.withValue(creator):
-      if creator == peerId:
-        group.creator = Opt.none(PeerId)
+    if not group.createdBy(peerId):
+      continue
+    if group.isReclaimable():
+      toEvict.add(key)
+      continue
+    group.creator = Opt.none(PeerId)
+  for key in toEvict:
+    ext.evictGroup(key)
   ext.peerGroupCount.del(peerId)
 
   # remove peer subscription options from _peerTopicOpts_
@@ -416,6 +443,7 @@ proc publishPartial*(
   var groupState = ext.getGroupState(topic, pm.groupId())
   groupState.heartbeatsTillEviction = ext.config.heartbeatsTillEviction
   groupState.lastPublishedMetadata = pm.partsMetadata()
+  ext.updateGroupCountMetric()
 
   let publishToPeers =
     if peers.len > 0:

--- a/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import tables, sets, sequtils, chronicles, results
+import tables, sets, sequtils, chronicles, results, metrics
 import ../../../utils/tablekey
 import ../../../[peerid]
 import ../rpc/messages
@@ -9,6 +9,15 @@ import ./[extensions_types, partial_message]
 
 logScope:
   topics = "libp2p partial message"
+
+declareGauge(
+  libp2p_gossipsub_partial_message_groups,
+  "number of partial-message groups currently tracked",
+)
+declareCounter(
+  libp2p_gossipsub_partial_message_groups_dropped,
+  "number of partial-message groups dropped due to configured limits",
+)
 
 type
   TopicOpts* = object
@@ -54,6 +63,9 @@ type
       # needs to be implemented by application.
     heartbeatsTillEviction*: int
       # number of heartbeats for which metadata will be retained before eviction
+    maxPartialGroups*: int = 1000
+      # upper bound on (topic, group) entries; new groups are rejected at the limit
+    maxPartialGroupsPerPeer*: int = 100 # upper bound on groups a single peer can create
 
   PeerGroupState = ref object
     receivedPartsMetadata: Opt[PartsMetadata] # parts metadata peer sent to this node
@@ -63,6 +75,7 @@ type
     peerState: Table[PeerId, PeerGroupState]
     heartbeatsTillEviction: int
     lastPublishedMetadata: PartsMetadata
+    creator: Opt[PeerId] # peer this group was allocated for, none if locally published
 
   PeerTopicKey = object of TableKey
     peerId: PeerId
@@ -76,6 +89,7 @@ type
     config: PartialMessageExtensionConfig
     groupState: Table[TopicGroupKey, GroupState]
     peerTopicOpts: Table[PeerTopicKey, TopicOpts]
+    peerGroupCount: Table[PeerId, int] # groups allocated per peer, keyed by creator
 
 proc new(T: typedesc[PeerTopicKey], peerId: PeerId, topic: string): PeerTopicKey =
   PeerTopicKey(key: TableKey.makeKey(peerId, topic), peerId: peerId, topic: topic)
@@ -96,6 +110,8 @@ proc doAssert(config: PartialMessageExtensionConfig) =
   doAssert(config.validateRPC != nil, msg("validateRPC"))
   doAssert(config.onIncomingRPC != nil, msg("onIncomingRPC"))
   doAssert(config.heartbeatsTillEviction >= 1, msg("heartbeatsTillEviction"))
+  doAssert(config.maxPartialGroups >= 1, msg("maxPartialGroups"))
+  doAssert(config.maxPartialGroupsPerPeer >= 1, msg("maxPartialGroupsPerPeer"))
 
 proc new*(
     T: typedesc[PartialMessageExtension], config: PartialMessageExtensionConfig
@@ -114,20 +130,64 @@ proc peerRequestsPartial*(
   let opt = ext.peerTopicOpts.getOrDefault(PeerTopicKey.new(peerId, topic))
   return opt.requestsPartial
 
+proc updateGroupCountMetric(ext: PartialMessageExtension) =
+  libp2p_gossipsub_partial_message_groups.set(ext.groupState.len.int64)
+
+proc releasePeerGroup(ext: PartialMessageExtension, peerId: PeerId) =
+  let count = ext.peerGroupCount.getOrDefault(peerId)
+  if count <= 1:
+    ext.peerGroupCount.del(peerId)
+    return
+  ext.peerGroupCount[peerId] = count - 1
+
+proc evictGroup(ext: PartialMessageExtension, key: TopicGroupKey) =
+  let group = ext.groupState.getOrDefault(key)
+  if group.isNil():
+    return
+  group.creator.withValue(creator):
+    ext.releasePeerGroup(creator)
+  ext.groupState.del(key)
+
 proc reduceHeartbeatsTillEviction(ext: PartialMessageExtension) =
-  # reduce heartbeatsTillEviction and remove groups that hit 0
   var toRemove: seq[TopicGroupKey] = @[]
   for key, group in ext.groupState.mpairs:
     group.heartbeatsTillEviction.dec
     if group.heartbeatsTillEviction <= 0:
       toRemove.add(key)
   for key in toRemove:
-    ext.groupState.del(key)
+    ext.evictGroup(key)
+  ext.updateGroupCountMetric()
 
-template getGroupState(
+proc getGroupState(
     ext: PartialMessageExtension, topic: string, groupId: GroupId
 ): GroupState =
-  ext.groupState.mgetOrPut(TopicGroupKey.new(topic, groupId), GroupState())
+  let group = ext.groupState.mgetOrPut(TopicGroupKey.new(topic, groupId), GroupState())
+  ext.updateGroupCountMetric()
+  group
+
+proc acquireGroupState(
+    ext: PartialMessageExtension, peerId: PeerId, topic: string, groupId: GroupId
+): GroupState =
+  ## Returns the existing group for (topic, groupId), or allocates one for peerId.
+  ## Returns nil when a new group would exceed the global or per-peer limit.
+  let key = TopicGroupKey.new(topic, groupId)
+  let existing = ext.groupState.getOrDefault(key)
+  if not existing.isNil():
+    return existing
+
+  if ext.groupState.len >= ext.config.maxPartialGroups or
+      ext.peerGroupCount.getOrDefault(peerId) >= ext.config.maxPartialGroupsPerPeer:
+    libp2p_gossipsub_partial_message_groups_dropped.inc()
+    return nil
+
+  let group = GroupState(creator: Opt.some(peerId))
+  ext.groupState[key] = group
+  ext.peerGroupCount[peerId] = ext.peerGroupCount.getOrDefault(peerId) + 1
+  ext.updateGroupCountMetric()
+  group
+
+proc trackedGroups*(ext: PartialMessageExtension): int =
+  ext.groupState.len
 
 template getPeerState(gs: GroupState, peerId: PeerId): PeerGroupState =
   gs.peerState.mgetOrPut(peerId, PeerGroupState())
@@ -203,6 +263,10 @@ method onRemovePeer*(
   # remove peer data from _groupState_
   for key, group in ext.groupState:
     group.peerState.del(peerId)
+    group.creator.withValue(creator):
+      if creator == peerId:
+        group.creator = Opt.none(PeerId)
+  ext.peerGroupCount.del(peerId)
 
   # remove peer subscription options from _peerTopicOpts_
   var toRemove: seq[PeerTopicKey] = @[]
@@ -250,6 +314,18 @@ proc shouldHandlePartialRPC(
     ext.groupState.getOrDefault(TopicGroupKey.new(rpc.topicID, rpc.groupID))
   groupState != nil and groupState.hasPublished()
 
+proc recordReceivedMetadata(
+    ext: PartialMessageExtension, peerId: PeerId, rpc: PartialMessageExtensionRPC
+) =
+  if rpc.partsMetadata.len == 0:
+    return
+  let groupState = ext.acquireGroupState(peerId, rpc.topicID, rpc.groupID)
+  if groupState.isNil():
+    return
+  var peerState = groupState.getPeerState(peerId)
+  peerState.receivedPartsMetadata = Opt.some(rpc.partsMetadata)
+  groupState.heartbeatsTillEviction = ext.config.heartbeatsTillEviction
+
 proc handlePartialRPC(
     ext: PartialMessageExtension, peerId: PeerId, rpc: PartialMessageExtensionRPC
 ) =
@@ -263,11 +339,7 @@ proc handlePartialRPC(
     debug "RPC did not pass application validation", msg = validateRes.error
     return
 
-  if rpc.partsMetadata.len > 0:
-    var groupState = ext.getGroupState(rpc.topicID, rpc.groupID)
-    var peerState = groupState.getPeerState(peerId)
-    peerState.receivedPartsMetadata = Opt.some(rpc.partsMetadata)
-    groupState.heartbeatsTillEviction = ext.config.heartbeatsTillEviction
+  ext.recordReceivedMetadata(peerId, rpc)
 
   if shouldHandlePartialRPC(ext, peerId, rpc):
     ext.config.onIncomingRPC(peerId, rpc)

--- a/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
@@ -89,7 +89,7 @@ type
     config: PartialMessageExtensionConfig
     groupState: Table[TopicGroupKey, GroupState]
     peerTopicOpts: Table[PeerTopicKey, TopicOpts]
-    peerGroupCount: Table[PeerId, int] # groups allocated per peer, keyed by creator
+    peerGroupCount: CountTable[PeerId] # groups allocated per peer, keyed by creator
 
 proc new(T: typedesc[PeerTopicKey], peerId: PeerId, topic: string): PeerTopicKey =
   PeerTopicKey(key: TableKey.makeKey(peerId, topic), peerId: peerId, topic: topic)
@@ -134,11 +134,10 @@ proc updateGroupCountMetric(ext: PartialMessageExtension) =
   libp2p_gossipsub_partial_message_groups.set(ext.groupState.len.int64)
 
 proc releasePeerGroup(ext: PartialMessageExtension, peerId: PeerId) =
-  let count = ext.peerGroupCount.getOrDefault(peerId)
-  if count <= 1:
+  if ext.peerGroupCount.getOrDefault(peerId) <= 1:
     ext.peerGroupCount.del(peerId)
     return
-  ext.peerGroupCount[peerId] = count - 1
+  ext.peerGroupCount.inc(peerId, -1)
 
 proc evictGroup(ext: PartialMessageExtension, key: TopicGroupKey) =
   let group = ext.groupState.getOrDefault(key)
@@ -158,12 +157,10 @@ proc reduceHeartbeatsTillEviction(ext: PartialMessageExtension) =
     ext.evictGroup(key)
   ext.updateGroupCountMetric()
 
-proc getGroupState(
+template getGroupState(
     ext: PartialMessageExtension, topic: string, groupId: GroupId
 ): GroupState =
-  let group = ext.groupState.mgetOrPut(TopicGroupKey.new(topic, groupId), GroupState())
-  ext.updateGroupCountMetric()
-  group
+  ext.groupState.mgetOrPut(TopicGroupKey.new(topic, groupId), GroupState())
 
 proc acquireGroupState(
     ext: PartialMessageExtension, peerId: PeerId, topic: string, groupId: GroupId
@@ -182,12 +179,14 @@ proc acquireGroupState(
 
   let group = GroupState(creator: Opt.some(peerId))
   ext.groupState[key] = group
-  ext.peerGroupCount[peerId] = ext.peerGroupCount.getOrDefault(peerId) + 1
-  ext.updateGroupCountMetric()
+  ext.peerGroupCount.inc(peerId)
   group
 
-proc trackedGroups*(ext: PartialMessageExtension): int =
+proc trackedGroups(ext: PartialMessageExtension): int =
   ext.groupState.len
+
+when defined(libp2p_testing):
+  export trackedGroups
 
 template getPeerState(gs: GroupState, peerId: PeerId): PeerGroupState =
   gs.peerState.mgetOrPut(peerId, PeerGroupState())

--- a/tests/libp2p/pubsub/extensions/test_extension_partial_message.nim
+++ b/tests/libp2p/pubsub/extensions/test_extension_partial_message.nim
@@ -88,6 +88,18 @@ proc handlePartialMessage(
 ) =
   ext.onHandleRPC(peerId, RPCMsg(partialMessageExtension: Opt.some(rpc)))
 
+proc sendGroupMetadata(
+    ext: PartialMessageExtension, peerId: PeerId, topic, groupId: string
+) =
+  ext.handlePartialMessage(
+    peerId,
+    PartialMessageExtensionRPC(
+      topicID: topic,
+      groupID: groupId.toBytes,
+      partsMetadata: MyPartsMetadata.want(@[1]),
+    ),
+  )
+
 suite "GossipSub Extensions :: Partial Message Extension":
   let peerId = PeerId.random(rng()).get()
   let groupId = "group-id-1".toBytes
@@ -669,3 +681,77 @@ suite "GossipSub Extensions :: Partial Message Extension":
     # because peer already knows the same parts metadata.
     ext.onHeartbeat()
     check cr.sentRPC.len == 1
+
+  test "group store enforces global limit":
+    const topic = "partial-topic"
+    var cr = CallbackRecorder()
+    var cfg = cr.config()
+    cfg.maxPartialGroups = 3
+    cfg.heartbeatsTillEviction = 100
+    var ext = PartialMessageExtension.new(cfg)
+
+    # distinct peers each adding one group so per-peer cap is not the limiter
+    for i in 0 ..< 10:
+      let p = PeerId.random(rng()).get()
+      ext.sendGroupMetadata(p, topic, "g-" & $i)
+
+    check ext.trackedGroups == 3
+
+  test "group store enforces per-peer limit":
+    const topic = "partial-topic"
+    var cr = CallbackRecorder()
+    var cfg = cr.config()
+    cfg.maxPartialGroups = 100
+    cfg.maxPartialGroupsPerPeer = 2
+    cfg.heartbeatsTillEviction = 100
+    var ext = PartialMessageExtension.new(cfg)
+
+    for i in 0 ..< 10:
+      ext.sendGroupMetadata(peerId, topic, "g-" & $i)
+
+    # single peer cannot exceed its own budget despite global budget remaining
+    check ext.trackedGroups == 2
+
+    # a different peer still has its own budget
+    let otherPeer = PeerId.random(rng()).get()
+    ext.sendGroupMetadata(otherPeer, topic, "other")
+    check ext.trackedGroups == 3
+
+  test "removing a peer frees its group budget":
+    const topic = "partial-topic"
+    var cr = CallbackRecorder()
+    var cfg = cr.config()
+    cfg.maxPartialGroups = 100
+    cfg.maxPartialGroupsPerPeer = 1
+    cfg.heartbeatsTillEviction = 100
+    var ext = PartialMessageExtension.new(cfg)
+
+    ext.sendGroupMetadata(peerId, topic, "g-1")
+    ext.sendGroupMetadata(peerId, topic, "g-2") # rejected, peer at budget
+    check ext.trackedGroups == 1
+
+    ext.onRemovePeer(peerId)
+    ext.sendGroupMetadata(peerId, topic, "g-3") # budget reclaimed
+    check ext.trackedGroups == 2
+
+  test "heartbeat eviction frees group budget":
+    const topic = "partial-topic"
+    var cr = CallbackRecorder()
+    var cfg = cr.config()
+    cfg.maxPartialGroups = 1
+    cfg.maxPartialGroupsPerPeer = 1
+    cfg.heartbeatsTillEviction = 1
+    var ext = PartialMessageExtension.new(cfg)
+
+    ext.sendGroupMetadata(peerId, topic, "g-1")
+    check ext.trackedGroups == 1
+
+    ext.sendGroupMetadata(peerId, topic, "g-2") # at capacity, rejected
+    check ext.trackedGroups == 1
+
+    # heartbeat reclaims the expired group, freeing both global and per-peer budget
+    ext.onHeartbeat()
+    check ext.trackedGroups == 0
+
+    ext.sendGroupMetadata(peerId, topic, "g-3")
+    check ext.trackedGroups == 1

--- a/tests/libp2p/pubsub/extensions/test_extension_partial_message.nim
+++ b/tests/libp2p/pubsub/extensions/test_extension_partial_message.nim
@@ -682,7 +682,7 @@ suite "GossipSub Extensions :: Partial Message Extension":
     ext.onHeartbeat()
     check cr.sentRPC.len == 1
 
-  test "group store enforces global limit":
+  test "heartbeat trims groups to global limit":
     const topic = "partial-topic"
     var cr = CallbackRecorder()
     var cfg = cr.config()
@@ -695,7 +695,38 @@ suite "GossipSub Extensions :: Partial Message Extension":
       let p = PeerId.random(rng()).get()
       ext.sendGroupMetadata(p, topic, "g-" & $i)
 
+    # all groups are accepted; the global limit is enforced lazily on heartbeat
+    check ext.trackedGroups == 10
+    ext.onHeartbeat()
     check ext.trackedGroups == 3
+
+  test "heartbeat trims least-recently-used groups first":
+    const topic = "partial-topic"
+    var cr = CallbackRecorder()
+    var cfg = cr.config()
+    cfg.maxPartialGroups = 2
+    cfg.maxPartialGroupsPerPeer = 100
+    cfg.heartbeatsTillEviction = 10
+    var ext = PartialMessageExtension.new(cfg)
+
+    let p1 = PeerId.random(rng()).get()
+    let p2 = PeerId.random(rng()).get()
+    let p3 = PeerId.random(rng()).get()
+
+    ext.sendGroupMetadata(p1, topic, "g-1")
+    ext.sendGroupMetadata(p2, topic, "g-2")
+    ext.onHeartbeat() # ages g-1 and g-2 equally
+
+    ext.sendGroupMetadata(p1, topic, "g-1") # refresh g-1, making g-2 the oldest
+    ext.sendGroupMetadata(p3, topic, "g-3") # fresh group, total now exceeds limit
+    check ext.trackedGroups == 3
+
+    ext.onHeartbeat() # trims down to 2, evicting the least-recently-used g-2
+    check:
+      ext.trackedGroups == 2
+      ext.hasGroup(topic, "g-1".toBytes)
+      ext.hasGroup(topic, "g-3".toBytes)
+      not ext.hasGroup(topic, "g-2".toBytes)
 
   test "group store enforces per-peer limit":
     const topic = "partial-topic"
@@ -730,9 +761,12 @@ suite "GossipSub Extensions :: Partial Message Extension":
     ext.sendGroupMetadata(peerId, topic, "g-2") # rejected, peer at budget
     check ext.trackedGroups == 1
 
+    # removal evicts the empty group the peer created instead of orphaning it
     ext.onRemovePeer(peerId)
+    check ext.trackedGroups == 0
+
     ext.sendGroupMetadata(peerId, topic, "g-3") # budget reclaimed
-    check ext.trackedGroups == 2
+    check ext.trackedGroups == 1
 
   test "heartbeat eviction frees group budget":
     const topic = "partial-topic"


### PR DESCRIPTION
Adds upper bounds on the number of partial-message groups GossipSub keeps in memory, so a flood of distinct (topic, group) ids cannot grow the per-extension state without limit.

Two independent caps:
- `maxPartialGroups` (default 1000) — global cap. Enforced lazily on each heartbeat: when the group count exceeds the cap, the least-recently-used groups are trimmed. Recency is the existing `heartbeatsTillEviction` counter, refreshed whenever a group sees new metadata, so actively used groups are trimmed last.
- `maxPartialGroupsPerPeer` (default 100) — per-peer cap. A group created from a peer's received metadata is attributed to that peer; once the peer is at its budget, further new groups are rejected and never allocated.

Each group records its creating peer. The per-peer budget is released when a group is evicted (heartbeat expiry or LRU trim) and when the peer is removed; on peer removal, groups the peer created that are now empty are evicted immediately instead of lingering until heartbeat expiry. Locally-published groups are uncounted (no creator) and bypass the per-peer cap, but remain subject to the global LRU trim.

Two metrics:
- `libp2p_gossipsub_partial_message_groups` — gauge of groups currently tracked, updated at each allocation/eviction.
- `libp2p_gossipsub_partial_message_groups_dropped` — counter of groups that did not survive a limit, covering both per-peer rejections and global LRU trims.

Tests cover the global LRU trim (including least-recently-used ordering), the per-peer cap, and budget reclaim on both peer removal and heartbeat eviction.