### PR TITLE
fix(pubsub): stop & drain validator and topic handler futs

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -736,7 +736,13 @@ method rpcHandler*(
     # as we have a "lax" policy and allow signed messages
 
     # Be careful not to fill the validationSeen table
-    # (eg, pop everything you put in it)
+    # (eg, pop everything you put in it). rpcHandler itself is owned by
+    # the stream read loop, not g.pendingTasks, and it can resume here
+    # after stop() has set started=false. A nil heartbeatFut means
+    # start() was never called, so direct rpcHandler calls are still allowed.
+    if not g.started and not g.heartbeatFut.isNil():
+      raise newException(CancelledError, "gossipsub stopped")
+
     g.validationSeen[msgIdSalted] = initHashSet[PubSubPeer]()
 
     g.pendingTasks.trackFut(g.validateAndRelay(msg, msgId, msgIdSalted, peer))
@@ -1096,20 +1102,29 @@ method start*(
   g.started = true
   newFutureCompleted[void]()
 
-method stop*(g: GossipSub): Future[void] {.async: (raises: [], raw: true).} =
+method stop*(g: GossipSub): Future[void] {.async: (raises: []).} =
   trace "gossipsub stop"
 
   if not g.started:
     warn "Stopping gossipsub without starting it"
-    return newFutureCompleted[void]()
+    return
 
   g.started = false
-  g.directPeersLoop.cancelSoon()
-  g.scoringHeartbeatFut.cancelSoon()
-  g.heartbeatFut.cancelSoon()
-  g.pendingTasks.cancelSoon()
-  g.pendingTasks = @[]
-  newFutureCompleted[void]()
+
+  await noCancel g.directPeersLoop.cancelAndWait()
+  g.directPeersLoop = nil
+
+  await noCancel g.scoringHeartbeatFut.cancelAndWait()
+  g.scoringHeartbeatFut = nil
+
+  # Keep heartbeatFut set after draining; rpcHandler uses it to distinguish
+  # stopped instances from ones where start() was never called.
+  await noCancel g.heartbeatFut.cancelAndWait()
+
+  while g.pendingTasks.len > 0:
+    let tasks = g.pendingTasks
+    g.pendingTasks = @[]
+    await noCancel tasks.cancelAndWait()
 
 method initPubSub*(g: GossipSub) {.raises: [InitializationError].} =
   procCall FloodSub(g).initPubSub()

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -440,8 +440,8 @@ proc handleData*(
         try:
           futs = await allFinished(futs)
         except CancelledError:
-          # propagate cancellation
-          futs.cancelSoon()
+          await noCancel futs.cancelAndWait()
+          return
 
         # check for errors in futures
         for fut in futs:
@@ -675,7 +675,13 @@ method validate*(
       for validator in validators[]:
         pending.add(validator(topic, message))
   var valResult = ValidationResult.Accept
-  let futs = await allFinished(pending)
+  let futs =
+    try:
+      await allFinished(pending)
+    except CancelledError as exc:
+      await noCancel pending.cancelAndWait()
+      raise exc
+
   for fut in futs:
     if fut.failed:
       valResult = ValidationResult.Reject


### PR DESCRIPTION
## Summary

Make pubsub shutdown wait for in-flight async work to finish cancellation instead of cancelling it fire-and-forget.

This updates GossipSub stop handling to drain its background loops and pending validation/relay tasks, and prevents an in-flight RPC handler from queuing new validation work after shutdown has started. It also drains topic handlers and validators when their parent message-processing flow is cancelled.

## Affected Areas

- [x] Gossipsub  
  Shutdown now waits for owned background tasks and pending message-processing tasks to cancel.

- [x] Protocol Logic  
  Pubsub topic handlers and message validators are drained on cancellation.

## Impact on Library Users

No API changes.

Shutdown may now wait for in-flight pubsub callbacks or validators to observe cancellation instead of returning immediately after requesting cancellation.

## Risk Assessment

The main behavioral change is shutdown timing: callbacks or validators that do not respond to cancellation can delay `stop()`. This makes shutdown more deterministic, but depends on callback code being cancellation-friendly.