### PR TITLE
ci: add build cache to workflows

### DIFF
--- a/.github/workflows/cbindings.yml
+++ b/.github/workflows/cbindings.yml
@@ -54,6 +54,14 @@ jobs:
         run: |
           nimble install_pinned
 
+      - name: Restore build cache
+        uses: actions/cache@v5
+        with:
+          path: nimcache
+          key: ${{ github.ref_name }}-nimcache-cbindings-linux-amd64-gcc-v2.2.10
+          restore-keys: |
+            master-nimcache-cbindings-linux-amd64-gcc-v2.2.10
+
       - name: Build and run c bindings examples
         run: |
           nim --version

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,6 +32,7 @@ jobs:
           os: linux
           cpu: amd64
           shell: bash
+          nim_ref: v2.2.10
 
       - name: Restore deps from cache
         id: deps-cache
@@ -47,19 +48,28 @@ jobs:
         run: |
           nimble install_pinned
 
+      - name: Restore build cache
+        uses: actions/cache@v5
+        with:
+          path: nimcache
+          key: ${{ github.ref_name }}-nimcache-coverage-linux-amd64-gcc-2.2.10
+          restore-keys: |
+            master-nimcache-coverage-linux-amd64-gcc-2.2.10
+
       - name: Setup coverage
         run: |
           sudo apt-get update
           sudo apt-get install -y lcov build-essential git curl
           mkdir coverage
 
-      - name: Run test suite with coverage flags
+      - name: Build test_all
         run: |
-          export NIMFLAGS="--lineDir:on --passC:-fprofile-arcs --passC:-ftest-coverage --passL:-fprofile-arcs --passL:-ftest-coverage"
-          # amd64 (64-bit): compile and run the test binaries concurrently. Each
-          # binary keeps its own nimcache, so the per-source .gcda files stay
-          # isolated and lcov still captures all of nimcache/ recursively.
-          make TEST_JOBS=3 test
+          NIMFLAGS="--nimcache:nimcache/test_all --lineDir:on --passC:-fprofile-arcs --passC:-ftest-coverage --passL:-fprofile-arcs --passL:-ftest-coverage --threads:on --skipUserCfg"
+          nim c $NIMFLAGS ./tests/test_all
+
+      - name: Run tests
+        run: |
+          ./tests/test_all
 
       - name: Run coverage
         run: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -54,6 +54,14 @@ jobs:
         run: |
           nimble install_pinned
 
+      - name: Restore build cache
+        uses: actions/cache@v5
+        with:
+          path: nimcache
+          key: ${{ github.ref_name }}-nimcache-examples-linux-amd64-gcc-v2.2.10
+          restore-keys: |
+            master-nimcache-examples-linux-amd64-gcc-v2.2.10
+
       - name: Build and run examples
         run: |
           nim --version

--- a/examples/examples.nimble
+++ b/examples/examples.nimble
@@ -11,7 +11,7 @@ license = "MIT"
 
 proc buildSample(filename: string, run = false) =
   # Add parent directory to search path for libp2p imports  
-  var excstr = "nim c --mm:refc -p:../"
+  var excstr = "nim c --nimcache:nimcache/examples --mm:refc -p:../"
   excstr.add(" " & filename)
   exec excstr
   if run:


### PR DESCRIPTION
- adding build cache to `cbindings`, `examples` and `coverage` workflows
- `cbindings` and `examples` are first to finish compile, but still we don't need to spend ci time here
- `coverage` needs build cache the most as this is taking the same time to compile as tests