### PR TITLE
chore(protobuf): add metric for count of messages received/set

### DIFF
--- a/libp2p/utils/protobuf.nim
+++ b/libp2p/utils/protobuf.nim
@@ -15,15 +15,15 @@ func makeLabel(domain, msgType: string): string =
 
 template trackEncodeBytes*(count: int, msgType: typedesc, domain: string) =
   when defined(libp2p_protobuf_metrics):
-    libp2p_protobuf_bytes_write.inc(
-      count.int64, labelValues = [makeLabel(domain, $msgType)]
-    )
+    let label = makeLabel(domain, $msgType)
+    libp2p_protobuf_bytes_sent.inc(count.int64, labelValues = [label])
+    libp2p_protobuf_messages_sent.inc(labelValues = [label])
 
 template trackDecodeBytes*(count: int, msgType: typedesc, domain: string) =
   when defined(libp2p_protobuf_metrics):
-    libp2p_protobuf_bytes_read.inc(
-      count.int64, labelValues = [makeLabel(domain, $msgType)]
-    )
+    let label = makeLabel(domain, $msgType)
+    libp2p_protobuf_bytes_received.inc(count.int64, labelValues = [label])
+    libp2p_protobuf_messages_received.inc(labelValues = [label])
 
 macro decodeFor*(
     _: type Protobuf, Types: untyped, withMetrics: bool = false, domain: string = ""
@@ -37,7 +37,10 @@ macro decodeFor*(
     stmts.add quote do:
       proc `decodeName`(buf2: seq[byte]): `T` {.raises: [SerializationError].} =
         when defined(libp2p_protobuf_metrics) and `doMetrics`:
-          libp2p_protobuf_bytes_read.inc(buf2.len.int64, labelValues = [`metricLabel`])
+          libp2p_protobuf_bytes_received.inc(
+            buf2.len.int64, labelValues = [`metricLabel`]
+          )
+          libp2p_protobuf_messages_received.inc(labelValues = [`metricLabel`])
 
         decode(Protobuf, buf2, `T`)
 
@@ -62,12 +65,16 @@ macro serializerFor*(
       proc encode*(c: `T`): seq[byte] =
         let buf = encode(Protobuf, c)
         when defined(libp2p_protobuf_metrics) and `doMetrics`:
-          libp2p_protobuf_bytes_write.inc(buf.len.int64, labelValues = [`metricLabel`])
+          libp2p_protobuf_bytes_sent.inc(buf.len.int64, labelValues = [`metricLabel`])
+          libp2p_protobuf_messages_sent.inc(labelValues = [`metricLabel`])
         buf
 
       proc `decodeName`(buf2: seq[byte]): `T` {.raises: [SerializationError].} =
         when defined(libp2p_protobuf_metrics) and `doMetrics`:
-          libp2p_protobuf_bytes_read.inc(buf2.len.int64, labelValues = [`metricLabel`])
+          libp2p_protobuf_bytes_received.inc(
+            buf2.len.int64, labelValues = [`metricLabel`]
+          )
+          libp2p_protobuf_messages_received.inc(labelValues = [`metricLabel`])
 
         decode(Protobuf, buf2, `T`)
 

--- a/libp2p/utils/protobuf_metrics.nim
+++ b/libp2p/utils/protobuf_metrics.nim
@@ -7,8 +7,19 @@ when defined(libp2p_protobuf_metrics):
   import metrics
   export metrics
 
-  declareCounter(libp2p_protobuf_bytes_read, "protobuf bytes read", labels = ["kind"])
-  declareCounter(libp2p_protobuf_bytes_write, "protobuf bytes write", labels = ["kind"])
+  declareCounter(
+    libp2p_protobuf_bytes_received, "protobuf bytes received", labels = ["kind"]
+  )
+  declareCounter(libp2p_protobuf_bytes_sent, "protobuf bytes sent", labels = ["kind"])
+
+  declareCounter(
+    libp2p_protobuf_messages_received, "protobuf messages received", labels = ["kind"]
+  )
+  declareCounter(
+    libp2p_protobuf_messages_sent, "protobuf messages sent", labels = ["kind"]
+  )
 
   when defined(libp2p_testing):
-    export libp2p_protobuf_bytes_read, libp2p_protobuf_bytes_write
+    export
+      libp2p_protobuf_bytes_received, libp2p_protobuf_bytes_sent,
+      libp2p_protobuf_messages_received, libp2p_protobuf_messages_sent

--- a/tests/libp2p/utils/test_protobuf_metrics.nim
+++ b/tests/libp2p/utils/test_protobuf_metrics.nim
@@ -28,79 +28,142 @@ when defined(libp2p_protobuf_metrics):
     )
 
   suite "protobuf_metrics":
-    test "PeerRecord encode does not increment write counter (withMetrics = false)":
+    test "PeerRecord encode does not increment sent counter (withMetrics = false)":
       let record = makePeerRecord()
-      let before = counterValue(libp2p_protobuf_bytes_write, "PeerRecord")
+      let before = counterValue(libp2p_protobuf_bytes_sent, "PeerRecord")
       discard encode(record)
-      let after = counterValue(libp2p_protobuf_bytes_write, "PeerRecord")
+      let after = counterValue(libp2p_protobuf_bytes_sent, "PeerRecord")
       check after == before
 
-    test "PeerRecord decode does not increment read counter (withMetrics = false)":
+    test "PeerRecord decode does not increment received counter (withMetrics = false)":
       let record = makePeerRecord()
       let encoded = encode(record)
-      let before = counterValue(libp2p_protobuf_bytes_read, "PeerRecord")
+      let before = counterValue(libp2p_protobuf_bytes_received, "PeerRecord")
       discard PeerRecord.decode(encoded)
-      let after = counterValue(libp2p_protobuf_bytes_read, "PeerRecord")
+      let after = counterValue(libp2p_protobuf_bytes_received, "PeerRecord")
       check after == before
 
-    test "write counter incremented on encode":
+    test "sent counter incremented on encode":
       let msg = MetricsTestMsg(value: 42)
-      let before = counterValue(libp2p_protobuf_bytes_write, "MetricsTestMsg")
+      let before = counterValue(libp2p_protobuf_bytes_sent, "MetricsTestMsg")
       let encoded = encode(msg)
-      let after = counterValue(libp2p_protobuf_bytes_write, "MetricsTestMsg")
+      let after = counterValue(libp2p_protobuf_bytes_sent, "MetricsTestMsg")
       check after == before + float64(encoded.len)
 
-    test "read counter incremented on decode":
+    test "received counter incremented on decode":
       let msg = MetricsTestMsg(value: 42)
       let encoded = encode(msg)
-      let before = counterValue(libp2p_protobuf_bytes_read, "MetricsTestMsg")
+      let before = counterValue(libp2p_protobuf_bytes_received, "MetricsTestMsg")
       let decoded = MetricsTestMsg.decode(encoded)
-      let after = counterValue(libp2p_protobuf_bytes_read, "MetricsTestMsg")
+      let after = counterValue(libp2p_protobuf_bytes_received, "MetricsTestMsg")
       check decoded.isOk
       check after == before + float64(encoded.len)
 
-    test "encode does not increment read counter":
+    test "encode does not increment received counter":
       let msg = MetricsTestMsg(value: 42)
-      let beforeRead = counterValue(libp2p_protobuf_bytes_read, "MetricsTestMsg")
+      let beforeRead = counterValue(libp2p_protobuf_bytes_received, "MetricsTestMsg")
       discard encode(msg)
-      let afterRead = counterValue(libp2p_protobuf_bytes_read, "MetricsTestMsg")
+      let afterRead = counterValue(libp2p_protobuf_bytes_received, "MetricsTestMsg")
       check afterRead == beforeRead
 
-    test "decode does not increment write counter":
+    test "decode does not increment sent counter":
       let msg = MetricsTestMsg(value: 42)
       let encoded = encode(msg)
-      let beforeWrite = counterValue(libp2p_protobuf_bytes_write, "MetricsTestMsg")
+      let beforeWrite = counterValue(libp2p_protobuf_bytes_sent, "MetricsTestMsg")
       discard MetricsTestMsg.decode(encoded)
-      let afterWrite = counterValue(libp2p_protobuf_bytes_write, "MetricsTestMsg")
+      let afterWrite = counterValue(libp2p_protobuf_bytes_sent, "MetricsTestMsg")
       check afterWrite == beforeWrite
 
-    test "multiple encodes accumulate write counter":
+    test "multiple encodes accumulate sent counter":
       let msg = MetricsTestMsg(value: 42)
-      let before = counterValue(libp2p_protobuf_bytes_write, "MetricsTestMsg")
+      let before = counterValue(libp2p_protobuf_bytes_sent, "MetricsTestMsg")
       let enc1 = encode(msg)
       let enc2 = encode(msg)
-      let after = counterValue(libp2p_protobuf_bytes_write, "MetricsTestMsg")
+      let after = counterValue(libp2p_protobuf_bytes_sent, "MetricsTestMsg")
       check after == before + float64(enc1.len + enc2.len)
 
-    test "multiple decodes accumulate read counter":
+    test "multiple decodes accumulate received counter":
       let msg = MetricsTestMsg(value: 42)
       let encoded = encode(msg)
-      let before = counterValue(libp2p_protobuf_bytes_read, "MetricsTestMsg")
+      let before = counterValue(libp2p_protobuf_bytes_received, "MetricsTestMsg")
       discard MetricsTestMsg.decode(encoded)
       discard MetricsTestMsg.decode(encoded)
-      let after = counterValue(libp2p_protobuf_bytes_read, "MetricsTestMsg")
+      let after = counterValue(libp2p_protobuf_bytes_received, "MetricsTestMsg")
       check after == before + float64(encoded.len * 2)
 
     test "counters track bytes per type label independently":
       let msg = MetricsTestMsg(value: 42)
-      let beforeMsg = counterValue(libp2p_protobuf_bytes_write, "MetricsTestMsg")
-      let beforeOther = counterValue(libp2p_protobuf_bytes_write, "PeerRecord")
+      let beforeMsg = counterValue(libp2p_protobuf_bytes_sent, "MetricsTestMsg")
+      let beforeOther = counterValue(libp2p_protobuf_bytes_sent, "PeerRecord")
       discard encode(msg)
-      let afterMsg = counterValue(libp2p_protobuf_bytes_write, "MetricsTestMsg")
-      let afterOther = counterValue(libp2p_protobuf_bytes_write, "PeerRecord")
+      let afterMsg = counterValue(libp2p_protobuf_bytes_sent, "MetricsTestMsg")
+      let afterOther = counterValue(libp2p_protobuf_bytes_sent, "PeerRecord")
       check afterMsg > beforeMsg
       check afterOther == beforeOther
 
     test "counter for unregistered label returns zero":
-      check counterValue(libp2p_protobuf_bytes_read, "NonExistentType") == 0.0
-      check counterValue(libp2p_protobuf_bytes_write, "NonExistentType") == 0.0
+      check counterValue(libp2p_protobuf_bytes_received, "NonExistentType") == 0.0
+      check counterValue(libp2p_protobuf_bytes_sent, "NonExistentType") == 0.0
+
+    test "messages_sent counter incremented on encode":
+      let msg = MetricsTestMsg(value: 42)
+      let before = counterValue(libp2p_protobuf_messages_sent, "MetricsTestMsg")
+      discard encode(msg)
+      let after = counterValue(libp2p_protobuf_messages_sent, "MetricsTestMsg")
+      check after == before + 1.0
+
+    test "messages_received counter incremented on decode":
+      let msg = MetricsTestMsg(value: 42)
+      let encoded = encode(msg)
+      let before = counterValue(libp2p_protobuf_messages_received, "MetricsTestMsg")
+      discard MetricsTestMsg.decode(encoded)
+      let after = counterValue(libp2p_protobuf_messages_received, "MetricsTestMsg")
+      check after == before + 1.0
+
+    test "encode does not increment messages_received counter":
+      let msg = MetricsTestMsg(value: 42)
+      let before = counterValue(libp2p_protobuf_messages_received, "MetricsTestMsg")
+      discard encode(msg)
+      let after = counterValue(libp2p_protobuf_messages_received, "MetricsTestMsg")
+      check after == before
+
+    test "decode does not increment messages_sent counter":
+      let msg = MetricsTestMsg(value: 42)
+      let encoded = encode(msg)
+      let before = counterValue(libp2p_protobuf_messages_sent, "MetricsTestMsg")
+      discard MetricsTestMsg.decode(encoded)
+      let after = counterValue(libp2p_protobuf_messages_sent, "MetricsTestMsg")
+      check after == before
+
+    test "multiple encodes accumulate messages_sent counter":
+      let msg = MetricsTestMsg(value: 42)
+      let before = counterValue(libp2p_protobuf_messages_sent, "MetricsTestMsg")
+      discard encode(msg)
+      discard encode(msg)
+      let after = counterValue(libp2p_protobuf_messages_sent, "MetricsTestMsg")
+      check after == before + 2.0
+
+    test "multiple decodes accumulate messages_received counter":
+      let msg = MetricsTestMsg(value: 42)
+      let encoded = encode(msg)
+      let before = counterValue(libp2p_protobuf_messages_received, "MetricsTestMsg")
+      discard MetricsTestMsg.decode(encoded)
+      discard MetricsTestMsg.decode(encoded)
+      let after = counterValue(libp2p_protobuf_messages_received, "MetricsTestMsg")
+      check after == before + 2.0
+
+    test "messages counters track per type label independently":
+      let msg = MetricsTestMsg(value: 42)
+      let beforeMsg = counterValue(libp2p_protobuf_messages_sent, "MetricsTestMsg")
+      let beforeOther = counterValue(libp2p_protobuf_messages_sent, "PeerRecord")
+      discard encode(msg)
+      let afterMsg = counterValue(libp2p_protobuf_messages_sent, "MetricsTestMsg")
+      let afterOther = counterValue(libp2p_protobuf_messages_sent, "PeerRecord")
+      check afterMsg > beforeMsg
+      check afterOther == beforeOther
+
+    test "messages_sent counter for unregistered label returns zero":
+      check counterValue(libp2p_protobuf_messages_sent, "NonExistentType") == 0.0
+
+    test "messages_received counter for unregistered label returns zero":
+      check counterValue(libp2p_protobuf_messages_received, "NonExistentType") == 0.0


### PR DESCRIPTION
this pr adds two metrics `libp2p_protobuf_messages_received` and  `libp2p_protobuf_messages_sent` that represent number of messages sent/revived. these metrics where added becasue kademlia has similar metrics `kad_messages_sent`, `kad_messages_received`. in future this will enable transition of kad specific metrics. 

did a a rename to have consistent metrics namaing:
- `libp2p_protobuf_bytes_read` -> `libp2p_protobuf_bytes_received`
- `libp2p_protobuf_bytes_write` -> `libp2p_protobuf_bytes_sent`
- and newly added:
  -   `libp2p_protobuf_messages_received`
  -    `libp2p_protobuf_messages_sent`