### PR TITLE
chore(deps): Bump `protobuf_serialization` to v0.5.3

### DIFF
--- a/.pinned
+++ b/.pinned
@@ -16,6 +16,6 @@ testutils;https://github.com/status-im/nim-testutils@#e85cb6ff9c328a6e12441e81ff
 unittest2;https://github.com/status-im/nim-unittest2@#26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189
 websock;https://github.com/status-im/nim-websock@#387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d
 zlib;https://github.com/status-im/nim-zlib@#e680f269fb01af2c34a2ba879ff281795a5258fe
-protobuf_serialization;https://github.com/status-im/nim-protobuf-serialization@#f45476a3c1f4e7bff73845e6450d686be040ddeb
+protobuf_serialization;https://github.com/nitely/nim-protobuf-serialization@#bbbd902d046126d077800dbbaac76f76fdcd5597
 nat_traversal;https://github.com/status-im/nim-nat-traversal@#860e18c37667b5dd005b94c63264560c35d88004
 npeg;https://github.com/zevv/npeg@#409f6796d0e880b3f0222c964d1da7de6e450811

--- a/.pinned
+++ b/.pinned
@@ -16,6 +16,6 @@ testutils;https://github.com/status-im/nim-testutils@#e85cb6ff9c328a6e12441e81ff
 unittest2;https://github.com/status-im/nim-unittest2@#26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189
 websock;https://github.com/status-im/nim-websock@#387a8eb7e961e8fdd3b1a717d36bc53b55e4dc5d
 zlib;https://github.com/status-im/nim-zlib@#e680f269fb01af2c34a2ba879ff281795a5258fe
-protobuf_serialization;https://github.com/nitely/nim-protobuf-serialization@#bbbd902d046126d077800dbbaac76f76fdcd5597
+protobuf_serialization;https://github.com/status-im/nim-protobuf-serialization@#8406e7287196661614ce6a8e8be20f755376af7f
 nat_traversal;https://github.com/status-im/nim-nat-traversal@#860e18c37667b5dd005b94c63264560c35d88004
 npeg;https://github.com/zevv/npeg@#409f6796d0e880b3f0222c964d1da7de6e450811

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -12,8 +12,7 @@ requires "nim >= 2.2.4",
   "nimcrypto >= 0.6.0", "bearssl >= 0.2.7",
   "https://github.com/vacp2p/nim-boringssl >= 0.0.8", "chronicles >= 0.11.0",
   "chronos >= 4.2.2", "metrics >= 0.2.2", "secp256k1", "stew >= 0.4.2", "unittest2",
-  # XXX undo
-  "results", "serialization", "lsquic >= 0.5.1", "protobuf_serialization == 0.4.0",
+  "results", "serialization", "lsquic >= 0.5.1", "protobuf_serialization >= 0.5.0",
   "https://github.com/status-im/nim-websock >= 0.4.0",
   "https://github.com/status-im/nim-nat-traversal >= 0.0.1"
 

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -12,7 +12,8 @@ requires "nim >= 2.2.4",
   "nimcrypto >= 0.6.0", "bearssl >= 0.2.7",
   "https://github.com/vacp2p/nim-boringssl >= 0.0.8", "chronicles >= 0.11.0",
   "chronos >= 4.2.2", "metrics >= 0.2.2", "secp256k1", "stew >= 0.4.2", "unittest2",
-  "results", "serialization", "lsquic >= 0.5.1", "protobuf_serialization >= 0.5.0",
+  # XXX undo
+  "results", "serialization", "lsquic >= 0.5.1", "protobuf_serialization == 0.4.0",
   "https://github.com/status-im/nim-websock >= 0.4.0",
   "https://github.com/status-im/nim-nat-traversal >= 0.0.1"
 

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -12,7 +12,7 @@ requires "nim >= 2.2.4",
   "nimcrypto >= 0.6.0", "bearssl >= 0.2.7",
   "https://github.com/vacp2p/nim-boringssl >= 0.0.8", "chronicles >= 0.11.0",
   "chronos >= 4.2.2", "metrics >= 0.2.2", "secp256k1", "stew >= 0.4.2", "unittest2",
-  "results", "serialization", "lsquic >= 0.5.1", "protobuf_serialization >= 0.5.0",
+  "results", "serialization", "lsquic >= 0.5.1", "protobuf_serialization >= 0.5.3",
   "https://github.com/status-im/nim-websock >= 0.4.0",
   "https://github.com/status-im/nim-nat-traversal >= 0.0.1"
 

--- a/libp2p/crypto/crypto.nim
+++ b/libp2p/crypto/crypto.nim
@@ -1007,7 +1007,7 @@ proc getField*(pb: ProtoBuffer, field: int, value: var Signature): ProtoResult[b
 
 ## protobuf_serialization extension
 
-Protobuf.extensionDefaults(PublicKey, packed = false)
+Protobuf.extensionDefaults(PublicKey, pbytes)
 
 func computeFieldSize*(
     field: int, value: PublicKey, ProtoType: type ProtobufExt, skipDefault: static bool
@@ -1042,7 +1042,7 @@ proc readFieldInto*(
 
   false
 
-Protobuf.extensionDefaults(Signature, packed = false)
+Protobuf.extensionDefaults(Signature, pbytes)
 
 func computeFieldSize*(
     field: int, value: Signature, ProtoType: type ProtobufExt, skipDefault: static bool

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -1332,7 +1332,7 @@ func shortLog*(addrs: seq[MultiAddress], maxAddrs: int): string =
 
 ## protobuf_serialization extension
 
-Protobuf.extensionDefaults(MultiAddress, defaultWriteSeq = true, packed = false)
+Protobuf.extensionDefaults(MultiAddress, pbytes, defaultWriteSeq = true)
 
 func computeFieldSize*(
     field: int,

--- a/libp2p/peerid.nim
+++ b/libp2p/peerid.nim
@@ -287,7 +287,7 @@ func getField*(pb: ProtoBuffer, field: int, pid: var PeerId): ProtoResult[bool] 
 
 ## protobuf_serialization extension
 
-Protobuf.extensionDefaults(PeerId, defaultSeq = true, packed = false)
+Protobuf.extensionDefaults(PeerId, pbytes, defaultSeq = true)
 
 func computeFieldSize*(
     field: int, value: PeerId, ProtoType: type ProtobufExt, skipDefault: static bool

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -83,7 +83,7 @@ proc updateShortlist*(state: LookupState, msg: Message): seq[PeerInfo] {.raises:
       continue
 
     state.shortlist[pid] = dist
-    newPeerInfos.add(PeerInfo(peerId: pid, addrs: newPeer.addrs.get(@[])))
+    newPeerInfos.add(PeerInfo(peerId: pid, addrs: newPeer.addrs))
 
   return newPeerInfos
 

--- a/libp2p/protocols/kademlia/protobuf.nim
+++ b/libp2p/protocols/kademlia/protobuf.nim
@@ -37,7 +37,7 @@ type
 
   Peer* {.proto2.} = object
     id* {.fieldNumber: 1.}: Opt[seq[byte]]
-    addrs* {.fieldNumber: 2, ext.}: Opt[seq[MultiAddress]]
+    addrs* {.fieldNumber: 2, ext.}: seq[MultiAddress]
     connection* {.fieldNumber: 3, ext.}: Opt[ConnectionStatus]
 
   # Registration status for Service Discovery

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -80,7 +80,7 @@ proc toPeer*(k: Key, switch: Switch): Result[Peer, string] =
   ok(
     Peer(
       id: Opt.some(peer.getBytes()),
-      addrs: Opt.some(addrs),
+      addrs: addrs,
       connection: Opt.none(ConnectionStatus),
     )
   )
@@ -88,7 +88,7 @@ proc toPeer*(k: Key, switch: Switch): Result[Peer, string] =
 proc toPeer*(peerInfo: PeerInfo): Peer =
   Peer(
     id: Opt.some(peerInfo.peerId.getBytes()),
-    addrs: Opt.some(peerInfo.addrs),
+    addrs: peerInfo.addrs,
     connection: Opt.none(ConnectionStatus),
   )
 

--- a/libp2p/protocols/service_discovery/types.nim
+++ b/libp2p/protocols/service_discovery/types.nim
@@ -261,7 +261,7 @@ proc toPeerInfos*(peers: seq[Peer]): seq[PeerInfo] =
     let pid = PeerId.init(raw).valueOr:
       continue
 
-    let peerInfo = PeerInfo(peerId: pid, addrs: p.addrs.get(@[]))
+    let peerInfo = PeerInfo(peerId: pid, addrs: p.addrs)
 
     peerInfos.add(peerInfo)
 

--- a/libp2p/utils/protobuf_chronos_sec.nim
+++ b/libp2p/utils/protobuf_chronos_sec.nim
@@ -35,17 +35,12 @@ proc readFieldInto*(
     false
 
 func computeFieldSizePacked*(
-    field: int,
-    value: Duration,
-    ProtoType: type ProtobufExt
+    field: int, value: Duration, ProtoType: type ProtobufExt
 ): int =
   computeFieldSizePackedIt(field, value, pint64, it.seconds)
 
 proc writeFieldPacked*(
-    stream: OutputStream,
-    field: int,
-    value: Duration,
-    ProtoType: type ProtobufExt
+    stream: OutputStream, field: int, value: Duration, ProtoType: type ProtobufExt
 ) {.raises: [IOError].} =
   writeFieldPackedIt(stream, field, value, pint64, it.seconds)
 
@@ -53,7 +48,7 @@ proc readFieldPackedInto*(
     stream: InputStream,
     value: var Duration,
     header: FieldHeader,
-    ProtoType: type ProtobufExt
+    ProtoType: type ProtobufExt,
 ): bool {.raises: [SerializationError, IOError].} =
   readFieldPackedIntoIt(stream, value, header, pint64):
     value.add it.seconds
@@ -87,17 +82,12 @@ proc readFieldInto*(
     false
 
 func computeFieldSizePacked*(
-    field: int,
-    value: Moment,
-    ProtoType: type ProtobufExt
+    field: int, value: Moment, ProtoType: type ProtobufExt
 ): int =
   computeFieldSizePackedIt(field, value, pint64, it.epochSeconds())
 
 proc writeFieldPacked*(
-    stream: OutputStream,
-    field: int,
-    value: Moment,
-    ProtoType: type ProtobufExt
+    stream: OutputStream, field: int, value: Moment, ProtoType: type ProtobufExt
 ) {.raises: [IOError].} =
   writeFieldPackedIt(stream, field, value, pint64, it.epochSeconds())
 
@@ -105,7 +95,7 @@ proc readFieldPackedInto*(
     stream: InputStream,
     value: var Moment,
     header: FieldHeader,
-    ProtoType: type ProtobufExt
+    ProtoType: type ProtobufExt,
 ): bool {.raises: [SerializationError, IOError].} =
   readFieldPackedIntoIt(stream, value, header, pint64):
     value.add Moment.init(it, Second)

--- a/libp2p/utils/protobuf_chronos_sec.nim
+++ b/libp2p/utils/protobuf_chronos_sec.nim
@@ -35,18 +35,18 @@ proc readFieldInto*(
     false
 
 func computeFieldSizePacked*(
-    field: int, value: Duration, ProtoType: type ProtobufExt
+    field: int, value: seq[Duration], ProtoType: type ProtobufExt
 ): int =
   computeFieldSizePackedIt(field, value, pint64, it.seconds)
 
 proc writeFieldPacked*(
-    stream: OutputStream, field: int, value: Duration, ProtoType: type ProtobufExt
+    stream: OutputStream, field: int, value: seq[Duration], ProtoType: type ProtobufExt
 ) {.raises: [IOError].} =
   writeFieldPackedIt(stream, field, value, pint64, it.seconds)
 
 proc readFieldPackedInto*(
     stream: InputStream,
-    value: var Duration,
+    value: var seq[Duration],
     header: FieldHeader,
     ProtoType: type ProtobufExt,
 ): bool {.raises: [SerializationError, IOError].} =
@@ -82,18 +82,18 @@ proc readFieldInto*(
     false
 
 func computeFieldSizePacked*(
-    field: int, value: Moment, ProtoType: type ProtobufExt
+    field: int, value: seq[Moment], ProtoType: type ProtobufExt
 ): int =
   computeFieldSizePackedIt(field, value, pint64, it.epochSeconds())
 
 proc writeFieldPacked*(
-    stream: OutputStream, field: int, value: Moment, ProtoType: type ProtobufExt
+    stream: OutputStream, field: int, value: seq[Moment], ProtoType: type ProtobufExt
 ) {.raises: [IOError].} =
   writeFieldPackedIt(stream, field, value, pint64, it.epochSeconds())
 
 proc readFieldPackedInto*(
     stream: InputStream,
-    value: var Moment,
+    value: var seq[Moment],
     header: FieldHeader,
     ProtoType: type ProtobufExt,
 ): bool {.raises: [SerializationError, IOError].} =

--- a/libp2p/utils/protobuf_chronos_sec.nim
+++ b/libp2p/utils/protobuf_chronos_sec.nim
@@ -5,7 +5,7 @@
 
 import chronos, protobuf_serialization, protobuf_serialization/extension
 
-Protobuf.extensionDefaults(Duration, defaultSeq = true)
+Protobuf.extensionDefaults(Duration, pint64, defaultSeq = true)
 
 func computeFieldSize*(
     field: int, value: Duration, ProtoType: type ProtobufExt, skipDefault: static bool
@@ -34,7 +34,31 @@ proc readFieldInto*(
   else:
     false
 
-Protobuf.extensionDefaults(Moment, defaultSeq = true)
+func computeFieldSizePacked*(
+    field: int,
+    value: Duration,
+    ProtoType: type ProtobufExt
+): int =
+  computeFieldSizePackedIt(field, value, pint64, it.seconds)
+
+proc writeFieldPacked*(
+    stream: OutputStream,
+    field: int,
+    value: Duration,
+    ProtoType: type ProtobufExt
+) {.raises: [IOError].} =
+  writeFieldPackedIt(stream, field, value, pint64, it.seconds)
+
+proc readFieldPackedInto*(
+    stream: InputStream,
+    value: var Duration,
+    header: FieldHeader,
+    ProtoType: type ProtobufExt
+): bool {.raises: [SerializationError, IOError].} =
+  readFieldPackedIntoIt(stream, value, header, pint64):
+    value.add it.seconds
+
+Protobuf.extensionDefaults(Moment, pint64, defaultSeq = true)
 
 func computeFieldSize*(
     field: int, value: Moment, ProtoType: type ProtobufExt, skipDefault: static bool
@@ -61,3 +85,27 @@ proc readFieldInto*(
     return true
   else:
     false
+
+func computeFieldSizePacked*(
+    field: int,
+    value: Moment,
+    ProtoType: type ProtobufExt
+): int =
+  computeFieldSizePackedIt(field, value, pint64, it.epochSeconds())
+
+proc writeFieldPacked*(
+    stream: OutputStream,
+    field: int,
+    value: Moment,
+    ProtoType: type ProtobufExt
+) {.raises: [IOError].} =
+  writeFieldPackedIt(stream, field, value, pint64, it.epochSeconds())
+
+proc readFieldPackedInto*(
+    stream: InputStream,
+    value: var Moment,
+    header: FieldHeader,
+    ProtoType: type ProtobufExt
+): bool {.raises: [SerializationError, IOError].} =
+  readFieldPackedIntoIt(stream, value, header, pint64):
+    value.add Moment.init(it, Second)

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -103,8 +103,8 @@
 
   protobuf_serialization = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-protobuf-serialization";
-    rev = "f45476a3c1f4e7bff73845e6450d686be040ddeb";
-    sha256 = "1b4cnlkqlmnhx5gd4smiz4xwaj2zmyccc2q20r26gcqfiyp9na0v";
+    rev = "8406e7287196661614ce6a8e8be20f755376af7f";
+    sha256 = "0lb4756a77vr1x1khy3dxl97kyxy7w09ap92ylkkgjp093dic59k";
     fetchSubmodules = true;
   };
 

--- a/tests/libp2p/kademlia/test_add_provider.nim
+++ b/tests/libp2p/kademlia/test_add_provider.nim
@@ -340,7 +340,7 @@ suite "KadDHT - Add Provider":
       # Provider with empty addresses
       providerWithNoAddrs = Peer(
         id: senderKad.switch.peerInfo.peerId.getBytes(),
-        addrs: Opt.none(seq[MultiAddress]),
+        addrs: @[],
         connection: ConnectionStatus.connected,
       )
     receiverKad.handleAddProviderMessage = Opt.some(
@@ -357,7 +357,7 @@ suite "KadDHT - Add Provider":
       receiverKad.providerManager.providerRecords.len == 1
       receiverKad.providerManager.providerRecords[0].provider.id.get() ==
         senderKad.switch.peerInfo.peerId.getBytes()
-      receiverKad.providerManager.providerRecords[0].provider.addrs.isNone
+      receiverKad.providerManager.providerRecords[0].provider.addrs.len == 0
 
   asyncTest "Add provider includes local multiaddresses":
     let kads = setupKadSwitches(2)
@@ -384,7 +384,7 @@ suite "KadDHT - Add Provider":
     let storedProvider = kads[0].providerManager.providerRecords[0].provider
     check:
       storedProvider.id.get() == kads[1].rtable.selfId
-      storedProvider.addrs.get() == kads[1].switch.peerInfo.addrs
+      storedProvider.addrs == kads[1].switch.peerInfo.addrs
 
   asyncTest "Add provider completes when some peers fail":
     let kads = setupKadSwitches(3)

--- a/tests/libp2p/kademlia/test_encoding.nim
+++ b/tests/libp2p/kademlia/test_encoding.nim
@@ -37,11 +37,7 @@ suite "KadDHT Protobuffers":
     check msg == Message.decode(msg.encode(hideConnectionStatus = false)).get()
 
   test "peer with empty addr list and no connection":
-    let peer = Peer(
-      id: @[0x42'u8],
-      addrs: @[],
-      connection: Opt.none(ConnectionStatus),
-    )
+    let peer = Peer(id: @[0x42'u8], addrs: @[], connection: Opt.none(ConnectionStatus))
     let encoded = peer.encode()
     let decoded = Peer.decode(encoded).get()
     check:

--- a/tests/libp2p/kademlia/test_encoding.nim
+++ b/tests/libp2p/kademlia/test_encoding.nim
@@ -39,7 +39,7 @@ suite "KadDHT Protobuffers":
   test "peer with empty addr list and no connection":
     let peer = Peer(
       id: @[0x42'u8],
-      addrs: Opt.none(seq[MultiAddress]),
+      addrs: @[],
       connection: Opt.none(ConnectionStatus),
     )
     let encoded = peer.encode()

--- a/tests/libp2p/kademlia/test_limits.nim
+++ b/tests/libp2p/kademlia/test_limits.nim
@@ -25,7 +25,7 @@ suite "KadDHT - Limits":
     # Generate 20 fresh peers and feed them through updateShortlist.
     var peers: seq[Peer]
     for i in 0 ..< 20:
-      peers.add(Peer(id: randomPeerId().toKey(), addrs: Opt.none(seq[MultiAddress])))
+      peers.add(Peer(id: randomPeerId().toKey(), addrs: @[]))
 
     let msg = Message(msgType: MessageType.findNode, closerPeers: peers)
     discard state.updateShortlist(msg)


### PR DESCRIPTION
Protobuf changes:

- Adds `extensionDefaults` taking the underlying proto type, and deprecates the one with the packed param; the proto type is used to decide if the field is packed. This forces the user to implement packed procs when needed.
- Validates Opt[seq[T]] where [T: not byte] is not allowed.

libp2p changes:

- Adds missing packed handling for chronos type extensions
- Changes one kademlia field from Opt[seq] to seq.
- Bump `protobuf_serialization >= 0.5.3`