### PR TITLE
ci: add line trace

### DIFF
--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -171,6 +171,7 @@ jobs:
         id: build-test-all
         run: |
           NIMFLAGS="--nimcache:nimcache/test_all --mm:${{ matrix.nim.memory_management }} --opt:speed --styleCheck:usages --styleCheck:error --parallelBuild:0 --threads:on --skipUserCfg"
+          NIMFLAGS="$NIMFLAGS --debugger:native --stacktrace:off --import:libbacktrace --define:nimStackTraceOverride"
           if [[ '${{ matrix.platform.cc }}' == 'clang' ]]; then
             NIMFLAGS="$NIMFLAGS --cc:clang"
           fi

--- a/.pinned
+++ b/.pinned
@@ -19,3 +19,4 @@ zlib;https://github.com/status-im/nim-zlib@#e680f269fb01af2c34a2ba879ff281795a52
 protobuf_serialization;https://github.com/status-im/nim-protobuf-serialization@#8406e7287196661614ce6a8e8be20f755376af7f
 nat_traversal;https://github.com/status-im/nim-nat-traversal@#860e18c37667b5dd005b94c63264560c35d88004
 npeg;https://github.com/zevv/npeg@#409f6796d0e880b3f0222c964d1da7de6e450811
+libbacktrace;https://github.com/status-im/nim-libbacktrace@#af60500cb0383231065f1d6624beeeefa308d085

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,8 @@ NIM_FLAGS = \
   -f \
   --threads:on \
   --opt:speed \
+  --stackTrace:on \
+  --lineTrace:on \
   $(NIMFLAGS)
 
 RUNNER_FLAGS = --output-level=VERBOSE --console

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,6 @@ NIM_FLAGS = \
   -f \
   --threads:on \
   --opt:speed \
-  --debugger:native \
-  --stacktrace:off \
-  --import:libbacktrace \
-  --define:nimStackTraceOverride \
   $(NIMFLAGS)
 
 RUNNER_FLAGS = --output-level=VERBOSE --console

--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,10 @@ NIM_FLAGS = \
   -f \
   --threads:on \
   --opt:speed \
-  --stackTrace:on \
-  --lineTrace:on \
+  --debugger:native \
+  --stacktrace:off \
+  --import:libbacktrace \
+  --define:nimStackTraceOverride \
   $(NIMFLAGS)
 
 RUNNER_FLAGS = --output-level=VERBOSE --console

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -8,7 +8,7 @@ license = "MIT"
 skipDirs = @["cbind", "examples", "interop", "simulation", "tests", "tools"]
 
 requires "nim >= 2.2.4",
-  "libbacktrace", "nimcrypto >= 0.6.0", "bearssl >= 0.2.7", 
+  "libbacktrace", "nimcrypto >= 0.6.0", "bearssl >= 0.2.7",
   "https://github.com/vacp2p/nim-boringssl >= 0.0.8", "chronicles >= 0.11.0",
   "chronos >= 4.2.2", "metrics >= 0.2.2", "secp256k1", "stew >= 0.4.2", "unittest2",
   "results", "serialization", "lsquic >= 0.5.4", "protobuf_serialization >= 0.5.3",

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -8,12 +8,13 @@ license = "MIT"
 skipDirs = @["cbind", "examples", "interop", "simulation", "tests", "tools"]
 
 requires "nim >= 2.2.4",
-  "nimcrypto >= 0.6.0", "bearssl >= 0.2.7",
+  "nimcrypto >= 0.6.0", "bearssl >= 0.2.7", 
   "https://github.com/vacp2p/nim-boringssl >= 0.0.8", "chronicles >= 0.11.0",
   "chronos >= 4.2.2", "metrics >= 0.2.2", "secp256k1", "stew >= 0.4.2", "unittest2",
   "results", "serialization", "lsquic >= 0.5.4", "protobuf_serialization >= 0.5.3",
   "https://github.com/status-im/nim-websock >= 0.4.0",
-  "https://github.com/status-im/nim-nat-traversal >= 0.0.1"
+  "https://github.com/status-im/nim-nat-traversal >= 0.0.1",
+  "libbacktrace"
 
 import os, sequtils, strutils
 

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -8,13 +8,12 @@ license = "MIT"
 skipDirs = @["cbind", "examples", "interop", "simulation", "tests", "tools"]
 
 requires "nim >= 2.2.4",
-  "nimcrypto >= 0.6.0", "bearssl >= 0.2.7", 
+  "libbacktrace", "nimcrypto >= 0.6.0", "bearssl >= 0.2.7", 
   "https://github.com/vacp2p/nim-boringssl >= 0.0.8", "chronicles >= 0.11.0",
   "chronos >= 4.2.2", "metrics >= 0.2.2", "secp256k1", "stew >= 0.4.2", "unittest2",
   "results", "serialization", "lsquic >= 0.5.4", "protobuf_serialization >= 0.5.3",
   "https://github.com/status-im/nim-websock >= 0.4.0",
-  "https://github.com/status-im/nim-nat-traversal >= 0.0.1",
-  "libbacktrace"
+  "https://github.com/status-im/nim-nat-traversal >= 0.0.1"
 
 import os, sequtils, strutils
 

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -12,8 +12,8 @@
 
   libbacktrace = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-libbacktrace";
-    rev = "ebc972d99769633b9ef3ee766778ee5aa1996499";
-    sha256 = "192wwixwp36r6wiq495d7yr3nbskay75447p99snqq359bqv9snb";
+    rev = "af60500cb0383231065f1d6624beeeefa308d085";
+    sha256 = "0gmdjb04qqj1hpm79apnbdlk150ns2w59ky5g511wzkacyv81ki3";
     fetchSubmodules = true;
   };
 
@@ -24,7 +24,7 @@
     fetchSubmodules = true;
   };
 
-  bearssl = pkgs.fetchgit {
+ bearssl = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-bearssl";
     rev = "25197fec8a3988d1153be7a1a79890b70e69d6db";
     sha256 = "04nhfvrfm72nmhb821q3ikvbfq65idn88gd355c5xhig63jwhv6j";

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -9,7 +9,7 @@
     sha256 = "1d2d9pv3x3i7im1cbnbj3qg9rvqg34f320pzjb1xriay89d30kr7";
     fetchSubmodules = true;
   };
-
+  
   libbacktrace = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-libbacktrace";
     rev = "af60500cb0383231065f1d6624beeeefa308d085";
@@ -26,8 +26,8 @@
 
   bearssl = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-bearssl";
-    rev = "25197fec8a3988d1153be7a1a79890b70e69d6db";
-    sha256 = "04nhfvrfm72nmhb821q3ikvbfq65idn88gd355c5xhig63jwhv6j";
+    rev = "22c6a76ce015bc07e011562bdcfc51d9446c1e82";
+    sha256 = "1cvdd7lfrpa6asmc39al3g4py5nqhpqmvypc36r5qyv7p5arc8a3";
     fetchSubmodules = true;
   };
 
@@ -103,8 +103,8 @@
 
   serialization = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-serialization";
-    rev = "4092500cea76154576539371709ae801afbd2a9d";
-    sha256 = "04pz6d6p3nd1y2khbb667fcd6p2jk4bxv65iaffzq06bqqhalcwc";
+    rev = "b0f2fa32960ea532a184394b0f27be37bd80248b";
+    sha256 = "0wip1fjx7ka39ck1g1xvmyarzq1p5dlngpqil6zff8k8z5skiz27";
     fetchSubmodules = true;
   };
 
@@ -152,15 +152,15 @@
 
   boringssl = pkgs.fetchgit {
     url = "https://github.com/vacp2p/nim-boringssl";
-    rev = "084f2c8994137a72655b72745936a05949c768cc";
-    sha256 = "0j62rq4hzxs2xbkvbv6i6hw21nx1l9j1g587gmk656xzgi61gfri";
+    rev = "e77caabae78fbc9aa5b78a0a521181b077c82571";
+    sha256 = "15k4dqh1hlcpq9zm30lpr728h7apdmgm22xzqhdm3clq9kia6fr8";
     fetchSubmodules = true;
   };
 
   lsquic = pkgs.fetchgit {
     url = "https://github.com/vacp2p/nim-lsquic";
-    rev = "186ec5b98747bdeaa98d3460b9e71823cac3b57a";
-    sha256 = "0c9q21avjk670vgj5yym7f8pf8ibj79bsp0x0lsjg4rda827gbzw";
+    rev = "3813b849d70edbef24dac3926b32949029721fdc";
+    sha256 = "016r3i7xj5mriaf199xr91j1f8312s89zgp66fiy9bj1j1i22yp7";
     fetchSubmodules = true;
   };
 

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -10,6 +10,13 @@
     fetchSubmodules = true;
   };
 
+  libbacktrace = pkgs.fetchgit {
+    url = "https://github.com/status-im/nim-libbacktrace";
+    rev = "ebc972d99769633b9ef3ee766778ee5aa1996499";
+    sha256 = "192wwixwp36r6wiq495d7yr3nbskay75447p99snqq359bqv9snb";
+    fetchSubmodules = true;
+  };
+
   unittest2 = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-unittest2.git";
     rev = "26f2ef3ae0ec72a2a75bfe557e02e88f6a31c189";
@@ -19,8 +26,8 @@
 
   bearssl = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-bearssl";
-    rev = "22c6a76ce015bc07e011562bdcfc51d9446c1e82";
-    sha256 = "1cvdd7lfrpa6asmc39al3g4py5nqhpqmvypc36r5qyv7p5arc8a3";
+    rev = "25197fec8a3988d1153be7a1a79890b70e69d6db";
+    sha256 = "04nhfvrfm72nmhb821q3ikvbfq65idn88gd355c5xhig63jwhv6j";
     fetchSubmodules = true;
   };
 
@@ -96,8 +103,8 @@
 
   serialization = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-serialization";
-    rev = "b0f2fa32960ea532a184394b0f27be37bd80248b";
-    sha256 = "0wip1fjx7ka39ck1g1xvmyarzq1p5dlngpqil6zff8k8z5skiz27";
+    rev = "4092500cea76154576539371709ae801afbd2a9d";
+    sha256 = "04pz6d6p3nd1y2khbb667fcd6p2jk4bxv65iaffzq06bqqhalcwc";
     fetchSubmodules = true;
   };
 
@@ -145,15 +152,15 @@
 
   boringssl = pkgs.fetchgit {
     url = "https://github.com/vacp2p/nim-boringssl";
-    rev = "e77caabae78fbc9aa5b78a0a521181b077c82571";
-    sha256 = "15k4dqh1hlcpq9zm30lpr728h7apdmgm22xzqhdm3clq9kia6fr8";
+    rev = "084f2c8994137a72655b72745936a05949c768cc";
+    sha256 = "0j62rq4hzxs2xbkvbv6i6hw21nx1l9j1g587gmk656xzgi61gfri";
     fetchSubmodules = true;
   };
 
   lsquic = pkgs.fetchgit {
     url = "https://github.com/vacp2p/nim-lsquic";
-    rev = "3813b849d70edbef24dac3926b32949029721fdc";
-    sha256 = "016r3i7xj5mriaf199xr91j1f8312s89zgp66fiy9bj1j1i22yp7";
+    rev = "186ec5b98747bdeaa98d3460b9e71823cac3b57a";
+    sha256 = "0c9q21avjk670vgj5yym7f8pf8ibj79bsp0x0lsjg4rda827gbzw";
     fetchSubmodules = true;
   };
 

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -24,7 +24,7 @@
     fetchSubmodules = true;
   };
 
- bearssl = pkgs.fetchgit {
+  bearssl = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-bearssl";
     rev = "25197fec8a3988d1153be7a1a79890b70e69d6db";
     sha256 = "04nhfvrfm72nmhb821q3ikvbfq65idn88gd355c5xhig63jwhv6j";


### PR DESCRIPTION
add line trace via `libbacktrace` to CI `test_all` workflow to get more detail information on strack trace 

**NOTE**
build times, even when cache, has gotten worse with this change. test execution time is unchanged. it behave is if there is not cache - judging by compile times. 