### PR TITLE
chore: fix job names in daily jobs

### DIFF
--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -85,7 +85,7 @@ jobs:
       run:
         shell: ${{ matrix.config.shell }}
 
-    name: "${{ matrix.config.os }} (nim ${{ matrix.nim.ref }} / ${{ matrix.config.cc }})"
+    name: "${{ matrix.config.os }}-${{ matrix.config.cpu }} (${{ matrix.nim.ref }}; ${{ matrix.config.cc }}; ${{ matrix.nim.memory_management }})"
     runs-on: ${{ matrix.config.builder }}
     steps:
       - name: Checkout


### PR DESCRIPTION
<img width="394" height="441" alt="image" src="https://github.com/user-attachments/assets/fe871bcf-bbd0-46d9-bed1-3d9e06a7915a" />

Curiously, it seems that reusable jobs cannot have `/` in their names