### PR TITLE
ci: no force

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ NIM_FLAGS = \
   --styleCheck:usages --styleCheck:error \
   $(VERBOSITY_FLAG) \
   --skipUserCfg \
-  -f \
   --threads:on \
   --opt:speed \
   $(NIMFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ NIM_FLAGS = \
   $(VERBOSITY_FLAG) \
   --skipUserCfg \
   --threads:on \
-  --opt:speed \
+  --incremental:on \
   $(NIMFLAGS)
 
 RUNNER_FLAGS = --output-level=VERBOSE --console


### PR DESCRIPTION
removing `-f` because:
> The -f or --forceBuild option in the nim c command tells the compiler to force a full rebuild of all project modules, ignoring any previously compiled files (cached in nimcache)

can speed up compile?