### PR TITLE
chore(protobuf): main type encode/decode metrics

### DIFF
--- a/libp2p/protocols/connectivity/autonat/types.nim
+++ b/libp2p/protocols/connectivity/autonat/types.nim
@@ -60,4 +60,5 @@ type
 proc isReachable*(self: NetworkReachability): bool =
   self == NetworkReachability.Reachable
 
-Protobuf.serializerFor([AutonatPeerInfo, AutonatDial, AutonatDialResponse, AutonatMsg])
+Protobuf.serializerFor([AutonatPeerInfo, AutonatDial, AutonatDialResponse])
+Protobuf.serializerFor([AutonatMsg], withMetrics = true, domain = "autonat-v1")

--- a/libp2p/protocols/connectivity/autonatv2/types.nim
+++ b/libp2p/protocols/connectivity/autonatv2/types.nim
@@ -105,9 +105,10 @@ type
 Protobuf.serializerFor(
   [
     DialRequest, DialResponse, DialBack, DialBackResponse, DialDataRequest,
-    DialDataResponse, AutonatV2Msg,
+    DialDataResponse,
   ]
 )
+Protobuf.serializerFor([AutonatV2Msg], withMetrics = true, domain = "autonat-v2")
 
 # Custom `==` is needed to ensure consistent comparison with Opt-based fields
 proc `==`*(a, b: AutonatV2Msg): bool =

--- a/libp2p/protocols/connectivity/dcutr/core.nim
+++ b/libp2p/protocols/connectivity/dcutr/core.nim
@@ -36,7 +36,7 @@ type
 
   DcutrError* = object of LPError
 
-Protobuf.serializerFor([DcutrMsg])
+Protobuf.serializerFor([DcutrMsg], withMetrics = true, domain = "dcutr")
 
 proc expectDcutrConnection*(
     connManager: ConnManager, peerId: PeerId, dir: Direction

--- a/libp2p/protocols/connectivity/relay/messages.nim
+++ b/libp2p/protocols/connectivity/relay/messages.nim
@@ -49,7 +49,8 @@ type
     dstPeer* {.fieldNumber: 3.}: Opt[RelayPeer]
     status* {.fieldNumber: 4, ext.}: Opt[StatusV1]
 
-Protobuf.serializerFor([RelayPeer, RelayMessage])
+Protobuf.serializerFor([RelayPeer])
+Protobuf.serializerFor([RelayMessage], withMetrics = true, domain = "relay-v1")
 
 # Circuit Relay V2 Messages
 
@@ -105,7 +106,10 @@ type
     limit* {.fieldNumber: 3.}: Opt[Limit]
     status* {.fieldNumber: 4, ext.}: Opt[StatusV2]
 
-Protobuf.serializerFor([Peer, Reservation, Limit, HopMessage, StopMessage, Voucher])
+Protobuf.serializerFor([Peer, Reservation, Limit, Voucher])
+Protobuf.serializerFor(
+  [StopMessage, HopMessage], withMetrics = true, domain = "relay-v2"
+)
 
 proc init*(
     T: typedesc[Voucher],

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -75,7 +75,8 @@ type
   IdentifyPush* = ref object of LPProtocol
     identifyHandler: IdentifyPushHandler
 
-Protobuf.serializerFor([IdentifyMsg, Delta])
+Protobuf.serializerFor([Delta])
+Protobuf.serializerFor([IdentifyMsg], withMetrics = true, domain = "identify")
 
 chronicles.expandIt(IdentifyMsg):
   pubkey = ($it.publicKey).shortLog

--- a/libp2p/protocols/kademlia/protobuf.nim
+++ b/libp2p/protocols/kademlia/protobuf.nim
@@ -124,7 +124,7 @@ proc encode*(
       p.connection = p.connection.hide(hideConnectionStatus)
 
   let buffer = Protobuf.encode(m)
-  trackEncodeBytes(buffer.len, $Message, "kademlia")
+  trackEncodeBytes(buffer.len, Message, "kademlia")
   buffer
 
 proc toBytes*(ticket: Ticket): seq[byte] {.raises: [], gcsafe.} =

--- a/libp2p/protocols/kademlia/protobuf.nim
+++ b/libp2p/protocols/kademlia/protobuf.nim
@@ -103,7 +103,8 @@ proc `==`*(a, b: Peer): bool =
 Protobuf.serializerFor([Record, Ticket, RegisterMessage, GetAdsMessage])
 
 # Peer and Message have custom encode because of additional hideConnectionStatus parameter
-Protobuf.decodeFor([Peer, Message])
+Protobuf.decodeFor([Peer])
+Protobuf.decodeFor([Message], withMetrics = true, domain = "kademlia")
 
 proc encode*(
     msg: Peer, hideConnectionStatus: bool = true
@@ -121,7 +122,10 @@ proc encode*(
       p.connection = p.connection.hide(hideConnectionStatus)
     for p in m.providerPeers.mitems:
       p.connection = p.connection.hide(hideConnectionStatus)
-  Protobuf.encode(m)
+
+  let buffer = Protobuf.encode(m)
+  trackEncodeBytes(buffer.len, $Message, "kademlia")
+  buffer
 
 proc toBytes*(ticket: Ticket): seq[byte] {.raises: [], gcsafe.} =
   ## Returns the canonical byte representation of a Ticket used for signing.

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -30,12 +30,12 @@ proc decode*(_: type Message, buf: seq[byte]): Result[Message, string] =
 
 proc encode*(msg: RPCMsg, anonymize: bool): seq[byte] =
   let encoded = encode(Protobuf, msg.anonymize(anonymize))
-  trackEncodeBytes(encoded.len, $RPCMsg, "gossipsub")
+  trackEncodeBytes(encoded.len, RPCMsg, "gossipsub")
   encoded
 
 proc decodeRPCMessage(buf: seq[byte]): RPCMsg {.raises: [SerializationError].} =
   let msg = decode(Protobuf, buf, RPCMsg)
-  trackDecodeBytes(buf.len, $RPCMsg, "gossipsub")
+  trackDecodeBytes(buf.len, RPCMsg, "gossipsub")
   msg
 
 proc decode*(_: type RPCMsg, buf: seq[byte]): Result[RPCMsg, string] =

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -34,8 +34,8 @@ proc encode*(msg: RPCMsg, anonymize: bool): seq[byte] =
   encoded
 
 proc decodeRPCMessage(buf: seq[byte]): RPCMsg {.raises: [SerializationError].} =
-  let msg = decode(Protobuf, buf, RPCMsg)
   trackDecodeBytes(buf.len, RPCMsg, "gossipsub")
+  let msg = decode(Protobuf, buf, RPCMsg)
   msg
 
 proc decode*(_: type RPCMsg, buf: seq[byte]): Result[RPCMsg, string] =

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -29,10 +29,14 @@ proc decode*(_: type Message, buf: seq[byte]): Result[Message, string] =
     err("failed to decode Message from protobuf bytes. " & e.msg)
 
 proc encode*(msg: RPCMsg, anonymize: bool): seq[byte] =
-  encode(Protobuf, msg.anonymize(anonymize))
+  let encoded = encode(Protobuf, msg.anonymize(anonymize))
+  trackEncodeBytes(encoded.len, $RPCMsg, "gossipsub")
+  encoded
 
 proc decodeRPCMessage(buf: seq[byte]): RPCMsg {.raises: [SerializationError].} =
-  decode(Protobuf, buf, RPCMsg)
+  let msg = decode(Protobuf, buf, RPCMsg)
+  trackDecodeBytes(buf.len, $RPCMsg, "gossipsub")
+  msg
 
 proc decode*(_: type RPCMsg, buf: seq[byte]): Result[RPCMsg, string] =
   try:

--- a/libp2p/protocols/rendezvous/protobuf.nim
+++ b/libp2p/protocols/rendezvous/protobuf.nim
@@ -69,5 +69,7 @@ type
     discoverResponse* {.fieldNumber: 6.}: Opt[DiscoverResponse]
 
 Protobuf.serializerFor(
-  [Cookie, Register, RegisterResponse, Unregister, Discover, DiscoverResponse, Message]
+  [Cookie, Register, RegisterResponse, Unregister, Discover, DiscoverResponse]
 )
+
+Protobuf.serializerFor([Message], withMetrics = true, domain = "rendezvous")

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -91,7 +91,7 @@ type
 
 # Utility
 
-Protobuf.serializerFor([NoiseHandshakePayloadMsg])
+Protobuf.serializerFor([NoiseHandshakePayloadMsg], withMetrics = true, domain = "noise")
 
 func shortLog*(conn: NoiseConnection): auto =
   try:

--- a/libp2p/utils/protobuf.nim
+++ b/libp2p/utils/protobuf.nim
@@ -10,7 +10,9 @@ when defined(libp2p_protobuf_metrics):
 
 template trackEncodeBytes*(count: int, msgType: typedesc, domain: string) =
   when defined(libp2p_protobuf_metrics):
-    libp2p_protobuf_bytes_write.inc(count.int64, labelValues = [domain & "." & $msgType])
+    libp2p_protobuf_bytes_write.inc(
+      count.int64, labelValues = [domain & "." & $msgType]
+    )
 
 template trackDecodeBytes*(count: int, msgType: typedesc, domain: string) =
   when defined(libp2p_protobuf_metrics):

--- a/libp2p/utils/protobuf.nim
+++ b/libp2p/utils/protobuf.nim
@@ -8,13 +8,13 @@ import std/macros, results, protobuf_serialization
 when defined(libp2p_protobuf_metrics):
   import ./protobuf_metrics
 
-template trackEncodeBytes*(count: int64, msgType: typedesc, domain: string) =
+template trackEncodeBytes*(count: int, msgType: typedesc, domain: string) =
   when defined(libp2p_protobuf_metrics):
-    libp2p_protobuf_bytes_write.inc(count, labelValues = [domain & "." & $msgType])
+    libp2p_protobuf_bytes_write.inc(count.int64, labelValues = [domain & "." & $msgType])
 
-template trackDecodeBytes*(count: int64, msgType: typedesc, domain: string) =
+template trackDecodeBytes*(count: int, msgType: typedesc, domain: string) =
   when defined(libp2p_protobuf_metrics):
-    libp2p_protobuf_bytes_read.inc(count, labelValues = [domain & "." & $msgType])
+    libp2p_protobuf_bytes_read.inc(count.int64, labelValues = [domain & "." & $msgType])
 
 macro decodeFor*(
     _: type Protobuf, Types: untyped, withMetrics: bool = false, domain: string = ""

--- a/libp2p/utils/protobuf.nim
+++ b/libp2p/utils/protobuf.nim
@@ -8,13 +8,13 @@ import std/macros, results, protobuf_serialization
 when defined(libp2p_protobuf_metrics):
   import ./protobuf_metrics
 
-template trackEncodeBytes*(count: int64, typeName: string, domain: string) =
+template trackEncodeBytes*(count: int64, msgType: typedesc, domain: string) =
   when defined(libp2p_protobuf_metrics):
-    libp2p_protobuf_bytes_write.inc(count, labelValues = [domain & "." & typeName])
+    libp2p_protobuf_bytes_write.inc(count, labelValues = [domain & "." & $msgType])
 
-template trackDecodeBytes*(count: int64, typeName: string, domain: string) =
+template trackDecodeBytes*(count: int64, msgType: typedesc, domain: string) =
   when defined(libp2p_protobuf_metrics):
-    libp2p_protobuf_bytes_read.inc(count, labelValues = [domain & "." & typeName])
+    libp2p_protobuf_bytes_read.inc(count, labelValues = [domain & "." & $msgType])
 
 macro decodeFor*(
     _: type Protobuf, Types: untyped, withMetrics: bool = false, domain: string = ""

--- a/libp2p/utils/protobuf.nim
+++ b/libp2p/utils/protobuf.nim
@@ -8,15 +8,22 @@ import std/macros, results, protobuf_serialization
 when defined(libp2p_protobuf_metrics):
   import ./protobuf_metrics
 
+func makeLabel(domain, msgType: string): string =
+  if domain == "":
+    return msgType
+  return domain & "." & msgType
+
 template trackEncodeBytes*(count: int, msgType: typedesc, domain: string) =
   when defined(libp2p_protobuf_metrics):
     libp2p_protobuf_bytes_write.inc(
-      count.int64, labelValues = [domain & "." & $msgType]
+      count.int64, labelValues = [makeLabel(domain, $msgType)]
     )
 
 template trackDecodeBytes*(count: int, msgType: typedesc, domain: string) =
   when defined(libp2p_protobuf_metrics):
-    libp2p_protobuf_bytes_read.inc(count.int64, labelValues = [domain & "." & $msgType])
+    libp2p_protobuf_bytes_read.inc(
+      count.int64, labelValues = [makeLabel(domain, $msgType)]
+    )
 
 macro decodeFor*(
     _: type Protobuf, Types: untyped, withMetrics: bool = false, domain: string = ""
@@ -26,7 +33,7 @@ macro decodeFor*(
   var stmts = newStmtList()
   for T in Types:
     let decodeName = ident("decode" & $T)
-    let metricLabel = newLit(domain.strVal & "." & $T)
+    let metricLabel = newLit(makeLabel(domain.strVal, $T))
     stmts.add quote do:
       proc `decodeName`(buf2: seq[byte]): `T` {.raises: [SerializationError].} =
         when defined(libp2p_protobuf_metrics) and `doMetrics`:

--- a/libp2p/utils/protobuf.nim
+++ b/libp2p/utils/protobuf.nim
@@ -8,16 +8,27 @@ import std/macros, results, protobuf_serialization
 when defined(libp2p_protobuf_metrics):
   import ./protobuf_metrics
 
-macro decodeFor*(_: type Protobuf, Types: untyped, withMetrics: bool = false): untyped =
+template trackEncodeBytes*(count: int64, label: string, domain: string) =
+  when defined(libp2p_protobuf_metrics):
+    libp2p_protobuf_bytes_write.inc(count, labelValues = [domain & "." & label])
+
+template trackDecodeBytes*(count: int64, label: string, domain: string) =
+  when defined(libp2p_protobuf_metrics):
+    libp2p_protobuf_bytes_read.inc(count, labelValues = [domain & "." & label])
+
+macro decodeFor*(
+    _: type Protobuf, Types: untyped, withMetrics: bool = false, domain: string = ""
+): untyped =
   ## This generates decode protobuf procs for `Types`
   let doMetrics = newLit(withMetrics.eqIdent("true"))
   var stmts = newStmtList()
   for T in Types:
     let decodeName = ident("decode" & $T)
+    let metricLabel = newLit(domain.strVal & "." & $T)
     stmts.add quote do:
       proc `decodeName`(buf2: seq[byte]): `T` {.raises: [SerializationError].} =
         when defined(libp2p_protobuf_metrics) and `doMetrics`:
-          libp2p_protobuf_bytes_read.inc(buf2.len.int64, labelValues = [$(`T`)])
+          libp2p_protobuf_bytes_read.inc(buf2.len.int64, labelValues = [`metricLabel`])
 
         decode(Protobuf, buf2, `T`)
 
@@ -30,23 +41,24 @@ macro decodeFor*(_: type Protobuf, Types: untyped, withMetrics: bool = false): u
   stmts
 
 macro serializerFor*(
-    _: type Protobuf, Types: untyped, withMetrics: bool = false
+    _: type Protobuf, Types: untyped, withMetrics: bool = false, domain: string = ""
 ): untyped =
   ## This generates encode/decode protobuf procs for `Types`
   let doMetrics = newLit(withMetrics.eqIdent("true"))
   var stmts = newStmtList()
   for T in Types:
     let decodeName = ident("decode" & $T)
+    let metricLabel = newLit(domain.strVal & "." & $T)
     stmts.add quote do:
       proc encode*(c: `T`): seq[byte] =
         let buf = encode(Protobuf, c)
         when defined(libp2p_protobuf_metrics) and `doMetrics`:
-          libp2p_protobuf_bytes_write.inc(buf.len.int64, labelValues = [$(`T`)])
+          libp2p_protobuf_bytes_write.inc(buf.len.int64, labelValues = [`metricLabel`])
         buf
 
       proc `decodeName`(buf2: seq[byte]): `T` {.raises: [SerializationError].} =
         when defined(libp2p_protobuf_metrics) and `doMetrics`:
-          libp2p_protobuf_bytes_read.inc(buf2.len.int64, labelValues = [$(`T`)])
+          libp2p_protobuf_bytes_read.inc(buf2.len.int64, labelValues = [`metricLabel`])
 
         decode(Protobuf, buf2, `T`)
 

--- a/libp2p/utils/protobuf.nim
+++ b/libp2p/utils/protobuf.nim
@@ -8,13 +8,13 @@ import std/macros, results, protobuf_serialization
 when defined(libp2p_protobuf_metrics):
   import ./protobuf_metrics
 
-template trackEncodeBytes*(count: int64, label: string, domain: string) =
+template trackEncodeBytes*(count: int64, typeName: string, domain: string) =
   when defined(libp2p_protobuf_metrics):
-    libp2p_protobuf_bytes_write.inc(count, labelValues = [domain & "." & label])
+    libp2p_protobuf_bytes_write.inc(count, labelValues = [domain & "." & typeName])
 
-template trackDecodeBytes*(count: int64, label: string, domain: string) =
+template trackDecodeBytes*(count: int64, typeName: string, domain: string) =
   when defined(libp2p_protobuf_metrics):
-    libp2p_protobuf_bytes_read.inc(count, labelValues = [domain & "." & label])
+    libp2p_protobuf_bytes_read.inc(count, labelValues = [domain & "." & typeName])
 
 macro decodeFor*(
     _: type Protobuf, Types: untyped, withMetrics: bool = false, domain: string = ""

--- a/libp2p/utils/protobuf.nim
+++ b/libp2p/utils/protobuf.nim
@@ -57,7 +57,7 @@ macro serializerFor*(
   var stmts = newStmtList()
   for T in Types:
     let decodeName = ident("decode" & $T)
-    let metricLabel = newLit(domain.strVal & "." & $T)
+    let metricLabel = newLit(makeLabel(domain.strVal, $T))
     stmts.add quote do:
       proc encode*(c: `T`): seq[byte] =
         let buf = encode(Protobuf, c)

--- a/tests/libp2p/utils/test_protobuf_metrics.nim
+++ b/tests/libp2p/utils/test_protobuf_metrics.nim
@@ -12,11 +12,11 @@ when defined(libp2p_protobuf_metrics):
   type MetricsTestMsg* {.proto2.} = object
     value* {.fieldNumber: 1, required, pint.}: uint64
 
-  Protobuf.serializerFor([MetricsTestMsg], withMetrics = true)
+  Protobuf.serializerFor([MetricsTestMsg], withMetrics = true, domain = "test")
 
   template counterValue(counter: untyped, label: string): float64 =
     try:
-      counter.value([label])
+      counter.value(["test." & label])
     except exceptions.KeyError:
       0.0
 


### PR DESCRIPTION
- adding encode/decode metrics for all main types
- added `domain` argument to `serializerFor` to avoid any clash when types have same name (kademlia: Message, rendezvous: Message, etc....)
- added `trackEncodeBytes` and `trackDecodeBytes` utility templates for custom (manual) encode/decode implementations