### PR TITLE
feat(service-disco): service table bootstrapping

### DIFF
--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -2,7 +2,7 @@
 # Copyright (c) Status Research & Development GmbH
 
 import chronos, chronicles, results, sets
-import ../utils/heartbeat
+import ../utils/[heartbeat, future]
 import ../[peerid, switch, multihash, peerinfo, extended_peer_record]
 import ./kademlia
 import
@@ -50,6 +50,15 @@ proc maintainServiceTables(
     disco.config.bucketRefreshTime, sleepFirst = true:
     await disco.rtManager.refreshAllTables(disco)
 
+proc bootstrapServiceTable*(
+    disco: ServiceDiscovery, serviceId: ServiceId
+) {.async: (raises: [CancelledError]).} =
+  let rtable = disco.rtManager.getTable(serviceId).valueOr:
+    return
+
+  await disco.refreshTable(rtable, forceRefresh = true)
+  debug "Service table bootstrap complete", serviceId
+
 proc new*(
     T: typedesc[ServiceDiscovery],
     switch: Switch,
@@ -86,6 +95,15 @@ proc new*(
 
   # Fill up buckets with initial bootstrap nodes
   disco.updatePeers(bootstrapNodes)
+
+  # Whenever a brand-new service table is created, bootstrap it immediately
+  # (mirroring kademlia's startup bootstrap) instead of waiting up to one
+  # `bucketRefreshTime` for the maintenance heartbeat. Fire-and-forget so the
+  # (often synchronous) creation paths don't block on the network.
+  disco.rtManager.onServiceTableCreated = proc(serviceId: ServiceId) =
+    if disco.config.disableBootstrapping:
+      return
+    trackFut(disco.serviceBootstrapFuts, disco.bootstrapServiceTable(serviceId))
 
   disco.codec = codec
   if client:
@@ -157,6 +175,9 @@ method stop*(disco: ServiceDiscovery) {.async: (raises: []).} =
     return
 
   disco.advertiser.clear()
+
+  disco.serviceBootstrapFuts.cancelSoon()
+  disco.serviceBootstrapFuts = @[]
 
   if not disco.selfSignedPeerRecordLoop.isNil():
     disco.selfSignedPeerRecordLoop.cancelSoon()

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -96,14 +96,11 @@ proc new*(
   # Fill up buckets with initial bootstrap nodes
   disco.updatePeers(bootstrapNodes)
 
-  # Whenever a brand-new service table is created, bootstrap it immediately
-  # (mirroring kademlia's startup bootstrap) instead of waiting up to one
-  # `bucketRefreshTime` for the maintenance heartbeat. Fire-and-forget so the
-  # (often synchronous) creation paths don't block on the network.
   disco.rtManager.onServiceTableCreated = proc(serviceId: ServiceId) =
     if disco.config.disableBootstrapping:
       return
-    trackFut(disco.serviceBootstrapFuts, disco.bootstrapServiceTable(serviceId))
+
+    disco.serviceBootstrapFuts.trackFut(disco.bootstrapServiceTable(serviceId))
 
   disco.codec = codec
   if client:

--- a/libp2p/protocols/service_discovery/routing_table_manager.nim
+++ b/libp2p/protocols/service_discovery/routing_table_manager.nim
@@ -61,6 +61,10 @@ proc addService*(
   manager.serviceStatus[serviceId] = status
 
   manager.updateServiceTablesMetrics()
+
+  if not manager.onServiceTableCreated.isNil:
+    manager.onServiceTableCreated(serviceId)
+
   return true
 
 proc removeService*(

--- a/libp2p/protocols/service_discovery/types.nim
+++ b/libp2p/protocols/service_discovery/types.nim
@@ -43,6 +43,7 @@ type
   ServiceRoutingTableManager* = ref object
     tables*: Table[ServiceId, RoutingTable]
     serviceStatus*: Table[ServiceId, ServiceStatus]
+    onServiceTableCreated*: proc(serviceId: ServiceId) {.gcsafe, closure.}
 
   AdvertisementKey* = tuple[peerId: PeerId, seqNo: uint64]
 
@@ -94,6 +95,7 @@ type
     refreshServiceTablesLoop*: Future[void]
     advertiserMaintenanceLoop*: Future[void]
     localRegistrationLoop*: Future[void]
+    serviceBootstrapFuts*: seq[Future[void]]
     clientMode*: bool
 
 proc new*(

--- a/libp2p/protocols/service_discovery/types.nim
+++ b/libp2p/protocols/service_discovery/types.nim
@@ -43,7 +43,7 @@ type
   ServiceRoutingTableManager* = ref object
     tables*: Table[ServiceId, RoutingTable]
     serviceStatus*: Table[ServiceId, ServiceStatus]
-    onServiceTableCreated*: proc(serviceId: ServiceId) {.gcsafe, closure.}
+    onServiceTableCreated*: proc(serviceId: ServiceId) {.gcsafe, closure, raises: [].}
 
   AdvertisementKey* = tuple[peerId: PeerId, seqNo: uint64]
 

--- a/tests/libp2p/service_discovery/test_routing_table_manager.nim
+++ b/tests/libp2p/service_discovery/test_routing_table_manager.nim
@@ -18,6 +18,11 @@ proc makeKey(x: byte): Key =
 proc makeServiceId(x: byte): ServiceId =
   return makeKey(x)
 
+# Heap-allocated recorder so a closure capturing it stays GC-safe (mirrors how
+# the production callback captures the disco ref rather than a stack local).
+type HitRecorder = ref object
+  ids: seq[ServiceId]
+
 proc makeMainTable(selfId: Key, peers: seq[Key]): RoutingTable =
   var rt = RoutingTable.new(selfId)
   for p in peers:
@@ -74,6 +79,53 @@ suite "ServiceRoutingTableManager":
     check:
       upgraded == true
       manager.serviceStatus[serviceId] == Both
+
+  test "addService fires onServiceTableCreated only for brand-new tables":
+    let manager = ServiceRoutingTableManager.new()
+    let mainRt = RoutingTable.new(makeKey(0))
+
+    let hits = HitRecorder()
+    manager.onServiceTableCreated = proc(sid: ServiceId) =
+      hits.ids.add(sid)
+
+    let serviceId = makeServiceId(1)
+
+    check manager.addService(
+      serviceId, mainRt, DefaultReplication, DefaultMaxBuckets, Interest
+    )
+    check:
+      hits.ids.len == 1
+      hits.ids[0] == serviceId
+
+    discard manager.addService(
+      serviceId, mainRt, DefaultReplication, DefaultMaxBuckets, Interest
+    )
+    check hits.ids.len == 1
+
+    discard manager.addService(
+      serviceId, mainRt, DefaultReplication, DefaultMaxBuckets, Provided
+    )
+    check:
+      hits.ids.len == 1
+      manager.serviceStatus[serviceId] == Both
+
+    let otherId = makeServiceId(2)
+    check manager.addService(
+      otherId, mainRt, DefaultReplication, DefaultMaxBuckets, Provided
+    )
+    check:
+      hits.ids.len == 2
+      otherId in hits.ids
+
+  test "addService with no callback set does not crash":
+    let manager = ServiceRoutingTableManager.new()
+    let serviceId = makeServiceId(1)
+    let mainRt = RoutingTable.new(makeKey(0))
+
+    check manager.addService(
+      serviceId, mainRt, DefaultReplication, DefaultMaxBuckets, Interest
+    )
+    check manager.hasService(serviceId)
 
   test "addService pre-populates table from main routing table":
     let selfId = makeKey(0)


### PR DESCRIPTION
Newly created service table now trigger a bootstrapping process to populate them, in addition to using peers from the main table.