### PR TITLE
fix(cbind): error on invalid private key instead of generating a random one

### DIFF
--- a/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_lifecycle_requests.nim
+++ b/cbind/libp2p_thread/inter_thread_communication/requests/libp2p_lifecycle_requests.nim
@@ -229,8 +229,9 @@ proc createLibp2p(appCallbacks: AppCallbacks, config: Libp2pConfig): LibP2P =
   var privKey = Opt.none(PrivateKey)
   if config.privKey.data != nil and config.privKey.dataLen > 0:
     let keySeq = config.privKey.toByteSeq()
-    PrivateKey.init(keySeq).withValue(copyKey):
-      privKey = Opt.some(copyKey)
+    let key = PrivateKey.init(keySeq).valueOr:
+      raise newException(LPError, "invalid private key: " & $error)
+    privKey = Opt.some(key)
 
   var addrs: seq[MultiAddress] = @[]
   if config.addrsLen > 0 and not config.addrs.isNil():


### PR DESCRIPTION
## Summary

When a private key is supplied through the C API (`Libp2pConfig.privKey`), `createLibp2p` parsed it with `PrivateKey.init(keySeq).withValue(...)`. `withValue` only runs its body on success, so a malformed key was **silently dropped**: `privKey` stayed `Opt.none`, and the switch builder then minted a fresh random identity. The node came up with a peer ID the operator never asked for — the opposite of what supplying a key means, and a real problem for a stable/bootstrap node whose peer ID other peers pin.

This makes an invalid private key a hard, surfaced error instead of a silent fallback. The parse now uses `valueOr` and `raise newException(LPError, ...)`. `LPError` is a `CatchableError` already handled by `process*`, which converts it into `err("could not create libp2p node: invalid private key: ...")` and returns it to the C caller — so the failure is reported cleanly rather than crashing the libp2p worker thread.

The valid-key and no-key (intentional ephemeral random identity) paths are unchanged.

This was originally flagged downstream: https://github.com/logos-co/logos-libp2p-module/pull/64#discussion_r3500718909 — the same swallowing pattern was copied from this cbind.

## Affected Areas

- [x] Build / Tooling
  cbind C API node construction (`createLibp2p`); no core protocol logic touched.

## Compatibility & Downstream Validation

Pure cbind-layer change with no public Nim API change. Downstream (Nimbus / Waku / Codex) use nim-libp2p directly and do not go through this C entrypoint, so no integration branch is required.

## Impact on Library Users

Behavior change for C-API users only: passing an invalid `privKey` now returns an error from node creation instead of silently starting the node with a random identity. Callers already supplying a valid key, or no key at all, are unaffected.

## Risk Assessment

Low. The change is confined to one branch of `createLibp2p` in the cbind layer. It is strictly stricter (rejects input that was previously accepted-then-ignored). The error is a `CatchableError` caught by the existing `process*` handler, so it propagates as a `Result` error rather than escaping as an uncatchable `Defect`.

## References

- Downstream report: https://github.com/logos-co/logos-libp2p-module/pull/64#discussion_r3500718909

## Additional Notes

Could not fully compile cbind in the dev sandbox (dependency version mismatch in the cbind build); verified with `nph` and by confirming `LPError` is the type the caller already catches. Worth a CI run on the real toolchain to confirm the build.