### PR TITLE
test(transports): dual stack 1

### DIFF
--- a/tests/libp2p/transports/stream_tests.nim
+++ b/tests/libp2p/transports/stream_tests.nim
@@ -101,43 +101,6 @@ template streamTransportTest*(
       clientStreamHandler,
     )
 
-  asyncTest "should allow multiple local addresses":
-    if isTorTransport(addressIP4):
-      skip() # Tor uses fixed onion ports, not duplicate port-0 listeners
-      return
-
-    let server = transportProvider()
-    # two port-0 addresses of the same family get distinct OS-assigned ports
-    await server.start(@[addressIP4, addressIP4])
-    defer:
-      await server.stop()
-
-    check:
-      server.addrs.len == 2
-      server.addrs[0] != server.addrs[1]
-      extractPort(server.addrs[0]) > 0
-      extractPort(server.addrs[1]) > 0
-
-    # dial both addresses and verify a single accept() services either listener
-    let client1 = transportProvider()
-    let client2 = transportProvider()
-    defer:
-      await allFutures(client1.stop(), client2.stop())
-
-    let acceptFut1 = server.accept()
-    let conn1 = await client1.dial("", server.addrs[0])
-    let serverConn1 = await acceptFut1
-
-    let acceptFut2 = server.accept()
-    let conn2 = await client2.dial("", server.addrs[1])
-    let serverConn2 = await acceptFut2
-
-    check:
-      not conn1.closed()
-      not conn2.closed()
-      not serverConn1.closed()
-      not serverConn2.closed()
-
   asyncTest "read/write Lp":
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):

--- a/tests/libp2p/transports/stream_tests.nim
+++ b/tests/libp2p/transports/stream_tests.nim
@@ -4,7 +4,8 @@
 {.used.}
 
 import chronos, stew/byteutils, std/random
-import ../../../libp2p/[stream/connection, transports/transport, muxers/muxer]
+import
+  ../../../libp2p/[stream/connection, transports/transport, muxers/muxer, multiaddress]
 import ../../tools/[stream, sync]
 import ./utils
 
@@ -57,6 +58,86 @@ template streamTransportTest*(
 
     runTransportTest(transportProvider, streamProvider, addressIP6.get())
 
+  asyncTest "start binds both IPv4 and IPv6 addresses":
+    if addressIP6.isNone:
+      skip() # ipv6 not supported
+      return
+
+    let server = transportProvider()
+    await server.start(@[addressIP4, addressIP6.get()])
+    defer:
+      await server.stop()
+
+    check:
+      server.addrs.len == 2
+      extractPort(server.addrs.addrByFamily(IP4)) > 0
+      extractPort(server.addrs.addrByFamily(IP6)) > 0
+
+  asyncTest "dual-stack server exchanges data with IPv4 and IPv6 clients":
+    if addressIP6.isNone:
+      skip() # ipv6 not supported
+      return
+
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
+      noExceptionWithStreamClose(stream):
+        var buffer: array[clientMessage.len, byte]
+        await stream.readExactly(addr buffer, clientMessage.len)
+        check string.fromBytes(buffer) == clientMessage
+        await stream.write(serverMessage)
+
+    proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
+      noExceptionWithStreamClose(stream):
+        await stream.write(clientMessage)
+
+        var buffer: array[serverMessage.len, byte]
+        await stream.readExactly(addr buffer, serverMessage.len)
+        check string.fromBytes(buffer) == serverMessage
+
+    await dualStackStreamScenario(
+      @[addressIP4, addressIP6.get()],
+      transportProvider,
+      streamProvider,
+      serverStreamHandler,
+      clientStreamHandler,
+    )
+
+  asyncTest "should allow multiple local addresses":
+    if isTorTransport(addressIP4):
+      skip() # Tor uses fixed onion ports, not duplicate port-0 listeners
+      return
+
+    let server = transportProvider()
+    # two port-0 addresses of the same family get distinct OS-assigned ports
+    await server.start(@[addressIP4, addressIP4])
+    defer:
+      await server.stop()
+
+    check:
+      server.addrs.len == 2
+      server.addrs[0] != server.addrs[1]
+      extractPort(server.addrs[0]) > 0
+      extractPort(server.addrs[1]) > 0
+
+    # dial both addresses and verify a single accept() services either listener
+    let client1 = transportProvider()
+    let client2 = transportProvider()
+    defer:
+      await allFutures(client1.stop(), client2.stop())
+
+    let acceptFut1 = server.accept()
+    let conn1 = await client1.dial("", server.addrs[0])
+    let serverConn1 = await acceptFut1
+
+    let acceptFut2 = server.accept()
+    let conn2 = await client2.dial("", server.addrs[1])
+    let serverConn2 = await acceptFut2
+
+    check:
+      not conn1.closed()
+      not conn2.closed()
+      not serverConn1.closed()
+      not serverConn2.closed()
+
   asyncTest "read/write Lp":
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
@@ -67,6 +148,35 @@ template streamTransportTest*(
       noExceptionWithStreamClose(stream):
         await stream.writeLp(fromHex("1234"))
         check (await stream.readLp(100)) == fromHex("5678")
+
+    await runSingleStreamScenario(
+      @[addressIP4],
+      transportProvider,
+      streamProvider,
+      serverStreamHandler,
+      clientStreamHandler,
+    )
+
+  asyncTest "Connection.reset aborts the initiator stream":
+    var serverResetDone = newFuture[void]()
+
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
+      noExceptionWithStreamClose(stream):
+        let msg = await stream.readLp(100)
+        check msg == fromHex("1234")
+        await stream.reset()
+        serverResetDone.complete()
+
+    proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
+      noExceptionWithStreamClose(stream):
+        await stream.writeLp(fromHex("1234"))
+        await serverResetDone
+
+        var buffer: array[1, byte]
+        check (await stream.readOnce(addr buffer[0], 1)) == 0
+
+        expect LPStreamResetError:
+          await stream.writeLp(fromHex("1234"))
 
     await runSingleStreamScenario(
       @[addressIP4],

--- a/tests/libp2p/transports/test_quic.nim
+++ b/tests/libp2p/transports/test_quic.nim
@@ -106,6 +106,39 @@ suite "Quic transport":
     expect QuicTransportDialError:
       discard await client.dial("", server.addrs[0], Opt.some(wrongPeerId))
 
+  asyncTest "should allow multiple local addresses":
+    let server = await createQuicTransport(
+      isServer = true, addresses = @[QuicAutoAddress, QuicAutoAddress]
+    )
+    defer:
+      await server.stop()
+
+    check:
+      server.addrs.len == 2
+      server.addrs[0] != server.addrs[1]
+      extractPort(server.addrs[0]) > 0
+      extractPort(server.addrs[1]) > 0
+
+    # Dial to both addresses and verify connections are accepted
+    let client1 = await createQuicTransport()
+    let client2 = await createQuicTransport()
+    defer:
+      await allFutures(client1.stop(), client2.stop())
+
+    let acceptFut1 = server.accept()
+    let conn1 = await client1.dial("", server.addrs[0])
+    let serverConn1 = await acceptFut1
+
+    let acceptFut2 = server.accept()
+    let conn2 = await client2.dial("", server.addrs[1])
+    let serverConn2 = await acceptFut2
+
+    check:
+      not conn1.closed()
+      not conn2.closed()
+      not serverConn1.closed()
+      not serverConn2.closed()
+
   asyncTest "dial reuses listener endpoint when available":
     let client = await createQuicTransport(isServer = true)
     let server = await createQuicTransport(isServer = true)

--- a/tests/libp2p/transports/test_quic.nim
+++ b/tests/libp2p/transports/test_quic.nim
@@ -39,8 +39,6 @@ const
     "/ip4/127.0.0.1/tcp/1234/quic-v1", # Wrong transport (TCP instead of UDP)
     "/ip4/127.0.0.1/udp/1234/quic", # Legacy quic (not quic-v1)
   ]
-  # multiaddress exports QUIC_V1_IP4 but has no IPv6 counterpart
-  QUIC_V1_IP6 = mapAnd(IP6, mapEq("udp"), mapEq("quic-v1"))
 
 suite "Quic transport":
   teardown:
@@ -56,35 +54,6 @@ suite "Quic transport":
     Opt.some(MultiAddress.init(addressIP6).get()),
     streamProvider,
   )
-
-  asyncTest "Connection.reset aborts the initiator stream":
-    var serverResetDone = newFuture[void]()
-
-    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
-      noExceptionWithStreamClose(stream):
-        let msg = await stream.readLp(100)
-        check msg == fromHex("1234")
-        await stream.reset()
-        serverResetDone.complete()
-
-    proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
-      noExceptionWithStreamClose(stream):
-        await stream.writeLp(fromHex("1234"))
-        await serverResetDone
-
-        var buffer: array[1, byte]
-        check (await stream.readOnce(addr buffer[0], 1)) == 0
-
-        expect LPStreamResetError:
-          await stream.writeLp(fromHex("1234"))
-
-    await runSingleStreamScenario(
-      @[MultiAddress.init(addressIP4).get()],
-      quicTransProvider,
-      streamProvider,
-      serverStreamHandler,
-      clientStreamHandler,
-    )
 
   asyncTest "transport e2e - invalid cert - server":
     let server = await createQuicTransport(isServer = true, withInvalidCert = true)
@@ -136,39 +105,6 @@ suite "Quic transport":
 
     expect QuicTransportDialError:
       discard await client.dial("", server.addrs[0], Opt.some(wrongPeerId))
-
-  asyncTest "should allow multiple local addresses":
-    let server = await createQuicTransport(
-      isServer = true, addresses = @[QuicAutoAddress, QuicAutoAddress]
-    )
-    defer:
-      await server.stop()
-
-    check:
-      server.addrs.len == 2
-      server.addrs[0] != server.addrs[1]
-      extractPort(server.addrs[0]) > 0
-      extractPort(server.addrs[1]) > 0
-
-    # Dial to both addresses and verify connections are accepted
-    let client1 = await createQuicTransport()
-    let client2 = await createQuicTransport()
-    defer:
-      await allFutures(client1.stop(), client2.stop())
-
-    let acceptFut1 = server.accept()
-    let conn1 = await client1.dial("", server.addrs[0])
-    let serverConn1 = await acceptFut1
-
-    let acceptFut2 = server.accept()
-    let conn2 = await client2.dial("", server.addrs[1])
-    let serverConn2 = await acceptFut2
-
-    check:
-      not conn1.closed()
-      not conn2.closed()
-      not serverConn1.closed()
-      not serverConn2.closed()
 
   asyncTest "dial reuses listener endpoint when available":
     let client = await createQuicTransport(isServer = true)
@@ -234,20 +170,6 @@ suite "Quic transport":
       extractPort(serverConn.observedAddr.get()) ==
         extractPort(clientConn.localAddr.get())
 
-  asyncTest "start binds both IPv4 and IPv6 addresses":
-    let server = await createQuicTransport(
-      isServer = true, addresses = @[QuicAutoAddressIP4, QuicAutoAddressIP6]
-    )
-    defer:
-      await server.stop()
-
-    check:
-      server.addrs.len == 2
-      countAddressesWithPattern(server.addrs, QUIC_V1_IP4) == 1
-      countAddressesWithPattern(server.addrs, QUIC_V1_IP6) == 1
-      extractPort(server.addrs[0]) > 0
-      extractPort(server.addrs[1]) > 0
-
   asyncTest "dual-stack dialer reuses the matching-family listener":
     # Dialing from the listener endpoint makes the remote observe the listen port.
     # Port reuse and DCUtR hole punching depend on that.
@@ -295,55 +217,6 @@ suite "Quic transport":
       serverConn.observedAddr.isSome()
       # a different port than the IPv4 listener means a separate endpoint was used
       extractPort(serverConn.observedAddr.get()) != dialerIPv4Port
-
-  asyncTest "dual-stack server exchanges data with IPv4 and IPv6 clients":
-    # A single accept() returns connections arriving on either listener, so one
-    # dual-stack server can serve both an IPv4 and an IPv6 client.
-    const
-      clientMsg = "client"
-      serverMsg = "server"
-
-    let server = await createQuicTransport(
-      isServer = true, addresses = @[QuicAutoAddressIP4, QuicAutoAddressIP6]
-    )
-    defer:
-      await server.stop()
-
-    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
-      noExceptionWithStreamClose(stream):
-        var buffer: array[clientMsg.len, byte]
-        await stream.readExactly(addr buffer, clientMsg.len)
-        check string.fromBytes(buffer) == clientMsg
-        await stream.write(serverMsg)
-
-    proc runClient(address: MultiAddress) {.async.} =
-      let client = await createQuicTransport()
-      let conn = await client.dial("", address)
-      let muxer = streamProvider(conn)
-
-      let stream = await muxer.newStream()
-      await stream.write(clientMsg)
-
-      var buffer: array[serverMsg.len, byte]
-      await stream.readExactly(addr buffer, serverMsg.len)
-      check string.fromBytes(buffer) == serverMsg
-
-      await stream.close()
-      await muxer.close()
-      await conn.close()
-      await client.stop()
-
-    # accept() is single-consumer, so serve the two clients one after another
-    proc serveBoth() {.async.} =
-      await serverHandlerSingleStream(server, streamProvider, serverStreamHandler)
-      await serverHandlerSingleStream(server, streamProvider, serverStreamHandler)
-
-    let serverTask = serveBoth()
-    await allFutures(
-      runClient(server.addrs.addrByFamily(IP4)),
-      runClient(server.addrs.addrByFamily(IP6)),
-    )
-    await serverTask
 
   asyncTest "server not accepting":
     let server = await createQuicTransport(isServer = true)

--- a/tests/libp2p/transports/test_quic.nim
+++ b/tests/libp2p/transports/test_quic.nim
@@ -5,8 +5,13 @@
 
 import chronos, random, stew/byteutils
 import
-  ../../../libp2p/
-    [transports/transport, transports/quictransport, upgrademngrs/upgrade, muxers/muxer]
+  ../../../libp2p/[
+    transports/transport,
+    transports/quictransport,
+    upgrademngrs/upgrade,
+    muxers/muxer,
+    multiaddress,
+  ]
 import ../../tools/[unittest, crypto as cryptoTools, multiaddress]
 import ./basic_tests
 import ./stream_tests
@@ -34,6 +39,8 @@ const
     "/ip4/127.0.0.1/tcp/1234/quic-v1", # Wrong transport (TCP instead of UDP)
     "/ip4/127.0.0.1/udp/1234/quic", # Legacy quic (not quic-v1)
   ]
+  # multiaddress exports QUIC_V1_IP4 but has no IPv6 counterpart
+  QUIC_V1_IP6 = mapAnd(IP6, mapEq("udp"), mapEq("quic-v1"))
 
 suite "Quic transport":
   teardown:
@@ -131,9 +138,9 @@ suite "Quic transport":
       discard await client.dial("", server.addrs[0], Opt.some(wrongPeerId))
 
   asyncTest "should allow multiple local addresses":
-    let key = PrivateKey.random(ECDSA, rng()).tryGet()
-    let server = QuicTransport.new(Upgrade(), key)
-    await server.start(@[QuicAutoAddress, QuicAutoAddress])
+    let server = await createQuicTransport(
+      isServer = true, addresses = @[QuicAutoAddress, QuicAutoAddress]
+    )
     defer:
       await server.stop()
 
@@ -183,9 +190,9 @@ suite "Quic transport":
       extractPort(serverConn.observedAddr.get()) == clientListenPort
 
   asyncTest "dial uses dial-only endpoint with multiple listener matches":
-    let key = PrivateKey.random(ECDSA, rng()).tryGet()
-    let client = QuicTransport.new(Upgrade(), key)
-    await client.start(@[QuicAutoAddress, QuicAutoAddress])
+    let client = await createQuicTransport(
+      isServer = true, addresses = @[QuicAutoAddress, QuicAutoAddress]
+    )
     let server = await createQuicTransport(isServer = true)
     defer:
       await allFutures(client.stop(), server.stop())
@@ -226,6 +233,117 @@ suite "Quic transport":
       serverConn.observedAddr.isSome()
       extractPort(serverConn.observedAddr.get()) ==
         extractPort(clientConn.localAddr.get())
+
+  asyncTest "start binds both IPv4 and IPv6 addresses":
+    let server = await createQuicTransport(
+      isServer = true, addresses = @[QuicAutoAddressIP4, QuicAutoAddressIP6]
+    )
+    defer:
+      await server.stop()
+
+    check:
+      server.addrs.len == 2
+      countAddressesWithPattern(server.addrs, QUIC_V1_IP4) == 1
+      countAddressesWithPattern(server.addrs, QUIC_V1_IP6) == 1
+      extractPort(server.addrs[0]) > 0
+      extractPort(server.addrs[1]) > 0
+
+  asyncTest "dual-stack dialer reuses the matching-family listener":
+    # Dialing from the listener endpoint makes the remote observe the listen port.
+    # Port reuse and DCUtR hole punching depend on that.
+    let dialer = await createQuicTransport(
+      isServer = true, addresses = @[QuicAutoAddressIP4, QuicAutoAddressIP6]
+    )
+    let server =
+      await createQuicTransport(isServer = true, addresses = @[QuicAutoAddressIP6])
+    defer:
+      await allFutures(dialer.stop(), server.stop())
+
+    let dialerIPv6Port = extractPort(dialer.addrs.addrByFamily(IP6))
+
+    let acceptFut = server.accept()
+    let dialerConn = await dialer.dial("", server.addrs[0])
+    let serverConn = await acceptFut
+    defer:
+      await allFutures(dialerConn.close(), serverConn.close())
+
+    check:
+      serverConn.observedAddr.isSome()
+      # same port as the IPv6 listener means that listener was reused
+      extractPort(serverConn.observedAddr.get()) == dialerIPv6Port
+
+  asyncTest "dial uses an IPv6 dial-only endpoint when only an IPv4 listener exists":
+    # An IPv4 socket cannot carry an IPv6 dial, so the IPv4 listener cannot be
+    # reused and a separate IPv6 dial-only endpoint has to be opened.
+    let dialer =
+      await createQuicTransport(isServer = true, addresses = @[QuicAutoAddressIP4])
+    let server =
+      await createQuicTransport(isServer = true, addresses = @[QuicAutoAddressIP6])
+    defer:
+      await allFutures(dialer.stop(), server.stop())
+
+    let dialerIPv4Port = extractPort(dialer.addrs[0])
+
+    let acceptFut = server.accept()
+    let dialerConn = await dialer.dial("", server.addrs[0])
+    let serverConn = await acceptFut
+    defer:
+      await allFutures(dialerConn.close(), serverConn.close())
+
+    check:
+      dialer.addrs.len == 1
+      serverConn.observedAddr.isSome()
+      # a different port than the IPv4 listener means a separate endpoint was used
+      extractPort(serverConn.observedAddr.get()) != dialerIPv4Port
+
+  asyncTest "dual-stack server exchanges data with IPv4 and IPv6 clients":
+    # A single accept() returns connections arriving on either listener, so one
+    # dual-stack server can serve both an IPv4 and an IPv6 client.
+    const
+      clientMsg = "client"
+      serverMsg = "server"
+
+    let server = await createQuicTransport(
+      isServer = true, addresses = @[QuicAutoAddressIP4, QuicAutoAddressIP6]
+    )
+    defer:
+      await server.stop()
+
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
+      noExceptionWithStreamClose(stream):
+        var buffer: array[clientMsg.len, byte]
+        await stream.readExactly(addr buffer, clientMsg.len)
+        check string.fromBytes(buffer) == clientMsg
+        await stream.write(serverMsg)
+
+    proc runClient(address: MultiAddress) {.async.} =
+      let client = await createQuicTransport()
+      let conn = await client.dial("", address)
+      let muxer = streamProvider(conn)
+
+      let stream = await muxer.newStream()
+      await stream.write(clientMsg)
+
+      var buffer: array[serverMsg.len, byte]
+      await stream.readExactly(addr buffer, serverMsg.len)
+      check string.fromBytes(buffer) == serverMsg
+
+      await stream.close()
+      await muxer.close()
+      await conn.close()
+      await client.stop()
+
+    # accept() is single-consumer, so serve the two clients one after another
+    proc serveBoth() {.async.} =
+      await serverHandlerSingleStream(server, streamProvider, serverStreamHandler)
+      await serverHandlerSingleStream(server, streamProvider, serverStreamHandler)
+
+    let serverTask = serveBoth()
+    await allFutures(
+      runClient(server.addrs.addrByFamily(IP4)),
+      runClient(server.addrs.addrByFamily(IP6)),
+    )
+    await serverTask
 
   asyncTest "server not accepting":
     let server = await createQuicTransport(isServer = true)

--- a/tests/libp2p/transports/utils.nim
+++ b/tests/libp2p/transports/utils.nim
@@ -213,6 +213,8 @@ proc dualStackStreamScenario*(
   ## a fresh client, serving each accepted connection with `serverStreamHandler`.
   let server = transportProvider()
   await server.start(listenAddrs)
+  defer:
+    await server.stop()
 
   # dial the server's resolved address of each family, not the wildcard input
   let targets = @[server.addrs.addrByFamily(IP4), server.addrs.addrByFamily(IP6)]
@@ -232,7 +234,6 @@ proc dualStackStreamScenario*(
     )
   await allFutures(clientTasks)
   await serverTask
-  await server.stop()
 
 proc countTransitions*(readOrder: seq[byte]): int =
   var transitions = 0

--- a/tests/libp2p/transports/utils.nim
+++ b/tests/libp2p/transports/utils.nim
@@ -80,7 +80,7 @@ proc createQuicTransport*(
     isServer: bool = false,
     withInvalidCert: bool = false,
     privateKey: Opt[PrivateKey] = Opt.none(PrivateKey),
-    address: MultiAddress = QuicAutoAddress,
+    addresses: seq[MultiAddress] = @[QuicAutoAddress],
 ): Future[QuicTransport] {.async.} =
   let key =
     if privateKey.isNone:
@@ -95,8 +95,7 @@ proc createQuicTransport*(
       QuicTransport.new(Upgrade(), key)
 
   if isServer: # servers are started because they need to listen
-    let ma = @[address]
-    await trans.start(ma)
+    await trans.start(addresses)
 
   return trans
 
@@ -108,6 +107,13 @@ type StreamProvider* =
   proc(conn: RawConn, handle: bool = true): Muxer {.gcsafe, raises: [].}
 
 type StreamHandler* = proc(stream: MuxedStream) {.async: (raises: []).}
+
+proc addrByFamily*(addrs: seq[MultiAddress], family: MaPattern): MultiAddress =
+  ## First address whose leading ip component matches `family` (IP4 or IP6).
+  for a in addrs:
+    if family.matchPartial(a):
+      return a
+  raiseAssert "no address for the requested family"
 
 proc extractPort*(ma: MultiAddress): int =
   var codec =

--- a/tests/libp2p/transports/utils.nim
+++ b/tests/libp2p/transports/utils.nim
@@ -154,15 +154,15 @@ proc serverHandlerSingleStream*(
   except CatchableError as exc:
     raiseAssert "should not fail: " & exc.msg
 
-proc clientRunSingleStream*(
-    server: Transport,
+proc clientRunSingleStreamTo*(
+    address: MultiAddress,
     transportProvider: TransportProvider,
     streamProvider: StreamProvider,
     handler: StreamHandler,
 ) {.async: (raises: []).} =
   try:
     let client = transportProvider()
-    let conn = await client.dial("", server.addrs[0])
+    let conn = await client.dial("", address)
     let muxer = streamProvider(conn)
 
     let stream = await muxer.newStream()
@@ -173,6 +173,16 @@ proc clientRunSingleStream*(
     await client.stop()
   except CatchableError as exc:
     raiseAssert "should not fail: " & exc.msg
+
+proc clientRunSingleStream*(
+    server: Transport,
+    transportProvider: TransportProvider,
+    streamProvider: StreamProvider,
+    handler: StreamHandler,
+) {.async: (raises: []).} =
+  await clientRunSingleStreamTo(
+    server.addrs[0], transportProvider, streamProvider, handler
+  )
 
 proc runSingleStreamScenario*(
     multiAddress: seq[MultiAddress],
@@ -190,6 +200,38 @@ proc runSingleStreamScenario*(
     server, transportProvider, streamProvider, clientStreamHandler
   )
   await allFutures(clientTask, serverTask)
+  await server.stop()
+
+proc dualStackStreamScenario*(
+    listenAddrs: seq[MultiAddress],
+    transportProvider: TransportProvider,
+    streamProvider: StreamProvider,
+    serverStreamHandler: StreamHandler,
+    clientStreamHandler: StreamHandler,
+) {.async: (raises: [CancelledError, LPError]).} =
+  ## Start one server on `listenAddrs`, then dial it once per address family from
+  ## a fresh client, serving each accepted connection with `serverStreamHandler`.
+  let server = transportProvider()
+  await server.start(listenAddrs)
+
+  # dial the server's resolved address of each family, not the wildcard input
+  let targets = @[server.addrs.addrByFamily(IP4), server.addrs.addrByFamily(IP6)]
+
+  # accept() is single-consumer, so serve the clients one after another
+  proc serveAll() {.async: (raises: []).} =
+    for _ in targets:
+      await serverHandlerSingleStream(server, streamProvider, serverStreamHandler)
+
+  let serverTask = serveAll()
+  var clientTasks: seq[Future[void]]
+  for target in targets:
+    clientTasks.add(
+      clientRunSingleStreamTo(
+        target, transportProvider, streamProvider, clientStreamHandler
+      )
+    )
+  await allFutures(clientTasks)
+  await serverTask
   await server.stop()
 
 proc countTransitions*(readOrder: seq[byte]): int =


### PR DESCRIPTION
## Summary

Adds dual-stack IPv4/IPv6 test coverage for the QUIC transport and pulls the transport-agnostic parts up into the shared stream-test template so every transport gets them.

The QUIC transport can already listen on both IPv4 and IPv6 at the same time and picks a dial endpoint that matches the target's address family, but the tests only covered IPv4.

What's added:

- **QUIC cross-family dial tests** (`test_quic.nim`): a dual-stack dialer reuses the matching-family listener endpoint (the port-reuse path DCUtR hole punching depends on), and a dialer with only an IPv4 listener opens a separate IPv6 dial-only endpoint when dialing an IPv6 peer.
- **Generic dual-stack tests** moved into `streamTransportTest`: a server binds both IPv4 and IPv6 in one `start`, and a single dual-stack server serves an IPv4 and an IPv6 client through one `accept()` loop.
- **`Connection.reset` test** moved from the QUIC suite into `streamTransportTest`. It's pure muxer-reset semantics, so all four transports now run it.

Supporting changes in `utils.nim`:

- `createQuicTransport` now takes `addresses: seq[MultiAddress]` instead of a single address, so a server can listen on a mixed-family set.
- New `dualStackStreamScenario` driver (starts one server on a multi-family address set, dials it once per family, serves each), plus `addrByFamily` and an address-parameterized `clientRunSingleStreamTo` that the existing `clientRunSingleStream` now delegates to.

## Affected Areas

- [x] Tests

## Impact on Library Users

None. 

## Risk Assessment

None.