### PR TITLE
fix(autotls): decouple ACME RSA keys from libp2p identity schemes

### DIFF
--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName = "libp2p"
-version = "2.1.0"
+version = "2.1.1"
 author = "Status Research & Development GmbH"
 description = "LibP2P implementation"
 license = "MIT"

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -7,8 +7,8 @@ import chronos/apps/http/httpclient, results, chronicles
 
 import ./jws
 import ./utils
-import ../../crypto/crypto
 import ../../crypto/rsa
+import ../../utils/opt
 
 export ACMEError, ACMENetworkError
 
@@ -108,7 +108,7 @@ type ACMECertificateResponse* = object
 type ACMECertificate* = object
   rawCertificate*: string
   certificateExpiry*: DateTime
-  certKeyPair*: KeyPair
+  certKeyPair*: RsaPrivateKey
 
 const
   Alg = "RS256"
@@ -242,17 +242,14 @@ method requestNonce*(
 
 # TODO: save n and e in account so we don't have to recalculate every time
 proc acmeHeader(
-    self: ACMEApi, uri: Uri, key: KeyPair, needsJwk: bool, kid: Opt[Kid]
+    self: ACMEApi, uri: Uri, key: RsaPrivateKey, needsJwk: bool, kid: Opt[Kid]
 ): Future[ACMERequestHeader] {.async: (raises: [ACMEError, CancelledError]).} =
   if not needsJwk and kid.isNone():
     raise newException(ACMEError, "kid not set")
 
-  if key.pubkey.scheme != PKScheme.RSA or key.seckey.scheme != PKScheme.RSA:
-    raise newException(ACMEError, "Unsupported signing key type")
-
   let newNonce = await self.requestNonce()
   if needsJwk:
-    let pubkey = key.pubkey.rsakey
+    let pubkey = key.getPublicKey()
     let nArray = @(getArray(pubkey.buffer, pubkey.key.n, pubkey.key.nlen))
     let eArray = @(getArray(pubkey.buffer, pubkey.key.e, pubkey.key.elen))
     ACMERequestHeader(
@@ -302,19 +299,16 @@ proc createSignedAcmeRequest(
     self: ACMEApi,
     uri: Uri,
     payload: auto,
-    key: KeyPair,
+    key: RsaPrivateKey,
     needsJwk: bool = false,
     kid: Opt[Kid] = Opt.none(Kid),
 ): Future[string] {.async: (raises: [ACMEError, CancelledError]).} =
-  if key.pubkey.scheme != PKScheme.RSA or key.seckey.scheme != PKScheme.RSA:
-    raise newException(ACMEError, "Unsupported signing key type")
-
   let acmeHeader = await self.acmeHeader(uri, key, needsJwk, kid)
   handleError("createSignedAcmeRequest"):
-    $toFlattenedJws(%*acmeHeader, %*payload, key.seckey.rsakey)
+    $toFlattenedJws(%*acmeHeader, %*payload, key)
 
 proc requestRegister*(
-    self: ACMEApi, key: KeyPair
+    self: ACMEApi, key: RsaPrivateKey
 ): Future[ACMERegisterResponse] {.async: (raises: [ACMEError, CancelledError]).} =
   let registerRequest = ACMERegisterRequest(termsOfServiceAgreed: true)
   handleError("acmeRegister"):
@@ -333,7 +327,7 @@ proc requestRegister*(
     )
 
 proc requestNewOrder*(
-    self: ACMEApi, domains: seq[Domain], key: KeyPair, kid: Kid
+    self: ACMEApi, domains: seq[Domain], key: RsaPrivateKey, kid: Kid
 ): Future[ACMEChallengeResponse] {.async: (raises: [ACMEError, CancelledError]).} =
   # request challenge from ACME server
   let orderRequest = ACMEChallengeRequest(
@@ -359,7 +353,7 @@ proc requestNewOrder*(
     )
 
 proc requestAuthorizations*(
-    self: ACMEApi, authorizations: seq[Authorization], key: KeyPair, kid: Kid
+    self: ACMEApi, authorizations: seq[Authorization], key: RsaPrivateKey, kid: Kid
 ): Future[ACMEAuthorizationsResponse] {.async: (raises: [ACMEError, CancelledError]).} =
   handleError("requestAuthorizations"):
     doAssert authorizations.len > 0
@@ -379,7 +373,7 @@ proc requestAuthorizations*(
     ACMEAuthorizationsResponse(challenges: challenges)
 
 proc requestChallenge*(
-    self: ACMEApi, domains: seq[Domain], key: KeyPair, kid: Kid
+    self: ACMEApi, domains: seq[Domain], key: RsaPrivateKey, kid: Kid
 ): Future[ACMEChallengeDns01Response] {.async: (raises: [ACMEError, CancelledError]).} =
   let orderResp = await self.requestNewOrder(domains, key, kid)
 
@@ -399,7 +393,7 @@ proc requestChallenge*(
   )
 
 proc requestCheck*(
-    self: ACMEApi, checkURL: Uri, checkKind: ACMECheckKind, key: KeyPair, kid: Kid
+    self: ACMEApi, checkURL: Uri, checkKind: ACMECheckKind, key: RsaPrivateKey, kid: Kid
 ): Future[ACMECheckResponse] {.async: (raises: [ACMEError, CancelledError]).} =
   handleError("requestCheck"):
     let acmeResponse = await self.get(checkURL)
@@ -434,7 +428,7 @@ proc requestCheck*(
         )
 
 proc sendChallengeCompleted*(
-    self: ACMEApi, chalURL: Uri, key: KeyPair, kid: Kid
+    self: ACMEApi, chalURL: Uri, key: RsaPrivateKey, kid: Kid
 ): Future[ACMECompletedResponse] {.async: (raises: [ACMEError, CancelledError]).} =
   handleError("sendChallengeCompleted"):
     let payload =
@@ -445,7 +439,7 @@ proc sendChallengeCompleted*(
 proc checkChallengeCompleted*(
     self: ACMEApi,
     checkURL: Uri,
-    key: KeyPair,
+    key: RsaPrivateKey,
     kid: Kid,
     retries: int = DefaultChalCompletedRetries,
 ): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
@@ -467,7 +461,7 @@ proc checkChallengeCompleted*(
 proc completeChallenge*(
     self: ACMEApi,
     chalURL: Uri,
-    key: KeyPair,
+    key: RsaPrivateKey,
     kid: Kid,
     retries: int = DefaultChalCompletedRetries,
 ): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
@@ -479,8 +473,8 @@ proc requestFinalize*(
     self: ACMEApi,
     domain: Domain,
     finalize: Uri,
-    certKeyPair: KeyPair,
-    key: KeyPair,
+    certKeyPair: RsaPrivateKey,
+    key: RsaPrivateKey,
     kid: Kid,
 ): Future[ACMEFinalizeResponse] {.async: (raises: [ACMEError, CancelledError]).} =
   handleError("requestFinalize"):
@@ -494,7 +488,7 @@ proc requestFinalize*(
 proc checkCertFinalized*(
     self: ACMEApi,
     order: Uri,
-    key: KeyPair,
+    key: RsaPrivateKey,
     kid: Kid,
     retries: int = DefaultChalCompletedRetries,
 ): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =
@@ -517,8 +511,8 @@ proc certificateFinalized*(
     domain: Domain,
     finalize: Uri,
     order: Uri,
-    certKeyPair: KeyPair,
-    key: KeyPair,
+    certKeyPair: RsaPrivateKey,
+    key: RsaPrivateKey,
     kid: Kid,
     retries: int = DefaultFinalizeRetries,
 ): Future[bool] {.async: (raises: [ACMEError, CancelledError]).} =

--- a/libp2p/autotls/acme/client.nim
+++ b/libp2p/autotls/acme/client.nim
@@ -4,9 +4,11 @@
 {.push raises: [].}
 
 import uri
+import nimcrypto/sha2
 import chronos, chronicles, results, stew/byteutils
-import ../../crypto/crypto
 import ../../crypto/rsa
+import ../../crypto/rng
+import ../../utils/opt
 import ./api
 import ./utils
 
@@ -16,7 +18,7 @@ type KeyAuthorization* = string
 
 type ACMEClient* = ref object
   api: ACMEApi
-  key*: KeyPair
+  key*: RsaPrivateKey
   kid*: Kid
 
 logScope:
@@ -26,11 +28,11 @@ proc new*(
     T: typedesc[ACMEClient],
     rng: Rng,
     api: ACMEApi = ACMEApi.new(acmeServerURL = parseUri(LetsEncryptURL)),
-    key: Opt[KeyPair] = Opt.none(KeyPair),
+    key: Opt[RsaPrivateKey] = Opt.none(RsaPrivateKey),
     kid: Kid = Kid(""),
 ): T {.raises: [].} =
   let key = key.valueOr:
-    KeyPair.random(PKScheme.RSA, rng).get()
+    RsaPrivateKey.random(rng).get()
   T(api: api, key: key, kid: kid)
 
 proc getOrInitKid*(
@@ -52,7 +54,7 @@ proc getChallenge*(
 proc getCertificate*(
     self: ACMEClient,
     domain: api.Domain,
-    certKeyPair: KeyPair,
+    certKeyPair: RsaPrivateKey,
     challenge: ACMEChallengeDns01Response,
     acmeRetries: int = 10,
     finalizeRetries: int = 10,

--- a/libp2p/autotls/acme/utils.nim
+++ b/libp2p/autotls/acme/utils.nim
@@ -3,9 +3,9 @@
 
 import base64, strutils, json
 import chronos/apps/http/httpclient
+import nimcrypto/sha2
 import ../../errors
 import ../../transports/tls/certificate_ffi
-import ../../crypto/crypto
 import ../../crypto/rsa
 
 type ACMEError* = object of LPError
@@ -23,9 +23,8 @@ proc base64UrlEncode*(data: seq[byte]): string =
   encoded.removeSuffix("=")
   return encoded
 
-proc thumbprint*(key: KeyPair): string =
-  doAssert key.seckey.scheme == PKScheme.RSA, "unsupported keytype"
-  let pubkey = key.pubkey.rsakey
+proc thumbprint*(key: RsaPrivateKey): string =
+  let pubkey = key.getPublicKey()
   let nArray = @(getArray(pubkey.buffer, pubkey.key.n, pubkey.key.nlen))
   let eArray = @(getArray(pubkey.buffer, pubkey.key.e, pubkey.key.elen))
 
@@ -49,10 +48,11 @@ proc getResponseBody*(
     raise
       newException(ACMEError, "Unexpected error occurred while getting body bytes", exc)
 
-proc createCSR*(domain: string, certKeyPair: KeyPair): string {.raises: [ACMEError].} =
-  # convert KeyPair to cert_key_t
-  let rawSeckey: seq[byte] = certKeyPair.seckey.getRawBytes.valueOr:
-    raise newException(ACMEError, "Failed to get seckey raw bytes (DER)")
+proc createCSR*(
+    domain: string, certKeyPair: RsaPrivateKey
+): string {.raises: [ACMEError].} =
+  let rawSeckey: seq[byte] = certKeyPair.getBytes.valueOr:
+    raise newException(ACMEError, "Failed to get RSA private key bytes (DER)")
   let certKey = cert_new_key_t(rawSeckey).valueOr:
     raise newException(ACMEError, "Failed to convert key pair to cert_key_t")
 

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -12,8 +12,8 @@ import
   ./acme/client,
   ./broker,
   ./utils,
-  ../crypto/crypto,
   ../crypto/rsa,
+  ../crypto/rng,
   ../nameresolving/nameresolver,
   ../nameresolving/dnsresolver,
   ../switch,
@@ -185,9 +185,9 @@ method issueCertificate(
     raise newException(AutoTLSError, "DNS records not set")
 
   trace "Notifying challenge completion to ACME and downloading cert"
-  let certKeyPair = KeyPair.random(PKScheme.RSA, self.rng).valueOr:
+  let certKeyPair = RsaPrivateKey.random(self.rng).valueOr:
     raise newException(AutoTLSError, "Unable to generate certificate key pair")
-  let derPrivKey = certKeyPair.seckey.rsakey.getBytes.valueOr:
+  let derPrivKey = certKeyPair.getBytes.valueOr:
     raise newException(AutoTLSError, "Unable to get TLS private key")
 
   let certificate = await self.acmeClient.getCertificate(

--- a/tests/integration/test_autotls_integration.nim
+++ b/tests/integration/test_autotls_integration.nim
@@ -12,6 +12,7 @@ when defined(linux) and defined(amd64):
       autotls/acme/api,
       autotls/acme/client,
       autotls/service,
+      crypto/rsa,
       autotls/utils,
       multiaddress,
       utils/ipaddr,
@@ -35,7 +36,7 @@ when defined(linux) and defined(amd64):
       checkTrackers()
 
     asyncTest "request challenge without ACMEClient (ACMEApi only)":
-      let key = KeyPair.random(PKScheme.RSA, rng()).get()
+      let key = RsaPrivateKey.random(rng()).get()
       let acmeApi = ACMEApi.new(acmeServerURL = parseUri(LetsEncryptURLStaging))
       defer:
         await acmeApi.close()

--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -10,13 +10,14 @@ import
     upgrademngrs/upgrade,
     autotls/acme/mockapi,
     autotls/acme/client,
+    crypto/rsa,
     wire,
   ]
 import ../../tools/[unittest, crypto]
 
 suite "AutoTLS ACME API":
   var api {.threadvar.}: MockACMEApi
-  var key {.threadvar.}: KeyPair
+  var key {.threadvar.}: RsaPrivateKey
 
   asyncTeardown:
     await api.close()
@@ -24,7 +25,7 @@ suite "AutoTLS ACME API":
 
   asyncSetup:
     api = await MockACMEApi.new()
-    key = KeyPair.random(PKScheme.RSA, rng()).get()
+    key = RsaPrivateKey.random(rng()).get()
 
   asyncTest "register to acme server":
     api.mockedResponses.add(
@@ -87,13 +88,6 @@ suite "AutoTLS ACME API":
     check dns01.`type` == ACMEChallengeType.DNS01
     check dns01.token == ACMEChallengeToken("expected-dns01-token")
     check dns01.status == ACMEChallengeStatus.PENDING
-
-  asyncTest "register with unsupported keys":
-    let unsupportedSchemes = [PKScheme.Ed25519, PKScheme.Secp256k1, PKScheme.ECDSA]
-    for scheme in unsupportedSchemes:
-      let unsupportedKey = KeyPair.random(scheme, rng()).get()
-      expect(ACMEError):
-        discard await api.requestRegister(unsupportedKey)
 
   asyncTest "challenge completed successful":
     api.mockedResponses.add(
@@ -179,7 +173,7 @@ suite "AutoTLS ACME API":
       "some-domain",
       parseUri("http://example.com/some-finalize-url"),
       parseUri("http://example.com/some-order-url"),
-      KeyPair.random(PKScheme.RSA, rng()).get,
+      RsaPrivateKey.random(rng()).get,
       key,
       "kid",
     )
@@ -198,7 +192,7 @@ suite "AutoTLS ACME API":
       "some-domain",
       parseUri("http://example.com/some-finalize-url"),
       parseUri("http://example.com/some-order-url"),
-      KeyPair.random(PKScheme.RSA, rng()).get,
+      RsaPrivateKey.random(rng()).get,
       key,
       "kid",
       retries = 1,
@@ -222,7 +216,7 @@ suite "AutoTLS ACME API":
       "some-domain",
       parseUri("http://example.com/some-finalize-url"),
       parseUri("http://example.com/some-order-url"),
-      KeyPair.random(PKScheme.RSA, rng()).get,
+      RsaPrivateKey.random(rng()).get,
       key,
       "kid",
     )
@@ -315,7 +309,7 @@ suite "AutoTLS ACME API":
       discard await api.requestFinalize(
         "some-domain",
         parseUri("http://example.com/some-finalize-url"),
-        KeyPair.random(PKScheme.RSA, rng()).get,
+        RsaPrivateKey.random(rng()).get,
         key,
         "kid",
       )
@@ -389,5 +383,5 @@ suite "AutoTLS ACME Client":
     )
     expect(ACMEError):
       discard await acme.getCertificate(
-        api.Domain("some.domain"), KeyPair.random(PKScheme.RSA, rng()).get, challenge
+        api.Domain("some.domain"), RsaPrivateKey.random(rng()).get, challenge
       )

--- a/tests/libp2p/autotls/test_jws.nim
+++ b/tests/libp2p/autotls/test_jws.nim
@@ -5,7 +5,7 @@
 
 import json, base64, strutils
 import stew/byteutils
-import ../../../libp2p/[crypto/crypto, crypto/rsa]
+import ../../../libp2p/crypto/rsa
 import ../../../libp2p/autotls/acme/[jws, utils]
 import ../../tools/[unittest, crypto]
 
@@ -16,13 +16,13 @@ proc b64UrlDecode(s: string): seq[byte] {.raises: [ValueError].} =
   base64.decode(padded).toBytes()
 
 suite "ACME JWS":
-  let key = KeyPair.random(PKScheme.RSA, rng()).get()
+  let key = RsaPrivateKey.random(rng()).get()
 
   test "produces a valid RS256 flattened JWS":
     let header = %*{"alg": "RS256", "typ": "JWT", "nonce": "abc", "url": "https://e"}
     let payload = %*{"termsOfServiceAgreed": true}
 
-    let jws = toFlattenedJws(header, payload, key.seckey.rsakey)
+    let jws = toFlattenedJws(header, payload, key)
 
     # Flattened JWS has exactly the three members (no unprotected header).
     check jws.kind == JObject
@@ -37,23 +37,23 @@ suite "ACME JWS":
     # The signature verifies as RS256 over `protected.payload`.
     let signingInput = jws["protected"].getStr & "." & jws["payload"].getStr
     let sig = RsaSignature.init(b64UrlDecode(jws["signature"].getStr)).get()
-    check rsa.verify(sig, signingInput, key.pubkey.rsakey)
+    check rsa.verify(sig, signingInput, key.getPublicKey())
 
   test "base64url members carry no padding":
-    let jws = toFlattenedJws(%*{"alg": "RS256"}, %*{"a": 1}, key.seckey.rsakey)
+    let jws = toFlattenedJws(%*{"alg": "RS256"}, %*{"a": 1}, key)
     for field in ["protected", "payload", "signature"]:
       check not jws[field].getStr.contains('=')
       check not jws[field].getStr.contains('+')
       check not jws[field].getStr.contains('/')
 
   test "an empty payload still signs and verifies":
-    let jws = toFlattenedJws(%*{"alg": "RS256"}, %*{}, key.seckey.rsakey)
+    let jws = toFlattenedJws(%*{"alg": "RS256"}, %*{}, key)
     let signingInput = jws["protected"].getStr & "." & jws["payload"].getStr
     let sig = RsaSignature.init(b64UrlDecode(jws["signature"].getStr)).get()
-    check rsa.verify(sig, signingInput, key.pubkey.rsakey)
+    check rsa.verify(sig, signingInput, key.getPublicKey())
 
   test "rejects an unsupported algorithm":
     expect(ACMEError):
-      discard toFlattenedJws(%*{"alg": "ES256"}, %*{"a": 1}, key.seckey.rsakey)
+      discard toFlattenedJws(%*{"alg": "ES256"}, %*{"a": 1}, key)
     expect(ACMEError):
-      discard toFlattenedJws(%*{"typ": "JWT"}, %*{"a": 1}, key.seckey.rsakey)
+      discard toFlattenedJws(%*{"typ": "JWT"}, %*{"a": 1}, key)


### PR DESCRIPTION
## Summary

AutoTLS ACME now uses `RsaPrivateKey` directly for ACME account keys, certificate keys, CSR generation, and JWS signing instead of routing those RSA-only operations through the generic libp2p `KeyPair`.

Nimbus needs this because it builds nim-libp2p with `libp2p_pki_schemes=secp256k1`, which removes RSA from the generic libp2p identity key union. The previous AutoTLS ACME code still dereferenced RSA fields through `KeyPair`, causing Nimbus builds that import AutoTLS-related modules to fail at compile time.

## Affected Areas

- [x] Other  
  AutoTLS ACME key handling and related tests.

## Impact on Library Users

This changes lower-level AutoTLS ACME APIs from `KeyPair` parameters to `RsaPrivateKey` parameters. Callers using `ACMEApi` or `ACMEClient` directly should generate/pass RSA private keys directly.

Higher-level AutoTLS service usage continues to generate the required certificate key internally.

## Risk Assessment

Behavioral risk is low: ACME still uses RSA/RS256 as before, but the type boundary is now explicit. The main compatibility risk is source-level migration for callers of the lower-level ACME APIs.

## References

- Nimbus CI failure: https://github.com/status-im/nimbus-eth2/actions/runs/28470173703/job/84380389813