### PR TITLE
fix(autotls): release certificate keys after CSR generation

### DIFF
--- a/libp2p/autotls/acme/utils.nim
+++ b/libp2p/autotls/acme/utils.nim
@@ -55,6 +55,8 @@ proc createCSR*(domain: string, certKeyPair: KeyPair): string {.raises: [ACMEErr
     raise newException(ACMEError, "Failed to get seckey raw bytes (DER)")
   let certKey = cert_new_key_t(rawSeckey).valueOr:
     raise newException(ACMEError, "Failed to convert key pair to cert_key_t")
+  defer:
+    cert_free_key(certKey)
 
   # create CSR
   let derCSR = cert_signing_req(domain, certKey).valueOr:

--- a/tests/libp2p/transports/tls/test_certificate.nim
+++ b/tests/libp2p/transports/tls/test_certificate.nim
@@ -152,6 +152,8 @@ suite "utilities test":
     # make seckey into certKey
     let certKey = cert_new_key_t(rawSeckey).valueOr:
       raiseAssert("Failed to create key")
+    defer:
+      cert_free_key(certKey)
 
     # make certKey back into seq[byte]
     let rawSeckeyBack = cert_serialize_privk(certKey, CERT_FORMAT_DER).valueOr:
@@ -162,6 +164,8 @@ suite "utilities test":
 
   test "CSR generation":
     let certKey = cert_generate_key().expect("could not generate key")
+    defer:
+      cert_free_key(certKey)
 
     check:
       cert_signing_req("my.domain.string", certKey).isOk()


### PR DESCRIPTION
## Summary

Release temporary certificate keys after CSR-related operations finish.

This adds missing `cert_free_key` cleanup for the `CertificateKey` created by the AutoTLS ACME CSR helper and mirrors the same ownership cleanup in TLS certificate tests that convert or generate keys.

## Affected Areas

- [x] Other: AutoTLS ACME CSR generation
- [x] Transports: TLS certificate test coverage

## Impact on Library Users

No API change. This only releases native key allocations that are already no longer needed.

## Risk Assessment

Low. The cleanup runs after CSR serialization or test assertions have finished, so it should not affect generated CSR contents or certificate behavior.
