### PR TITLE
fix(quic): `cancelStreamHandlers` nil pointer dereference

### DIFF
--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -265,23 +265,17 @@ method handle*(m: QuicMuxer): Future[void] {.async: (raises: []).} =
   if not m.session.isClosed:
     await m.session.close()
 
-proc stopAcceptLoop(m: QuicMuxer) {.async: (raises: []).} =
-  ## Closes the session and joins the accept loop. The session must be closed
-  ## first or the loop won't exit and `cancelAndWait` would hang.
-  await m.session.close()
-  if not m.handleFut.isNil():
-    await noCancel m.handleFut.cancelAndWait()
-
-proc cancelStreamHandlers(m: QuicMuxer) {.async: (raises: []).} =
-  ## Cancels in-flight stream handlers so each stream is torn down here
-  ## (handlers run closeWithEOF on cancel) instead of being aborted during GC.
-  await noCancel m.handlerFuts.cancelAndWait()
-  m.handlerFuts = @[]
-
 method close*(m: QuicMuxer) {.async: (raises: []).} =
   try:
-    await m.stopAcceptLoop()
-    await m.cancelStreamHandlers()
+    ## Closes the session and joins the accept loop. The session must be closed
+    ## first or the loop won't exit and `cancelAndWait` would hang.
+    await m.session.close()
+
+    if not m.handleFut.isNil:
+      ## Cancels in-flight stream handlers so each stream is torn down here
+      ## (handlers run closeWithEOF on cancel) instead of being aborted during GC.
+      let handlerFuts = move m.handlerFuts
+      await noCancel handlerFuts.cancelAndWait()
   except CatchableError:
     discard
 


### PR DESCRIPTION
previously `cancelStreamHandlers` code calls `cancelAndWait` even when `m.handlerFuts` is nil.

stacktrace:
```
Traceback (most recent call last)
/home/runner/work/nim-libp2p/nim-libp2p/tests/tools/unittest.nim(18) test_gossipsub_message_handling
/home/runner/work/nim-libp2p/nim-libp2p/nimbledeps/pkgs2/unittest2-0.2.5-02bb3751ba9ddc3c17bfd89f2e41cb6bfb8fc0c9/unittest2.nim(1175) testSuite
/home/runner/work/nim-libp2p/nim-libp2p/nimbledeps/pkgs2/unittest2-0.2.5-02bb3751ba9ddc3c17bfd89f2e41cb6bfb8fc0c9/unittest2.nim(1102) runDirect
/home/runner/work/nim-libp2p/nim-libp2p/tests/tools/unittest.nim(40) runTest`gensym2631
/home/runner/work/nim-libp2p/nim-libp2p/nimbledeps/pkgs2/chronos-4.2.2-3a4c9477df8cef20a04e4f1b54a2d74fdfc2a3d0/chronos/internal/asyncfutures.nim(665) waitFor
/home/runner/work/nim-libp2p/nim-libp2p/nimbledeps/pkgs2/chronos-4.2.2-3a4c9477df8cef20a04e4f1b54a2d74fdfc2a3d0/chronos/internal/asyncfutures.nim(640) pollFor
/home/runner/work/nim-libp2p/nim-libp2p/nimbledeps/pkgs2/chronos-4.2.2-3a4c9477df8cef20a04e4f1b54a2d74fdfc2a3d0/chronos/internal/asyncengine.nim(150) poll
/home/runner/work/nim-libp2p/nim-libp2p/libp2p/transports/quictransport.nim(284) close
/home/runner/work/nim-libp2p/nim-libp2p/libp2p/transports/quictransport.nim(278) cancelStreamHandlers
/home/runner/work/nim-libp2p/nim-libp2p/nimbledeps/pkgs2/chronos-4.2.2-3a4c9477df8cef20a04e4f1b54a2d74fdfc2a3d0/chronos/internal/asyncfutures.nim(1103) noCancel
/home/runner/work/nim-libp2p/nim-libp2p/nim/lib/system/gc.nim(488) newObj
/home/runner/work/nim-libp2p/nim-libp2p/nim/lib/system/gc.nim decRef
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```