### PR TITLE
feat(cbind): user-provided XPRs

### DIFF
--- a/cbind/examples/cbindings.c
+++ b/cbind/examples/cbindings.c
@@ -60,6 +60,9 @@ static void create_cid_handler(int callerRet, const char *msg, size_t len,
                                void *userData);
 static void read_handler(int callerRet, const uint8_t *data, size_t dataLen,
                          const char *msg, size_t len, void *userData);
+static void create_xpr_handler(int callerRet, const uint8_t *data,
+                               size_t dataLen, const char *msg, size_t len,
+                               void *userData);
 static void print_bytes(const char *label, const uint8_t *data, size_t dataLen);
 
 // libp2p Context
@@ -232,6 +235,20 @@ int main(int argc, char **argv) {
   waitForCallback();
 
   libp2p_kad_get_providers(ctx2, cid, get_providers_handler, NULL);
+  waitForCallback();
+
+  // Build and sign node1's own Extended Peer Record for two services.
+  // NULL addrs uses node1's listen addresses; signed bytes come via the
+  // callback.
+  const uint8_t chat_data[] = {0x01, 0x02, 0x03};
+  Libp2pServiceInfo xpr_services[] = {
+      {.id = (char *)"chat", .data = chat_data, .dataLen = sizeof(chat_data)},
+      {.id = (char *)"file-share", .data = NULL, .dataLen = 0},
+  };
+  printf("Creating signed XPR for node1:\n");
+  libp2p_create_xpr(ctx1, NULL, 0, xpr_services,
+                    sizeof(xpr_services) / sizeof(xpr_services[0]), 0,
+                    create_xpr_handler, NULL);
   waitForCallback();
 
   // Peerstore operations
@@ -572,6 +589,20 @@ static void read_handler(int callerRet, const uint8_t *data, size_t dataLen,
   callback_executed = 1;
   pthread_cond_signal(&cond);
   pthread_mutex_unlock(&mutex);
+}
+
+static void create_xpr_handler(int callerRet, const uint8_t *data,
+                               size_t dataLen, const char *msg, size_t len,
+                               void *userData) {
+  if (callerRet != RET_OK) {
+    printf("Create XPR error(%d): %.*s\n", callerRet, (int)len,
+           msg != NULL ? msg : "");
+    exit(1);
+  }
+
+  print_bytes("Signed XPR bytes", data, dataLen);
+
+  signal_callback_executed();
 }
 
 static void free_peerinfo(PeerInfo *pi) {

--- a/cbind/libp2p.h
+++ b/cbind/libp2p.h
@@ -478,6 +478,15 @@ int libp2p_service_disco_start_advertising(
     libp2p_ctx_t *ctx, const char *serviceId, const uint8_t *serviceData,
     size_t serviceDataLen, Libp2pCallback callback, void *userData);
 
+// Builds and signs an Extended Peer Record (XPR) for the node's own peer with
+// its private key. peerId comes from the node; empty addrs uses the node's
+// listen addresses; seqNo 0 defaults to the current unix time. callback
+// receives the signed, protobuf-encoded XPR bytes, valid only during the call.
+int libp2p_create_xpr(libp2p_ctx_t *ctx, const char **addrs, size_t addrsLen,
+                      const Libp2pServiceInfo *services, size_t servicesLen,
+                      uint64_t seqNo, Libp2pBufferCallback callback,
+                      void *userData);
+
 int libp2p_service_disco_stop_advertising(libp2p_ctx_t *ctx,
                                           const char *serviceId,
                                           Libp2pCallback callback,

--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -1075,6 +1075,17 @@ proc libp2p_create_xpr(
   initializeLibrary()
   checkLibParams(ctx, callback, userData)
 
+  if addrsLen > 0 and addrs.isNil():
+    failWithBufferMsg(callback, userData, "addrs are not set")
+
+  if servicesLen > 0 and services.isNil():
+    failWithBufferMsg(callback, userData, "services are not set")
+
+  let serviceArray = cast[ptr UncheckedArray[Libp2pServiceInfo]](services)
+  for i in 0 ..< servicesLen.int:
+    if serviceArray[i].dataLen > 0 and serviceArray[i].data.isNil():
+      failWithBufferMsg(callback, userData, "service data is not set")
+
   libp2p_thread.sendRequestToLibP2PThread(
     ctx,
     RequestType.SERVICE_DISCOVERY,

--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -1062,6 +1062,39 @@ proc libp2p_service_disco_start_advertising(
 
   RET_OK.cint
 
+proc libp2p_create_xpr(
+    ctx: ptr LibP2PContext,
+    addrs: ptr cstring,
+    addrsLen: csize_t,
+    services: ptr Libp2pServiceInfo,
+    servicesLen: csize_t,
+    seqNo: uint64,
+    callback: Libp2pBufferCallback,
+    userData: pointer,
+): cint {.dynlib, exportc, cdecl.} =
+  initializeLibrary()
+  checkLibParams(ctx, callback, userData)
+
+  libp2p_thread.sendRequestToLibP2PThread(
+    ctx,
+    RequestType.SERVICE_DISCOVERY,
+    ServiceDiscoveryRequest.createSharedXpr(
+      addrs = addrs,
+      addrsLen = addrsLen,
+      services = services,
+      servicesLen = servicesLen,
+      seqNo = seqNo,
+    ),
+    callback,
+    CallbackKind.READ,
+    userData,
+  ).isOkOr:
+    let msg = "libp2p error: " & $error
+    callback(RET_ERR.cint, nil, 0, msg[0].addr, cast[csize_t](len(msg)), userData)
+    return RET_ERR.cint
+
+  RET_OK.cint
+
 proc libp2p_service_disco_stop_advertising(
     ctx: ptr LibP2PContext,
     serviceId: cstring,

--- a/cbind/libp2p_thread/inter_thread_communication/libp2p_thread_request.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/libp2p_thread_request.nim
@@ -394,6 +394,8 @@ proc processServiceDiscovery(
   case request[].callbackKind
   of CallbackKind.RANDOM_RECORDS:
     handleRandomRecordsRes(await req.processLookup(libp2p.kad), request)
+  of CallbackKind.READ:
+    handleReadRes(await req.processCreateXpr(libp2p), request)
   else:
     handleRes(await req.process(libp2p.kad), request)
 

--- a/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_service_discovery_requests.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_service_discovery_requests.nim
@@ -3,7 +3,7 @@
 
 import std/sequtils
 import chronos, results
-import ../../../alloc
+import ../../../[types, ffi_types, alloc]
 import ../../../../libp2p
 import ../../../../libp2p/extended_peer_record
 import ../../../../libp2p/protocols/kademlia
@@ -18,11 +18,20 @@ type ServiceDiscoveryMsgType* = enum
   SD_REGISTER_INTEREST
   SD_UNREGISTER_INTEREST
   SD_LOOKUP
+  SD_CREATE_XPR
+
+type SharedService = object
+  id: cstring
+  data: SharedSeq[byte]
 
 type ServiceDiscoveryRequest* = object
   operation: ServiceDiscoveryMsgType
   serviceId: cstring
   serviceData: SharedSeq[byte]
+  addrs: SharedSeq[cstring]
+  services: ptr UncheckedArray[SharedService]
+  servicesLen: int
+  seqNo: uint64
 
 proc createShared*(
     T: type ServiceDiscoveryRequest,
@@ -37,9 +46,44 @@ proc createShared*(
   ret[].serviceData = allocSharedSeqFromCArray(serviceData, serviceDataLen.int)
   return ret
 
+proc createSharedXpr*(
+    T: type ServiceDiscoveryRequest,
+    addrs: ptr cstring,
+    addrsLen: csize_t,
+    services: ptr Libp2pServiceInfo,
+    servicesLen: csize_t,
+    seqNo: uint64,
+): ptr type T =
+  var ret = createShared(T)
+  ret[].operation = SD_CREATE_XPR
+  ret[].addrs = allocSharedSeqFromCArray(addrs, addrsLen.int)
+  ret[].seqNo = seqNo
+  ret[].servicesLen = servicesLen.int
+
+  if servicesLen > 0 and not services.isNil():
+    ret[].services = cast[ptr UncheckedArray[SharedService]](allocShared0(
+      sizeof(SharedService) * servicesLen.int
+    ))
+    let src = cast[ptr UncheckedArray[Libp2pServiceInfo]](services)
+    for i in 0 ..< servicesLen.int:
+      ret[].services[i].id = src[i].id.alloc()
+      ret[].services[i].data = allocSharedSeqFromCArray(src[i].data, src[i].dataLen.int)
+
+  return ret
+
 proc destroyShared*(self: ptr ServiceDiscoveryRequest) =
-  deallocShared(self[].serviceId)
+  if not self[].serviceId.isNil():
+    deallocShared(self[].serviceId)
   deallocSharedSeq(self[].serviceData)
+  deallocSharedSeq(self[].addrs)
+
+  if not self[].services.isNil():
+    for i in 0 ..< self[].servicesLen:
+      if not self[].services[i].id.isNil():
+        deallocShared(self[].services[i].id)
+      deallocSharedSeq(self[].services[i].data)
+    deallocShared(self[].services)
+
   deallocShared(self)
 
 proc process*(
@@ -72,8 +116,59 @@ proc process*(
     disco.unregisterInterest($self[].serviceId)
   of SD_LOOKUP:
     raiseAssert "unsupported path, use processLookup"
+  of SD_CREATE_XPR:
+    raiseAssert "unsupported path, use processCreateXpr"
 
   ok()
+
+proc toServices(self: ptr ServiceDiscoveryRequest): seq[ServiceInfo] =
+  var services: seq[ServiceInfo]
+  for i in 0 ..< self[].servicesLen:
+    services.add(
+      ServiceInfo(id: $self[].services[i].id, data: self[].services[i].data.toSeq())
+    )
+  services
+
+proc toAddresses(self: ptr ServiceDiscoveryRequest): Result[seq[MultiAddress], string] =
+  var addresses: seq[MultiAddress]
+  for address in self[].addrs.toSeq():
+    let ma = MultiAddress.init($address).valueOr:
+      return err("invalid multiaddress '" & $address & "': " & $error)
+    addresses.add(ma)
+  ok(addresses)
+
+proc processCreateXpr*(
+    self: ptr ServiceDiscoveryRequest, libp2p: ptr LibP2P
+): Future[Result[ptr ReadResponse, string]] {.async: (raises: [CancelledError]).} =
+  defer:
+    destroyShared(self)
+
+  let peerInfo = libp2p[].switch.peerInfo
+  if peerInfo.isNil():
+    return err("switch peerInfo is nil")
+
+  var addresses = self.toAddresses().valueOr:
+    return err(error)
+  if addresses.len == 0:
+    addresses = peerInfo.addrs
+
+  let seqNo =
+    if self[].seqNo == 0:
+      Moment.now().epochSeconds.uint64
+    else:
+      self[].seqNo
+
+  let peerRecord = ExtendedPeerRecord.init(
+    peerId = peerInfo.peerId,
+    addresses = addresses,
+    seqNo = seqNo,
+    services = self.toServices(),
+  )
+
+  let xpr = SignedExtendedPeerRecord.build(peerInfo.privateKey, peerRecord).valueOr:
+    return err(error)
+
+  ok(allocReadResponse(xpr.encode()))
 
 proc processLookup*(
     self: ptr ServiceDiscoveryRequest, kadOpt: Opt[KadDHT]

--- a/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_service_discovery_requests.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_service_discovery_requests.nim
@@ -58,9 +58,9 @@ proc createSharedXpr*(
   ret[].operation = SD_CREATE_XPR
   ret[].addrs = allocSharedSeqFromCArray(addrs, addrsLen.int)
   ret[].seqNo = seqNo
-  ret[].servicesLen = servicesLen.int
 
   if servicesLen > 0 and not services.isNil():
+    ret[].servicesLen = servicesLen.int
     ret[].services = cast[ptr UncheckedArray[SharedService]](allocShared0(
       sizeof(SharedService) * servicesLen.int
     ))
@@ -126,7 +126,9 @@ proc toServices(self: ptr ServiceDiscoveryRequest): seq[ServiceInfo] =
   var services: seq[ServiceInfo]
   for i in 0 ..< self[].servicesLen:
     services.add(
-      ServiceInfo(id: $self[].services[i].id, data: self[].services[i].data.toSeq())
+      ServiceInfo(
+        id: $self[].services[i].id, data: Opt.some(self[].services[i].data.toSeq())
+      )
     )
   services
 

--- a/libp2p/extended_peer_record.nim
+++ b/libp2p/extended_peer_record.nim
@@ -142,6 +142,25 @@ proc isValid*(xpr: SignedExtendedPeerRecord): bool =
     return false
   true
 
+proc build*(
+    T: typedesc[SignedExtendedPeerRecord],
+    privateKey: PrivateKey,
+    record: ExtendedPeerRecord,
+): Result[SignedExtendedPeerRecord, string] =
+  for svc in record.services:
+    if not svc.isValid():
+      return err(
+        "ServiceInfo.data exceeds maximum size of " & $MaxServiceDataSize & " bytes"
+      )
+
+  let signed = SignedExtendedPeerRecord.init(privateKey, record).valueOr:
+    return err("failed to create signed extended peer record: " & $error)
+
+  if not signed.isValid():
+    return err("encoded XPR exceeds maximum size of " & $MaxXPRSize & " bytes")
+
+  ok(signed)
+
 # This is for internal use only
 proc hash*(service: ServiceInfo): Hash =
   return service.id.hash()

--- a/libp2p/protocols/service_discovery/types.nim
+++ b/libp2p/protocols/service_discovery/types.nim
@@ -221,33 +221,17 @@ method select*(
   return ok(bestIdx)
 
 proc record*(disco: ServiceDiscovery): Result[SignedExtendedPeerRecord, string] =
-  let
-    peerInfo: PeerInfo = disco.switch.peerInfo
-    services: seq[ServiceInfo] = disco.services.toSeq()
-
-  for svc in services:
-    if not svc.isValid():
-      return err(
-        "ServiceInfo.data exceeds maximum size of " & $MaxServiceDataSize & " bytes"
-      )
-
+  let peerInfo = disco.switch.peerInfo
   let filteredAddresses = disco.config.addressPolicy.filterAddrs(peerInfo.addrs)
 
-  let extPeerRecord = SignedExtendedPeerRecord.init(
-    peerInfo.privateKey,
-    ExtendedPeerRecord(
-      peerId: peerInfo.peerId,
-      seqNo: Moment.now().epochSeconds.uint64,
-      addresses: filteredAddresses.mapIt(AddressInfo(address: it)),
-      services: services,
-    ),
-  ).valueOr:
-    return err("Failed to create signed peer record: " & $error)
+  let peerRecord = ExtendedPeerRecord.init(
+    peerId = peerInfo.peerId,
+    addresses = filteredAddresses,
+    seqNo = Moment.now().epochSeconds.uint64,
+    services = disco.services.toSeq(),
+  )
 
-  if not extPeerRecord.isValid():
-    return err("encoded XPR exceeds maximum size of " & $MaxXPRSize & " bytes")
-
-  return ok(extPeerRecord)
+  SignedExtendedPeerRecord.build(peerInfo.privateKey, peerRecord)
 
 proc toPeerInfos*(peers: seq[Peer]): seq[PeerInfo] =
   var peerInfos: seq[PeerInfo]


### PR DESCRIPTION
## Summary

Adds a C API utility, `libp2p_create_xpr`, that lets an encapsulating application build and sign its **own node's** Extensible Peer Record (XPR) — choosing the advertised service set, addresses, and `seqNo` — and get the signed, protobuf-encoded bytes back.

Previously the only XPR path was the record auto-generated internally by service discovery during advertising; there was no cbind entry point to construct a `SignedExtendedPeerRecord` directly.

```c
int libp2p_create_xpr(libp2p_ctx_t *ctx, const char **addrs, size_t addrsLen,
                      const Libp2pServiceInfo *services, size_t servicesLen,
                      uint64_t seqNo, Libp2pBufferCallback callback,
                      void *userData);
```

Behavior:

- The record is signed on the worker thread with the node's own `peerInfo.privateKey`, so no private key crosses the FFI boundary. As a consequence, `peerId` is always the node's own — this call builds *the node's* record, not an arbitrary peer's.
- Unsupplied addresses (`addrs == NULL` / `addrsLen == 0`) fall back to the node's listen addresses.
- `seqNo == 0` defaults to the current unix time (`0` is used as the "unset" sentinel since the C ABI takes a plain `uint64_t`).
- Inputs are validated at the boundary: a non-NULL length with a NULL `addrs`/`services` pointer, or a service with `dataLen > 0` and NULL `data`, fails via the callback. The encoded record is checked against `MaxServiceDataSize` / `MaxXPRSize` before being returned.

The validate + sign + size-check logic shared with the existing `ServiceDiscovery.record()` is factored into a single `SignedExtendedPeerRecord.build` helper in `extended_peer_record.nim`, and `record()` is refactored to call it so the two paths can't drift.

## Affected Areas

- [x] Peer Management / Discovery
  <!-- New cbind utility for building/signing XPRs; shared build helper in extended_peer_record -->

- [x] Build / Tooling
  <!-- New exported C symbol + header declaration -->

## Compatibility & Downstream Validation

`libp2p_create_xpr` is purely additive. The `record()` refactor preserves behavior — same validation, signing, and size check in the same order — with the only observable change being unified error-message strings. No downstream integration required.

## Impact on Library Users

New C API; no behavior change to existing APIs.

- `libp2p_create_xpr` is added to `cbind/libp2p.h`.
- Signing uses the running node's key, so the node context (`ctx`) is required. This call does **not** advertise the record — it only returns the signed bytes.
- New internal `SignedExtendedPeerRecord.build` helper in `extended_peer_record.nim` (validate + sign + size-check in one place), now shared with `ServiceDiscovery.record()`.

## Risk Assessment

Low. The request reuses the existing worker-thread request / `READ` buffer-callback machinery and the shared `build` helper. It does not require service discovery to be mounted (it only reads the switch's `peerInfo`). The `record()` refactor changes no behavior.

## Scope / Follow-up

This PR is the create-and-sign half only: it returns signed XPR bytes but nothing in cbind consumes them yet. Advertising a user-provided XPR would require `libp2p_service_disco_start_advertising` to accept optional pre-built XPR bytes and forward them to the existing `startAdvertising(service, advert)` path in the Nim layer. That wiring is intentionally left out and tracked as follow-up.

## References

Branch: `feat/cbind/user-provided-xprs`
