### PR TITLE
fix(pubsub): peerEventHandler to unsubscribe peer only on left event

### DIFF
--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -742,10 +742,14 @@ proc init*[PubParams: object | bool](
   proc peerEventHandler(
       peerId: PeerId, event: PeerEvent
   ) {.async: (raises: [CancelledError]).} =
-    if event.kind == PeerEventKind.Joined:
+    case event.kind
+    of PeerEventKind.Joined:
       pubsub.subscribePeer(peerId)
-    else:
+    of PeerEventKind.Left:
       pubsub.unsubscribePeer(peerId)
+    of PeerEventKind.Identified:
+      # Identified events are handled by IdentifyPusher service
+      discard
 
   switch.addPeerEventHandler(peerEventHandler, PeerEventKind.Joined)
   switch.addPeerEventHandler(peerEventHandler, PeerEventKind.Left)


### PR DESCRIPTION
should not unsubscribe for `Identified` event