### PR TITLE
test(transports): multiple addresses

### DIFF
--- a/tests/libp2p/transports/basic_tests.nim
+++ b/tests/libp2p/transports/basic_tests.nim
@@ -73,6 +73,24 @@ template basicTransportTest*(
         clientConn.closed()
         serverConn.closed()
 
+    asyncTest "stopping transport unblocks a pending accept":
+      # TODO: nim-libp2p#2713
+      let ma = @[MultiAddress.init(address).tryGet()]
+
+      let server = transportProvider()
+      await server.start(ma)
+
+      # park an accept with nothing dialing, then stop the transport under it
+      let acceptFut = server.accept()
+      await server.stop()
+
+      # quic resolves the parked accept to nil, the rest raise a stopped error
+      if isQuicTransport(ma[0]):
+        check (await acceptFut).isNil
+      else:
+        expect TransportClosedError:
+          discard await acceptFut
+
     asyncTest "transport start/stop events":
       let ma = @[MultiAddress.init(address).tryGet()]
       let transport = transportProvider()

--- a/tests/libp2p/transports/stream_tests.nim
+++ b/tests/libp2p/transports/stream_tests.nim
@@ -101,6 +101,107 @@ template streamTransportTest*(
       clientStreamHandler,
     )
 
+  asyncTest "dial cancellation leaves established connection working":
+    if addressIP6.isNone:
+      skip() # scoped to dual-stack transports (tcp, quic)
+      return
+
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
+      noExceptionWithStreamClose(stream):
+        var buffer: array[clientMessage.len, byte]
+        await stream.readExactly(addr buffer, clientMessage.len)
+        check string.fromBytes(buffer) == clientMessage
+        await stream.write(serverMessage)
+
+    proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
+      noExceptionWithStreamClose(stream):
+        await stream.write(clientMessage)
+        var buffer: array[serverMessage.len, byte]
+        await stream.readExactly(addr buffer, serverMessage.len)
+        check string.fromBytes(buffer) == serverMessage
+
+    let server = transportProvider()
+    await server.start(@[addressIP4, addressIP6.get()])
+    defer:
+      await server.stop()
+    let serverTask =
+      serverHandlerSingleStream(server, streamProvider, serverStreamHandler)
+
+    # establish a connection on the first address
+    let client = transportProvider()
+    let conn = await client.dial("", server.addrs[0])
+    let muxer = streamProvider(conn)
+
+    # a completed exchange proves the server has accepted the connection and is
+    # now serving its streams
+    await runStreamHandler(muxer, clientStreamHandler)
+
+    # serverTask calls accept() only once and already used it on the established
+    # connection, so this dial is never accepted on the server side.
+    # cancelAndWait runs before the dial coroutine can resume, so the in-flight
+    # dial is cancelled rather than completed
+    let dialer = transportProvider()
+    let connFut = dialer.dial("", server.addrs[1])
+    await connFut.cancelAndWait()
+    check connFut.cancelled
+
+    # the established connection still exchanges data after the cancellation
+    await runStreamHandler(muxer, clientStreamHandler)
+
+    # closing the muxer ends the session so serverTask returns
+    await muxer.close()
+    await conn.close()
+    await allFutures(client.stop(), dialer.stop())
+    await serverTask
+
+  asyncTest "accept cancellation leaves established connection working":
+    if addressIP6.isNone:
+      skip() # scoped to dual-stack transports (tcp, quic)
+      return
+
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
+      noExceptionWithStreamClose(stream):
+        var buffer: array[clientMessage.len, byte]
+        await stream.readExactly(addr buffer, clientMessage.len)
+        check string.fromBytes(buffer) == clientMessage
+        await stream.write(serverMessage)
+
+    proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
+      noExceptionWithStreamClose(stream):
+        await stream.write(clientMessage)
+        var buffer: array[serverMessage.len, byte]
+        await stream.readExactly(addr buffer, serverMessage.len)
+        check string.fromBytes(buffer) == serverMessage
+
+    let server = transportProvider()
+    await server.start(@[addressIP4, addressIP6.get()])
+    defer:
+      await server.stop()
+    let serverTask =
+      serverHandlerSingleStream(server, streamProvider, serverStreamHandler)
+
+    let client = transportProvider()
+    let conn = await client.dial("", server.addrs[0])
+    let muxer = streamProvider(conn)
+
+    # serverTask has accepted the connection and moved on to serving its
+    # streams, so the only in-flight accept below is the one we start and cancel
+    await runStreamHandler(muxer, clientStreamHandler)
+
+    # a fresh accept with nobody dialing, cancelling it must not disturb
+    # the established connection, and no new connection forms
+    let acceptFut = server.accept()
+    await acceptFut.cancelAndWait()
+    check acceptFut.cancelled
+
+    # the established connection still exchanges data after the cancellation
+    await runStreamHandler(muxer, clientStreamHandler)
+
+    await muxer.close()
+    await conn.close()
+    await client.stop()
+    await serverTask
+
   asyncTest "read/write Lp":
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):

--- a/tests/libp2p/transports/stream_tests.nim
+++ b/tests/libp2p/transports/stream_tests.nim
@@ -20,9 +20,7 @@ template runTransportTest(
 ) =
   proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
     noExceptionWithStreamClose(stream):
-      var buffer: array[clientMessage.len, byte]
-      await stream.readExactly(addr buffer, clientMessage.len)
-      check string.fromBytes(buffer) == clientMessage
+      check (await stream.readExactlyAsStr(clientMessage.len)) == clientMessage
 
       await stream.write(serverMessage)
 
@@ -30,9 +28,7 @@ template runTransportTest(
     noExceptionWithStreamClose(stream):
       await stream.write(clientMessage)
 
-      var buffer: array[serverMessage.len, byte]
-      await stream.readExactly(addr buffer, serverMessage.len)
-      check string.fromBytes(buffer) == serverMessage
+      check (await stream.readExactlyAsStr(serverMessage.len)) == serverMessage
 
   await runSingleStreamScenario(
     @[address],
@@ -80,18 +76,14 @@ template streamTransportTest*(
 
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
-        var buffer: array[clientMessage.len, byte]
-        await stream.readExactly(addr buffer, clientMessage.len)
-        check string.fromBytes(buffer) == clientMessage
+        check (await stream.readExactlyAsStr(clientMessage.len)) == clientMessage
         await stream.write(serverMessage)
 
     proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         await stream.write(clientMessage)
 
-        var buffer: array[serverMessage.len, byte]
-        await stream.readExactly(addr buffer, serverMessage.len)
-        check string.fromBytes(buffer) == serverMessage
+        check (await stream.readExactlyAsStr(serverMessage.len)) == serverMessage
 
     await dualStackStreamScenario(
       @[addressIP4, addressIP6.get()],
@@ -108,17 +100,13 @@ template streamTransportTest*(
 
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
-        var buffer: array[clientMessage.len, byte]
-        await stream.readExactly(addr buffer, clientMessage.len)
-        check string.fromBytes(buffer) == clientMessage
+        check (await stream.readExactlyAsStr(clientMessage.len)) == clientMessage
         await stream.write(serverMessage)
 
     proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         await stream.write(clientMessage)
-        var buffer: array[serverMessage.len, byte]
-        await stream.readExactly(addr buffer, serverMessage.len)
-        check string.fromBytes(buffer) == serverMessage
+        check (await stream.readExactlyAsStr(serverMessage.len)) == serverMessage
 
     let server = transportProvider()
     await server.start(@[addressIP4, addressIP6.get()])
@@ -161,17 +149,13 @@ template streamTransportTest*(
 
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
-        var buffer: array[clientMessage.len, byte]
-        await stream.readExactly(addr buffer, clientMessage.len)
-        check string.fromBytes(buffer) == clientMessage
+        check (await stream.readExactlyAsStr(clientMessage.len)) == clientMessage
         await stream.write(serverMessage)
 
     proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         await stream.write(clientMessage)
-        var buffer: array[serverMessage.len, byte]
-        await stream.readExactly(addr buffer, serverMessage.len)
-        check string.fromBytes(buffer) == serverMessage
+        check (await stream.readExactlyAsStr(serverMessage.len)) == serverMessage
 
     let server = transportProvider()
     await server.start(@[addressIP4, addressIP6.get()])
@@ -255,10 +239,9 @@ template streamTransportTest*(
 
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
-        var buffer: array[serverMessage.len, byte]
-        await stream.readExactly(addr buffer, serverMessage.len)
-        check string.fromBytes(buffer) == serverMessage
+        check (await stream.readExactlyAsStr(serverMessage.len)) == serverMessage
 
+        var buffer: array[1, byte]
         # First readOnce after EOF
         let bytesRead = await stream.readOnce(addr buffer, 1)
         check bytesRead == 0
@@ -295,9 +278,7 @@ template streamTransportTest*(
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         # step 2: read message from client (ensure connection is established)
-        var buffer: array[serverMessage.len, byte]
-        await stream.readExactly(addr buffer, serverMessage.len)
-        check string.fromBytes(buffer) == serverMessage
+        check (await stream.readExactlyAsStr(serverMessage.len)) == serverMessage
         # and notify this to client
         serverReadDone.complete()
 
@@ -386,11 +367,10 @@ template streamTransportTest*(
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         # Client reads server data
-        var buffer: array[serverMessage.len, byte]
-        await stream.readExactly(addr buffer, serverMessage.len)
-        check string.fromBytes(buffer) == serverMessage
+        check (await stream.readExactlyAsStr(serverMessage.len)) == serverMessage
 
         # Server has closed write side, so further reads should EOF
+        var buffer: array[1, byte]
         let bytesRead = await stream.readOnce(addr buffer, 1)
         check bytesRead == 0
 
@@ -408,9 +388,7 @@ template streamTransportTest*(
           await stream.write("should fail")
 
         # Server should still be able to read from client
-        var buffer: array[clientMessage.len, byte]
-        await stream.readExactly(addr buffer, clientMessage.len)
-        check string.fromBytes(buffer) == clientMessage
+        check (await stream.readExactlyAsStr(clientMessage.len)) == clientMessage
 
     await runSingleStreamScenario(
       @[addressIP4],
@@ -474,9 +452,7 @@ template streamTransportTest*(
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         try:
-          var buffer: array[clientMessage.len, byte]
-          await stream.readExactly(addr buffer[0], clientMessage.len)
-          check string.fromBytes(buffer) == clientMessage
+          check (await stream.readExactlyAsStr(clientMessage.len)) == clientMessage
 
           successfulReadsWG.done()
         except LPStreamIncompleteError:

--- a/tests/libp2p/transports/utils.nim
+++ b/tests/libp2p/transports/utils.nim
@@ -184,9 +184,7 @@ proc clientRunSingleStream*(
     server.addrs[0], transportProvider, streamProvider, handler
   )
 
-proc runStreamHandler*(
-    muxer: Muxer, handler: StreamHandler
-) {.async: (raises: []).} =
+proc runStreamHandler*(muxer: Muxer, handler: StreamHandler) {.async: (raises: []).} =
   ## Open a new stream on an already-established muxer and run `handler` on it.
   try:
     let stream = await muxer.newStream()

--- a/tests/libp2p/transports/utils.nim
+++ b/tests/libp2p/transports/utils.nim
@@ -184,6 +184,16 @@ proc clientRunSingleStream*(
     server.addrs[0], transportProvider, streamProvider, handler
   )
 
+proc runStreamHandler*(
+    muxer: Muxer, handler: StreamHandler
+) {.async: (raises: []).} =
+  ## Open a new stream on an already-established muxer and run `handler` on it.
+  try:
+    let stream = await muxer.newStream()
+    await handler(stream)
+  except CatchableError as exc:
+    raiseAssert "should not fail: " & exc.msg
+
 proc runSingleStreamScenario*(
     multiAddress: seq[MultiAddress],
     transportProvider: TransportProvider,

--- a/tests/tools/stream.nim
+++ b/tests/tools/stream.nim
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import chronos
+import chronos, stew/byteutils
 import ../../libp2p/stream/connection
 
 proc newData*(size: int, val: byte = byte(0xFF)): seq[byte] =
@@ -24,3 +24,10 @@ proc readStreamByChunkTillEOF*(
     receivedData.add(chunk[0 ..< bytesRead])
 
   receivedData
+
+proc readExactlyAsStr*(stream: Stream, nbytes: int): Future[string] {.async.} =
+  ## Reads exactly `nbytes` from the stream and returns them decoded as a string
+  doAssert nbytes > 0, "readExactlyAsStr requires nbytes > 0"
+  var buffer = newSeq[byte](nbytes)
+  await stream.readExactly(addr buffer[0], nbytes)
+  string.fromBytes(buffer)


### PR DESCRIPTION
## Summary

Addresses #2194

Adds transport tests covering cancellation and shutdown edge cases around `accept()` and `dial()`. 

Three things:
- A dual-stack test proving that cancelling an in-flight `dial()` on one address family leaves an already-established connection fully working.
- A dual-stack test proving that cancelling a parked `accept()` doesn't disturb an established connection and doesn't spawn a stray one.
- A basic-transport test proving that stopping a transport unblocks a pending `accept()`. QUIC resolves the parked accept to nil, the others raise `TransportClosedError`. Inconsistency raised in https://github.com/vacp2p/nim-libp2p/issues/2713

Supporting this, a small `runStreamHandler` helper in `utils.nim` opens a stream on an existing muxer and runs a handler on it, so tests can reuse an established connection to prove it still exchanges data after a cancellation.

## Affected Areas

- [x] Tests