### PR TITLE
ci: force save build cache

### DIFF
--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -185,7 +185,7 @@ jobs:
             nim c $NIMFLAGS -d:sliceIdx=0 -o:tests/test_all_0 ./tests/test_all
             nim c $NIMFLAGS -d:sliceIdx=1 -o:tests/test_all_1 ./tests/test_all
           else
-            nim ic $NIMFLAGS ./tests/test_all
+            nim c $NIMFLAGS ./tests/test_all
           fi
 
       - name: Save build cache

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -164,10 +164,11 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: nimcache
-          key: ${{ github.ref_name }}-nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}-${{ github.run_id }}-${{ github.run_attempt }}
+          key: ${{ github.ref_name }}-nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}-${{ github.sha }}
           restore-keys: |
             ${{ github.ref_name }}-nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}-
             master-nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}-
+            master-nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}
 
       - name: Build test_all
         id: build-test-all

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -160,12 +160,14 @@ jobs:
         run: make nimble.paths nat_libs
 
       - name: Restore build cache
-        uses: actions/cache@v5
+        id: nimcache-restore
+        uses: actions/cache/restore@v5
         with:
           path: nimcache
-          key: ${{ github.ref_name }}-nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}
+          key: ${{ github.ref_name }}-nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
-            master-nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}
+            ${{ github.ref_name }}-nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}-
+            master-nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}-
 
       - name: Build test_all
         id: build-test-all
@@ -183,8 +185,14 @@ jobs:
             nim c $NIMFLAGS -d:sliceIdx=0 -o:tests/test_all_0 ./tests/test_all
             nim c $NIMFLAGS -d:sliceIdx=1 -o:tests/test_all_1 ./tests/test_all
           else
-            nim c $NIMFLAGS ./tests/test_all
+            nim ic $NIMFLAGS ./tests/test_all
           fi
+
+      - name: Save build cache
+        uses: actions/cache/save@v5
+        with:
+          path: nimcache
+          key: ${{ steps.nimcache-restore.outputs.cache-primary-key }}
 
       - name: Run tests
         id: run-tests


### PR DESCRIPTION
- save build cache right after build finishes
   - avoids wasting cache if tests fails (flaky, or cancelled job after build has finished)
- restore will restore cache by priority:
   1) use latest saved cache form this branch or 
   2) when this branch has no cache use cache from master