### PR TITLE
chore(ci): add mm to the job names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
       run:
         shell: ${{ matrix.shell }}
 
-    name: "${{ matrix.platform.os }}-${{ matrix.platform.cpu }} (Nim ${{ matrix.nim.ref }} / ${{ matrix.platform.cc }})"
+    name: "${{ matrix.platform.os }}-${{ matrix.platform.cpu }} (Nim ${{ matrix.nim.ref }} / ${{ matrix.platform.cc }} / ${{ matrix.nim.memory_management }})"
     runs-on: ${{ matrix.builder }}
     steps:
       - name: Checkout
@@ -145,7 +145,7 @@ jobs:
           runner.os == 'Windows' &&
           matrix.platform.cc == 'clang'
         run: |
-          echo '${{ github.workspace }}'"/external/mingw-${{ matrix.platform.cpu }}/bin" >> $GITHUB_PATH
+          echo '${{ github.workspace }}'"/external/mingw-${{ matrix.nim.cpu }}/bin" >> $GITHUB_PATH
           echo "." >> $GITHUB_PATH
 
       - name: Install nasm (Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
           runner.os == 'Windows' &&
           matrix.platform.cc == 'clang'
         run: |
-          echo '${{ github.workspace }}'"/external/mingw-${{ matrix.nim.cpu }}/bin" >> $GITHUB_PATH
+          echo '${{ github.workspace }}'"/external/mingw-${{ matrix.platform.cpu }}/bin" >> $GITHUB_PATH
           echo "." >> $GITHUB_PATH
 
       - name: Install nasm (Windows)


### PR DESCRIPTION
Currently the job names appear duplicated while in reality they're running under differemt `--mm` values