### PR TITLE
fix: avoid duplicate sending of control packet

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -759,14 +759,16 @@ proc onHeartbeat(g: GossipSub) =
   let peers = g.getGossipPeers()
   for peer, control in peers:
     # only ihave from here
+    var didSend = false
     for ihave in control.ihave:
       libp2p_pubsub_broadcast_ihave.inc(labelValues = [g.topicLabel(ihave.topicID)])
 
-      if ihave.topicID.isSome and
+      if not didSend and ihave.topicID.isSome and
           not g.extensionsState.peerRequestsPartial(peer.peerId, ihave.topicID.get()):
         # send IHAVE only if peer has not requested partial for topic.
         # these peers will receive gossip of partial metadata via extension.
         g.send(peer, RPCMsg.withControl(control), MessagePriority.High)
+        didSend = true
 
   g.mcache.shift() # shift the cache
 


### PR DESCRIPTION
## Summary

Send IHAVE only once per peer instead of spamming it with duplicates for each topic for which they did not already requested partial.

## Affected Areas
<!--
Indicate which parts of the codebase are impacted.
Check all that apply and briefly describe the scope of the changes.
-->

- [x] Gossipsub  
  <!-- e.g. scoring changes, message validation, peer handling -->

- [ ] Transports  
  <!-- e.g. TCP, QUIC, WebSockets, Noise, etc. -->

- [ ] Peer Management / Discovery

- [ ] Protocol Logic

- [ ] Build / Tooling

- [ ] Other  
  <!-- Describe below -->
