### PR TITLE
fix(kad): cancel timed-out lookup RPCs so they don't leak rpc slots

### DIFF
--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -21,6 +21,7 @@ type LookupState* = ref object
   shortlist*: Table[PeerId, XorDistance]
   responded*: Table[PeerId, RespondedStatus]
   attempts*: Table[PeerId, int]
+  inflight*: Table[PeerId, seq[FutureBase]]
 
 type DispatchProc* = proc(
   kad: KadDHT, peer: PeerId, target: Key
@@ -393,9 +394,10 @@ proc lookOnce*(
     let msg = await dispatch(kad, peerId, target)
     return (peerId, msg)
 
-  let
-    rpcBatch = toQuery.mapIt(dispatchWithPeer(it))
-    completedRPCBatch = await rpcBatch.collectCompleted(kad.config.timeout)
+  let rpcBatch = toQuery.mapIt(dispatchWithPeer(it))
+  for (fut, peerId) in zip(rpcBatch, toQuery):
+    state.inflight.mgetOrPut(peerId, @[]).add(FutureBase(fut))
+  let completedRPCBatch = await rpcBatch.collectCompleted(kad.config.timeout)
 
   for (fut, peerId) in zip(rpcBatch, toQuery):
     if not fut.finished():
@@ -420,6 +422,15 @@ proc lookOnce*(
     )
     await onReply(peerId, Opt.some(reply), state)
 
+  var doneFuts: seq[FutureBase]
+  for peerId in toQuery:
+    if state.responded.hasKey(peerId) or
+        state.attempts.getOrDefault(peerId, 0) > kad.config.retries:
+      doneFuts.add(state.inflight.getOrDefault(peerId).filterIt(not it.finished()))
+      state.inflight.del(peerId)
+  if doneFuts.len > 0:
+    await doneFuts.cancelAndWait()
+
   return true
 
 proc iterativeLookup*(
@@ -435,6 +446,12 @@ proc iterativeLookup*(
   while not stopCond(state):
     if not await kad.lookOnce(state, rtable, dispatch, onReply):
       break
+
+  var leftover: seq[FutureBase]
+  for futs in state.inflight.values:
+    leftover.add(futs.filterIt(not it.finished()))
+  if leftover.len > 0:
+    await leftover.cancelAndWait()
 
   state
 

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -400,7 +400,7 @@ proc lookOnce*(
   let completedRPCBatch = await rpcBatch.collectCompleted(kad.config.timeout)
 
   for (fut, peerId) in zip(rpcBatch, toQuery):
-    if not fut.finished():
+    if not fut.finished() or fut.cancelled():
       continue
     if fut.failed():
       state.responded[peerId] = RespondedStatus.Failed
@@ -412,6 +412,7 @@ proc lookOnce*(
       else:
         state.responded[peerId] = RespondedStatus.Success
 
+  var toCancel: seq[FutureBase]
   for (peerId, res) in completedRPCBatch:
     let reply = res.valueOr:
       continue
@@ -422,14 +423,18 @@ proc lookOnce*(
     )
     await onReply(peerId, Opt.some(reply), state)
 
-  var doneFuts: seq[FutureBase]
+  # Evicted peers are no longer eligible for retries, so cancel any abandoned RPCs.
+  for peerId in state.inflight.keys.toSeq:
+    if not state.shortlist.hasKey(peerId):
+      toCancel.add(state.inflight.getOrDefault(peerId).filterIt(not it.finished()))
+      state.inflight.del(peerId)
+
   for peerId in toQuery:
     if state.responded.hasKey(peerId) or
         state.attempts.getOrDefault(peerId, 0) > kad.config.retries:
-      doneFuts.add(state.inflight.getOrDefault(peerId).filterIt(not it.finished()))
+      toCancel.add(state.inflight.getOrDefault(peerId).filterIt(not it.finished()))
       state.inflight.del(peerId)
-  if doneFuts.len > 0:
-    await doneFuts.cancelAndWait()
+  await toCancel.cancelAndWait()
 
   return true
 


### PR DESCRIPTION
In a big bootstrap, a large fraction of nodes hang forever in `KadDHT.bootstrap()` and never finish. The iterative lookup (`lookOnce`, `kademlia/find.nim`) fires a batch of FIND_NODE RPCs and waits for them with `collectCompleted(timeout)` (`utils/future.nim`). On timeout, `collectCompleted` discards the futures that didn't answer but never cancels them. Each one is still parked in `readLp`, holding the `rpcSem` slot it acquired via `withRpcSlot`. `rpcSem` caps concurrent outbound RPCs at `maxConcurrentRpcs`, so every slow or unresponsive peer leaks one slot per lookup round. They pile up, and once they hold the whole pool the next FIND_NODE blocks on the semaphore and the lookup deadlocks.

**The fix:** cancel the still-pending futures in `collectCompleted` after the wait, so they release their stream and rpc slot instead of running on after their result has been abandoned. 
