### PR TITLE
test(autonat): dual stack 4

### DIFF
--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -448,6 +448,7 @@ const
   QUIC_V1_DNS* = mapAnd(UDP_DNS, mapEq("quic-v1"))
   QUIC_V1* = mapOr(QUIC_V1_DNS, QUIC_V1_IP)
   TCP_IP4* = mapAnd(IP4, mapEq("tcp"))
+  TCP_IP6* = mapAnd(IP6, mapEq("tcp"))
   UDP_IP4* = mapAnd(IP4, mapEq("udp"))
   QUIC_V1_IP4* = mapAnd(UDP_IP4, mapEq("quic-v1"))
   UNIX* = mapEq("unix")

--- a/tests/libp2p/protocols/test_autonat_v2.nim
+++ b/tests/libp2p/protocols/test_autonat_v2.nim
@@ -20,21 +20,13 @@ import
 import ../../tools/[unittest, crypto, switch_builder, multiaddress]
 
 proc setupAutonat(
-    srcAddrs: seq[MultiAddress] = newSeq[MultiAddress](),
-    dstAddrs: seq[MultiAddress] = newSeq[MultiAddress](),
+    srcAddrs: seq[MultiAddress] = @[TcpAutoAddress],
+    dstAddrs: seq[MultiAddress] = @[TcpAutoAddress],
     config: AutonatV2Config = AutonatV2Config.new(),
 ): Future[(Switch, Switch, AutonatV2Client)] {.async.} =
-  var srcBuilder = makeStandardSwitchBuilder(TcpAutoAddress)
-  if srcAddrs.len > 0:
-    srcBuilder = srcBuilder.withAddresses(srcAddrs)
-
-  var dstBuilder = makeStandardSwitchBuilder(TcpAutoAddress).withAutonatV2Server(config)
-  if dstAddrs.len > 0:
-    dstBuilder = dstBuilder.withAddresses(dstAddrs)
-
   let
-    src = srcBuilder.build()
-    dst = dstBuilder.build()
+    src = makeStandardSwitchBuilder(srcAddrs).build()
+    dst = makeStandardSwitchBuilder(dstAddrs).withAutonatV2Server(config).build()
     client = AutonatV2Client.new(rng())
 
   client.setup(src)
@@ -76,7 +68,7 @@ suite "AutonatV2":
     ) == Reachable
 
   asyncTest "asAutonatV2Response":
-    let addrs = @[MultiAddress.init("/ip4/127.0.0.1/tcp/4000").get()]
+    let addrs = @[ma("/ip4/127.0.0.1/tcp/4000")]
     let errorDialResp = DialResponse(
       status: ResponseStatus.Ok,
       addrIdx: Opt.none(AddrIdx),
@@ -143,8 +135,7 @@ suite "AutonatV2":
     # use ip address other than 127.0.0.1 for client
     let
       listenAddrs = @[
-        MultiAddress.init("/ip4/" & checkedGetIPAddress() & "/tcp/4040").get(),
-        MultiAddress.init("/ip4/127.0.0.1/tcp/4040").get(),
+        ma("/ip4/" & checkedGetIPAddress() & "/tcp/4040"), ma("/ip4/127.0.0.1/tcp/4040")
       ]
       reqAddrs = @[listenAddrs[0]]
       (src, dst, client) = await setupAutonat(srcAddrs = listenAddrs)
@@ -169,9 +160,7 @@ suite "AutonatV2":
       await allFutures(src.stop(), dst.stop())
 
     check (
-      await client.sendDialRequest(
-        dst.peerInfo.peerId, @[MultiAddress.init("/ip4/1.1.1.1/tcp/4040").get()]
-      )
+      await client.sendDialRequest(dst.peerInfo.peerId, @[ma("/ip4/1.1.1.1/tcp/4040")])
     ) ==
       AutonatV2Response(
         reachability: NotReachable,
@@ -180,17 +169,16 @@ suite "AutonatV2":
           dialStatus: Opt.some(DialStatus.EDialError),
           addrIdx: Opt.some(0.AddrIdx),
         ),
-        addrs: Opt.some(MultiAddress.init("/ip4/1.1.1.1/tcp/4040").get()),
+        addrs: Opt.some(ma("/ip4/1.1.1.1/tcp/4040")),
       )
 
   asyncTest "Failed DialRequest with amplification attack prevention":
     # use ip address other than 127.0.0.1 for client
     let
       listenAddrs = @[
-        MultiAddress.init("/ip4/" & checkedGetIPAddress() & "/tcp/4040").get(),
-        MultiAddress.init("/ip4/127.0.0.1/tcp/4040").get(),
+        ma("/ip4/" & checkedGetIPAddress() & "/tcp/4040"), ma("/ip4/127.0.0.1/tcp/4040")
       ]
-      reqAddrs = @[MultiAddress.init("/ip4/1.1.1.1/tcp/4040").get()]
+      reqAddrs = @[ma("/ip4/1.1.1.1/tcp/4040")]
       (src, dst, client) = await setupAutonat(
         srcAddrs = listenAddrs, config = AutonatV2Config.new(dialTimeout = 1.seconds)
       )
@@ -214,7 +202,7 @@ suite "AutonatV2":
     defer:
       await allFutures(src.stop(), dst.stop())
 
-    let reqAddrs = @[MultiAddress.init("/ip6/2001:db8::1/tcp/4040").get()]
+    let reqAddrs = @[ma("/ip6/2001:db8::1/tcp/4040")]
     check (await client.sendDialRequest(dst.peerInfo.peerId, reqAddrs)) ==
       AutonatV2Response(
         reachability: Unknown,
@@ -232,7 +220,7 @@ suite "AutonatV2":
     defer:
       await allFutures(src.stop(), dst.stop())
 
-    let reqAddrs = @[MultiAddress.init("/ip4/1.1.1.1/tcp/4040").get()]
+    let reqAddrs = @[ma("/ip4/1.1.1.1/tcp/4040")]
     check (await client.sendDialRequest(dst.peerInfo.peerId, reqAddrs)) ==
       AutonatV2Response(
         reachability: Unknown,
@@ -323,7 +311,7 @@ suite "AutonatV2":
       dst = makeStandardSwitch()
       client = AutonatV2Client.new(rng())
       autonatV2Mock = AutonatV2Mock.new()
-      reqAddrs = @[MultiAddress.init("/ip4/127.0.0.1/tcp/4040").get()]
+      reqAddrs = @[ma("/ip4/127.0.0.1/tcp/4040")]
 
     client.setup(src)
     dst.mount(autonatV2Mock)

--- a/tests/libp2p/protocols/test_autonat_v2.nim
+++ b/tests/libp2p/protocols/test_autonat_v2.nim
@@ -3,10 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import chronos, net
+import chronos, net, sequtils
 import
   ../../../libp2p/[
     switch,
+    multiaddress,
     transports/tcptransport,
     upgrademngrs/upgrade,
     builders,
@@ -20,15 +21,20 @@ import ../../tools/[unittest, crypto, switch_builder, multiaddress]
 
 proc setupAutonat(
     srcAddrs: seq[MultiAddress] = newSeq[MultiAddress](),
+    dstAddrs: seq[MultiAddress] = newSeq[MultiAddress](),
     config: AutonatV2Config = AutonatV2Config.new(),
 ): Future[(Switch, Switch, AutonatV2Client)] {.async.} =
   var srcBuilder = makeStandardSwitchBuilder(TcpAutoAddress)
   if srcAddrs.len > 0:
     srcBuilder = srcBuilder.withAddresses(srcAddrs)
 
+  var dstBuilder = makeStandardSwitchBuilder(TcpAutoAddress).withAutonatV2Server(config)
+  if dstAddrs.len > 0:
+    dstBuilder = dstBuilder.withAddresses(dstAddrs)
+
   let
     src = srcBuilder.build()
-    dst = makeStandardSwitchBuilder(TcpAutoAddress).withAutonatV2Server(config).build()
+    dst = dstBuilder.build()
     client = AutonatV2Client.new(rng())
 
   client.setup(src)
@@ -201,6 +207,115 @@ suite "AutonatV2":
         ),
         addrs: Opt.some(reqAddrs[0]),
       )
+
+  asyncTest "DialRequest with IPv6 addr refused by IPv4-only server":
+    # server listens on IPv4 only, so it refuses to dial any IPv6 addr
+    let (src, dst, client) = await setupAutonat()
+    defer:
+      await allFutures(src.stop(), dst.stop())
+
+    let reqAddrs = @[MultiAddress.init("/ip6/2001:db8::1/tcp/4040").get()]
+    check (await client.sendDialRequest(dst.peerInfo.peerId, reqAddrs)) ==
+      AutonatV2Response(
+        reachability: Unknown,
+        dialResp: DialResponse(
+          status: EDialRefused,
+          addrIdx: Opt.none(AddrIdx),
+          dialStatus: Opt.none(DialStatus),
+        ),
+        addrs: Opt.none(MultiAddress),
+      )
+
+  asyncTest "DialRequest with IPv4 addr refused by IPv6-only server":
+    # server listens on IPv6 only, so it refuses to dial any IPv4 addr
+    let (src, dst, client) = await setupAutonat(dstAddrs = @[TcpAutoAddressIP6])
+    defer:
+      await allFutures(src.stop(), dst.stop())
+
+    let reqAddrs = @[MultiAddress.init("/ip4/1.1.1.1/tcp/4040").get()]
+    check (await client.sendDialRequest(dst.peerInfo.peerId, reqAddrs)) ==
+      AutonatV2Response(
+        reachability: Unknown,
+        dialResp: DialResponse(
+          status: EDialRefused,
+          addrIdx: Opt.none(AddrIdx),
+          dialStatus: Opt.none(DialStatus),
+        ),
+        addrs: Opt.none(MultiAddress),
+      )
+
+  asyncTest "DialRequest with private IPv6 addr succeeds despite allowPrivateAddresses=false":
+    # TODO: nim-libp2p#2710
+    # isPrivate classifies every IPv6 address as non-private
+    # the server therefore dials back the loopback IPv6 addr instead of refusing it
+    let
+      dualStackAddrs = @[TcpAutoAddressIP4, TcpAutoAddressIP6]
+      (src, dst, client) =
+        await setupAutonat(srcAddrs = dualStackAddrs, dstAddrs = dualStackAddrs)
+    defer:
+      await allFutures(src.stop(), dst.stop())
+
+    # request only the IPv6 listen addr of the client
+    let reqAddrs = src.peerInfo.addrs.filterIt(TCP_IP6.match(it))
+    check reqAddrs.len == 1
+
+    check (await client.sendDialRequest(dst.peerInfo.peerId, reqAddrs)) ==
+      AutonatV2Response(
+        reachability: Reachable,
+        dialResp: DialResponse(
+          status: ResponseStatus.Ok,
+          dialStatus: Opt.some(DialStatus.Ok),
+          addrIdx: Opt.some(0.AddrIdx),
+        ),
+        addrs: Opt.some(reqAddrs[0]),
+      )
+
+  asyncTest "Amplification attack prevention skipped when observed IPv4 addr matches a requested addr":
+    # the requested addr matches the observed addr of the client,
+    # so the server dials back right away without demanding dial data
+    # dialDataSize is set above what the client accepts to prove the skip:
+    # a DialDataRequest would have failed the request with AutonatV2Error
+    let (src, dst, client) = await setupAutonat(
+      config = AutonatV2Config.new(
+        dialDataSize = (MaxAcceptedDialDataRequest + 1).uint64,
+        allowPrivateAddresses = true,
+      )
+    )
+    defer:
+      await allFutures(src.stop(), dst.stop())
+
+    check (await client.sendDialRequest(dst.peerInfo.peerId, src.peerInfo.addrs)) ==
+      AutonatV2Response(
+        reachability: Reachable,
+        dialResp: DialResponse(
+          status: ResponseStatus.Ok,
+          dialStatus: Opt.some(DialStatus.Ok),
+          addrIdx: Opt.some(0.AddrIdx),
+        ),
+        addrs: Opt.some(src.peerInfo.addrs[0]),
+      )
+
+  asyncTest "Amplification attack prevention not skipped when observed IPv6 addr matches a requested addr":
+    # TODO: nim-libp2p#2731
+    # the requested addr matches the observed addr of the client,
+    # yet the server demands dial data before the dial back
+    # dialDataSize is set above what the client accepts to prove the demand:
+    # the DialDataRequest fails the request with AutonatV2Error
+    let
+      ipv6Addrs = @[TcpAutoAddressIP6]
+      (src, dst, client) = await setupAutonat(
+        srcAddrs = ipv6Addrs,
+        dstAddrs = ipv6Addrs,
+        config = AutonatV2Config.new(
+          dialDataSize = (MaxAcceptedDialDataRequest + 1).uint64,
+          allowPrivateAddresses = true,
+        ),
+      )
+    defer:
+      await allFutures(src.stop(), dst.stop())
+
+    expect(AutonatV2Error):
+      discard await client.sendDialRequest(dst.peerInfo.peerId, src.peerInfo.addrs)
 
   asyncTest "Server responding with invalid messages":
     let

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -22,10 +22,6 @@ import
   ]
 import ../../tools/[unittest, crypto, multiaddress, switch_builder]
 
-const
-  IPv4Tcp = mapAnd(IP4, mapEq("tcp"))
-  IPv6Tcp = mapAnd(IP6, mapEq("tcp"))
-
 suite "Identify":
   teardown:
     checkTrackers()
@@ -198,10 +194,10 @@ suite "Identify":
 
       check:
         # ensure both IPv4 and IPv6 addresses are used in switch.
-        countAddressesWithPattern(switch1.peerInfo.addrs, IPv4Tcp) > 1
-        countAddressesWithPattern(switch1.peerInfo.addrs, IPv6Tcp) > 1
-        countAddressesWithPattern(switch2.peerInfo.addrs, IPv4Tcp) > 1
-        countAddressesWithPattern(switch2.peerInfo.addrs, IPv6Tcp) > 1
+        countAddressesWithPattern(switch1.peerInfo.addrs, TCP_IP4) > 1
+        countAddressesWithPattern(switch1.peerInfo.addrs, TCP_IP6) > 1
+        countAddressesWithPattern(switch2.peerInfo.addrs, TCP_IP4) > 1
+        countAddressesWithPattern(switch2.peerInfo.addrs, TCP_IP6) > 1
 
         # ensure all addresses are advertized.
         # that is, peer store will have all address of other peer
@@ -307,7 +303,7 @@ suite "Identify":
       await client.stop()
 
     check:
-      countAddressesWithPattern(server.peerInfo.addrs, IPv4Tcp) == 1
+      countAddressesWithPattern(server.peerInfo.addrs, TCP_IP4) == 1
       countAddressesWithPattern(server.peerInfo.addrs, QUIC_V1) == 1
 
     # Connect and request identify

--- a/tests/tools/switch_builder.nim
+++ b/tests/tools/switch_builder.nim
@@ -8,27 +8,41 @@ import ./[crypto, multiaddress]
 
 export builders
 
+proc makeStandardSwitchBuilder*(addresses: seq[MultiAddress]): SwitchBuilder =
+  ## Helper that creates a SwitchBuilder with standard configurations.
+  ## Transports are added automatically to match the listen `addresses`.
+
+  var b = SwitchBuilder.new().withRng(rng()).withNoise().withAddresses(addresses)
+
+  # the listen addresses decide which transports to use, deduped across addresses
+  var hasQuic, hasTcp, hasWs, hasMemory = false
+  for address in addresses:
+    if QUIC_V1.match(address):
+      hasQuic = true
+    elif TCP.match(address):
+      hasTcp = true
+    elif WebSockets.match(address):
+      hasWs = true
+    elif Memory.match(address):
+      hasMemory = true
+    else:
+      raiseAssert "could not infer transport from address: " & $address
+
+  if hasQuic:
+    b = b.withQuicTransport()
+  if hasTcp:
+    b = b.withTcpTransport().withMplex()
+  if hasWs:
+    b = b.withWsTransport().withMplex()
+  if hasMemory:
+    b = b.withMemoryTransport().withMplex()
+
+  b
+
 proc makeStandardSwitchBuilder*(
     address: MultiAddress = QuicAutoAddress
 ): SwitchBuilder =
-  ## Helper that creates a SwitchBuilder with standard configurations.
-  ## Transport is added automatically to match the listen `address`.
-
-  var b = SwitchBuilder.new().withRng(rng()).withNoise().withAddress(address)
-
-  # address will decide which transport to use
-  if QUIC_V1.match(address):
-    b = b.withQuicTransport()
-  elif TCP.match(address):
-    b = b.withTcpTransport().withMplex()
-  elif WebSockets.match(address):
-    b = b.withWsTransport().withMplex()
-  elif Memory.match(address):
-    b = b.withMemoryTransport().withMplex()
-  else:
-    raiseAssert "could not infer transport from address"
-
-  b
+  makeStandardSwitchBuilder(@[address])
 
 proc makeStandardSwitch*(
     address: MultiAddress = QuicAutoAddress

--- a/tests/tools/test_multiaddress.nim
+++ b/tests/tools/test_multiaddress.nim
@@ -17,12 +17,9 @@ suite "MultiAddress testing tools":
       MultiAddress.init("/ip4/127.0.0.1/tcp/55449").get(),
       MultiAddress.init("/ip4/192.168.1.24/tcp/55449").get(),
     ]
-    const
-      IPv4Tcp = mapAnd(IP4, mapEq("tcp"))
-      IPv6Tcp = mapAnd(IP6, mapEq("tcp"))
-      IPv4Ws = mapAnd(IP4, mapEq("ws"))
+    const IPv4Ws = mapAnd(IP4, mapEq("ws"))
 
     check:
-      countAddressesWithPattern(ma, IPv4Tcp) == 4
-      countAddressesWithPattern(ma, IPv6Tcp) == 2
+      countAddressesWithPattern(ma, TCP_IP4) == 4
+      countAddressesWithPattern(ma, TCP_IP6) == 2
       countAddressesWithPattern(ma, IPv4Ws) == 0


### PR DESCRIPTION
## Summary

Adds AutoNAT v2 dual-stack test coverage.

New tests in `test_autonat_v2.nim`:

- an IPv4-only server refuses a DialRequest for an IPv6 addr with `EDialRefused`, and an IPv6-only server refuses an IPv4 addr the same way.
- a dual-stack server dials back a loopback IPv6 addr even with `allowPrivateAddresses = false`, because `isPrivate` classifies every IPv6 address as non-private. Pins the protocol-level consequence of #2710.
- amplification attack prevention is skipped when the observed IPv4 addr matches a requested addr, but never skipped for IPv6. Pins #2731.

Supporting changes: `setupAutonat` takes an optional `dstAddrs` so tests control the server listen families, and the `TCP_IP6` pattern is now exported from `multiaddress.nim` next to `TCP_IP4`. The identical local definitions in `test_identify.nim` and `tests/tools/test_multiaddress.nim` are replaced with the exported patterns.

## Affected Areas

- [x] Tests
  Test-only coverage for AutoNAT v2, plus one new exported multiaddress pattern (`TCP_IP6`).

## Impact on Library Users

`TCP_IP6` is a new exported const in `multiaddress.nim`.