### PR TITLE
fix: Cleanup peers from readyEvents list when upgrade timed out

### DIFF
--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -262,8 +262,9 @@ proc waitForPeerReady*(
   c.readyWaiters.mgetOrPut(peerId, 0).inc()
   defer:
     c.readyWaiters.withValue(peerId, waiters):
-      waiters[].dec()
-      if waiters[] <= 0:
+      waiters[].dec() # remove myself as waiter
+      let noMoreWaiters = waiter[] <= 0
+      if noMoreWaiters:
         c.readyWaiters.del(peerId)
         c.clearReadyEvent(peerId)
 

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -263,7 +263,7 @@ proc waitForPeerReady*(
   defer:
     c.readyWaiters.withValue(peerId, waiters):
       waiters[].dec() # remove myself as waiter
-      let noMoreWaiters = waiter[] <= 0
+      let noMoreWaiters = waiters[] <= 0
       if noMoreWaiters:
         c.readyWaiters.del(peerId)
         c.clearReadyEvent(peerId)

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -108,6 +108,7 @@ type
     connEvents: array[ConnEventKind, OrderedSet[ConnEventHandler]]
     peerEvents: array[PeerEventKind, OrderedSet[PeerEventHandler]]
     readyEvents: Table[PeerId, Future[void].Raising([CancelledError])]
+    readyWaiters: Table[PeerId, int]
     readyPeers: HashSet[PeerId]
     expectedConnectionsOverLimit*: Table[(PeerId, Direction), Future[Muxer]]
     peerStore*: PeerStore
@@ -251,6 +252,17 @@ proc waitForPeerReady*(
     return true
 
   let readyEvent = c.getReadyEvent(peerId)
+  c.readyWaiters.mgetOrPut(peerId, 0) += 1
+  defer:
+    c.readyWaiters.withValue(peerId, waiters):
+      waiters[] -= 1
+      if waiters[] <= 0:
+        c.readyWaiters.del(peerId)
+        c.readyEvents.withValue(peerId, readyEvent):
+          if not readyEvent[].finished:
+            # All waiters timed out, but peer never completed an upgrade,
+            # so neither notifyPeerReady nor clearPeerReadyState were called.
+            c.readyEvents.del(peerId)
 
   let readyJoin = readyEvent.join()
   if timeout <= 0.seconds:

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -240,6 +240,13 @@ proc clearPeerReadyState(c: ConnManager, peerId: PeerId) =
     readyEvent[].cancelSoon()
     c.readyEvents.del(peerId)
 
+func clearReadyEvent(c: ConnManager, peerId: PeerId) =
+  c.readyEvents.withValue(peerId, readyEvent):
+    if not readyEvent[].finished:
+      # All waiters timed out, but peer never completed an upgrade,
+      # so neither notifyPeerReady nor clearPeerReadyState were called.
+      c.readyEvents.del(peerId)
+
 proc waitForPeerReady*(
     c: ConnManager, peerId: PeerId, timeout = 5.seconds
 ): Future[bool] {.async: (raises: [CancelledError]).} =
@@ -252,17 +259,13 @@ proc waitForPeerReady*(
     return true
 
   let readyEvent = c.getReadyEvent(peerId)
-  c.readyWaiters.mgetOrPut(peerId, 0) += 1
+  c.readyWaiters.mgetOrPut(peerId, 0).inc()
   defer:
     c.readyWaiters.withValue(peerId, waiters):
-      waiters[] -= 1
+      waiters[].dec()
       if waiters[] <= 0:
         c.readyWaiters.del(peerId)
-        c.readyEvents.withValue(peerId, readyEvent):
-          if not readyEvent[].finished:
-            # All waiters timed out, but peer never completed an upgrade,
-            # so neither notifyPeerReady nor clearPeerReadyState were called.
-            c.readyEvents.del(peerId)
+        c.clearReadyEvent(peerId)
 
   let readyJoin = readyEvent.join()
   if timeout <= 0.seconds:


### PR DESCRIPTION
## Summary

waitForPeerReady creates readyEvent, but if it times out and the peer never finishes an upgrade, the entry in c.readyEvents becomes stuck. Make sure that we drop the entry when every waiter timed out.

## Affected Areas
<!--
Indicate which parts of the codebase are impacted.
Check all that apply and briefly describe the scope of the changes.
-->

- [ ] Gossipsub  
  <!-- e.g. scoring changes, message validation, peer handling -->

- [ ] Transports  
  <!-- e.g. TCP, QUIC, WebSockets, Noise, etc. -->

- [X] Peer Management / Discovery

- [ ] Protocol Logic

- [ ] Build / Tooling

- [ ] Other  
  <!-- Describe below -->
