### PR TITLE
ci: avoiding cache for trivial jobs

### DIFF
--- a/.github/workflows/cbindings.yml
+++ b/.github/workflows/cbindings.yml
@@ -54,14 +54,6 @@ jobs:
         run: |
           nimble install_pinned
 
-      - name: Restore build cache
-        uses: actions/cache@v5
-        with:
-          path: nimcache
-          key: ${{ github.ref_name }}-nimcache-cbindings-linux-amd64-gcc-v2.2.10
-          restore-keys: |
-            master-nimcache-cbindings-linux-amd64-gcc-v2.2.10
-
       - name: Build and run c bindings examples
         run: |
           nim --version

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -54,14 +54,6 @@ jobs:
         run: |
           nimble install_pinned
 
-      - name: Restore build cache
-        uses: actions/cache@v5
-        with:
-          path: nimcache
-          key: ${{ github.ref_name }}-nimcache-examples-linux-amd64-gcc-v2.2.10
-          restore-keys: |
-            master-nimcache-examples-linux-amd64-gcc-v2.2.10
-
       - name: Build and run examples
         run: |
           nim --version

--- a/.github/workflows/test_multiformat_exts.yml
+++ b/.github/workflows/test_multiformat_exts.yml
@@ -125,18 +125,10 @@ jobs:
       - name: Build prerequisites
         run: make nimble.paths nat_libs
 
-      - name: Restore build cache
-        uses: actions/cache@v5
-        with:
-          path: nimcache
-          key: ${{ github.ref_name }}-nimcache-test_multiformat_exts-${{ needs.pick-platform.outputs.os }}-${{ needs.pick-platform.outputs.cpu }}-${{ needs.pick-platform.outputs.cc }}-${{ needs.pick-platform.outputs.nim_ref }}-${{ needs.pick-platform.outputs.nim_mm }}
-          restore-keys: |
-            master-nimcache-test_multiformat_exts-${{ needs.pick-platform.outputs.os }}-${{ needs.pick-platform.outputs.cpu }}-${{ needs.pick-platform.outputs.cc }}-${{ needs.pick-platform.outputs.nim_ref }}-${{ needs.pick-platform.outputs.nim_mm }}
-
       - name: Build test_multiformat_exts
         id: build-test
         run: |
-          NIMFLAGS="--nimcache:nimcache/test_multiformat_exts --mm:${{ needs.pick-platform.outputs.nim_mm }} --opt:speed --styleCheck:usages --styleCheck:error --parallelBuild:0 --threads:on --skipUserCfg"
+          NIMFLAGS="--mm:${{ needs.pick-platform.outputs.nim_mm }} --opt:speed --styleCheck:usages --styleCheck:error --parallelBuild:0 --threads:on --skipUserCfg"
           NIMFLAGS="$NIMFLAGS -d:libp2p_multicodec_exts=../tests/libp2p/multiformat_exts/multicodec_exts.nim"
           NIMFLAGS="$NIMFLAGS -d:libp2p_multiaddress_exts=../tests/libp2p/multiformat_exts/multiaddress_exts.nim"
           NIMFLAGS="$NIMFLAGS -d:libp2p_multihash_exts=../tests/libp2p/multiformat_exts/multihash_exts.nim"


### PR DESCRIPTION
 avoiding cache for trivial jobs in order to leave (save) space for test_all job that takes the most time