### PR TITLE
fix(gossipsub): keep extension subscriptions within topic cap

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -364,7 +364,9 @@ method unsubscribePeer*(g: GossipSub, peer: PeerId) =
 
   procCall FloodSub(g).unsubscribePeer(peer)
 
-proc handleSubscribe(g: GossipSub, peer: PubSubPeer, topic: string, subscribe: bool) =
+proc handleSubscribe(
+    g: GossipSub, peer: PubSubPeer, topic: string, subscribe: bool
+): bool =
   logScope:
     peer
     topic
@@ -376,19 +378,19 @@ proc handleSubscribe(g: GossipSub, peer: PubSubPeer, topic: string, subscribe: b
     # and eventually remove this workaround
     if peer.peerId notin g.peers:
       trace "ignoring unknown peer"
-      return
+      return false
 
     if not (isNil(g.subscriptionValidator)) and not (g.subscriptionValidator(topic)):
       # this is a violation, so warn should be in order
       trace "ignoring invalid topic subscription", topic, peer
       libp2p_gossipsub_invalid_topic_subscription.inc()
-      return
+      return false
 
     if peer.subscribedTopics >= g.topicsHigh and not g.gossipsub.hasPeer(topic, peer):
       trace "ignoring subscription over topicsHigh limit", limit = g.topicsHigh
       libp2p_gossipsub_over_topics_high_subscription.inc()
       peer.behaviourPenalty += SubscriptionFloodPenalty
-      return
+      return false
 
     trace "peer subscribed to topic"
 
@@ -414,6 +416,7 @@ proc handleSubscribe(g: GossipSub, peer: PubSubPeer, topic: string, subscribe: b
       g.subscribedDirectPeers.removePeer(topic, peer)
 
   trace "gossip peers", peers = g.gossipsub.peers(topic), topic
+  true
 
 proc handleControl(g: GossipSub, peer: PubSubPeer, control: ControlMessage) =
   g.handlePrune(peer, control.prune)
@@ -651,13 +654,16 @@ method rpcHandler*(
   # trigger hooks - these may modify the message
   peer.recvObservers(rpcMsg)
 
-  g.extensionsState.handleRPC(peer.peerId, rpcMsg)
-
+  var extensionsRpcMsg = rpcMsg
+  extensionsRpcMsg.subscriptions = @[]
   for i in 0 ..< min(g.topicsHigh, rpcMsg.subscriptions.len):
     template sub(): untyped =
       rpcMsg.subscriptions[i]
 
-    g.handleSubscribe(peer, sub.topic.get(), sub.isSubscribe)
+    if g.handleSubscribe(peer, sub.topic.get(), sub.isSubscribe):
+      extensionsRpcMsg.subscriptions.add(sub)
+
+  g.extensionsState.handleRPC(peer.peerId, extensionsRpcMsg)
 
   # the above call applied limits to subs number
   # in gossipsub we want to apply scoring as well

--- a/tests/libp2p/pubsub/test_gossipsub.nim
+++ b/tests/libp2p/pubsub/test_gossipsub.nim
@@ -6,8 +6,17 @@
 import chronos, chronos/rateLimit, stew/byteutils, utils, sequtils
 import ../../../libp2p/[muxers/muxer, connmanager, switch]
 import
-  ../../../libp2p/protocols/pubsub/
-    [floodsub, gossipsub, mcache, peertable, pubsubpeer, rpc/message, rpc/protobuf]
+  ../../../libp2p/protocols/pubsub/[
+    floodsub,
+    gossipsub,
+    gossipsub/extensions,
+    gossipsub/partial_message,
+    mcache,
+    peertable,
+    pubsubpeer,
+    rpc/message,
+    rpc/protobuf,
+  ]
 import ../../tools/[unittest, bufferstream, crypto, switch_builder, multiaddress]
 
 func withSubs*(T: type RPCMsg, topics: openArray[string], subscribe: bool): RPCMsg =
@@ -353,6 +362,55 @@ suite "GossipSub":
       gossipSub.gossipsub.hasKey(topic & "late")
 
     await conn.close()
+
+  asyncTest "rpcHandler - extensions only see accepted subscriptions":
+    proc unionPartsMetadata(
+        a, b: PartsMetadata
+    ): Result[PartsMetadata, string] {.gcsafe, raises: [].} =
+      ok(a & b)
+
+    proc validateRPC(
+        rpc: PartialMessageExtensionRPC
+    ): Result[void, string] {.gcsafe, raises: [].} =
+      ok()
+
+    proc onIncomingRPC(
+        peer: PeerId, rpc: PartialMessageExtensionRPC
+    ) {.gcsafe, raises: [].} =
+      discard
+
+    let gossipSub = TestGossipSub.init(
+      makeStandardSwitch(),
+      rng = rng(),
+      parameters = GossipSubParams.init(
+        partialMessageExtensionConfig = Opt.some(
+          PartialMessageExtensionConfig(
+            unionPartsMetadata: unionPartsMetadata,
+            validateRPC: validateRPC,
+            onIncomingRPC: onIncomingRPC,
+            heartbeatsTillEviction: 1,
+          )
+        )
+      ),
+    )
+    gossipSub.topicsHigh = 2
+
+    let peerId = randomPeerId()
+    let peer = gossipSub.getPubSubPeer(peerId)
+
+    var subs: seq[SubOpts]
+    for i in 0 .. gossipSub.topicsHigh:
+      subs.add(
+        SubOpts(subscribe: true, topic: topic & $i, requestsPartial: Opt.some(true))
+      )
+
+    await gossipSub.rpcHandler(peer, encode(RPCMsg.withSubscriptions(subs), false))
+
+    check:
+      gossipSub.extensionsState.peerRequestsPartial(peerId, topic & "0")
+      not gossipSub.extensionsState.peerRequestsPartial(
+        peerId, topic & $gossipSub.topicsHigh
+      )
 
   asyncTest "rpcHandler - invalid message bytes":
     let gossipSub = TestGossipSub.init(makeStandardSwitch(), rng = rng())


### PR DESCRIPTION
## Summary

This PR keeps GossipSub extension subscription state aligned with the core `topicsHigh` subscription cap.

Core subscription handling now reports whether a subscription record was accepted, and extension handling receives only accepted subscription records.

## Affected Areas

- [x] Gossipsub  
  Subscription handling and extension RPC handoff.

- [x] Protocol Logic  
  Partial-message extension subscription metadata now follows the same acceptance rules as core GossipSub subscriptions.
