### PR TITLE
fix(gossipsub): sending duplicate IHAVE

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -644,7 +644,7 @@ proc replenishFanout*(g: GossipSub, topic: string) =
 
   trace "fanout replenished with peers", peers = g.fanout.peers(topic)
 
-proc getGossipPeers*(g: GossipSub): Table[PubSubPeer, ControlMessage] =
+proc makeGossipControlMessages*(g: GossipSub): Table[PubSubPeer, ControlMessage] =
   ## gossip iHave messages to peers
   ##
 
@@ -761,8 +761,7 @@ proc onHeartbeat(g: GossipSub) =
   for t in toSeq(g.fanout.keys):
     g.replenishFanout(t)
 
-  let peers = g.getGossipPeers()
-  for peer, control in peers:
+  for peer, control in g.makeGossipControlMessages():
     # only ihave from here
     g.send(peer, RPCMsg.withControl(control), MessagePriority.High)
 

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -763,10 +763,9 @@ proc onHeartbeat(g: GossipSub) =
 
   for peer, control in g.makeGossipControlMessages():
     # only ihave from here
-    g.send(peer, RPCMsg.withControl(control), MessagePriority.High)
-
     for ihave in control.ihave:
       libp2p_pubsub_broadcast_ihave.inc(labelValues = [g.topicLabel(ihave.topicID)])
+    g.send(peer, RPCMsg.withControl(control), MessagePriority.High)
 
   g.mcache.shift() # shift the cache
 

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -765,7 +765,7 @@ proc onHeartbeat(g: GossipSub) =
   for peer, control in peers:
     # only ihave from here
     g.send(peer, RPCMsg.withControl(control), MessagePriority.High)
-    
+
     for ihave in control.ihave:
       libp2p_pubsub_broadcast_ihave.inc(labelValues = [g.topicLabel(ihave.topicID)])
 

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -697,6 +697,11 @@ proc getGossipPeers*(g: GossipSub): Table[PubSubPeer, ControlMessage] =
       allPeers.setLen(target)
 
     for peer in allPeers:
+      if g.extensionsState.peerRequestsPartial(peer.peerId, topic):
+        # add IHAVE only if peer has not requested partial for topic.
+        # these peers will receive gossip of partial metadata via extension.
+        continue
+
       control.mgetOrPut(peer, ControlMessage()).ihave.add(ihave)
       for msgId in ihave.messageIDs:
         peer.sentIHaves[0].incl(msgId)
@@ -759,14 +764,10 @@ proc onHeartbeat(g: GossipSub) =
   let peers = g.getGossipPeers()
   for peer, control in peers:
     # only ihave from here
+    g.send(peer, RPCMsg.withControl(control), MessagePriority.High)
+    
     for ihave in control.ihave:
       libp2p_pubsub_broadcast_ihave.inc(labelValues = [g.topicLabel(ihave.topicID)])
-
-      if ihave.topicID.isSome and
-          not g.extensionsState.peerRequestsPartial(peer.peerId, ihave.topicID.get()):
-        # send IHAVE only if peer has not requested partial for topic.
-        # these peers will receive gossip of partial metadata via extension.
-        g.send(peer, RPCMsg.withControl(control), MessagePriority.High)
 
   g.mcache.shift() # shift the cache
 

--- a/tests/libp2p/pubsub/test_behavior.nim
+++ b/tests/libp2p/pubsub/test_behavior.nim
@@ -818,7 +818,7 @@ suite "GossipSub Behavior":
     check topic1 notin gossipSub.fanout
     check topic2 in gossipSub.fanout
 
-  asyncTest "getGossipPeers - should gather up to degree D non intersecting peers":
+  asyncTest "makeGossipControlMessages - should gather up to degree D non intersecting peers":
     let (gossipSub, conns, peers) = setupGossipSubWithPeers(45, topic)
     defer:
       await teardownGossipSub(gossipSub, conns)
@@ -850,13 +850,13 @@ suite "GossipSub Behavior":
     check gossipSub.mesh[topic].len == 15
     check gossipSub.gossipsub[topic].len == 15
 
-    let gossipPeers = gossipSub.getGossipPeers()
+    let gossipPeers = gossipSub.makeGossipControlMessages()
     check gossipPeers.len == gossipSub.parameters.d
     for p in gossipPeers.keys:
       check not gossipSub.fanout.hasPeerId(topic, p.peerId)
       check not gossipSub.mesh.hasPeerId(topic, p.peerId)
 
-  asyncTest "getGossipPeers - should not crash on missing topics in mesh":
+  asyncTest "makeGossipControlMessages - should not crash on missing topics in mesh":
     let (gossipSub, conns, peers) = setupGossipSubWithPeers(30, topic)
     defer:
       await teardownGossipSub(gossipSub, conns)
@@ -877,10 +877,10 @@ suite "GossipSub Behavior":
         Message.init(conn.peerId, ("HELLO" & $i).toBytes(), topic, Opt.some(seqno))
       gossipSub.mcache.put(gossipSub.msgIdProvider(msg).expect(MsgIdSuccess), msg)
 
-    let gossipPeers = gossipSub.getGossipPeers()
+    let gossipPeers = gossipSub.makeGossipControlMessages()
     check gossipPeers.len == gossipSub.parameters.d
 
-  asyncTest "getGossipPeers - should not crash on missing topics in fanout":
+  asyncTest "makeGossipControlMessages - should not crash on missing topics in fanout":
     let (gossipSub, conns, peers) = setupGossipSubWithPeers(30, topic)
     defer:
       await teardownGossipSub(gossipSub, conns)
@@ -902,10 +902,10 @@ suite "GossipSub Behavior":
         Message.init(conn.peerId, ("HELLO" & $i).toBytes(), topic, Opt.some(seqno))
       gossipSub.mcache.put(gossipSub.msgIdProvider(msg).expect(MsgIdSuccess), msg)
 
-    let gossipPeers = gossipSub.getGossipPeers()
+    let gossipPeers = gossipSub.makeGossipControlMessages()
     check gossipPeers.len == gossipSub.parameters.d
 
-  asyncTest "getGossipPeers - should not crash on missing topics in gossip":
+  asyncTest "makeGossipControlMessages - should not crash on missing topics in gossip":
     let (gossipSub, conns, peers) = setupGossipSubWithPeers(30, topic)
     defer:
       await teardownGossipSub(gossipSub, conns)
@@ -927,10 +927,10 @@ suite "GossipSub Behavior":
         Message.init(conn.peerId, ("HELLO" & $i).toBytes(), topic, Opt.some(seqno))
       gossipSub.mcache.put(gossipSub.msgIdProvider(msg).expect(MsgIdSuccess), msg)
 
-    let gossipPeers = gossipSub.getGossipPeers()
+    let gossipPeers = gossipSub.makeGossipControlMessages()
     check gossipPeers.len == 0
 
-  asyncTest "getGossipPeers - do not select peer for IHave broadcast if peer score is below GossipThreshold threshold":
+  asyncTest "makeGossipControlMessages - do not select peer for IHave broadcast if peer score is below GossipThreshold threshold":
     const gossipThreshold = -100.0
     let
       (gossipSub, conns, peers) =
@@ -948,7 +948,7 @@ suite "GossipSub Behavior":
     gossipSub.mcache.put(id, Message(topic: topic))
 
     # When Node selects peers for IHave broadcast
-    let gossipPeers = gossipSub.getGossipPeers()
+    let gossipPeers = gossipSub.makeGossipControlMessages()
 
     # Then peer is not selected
     check:


### PR DESCRIPTION
the problem existed because:
`g.send(peer, RPCMsg.withControl(control), MessagePriority.High)` 
would be sent for every topic id in the control, this was wrong and issue was likely do to invalid indentation. `g.send` was under for that was updating metrics it should not be.


based on #2723
