### PR TITLE
test(transports): improve hanging test

### DIFF
--- a/tests/libp2p/transports/utils.nim
+++ b/tests/libp2p/transports/utils.nim
@@ -199,8 +199,9 @@ proc runSingleStreamScenario*(
   let clientTask = clientRunSingleStream(
     server, transportProvider, streamProvider, clientStreamHandler
   )
-  await allFutures(clientTask, serverTask)
+  await clientTask
   await server.stop()
+  await serverTask
 
 proc dualStackStreamScenario*(
     listenAddrs: seq[MultiAddress],


### PR DESCRIPTION
## Summary

Fixes a hang in the TCP transport stream test `stream with multiple parallel writes` that reproduces reliably locally on macOS (roughly 4 of 5 runs) and rarely in CI.

The data transfer itself is fine. The hang is in teardown. `runSingleStreamScenario` used to wait for both the client and server tasks before stopping the server:

  ```nim
  await allFutures(clientTask, serverTask)
  await server.stop()
  ```

`serverTask` only finishes once `muxer.handle()` reads EOF on the accepted socket, and that EOF depends on the client's FIN arriving. 

**Hypothesis**: under heavy traffic (this test pushes 20 MB) the FIN can be lost, leaving `handle()` blocked forever in `readMsg()` and hanging the test. Claude confirmed the symptom with lsof/netstat: the accepted socket stays ESTABLISHED with an empty receive queue after the client has fully closed and is gone.

The fix removes the dependency on the FIN. The test owns both endpoints, so once the client is done it stops the server, which closes the accepted socket and ends `handle()` deterministically:

```nim
  await clientTask
  await server.stop()
  await serverTask
```

## Affected Areas

- [x] Tests