### PR TITLE
feat(ci): speed up Windows test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,14 @@ jobs:
         with:
           submodules: true
 
+      - name: Exclude workspace from Defender (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+          Add-MpPreference -ExclusionPath "$Env:RUNNER_TEMP"
+
       - name: Select Nimble version
         if: matrix.nim.nimble_commit != ''
         shell: bash
@@ -183,6 +191,13 @@ jobs:
           if [[ '${{ matrix.platform.cpu }}' == 'i386' ]]; then
             TEST_JOBS=2
           fi
+
+          # Total C-compiler concurrency is TEST_JOBS * parallelBuild; split ncpu
+          # across the lanes so the product stays near ncpu instead of squaring it.
+          ncpu=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
+          PARALLEL_BUILD=$(( ncpu / TEST_JOBS ))
+          [[ $PARALLEL_BUILD -lt 1 ]] && PARALLEL_BUILD=1
+          export NIMFLAGS="${NIMFLAGS} --parallelBuild:$PARALLEL_BUILD"
           make TEST_JOBS=$TEST_JOBS test
 
       - name: Fix xml newlines

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,14 @@ jobs:
           if [[ '${{ matrix.platform.cc }}' == 'clang' ]]; then
             export NIMFLAGS="${NIMFLAGS} --cc:clang"
           fi
-          make test
+
+          # Build/run test binaries concurrently; fewer lanes on 32-bit to stay
+          # under the ~3 GB address cap.
+          TEST_JOBS=3
+          if [[ '${{ matrix.platform.cpu }}' == 'i386' ]]; then
+            TEST_JOBS=2
+          fi
+          make TEST_JOBS=$TEST_JOBS test
 
       - name: Fix xml newlines
         if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,7 +56,10 @@ jobs:
       - name: Run test suite with coverage flags
         run: |
           export NIMFLAGS="--lineDir:on --passC:-fprofile-arcs --passC:-ftest-coverage --passL:-fprofile-arcs --passL:-ftest-coverage"
-          make test
+          # amd64 (64-bit): compile and run the test binaries concurrently. Each
+          # binary keeps its own nimcache, so the per-source .gcda files stay
+          # isolated and lcov still captures all of nimcache/ recursively.
+          make TEST_JOBS=3 test
 
       - name: Run coverage
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -56,10 +56,15 @@ jobs:
       - name: Run test suite with coverage flags
         run: |
           export NIMFLAGS="--lineDir:on --passC:-fprofile-arcs --passC:-ftest-coverage --passL:-fprofile-arcs --passL:-ftest-coverage"
-          # amd64 (64-bit): compile and run the test binaries concurrently. Each
-          # binary keeps its own nimcache, so the per-source .gcda files stay
-          # isolated and lcov still captures all of nimcache/ recursively.
-          make TEST_JOBS=3 test
+          # Run the test binaries concurrently; per-target nimcache keeps each
+          # source's .gcda isolated and lcov still captures nimcache/ recursively.
+          # Split ncpu across the lanes so the compilers don't oversubscribe.
+          TEST_JOBS=3
+          ncpu=$(nproc 2>/dev/null || echo 1)
+          PARALLEL_BUILD=$(( ncpu / TEST_JOBS ))
+          [[ $PARALLEL_BUILD -lt 1 ]] && PARALLEL_BUILD=1
+          export NIMFLAGS="${NIMFLAGS} --parallelBuild:$PARALLEL_BUILD"
+          make TEST_JOBS=$TEST_JOBS test
 
       - name: Run coverage
         run: |

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -180,7 +180,14 @@ jobs:
             export NIMFLAGS="${NIMFLAGS} --cc:clang"
           fi
           export NIMFLAGS="${NIMFLAGS} -d:chronicles_log_level=DEBUG"
-          make test
+
+          # Build/run test binaries concurrently; fewer lanes on 32-bit to stay
+          # under the ~3 GB address cap.
+          TEST_JOBS=3
+          if [[ '${{ matrix.config.cpu }}' == 'i386' ]]; then
+            TEST_JOBS=2
+          fi
+          make TEST_JOBS=$TEST_JOBS test
 
       - name: Run integration tests
         if: ${{ matrix.config.os == 'linux' && matrix.config.cpu == 'amd64' }}

--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -93,6 +93,14 @@ jobs:
         with:
           submodules: true
 
+      - name: Exclude workspace from Defender (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+          Add-MpPreference -ExclusionPath "$Env:RUNNER_TEMP"
+
       - name: Setup Nim
         uses: "./.github/actions/install_nim"
         with:
@@ -187,6 +195,13 @@ jobs:
           if [[ '${{ matrix.config.cpu }}' == 'i386' ]]; then
             TEST_JOBS=2
           fi
+
+          # Total C-compiler concurrency is TEST_JOBS * parallelBuild; split ncpu
+          # across the lanes so the product stays near ncpu instead of squaring it.
+          ncpu=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
+          PARALLEL_BUILD=$(( ncpu / TEST_JOBS ))
+          [[ $PARALLEL_BUILD -lt 1 ]] && PARALLEL_BUILD=1
+          export NIMFLAGS="${NIMFLAGS} --parallelBuild:$PARALLEL_BUILD"
           make TEST_JOBS=$TEST_JOBS test
 
       - name: Run integration tests

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,15 @@
 # On 32-bit targets the Nim compiler is itself a 32-bit process capped at ~3 GB
 # of address space; the unsharded TU overran that on orc. Two slices halve the
 # memory footprint enough to fit, and the overhead is small on 64-bit targets.
-# Number of test binaries to compile and run concurrently; 1 keeps `make test`
-# serial. CI raises it, using fewer lanes on 32-bit to stay under the ~3 GB cap.
+TEST_ALL_SLICES ?= 2
+
+# Test binaries to compile and run concurrently; 1 keeps `make test` serial.
 TEST_JOBS ?= 1
 
-TEST_ALL_SLICES ?= 2
 TEST_ALL_SLICE_IDS := $(shell seq 0 $$(( $(TEST_ALL_SLICES) - 1 )))
 TEST_ALL_SLICE_TARGETS := $(addprefix _test_all_slice_,$(TEST_ALL_SLICE_IDS))
 
-.PHONY: all build deps cbind clean test _run_all_tests $(TEST_ALL_SLICE_TARGETS) \
+.PHONY: all build deps cbind clean test _test_all $(TEST_ALL_SLICE_TARGETS) \
         test_multiformat_exts test_integration \
         install_pinned pin unpin gen_multicodec format clean-nim nat_libs nat_pkg_dir_check
 
@@ -143,7 +143,7 @@ $(NAT_LIBS_STAMP): | nat_pkg_dir_check
 
 test: nimble.paths nat_libs
 ifeq ($(TEST_PATH),)
-	$(MAKE) -j$(TEST_JOBS) _run_all_tests
+	$(MAKE) -j$(TEST_JOBS) _test_all
 else
 	$(NIMC) c $(NIM_FLAGS) \
 	  $(if $(CICOV),--nimcache:nimcache/test_all,) \
@@ -152,7 +152,7 @@ else
 	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
 endif
 
-_run_all_tests: $(TEST_ALL_SLICE_TARGETS) test_multiformat_exts
+_test_all: $(TEST_ALL_SLICE_TARGETS) test_multiformat_exts
 
 # Per-target nimcache, always: concurrent compiles must not share one.
 $(TEST_ALL_SLICE_TARGETS): _test_all_slice_%: nimble.paths nat_libs

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,15 @@
 # On 32-bit targets the Nim compiler is itself a 32-bit process capped at ~3 GB
 # of address space; the unsharded TU overran that on orc. Two slices halve the
 # memory footprint enough to fit, and the overhead is small on 64-bit targets.
+# Number of test binaries to compile and run concurrently; 1 keeps `make test`
+# serial. CI raises it, using fewer lanes on 32-bit to stay under the ~3 GB cap.
+TEST_JOBS ?= 1
+
 TEST_ALL_SLICES ?= 2
 TEST_ALL_SLICE_IDS := $(shell seq 0 $$(( $(TEST_ALL_SLICES) - 1 )))
 TEST_ALL_SLICE_TARGETS := $(addprefix _test_all_slice_,$(TEST_ALL_SLICE_IDS))
 
-.PHONY: all build deps cbind clean test _test_all $(TEST_ALL_SLICE_TARGETS) \
+.PHONY: all build deps cbind clean test _run_all_tests $(TEST_ALL_SLICE_TARGETS) \
         test_multiformat_exts test_integration \
         install_pinned pin unpin gen_multicodec format clean-nim nat_libs nat_pkg_dir_check
 
@@ -139,8 +143,7 @@ $(NAT_LIBS_STAMP): | nat_pkg_dir_check
 
 test: nimble.paths nat_libs
 ifeq ($(TEST_PATH),)
-	$(MAKE) _test_all
-	$(MAKE) test_multiformat_exts
+	$(MAKE) -j$(TEST_JOBS) _run_all_tests
 else
 	$(NIMC) c $(NIM_FLAGS) \
 	  $(if $(CICOV),--nimcache:nimcache/test_all,) \
@@ -149,11 +152,12 @@ else
 	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
 endif
 
-_test_all: $(TEST_ALL_SLICE_TARGETS)
+_run_all_tests: $(TEST_ALL_SLICE_TARGETS) test_multiformat_exts
 
+# Per-target nimcache, always: concurrent compiles must not share one.
 $(TEST_ALL_SLICE_TARGETS): _test_all_slice_%: nimble.paths nat_libs
 	$(NIMC) c $(NIM_FLAGS) \
-	  $(if $(CICOV),--nimcache:nimcache/test_all_$*,) \
+	  --nimcache:nimcache/test_all_$* \
 	  -d:sliceTotal=$(TEST_ALL_SLICES) \
 	  -d:sliceIdx=$* \
 	  -o:tests/test_all_$* \
@@ -162,7 +166,7 @@ $(TEST_ALL_SLICE_TARGETS): _test_all_slice_%: nimble.paths nat_libs
 
 test_multiformat_exts: nimble.paths nat_libs
 	$(NIMC) c $(NIM_FLAGS) \
-	  $(if $(CICOV),--nimcache:nimcache/test_all_multiformat,) \
+	  --nimcache:nimcache/test_all_multiformat \
 	  -d:libp2p_multicodec_exts=../tests/libp2p/multiformat_exts/multicodec_exts.nim \
 	  -d:libp2p_multiaddress_exts=../tests/libp2p/multiformat_exts/multiaddress_exts.nim \
 	  -d:libp2p_multihash_exts=../tests/libp2p/multiformat_exts/multihash_exts.nim \


### PR DESCRIPTION
## Summary

Two low-risk changes to cut Windows CI wall-clock time. Stacked on
`feat/ci/parallelize-tests` (the `TEST_JOBS` parallelization this builds on).

- **Defender exclusion (Windows only):** a new step right after `Checkout`
  excludes `${{ github.workspace }}` and `$RUNNER_TEMP` from Windows Defender
  real-time scanning. The C backend emits a large number of object/`.exe`
  files; AV scanning each one is a Windows-only per-file tax. `continue-on-error`
  so a Defender/policy hiccup can't fail the job.
- **Cap `--parallelBuild`:** with `TEST_JOBS=3`, three Nim processes run
  concurrently, and each defaults `--parallelBuild` to `ncpu` — up to
  `3 × ncpu` concurrent C compilers, which oversubscribes the runner (worst on
  Windows, where process spawn + AV are expensive). The `Run tests` step now
  sets `--parallelBuild = ncpu / TEST_JOBS` (min 1) via `NIMFLAGS`, so total
  compiler concurrency stays near `ncpu`.

## Affected Areas

- [x] Build / Tooling
  `.github/workflows/ci.yml` and `.github/workflows/daily_common.yml`.

## Impact on Library Users

No impact — CI-only change. No library code, no API or behavior changes.

## Risk Assessment

- The `parallelBuild` cap applies on all platforms; it reduces oversubscription
  everywhere and only lowers per-process fan-out, so worst case it's neutral.
- `ncpu` is already exported to `$GITHUB_ENV` by the `install_nim` action's
  "Derive environment variables" step, so it's in scope in `Run tests`.
- Defender step is Windows-gated and `continue-on-error`, so it cannot break
  non-Windows jobs or fail a job if the cmdlet is unavailable.
- `NIMFLAGS` flows into the build via `$(NIMFLAGS)` in the Makefile — no
  Makefile change. Verified `--parallelBuild` is a valid Nim flag and reaches
  the `nim c` line.

## References

Builds on `feat/ci/parallelize-tests` (#2653).