### PR TITLE
chore(ci): parallelize test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,8 +177,13 @@ jobs:
             export NIMFLAGS="${NIMFLAGS} --cc:clang"
           fi
 
-          # Compile test binaries serially, run them concurrently.
-          make TEST_JOBS=3 test
+          # Build/run test binaries concurrently; fewer lanes on 32-bit to stay
+          # under the ~3 GB address cap.
+          TEST_JOBS=3
+          if [[ '${{ matrix.platform.cpu }}' == 'i386' ]]; then
+            TEST_JOBS=2
+          fi
+          make TEST_JOBS=$TEST_JOBS test
 
       - name: Fix xml newlines
         if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,14 @@ jobs:
           if [[ '${{ matrix.platform.cc }}' == 'clang' ]]; then
             export NIMFLAGS="${NIMFLAGS} --cc:clang"
           fi
-          make test
+
+          # Build/run test binaries concurrently; fewer lanes on 32-bit to stay
+          # under the ~3 GB address cap.
+          TEST_JOBS=3
+          if [[ '${{ matrix.platform.cpu }}' == 'i386' ]]; then
+            TEST_JOBS=2
+          fi
+          make TEST_JOBS=$TEST_JOBS test
 
       - name: Fix xml newlines
         if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,13 +177,8 @@ jobs:
             export NIMFLAGS="${NIMFLAGS} --cc:clang"
           fi
 
-          # Build/run test binaries concurrently; fewer lanes on 32-bit to stay
-          # under the ~3 GB address cap.
-          TEST_JOBS=3
-          if [[ '${{ matrix.platform.cpu }}' == 'i386' ]]; then
-            TEST_JOBS=2
-          fi
-          make TEST_JOBS=$TEST_JOBS test
+          # Compile test binaries serially, run them concurrently.
+          make TEST_JOBS=3 test
 
       - name: Fix xml newlines
         if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,8 +56,9 @@ jobs:
       - name: Run test suite with coverage flags
         run: |
           export NIMFLAGS="--lineDir:on --passC:-fprofile-arcs --passC:-ftest-coverage --passL:-fprofile-arcs --passL:-ftest-coverage"
-          # Each test binary keeps its own nimcache, so per-source .gcda files
-          # stay isolated and lcov captures all of nimcache/ recursively.
+          # amd64 (64-bit): compile and run the test binaries concurrently. Each
+          # binary keeps its own nimcache, so the per-source .gcda files stay
+          # isolated and lcov still captures all of nimcache/ recursively.
           make TEST_JOBS=3 test
 
       - name: Run coverage

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,7 +56,10 @@ jobs:
       - name: Run test suite with coverage flags
         run: |
           export NIMFLAGS="--lineDir:on --passC:-fprofile-arcs --passC:-ftest-coverage --passL:-fprofile-arcs --passL:-ftest-coverage"
-          make test
+          # amd64 (64-bit): compile and run the test binaries concurrently. Each
+          # binary keeps its own nimcache, so the per-source .gcda files stay
+          # isolated and lcov still captures all of nimcache/ recursively.
+          make TEST_JOBS=3 test
 
       - name: Run coverage
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,9 +56,8 @@ jobs:
       - name: Run test suite with coverage flags
         run: |
           export NIMFLAGS="--lineDir:on --passC:-fprofile-arcs --passC:-ftest-coverage --passL:-fprofile-arcs --passL:-ftest-coverage"
-          # amd64 (64-bit): compile and run the test binaries concurrently. Each
-          # binary keeps its own nimcache, so the per-source .gcda files stay
-          # isolated and lcov still captures all of nimcache/ recursively.
+          # Each test binary keeps its own nimcache, so per-source .gcda files
+          # stay isolated and lcov captures all of nimcache/ recursively.
           make TEST_JOBS=3 test
 
       - name: Run coverage

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -180,7 +180,14 @@ jobs:
             export NIMFLAGS="${NIMFLAGS} --cc:clang"
           fi
           export NIMFLAGS="${NIMFLAGS} -d:chronicles_log_level=DEBUG"
-          make test
+
+          # Build/run test binaries concurrently; fewer lanes on 32-bit to stay
+          # under the ~3 GB address cap.
+          TEST_JOBS=3
+          if [[ '${{ matrix.config.cpu }}' == 'i386' ]]; then
+            TEST_JOBS=2
+          fi
+          make TEST_JOBS=$TEST_JOBS test
 
       - name: Run integration tests
         if: ${{ matrix.config.os == 'linux' && matrix.config.cpu == 'amd64' }}

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -181,8 +181,13 @@ jobs:
           fi
           export NIMFLAGS="${NIMFLAGS} -d:chronicles_log_level=DEBUG"
 
-          # Compile test binaries serially, run them concurrently.
-          make TEST_JOBS=3 test
+          # Build/run test binaries concurrently; fewer lanes on 32-bit to stay
+          # under the ~3 GB address cap.
+          TEST_JOBS=3
+          if [[ '${{ matrix.config.cpu }}' == 'i386' ]]; then
+            TEST_JOBS=2
+          fi
+          make TEST_JOBS=$TEST_JOBS test
 
       - name: Run integration tests
         if: ${{ matrix.config.os == 'linux' && matrix.config.cpu == 'amd64' }}

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -181,13 +181,8 @@ jobs:
           fi
           export NIMFLAGS="${NIMFLAGS} -d:chronicles_log_level=DEBUG"
 
-          # Build/run test binaries concurrently; fewer lanes on 32-bit to stay
-          # under the ~3 GB address cap.
-          TEST_JOBS=3
-          if [[ '${{ matrix.config.cpu }}' == 'i386' ]]; then
-            TEST_JOBS=2
-          fi
-          make TEST_JOBS=$TEST_JOBS test
+          # Compile test binaries serially, run them concurrently.
+          make TEST_JOBS=3 test
 
       - name: Run integration tests
         if: ${{ matrix.config.os == 'linux' && matrix.config.cpu == 'amd64' }}

--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,16 @@
 # On 32-bit targets the Nim compiler is itself a 32-bit process capped at ~3 GB
 # of address space; the unsharded TU overran that on orc. Two slices halve the
 # memory footprint enough to fit, and the overhead is small on 64-bit targets.
-# Test binaries to run concurrently (1 = serial). Compilation stays serial.
+# Number of test binaries to compile and run concurrently; 1 keeps `make test`
+# serial. CI raises it, using fewer lanes on 32-bit to stay under the ~3 GB cap.
 TEST_JOBS ?= 1
 
 TEST_ALL_SLICES ?= 2
 TEST_ALL_SLICE_IDS := $(shell seq 0 $$(( $(TEST_ALL_SLICES) - 1 )))
-COMPILE_SLICE_TARGETS := $(addprefix _compile_slice_,$(TEST_ALL_SLICE_IDS))
-RUN_SLICE_TARGETS := $(addprefix _run_slice_,$(TEST_ALL_SLICE_IDS))
+TEST_ALL_SLICE_TARGETS := $(addprefix _test_all_slice_,$(TEST_ALL_SLICE_IDS))
 
-.PHONY: all build deps cbind clean test compile_tests run_tests \
-        $(COMPILE_SLICE_TARGETS) $(RUN_SLICE_TARGETS) \
-        compile_multiformat_exts run_multiformat_exts test_integration \
+.PHONY: all build deps cbind clean test _run_all_tests $(TEST_ALL_SLICE_TARGETS) \
+        test_multiformat_exts test_integration \
         install_pinned pin unpin gen_multicodec format clean-nim nat_libs nat_pkg_dir_check
 
 NIM_VERSION  ?= 2.2.10
@@ -144,8 +143,7 @@ $(NAT_LIBS_STAMP): | nat_pkg_dir_check
 
 test: nimble.paths nat_libs
 ifeq ($(TEST_PATH),)
-	$(MAKE) compile_tests
-	$(MAKE) -j$(TEST_JOBS) run_tests
+	$(MAKE) -j$(TEST_JOBS) _run_all_tests
 else
 	$(NIMC) c $(NIM_FLAGS) \
 	  $(if $(CICOV),--nimcache:nimcache/test_all,) \
@@ -154,22 +152,19 @@ else
 	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
 endif
 
-compile_tests: $(COMPILE_SLICE_TARGETS) compile_multiformat_exts
+_run_all_tests: $(TEST_ALL_SLICE_TARGETS) test_multiformat_exts
 
-run_tests: $(RUN_SLICE_TARGETS) run_multiformat_exts
-
-$(COMPILE_SLICE_TARGETS): _compile_slice_%: nimble.paths nat_libs
+# Per-target nimcache, always: concurrent compiles must not share one.
+$(TEST_ALL_SLICE_TARGETS): _test_all_slice_%: nimble.paths nat_libs
 	$(NIMC) c $(NIM_FLAGS) \
 	  --nimcache:nimcache/test_all_$* \
 	  -d:sliceTotal=$(TEST_ALL_SLICES) \
 	  -d:sliceIdx=$* \
 	  -o:tests/test_all_$* \
 	  tests/test_all.nim
-
-$(RUN_SLICE_TARGETS): _run_slice_%:
 	./tests/test_all_$* $(RUNNER_FLAGS) --xml:tests/results_test_all_$*.xml
 
-compile_multiformat_exts: nimble.paths nat_libs
+test_multiformat_exts: nimble.paths nat_libs
 	$(NIMC) c $(NIM_FLAGS) \
 	  --nimcache:nimcache/test_all_multiformat \
 	  -d:libp2p_multicodec_exts=../tests/libp2p/multiformat_exts/multicodec_exts.nim \
@@ -178,11 +173,8 @@ compile_multiformat_exts: nimble.paths nat_libs
 	  -d:libp2p_multibase_exts=../tests/libp2p/multiformat_exts/multibase_exts.nim \
 	  -d:libp2p_contentids_exts=../tests/libp2p/multiformat_exts/contentids_exts.nim \
 	  -d:path=multiformat_exts \
-	  -o:tests/test_all_multiformat \
 	  tests/test_all.nim
-
-run_multiformat_exts:
-	./tests/test_all_multiformat $(RUNNER_FLAGS) --xml:tests/results_test_all_multiformat.xml
+	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all_multiformat.xml
 
 test_integration: nimble.paths nat_libs
 	$(NIMC) c $(NIM_FLAGS) \

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,17 @@
 # On 32-bit targets the Nim compiler is itself a 32-bit process capped at ~3 GB
 # of address space; the unsharded TU overran that on orc. Two slices halve the
 # memory footprint enough to fit, and the overhead is small on 64-bit targets.
-# Number of test binaries to compile and run concurrently; 1 keeps `make test`
-# serial. CI raises it, using fewer lanes on 32-bit to stay under the ~3 GB cap.
+# Test binaries to run concurrently (1 = serial). Compilation stays serial.
 TEST_JOBS ?= 1
 
 TEST_ALL_SLICES ?= 2
 TEST_ALL_SLICE_IDS := $(shell seq 0 $$(( $(TEST_ALL_SLICES) - 1 )))
-TEST_ALL_SLICE_TARGETS := $(addprefix _test_all_slice_,$(TEST_ALL_SLICE_IDS))
+COMPILE_SLICE_TARGETS := $(addprefix _compile_slice_,$(TEST_ALL_SLICE_IDS))
+RUN_SLICE_TARGETS := $(addprefix _run_slice_,$(TEST_ALL_SLICE_IDS))
 
-.PHONY: all build deps cbind clean test _run_all_tests $(TEST_ALL_SLICE_TARGETS) \
-        test_multiformat_exts test_integration \
+.PHONY: all build deps cbind clean test compile_tests run_tests \
+        $(COMPILE_SLICE_TARGETS) $(RUN_SLICE_TARGETS) \
+        compile_multiformat_exts run_multiformat_exts test_integration \
         install_pinned pin unpin gen_multicodec format clean-nim nat_libs nat_pkg_dir_check
 
 NIM_VERSION  ?= 2.2.10
@@ -143,7 +144,8 @@ $(NAT_LIBS_STAMP): | nat_pkg_dir_check
 
 test: nimble.paths nat_libs
 ifeq ($(TEST_PATH),)
-	$(MAKE) -j$(TEST_JOBS) _run_all_tests
+	$(MAKE) compile_tests
+	$(MAKE) -j$(TEST_JOBS) run_tests
 else
 	$(NIMC) c $(NIM_FLAGS) \
 	  $(if $(CICOV),--nimcache:nimcache/test_all,) \
@@ -152,19 +154,22 @@ else
 	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
 endif
 
-_run_all_tests: $(TEST_ALL_SLICE_TARGETS) test_multiformat_exts
+compile_tests: $(COMPILE_SLICE_TARGETS) compile_multiformat_exts
 
-# Per-target nimcache, always: concurrent compiles must not share one.
-$(TEST_ALL_SLICE_TARGETS): _test_all_slice_%: nimble.paths nat_libs
+run_tests: $(RUN_SLICE_TARGETS) run_multiformat_exts
+
+$(COMPILE_SLICE_TARGETS): _compile_slice_%: nimble.paths nat_libs
 	$(NIMC) c $(NIM_FLAGS) \
 	  --nimcache:nimcache/test_all_$* \
 	  -d:sliceTotal=$(TEST_ALL_SLICES) \
 	  -d:sliceIdx=$* \
 	  -o:tests/test_all_$* \
 	  tests/test_all.nim
+
+$(RUN_SLICE_TARGETS): _run_slice_%:
 	./tests/test_all_$* $(RUNNER_FLAGS) --xml:tests/results_test_all_$*.xml
 
-test_multiformat_exts: nimble.paths nat_libs
+compile_multiformat_exts: nimble.paths nat_libs
 	$(NIMC) c $(NIM_FLAGS) \
 	  --nimcache:nimcache/test_all_multiformat \
 	  -d:libp2p_multicodec_exts=../tests/libp2p/multiformat_exts/multicodec_exts.nim \
@@ -173,8 +178,11 @@ test_multiformat_exts: nimble.paths nat_libs
 	  -d:libp2p_multibase_exts=../tests/libp2p/multiformat_exts/multibase_exts.nim \
 	  -d:libp2p_contentids_exts=../tests/libp2p/multiformat_exts/contentids_exts.nim \
 	  -d:path=multiformat_exts \
+	  -o:tests/test_all_multiformat \
 	  tests/test_all.nim
-	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all_multiformat.xml
+
+run_multiformat_exts:
+	./tests/test_all_multiformat $(RUNNER_FLAGS) --xml:tests/results_test_all_multiformat.xml
 
 test_integration: nimble.paths nat_libs
 	$(NIMC) c $(NIM_FLAGS) \

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,15 @@
 # On 32-bit targets the Nim compiler is itself a 32-bit process capped at ~3 GB
 # of address space; the unsharded TU overran that on orc. Two slices halve the
 # memory footprint enough to fit, and the overhead is small on 64-bit targets.
+# Number of test binaries to compile and run concurrently; 1 keeps `make test`
+# serial. CI raises it, using fewer lanes on 32-bit to stay under the ~3 GB cap.
+TEST_JOBS ?= 1
+
 TEST_ALL_SLICES ?= 2
 TEST_ALL_SLICE_IDS := $(shell seq 0 $$(( $(TEST_ALL_SLICES) - 1 )))
 TEST_ALL_SLICE_TARGETS := $(addprefix _test_all_slice_,$(TEST_ALL_SLICE_IDS))
 
-.PHONY: all build deps cbind clean test _test_all $(TEST_ALL_SLICE_TARGETS) \
+.PHONY: all build deps cbind clean test _run_all_tests $(TEST_ALL_SLICE_TARGETS) \
         test_multiformat_exts test_integration \
         install_pinned pin unpin gen_multicodec format clean-nim nat_libs nat_pkg_dir_check
 
@@ -139,8 +143,7 @@ $(NAT_LIBS_STAMP): | nat_pkg_dir_check
 
 test: nimble.paths nat_libs
 ifeq ($(TEST_PATH),)
-	$(MAKE) _test_all
-	$(MAKE) test_multiformat_exts
+	$(MAKE) -j$(TEST_JOBS) _run_all_tests
 else
 	$(NIMC) c $(NIM_FLAGS) \
 	  $(if $(CICOV),--nimcache:nimcache/test_all,) \
@@ -149,11 +152,12 @@ else
 	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
 endif
 
-_test_all: $(TEST_ALL_SLICE_TARGETS)
+_run_all_tests: $(TEST_ALL_SLICE_TARGETS) test_multiformat_exts
 
+# Per-target nimcache, always: concurrent compiles must not share one.
 $(TEST_ALL_SLICE_TARGETS): _test_all_slice_%: nimble.paths nat_libs
 	$(NIMC) c $(NIM_FLAGS) \
-	  $(if $(CICOV),--nimcache:nimcache/test_all_$*,) \
+	  --nimcache:nimcache/test_all_$* \
 	  -d:sliceTotal=$(TEST_ALL_SLICES) \
 	  -d:sliceIdx=$* \
 	  -o:tests/test_all_$* \
@@ -162,7 +166,7 @@ $(TEST_ALL_SLICE_TARGETS): _test_all_slice_%: nimble.paths nat_libs
 
 test_multiformat_exts: nimble.paths nat_libs
 	$(NIMC) c $(NIM_FLAGS) \
-	  $(if $(CICOV),--nimcache:nimcache/test_all_multiformat,) \
+	  --nimcache:nimcache/test_all_multiformat \
 	  -d:libp2p_multicodec_exts=../tests/libp2p/multiformat_exts/multicodec_exts.nim \
 	  -d:libp2p_multiaddress_exts=../tests/libp2p/multiformat_exts/multiaddress_exts.nim \
 	  -d:libp2p_multihash_exts=../tests/libp2p/multiformat_exts/multihash_exts.nim \


### PR DESCRIPTION
## Summary

`make test` built and ran the `test_all` slices and `test_multiformat_exts` strictly serially, which dominated CI wall-clock time. This adds a `TEST_JOBS` knob so the independent test binaries are **run** concurrently via `make -j`, while compilation stays serial.

- `TEST_JOBS ?= 1` keeps local `make test` serial by default; CI sets it to 3.
- `test` now compiles all slices serially (`compile_tests`) and then runs the resulting binaries under `make -j$(TEST_JOBS)` (`run_tests`).
- Compilation is intentionally left serial: a single `nim c` already parallelizes its C backend across all cores, so compiling slices concurrently mostly oversubscribes the C compiler while multiplying peak memory.
- Per-slice `--nimcache` is now unconditional (previously gated behind `CICOV`) so each binary keeps its own cache and coverage `.gcda` files stay isolated.

## Affected Areas

- [x] Build / Tooling
  Makefile test targets and the CI/coverage/daily workflows.

## Compatibility & Downstream Validation

N/A — CI/build-tooling only; no library code changes, so downstream builds are unaffected.

## Impact on Library Users

No impact. Internal build/CI change only; no API or behavior changes to the library.

## Risk Assessment

- Compilation stays serial, so the 32-bit ~3 GB compiler address-space limit is unaffected by this change.
- Main risk is runtime contention: under `make -j` multiple test binaries run concurrently, so tests that bind fixed ports or share fixtures could flake under load. Local `make test` stays serial (`TEST_JOBS=1`) by default.

## References

N/A
