### PR TITLE
fix(peerstore): keep connected peer addresses from expiring

### DIFF
--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -380,6 +380,7 @@ proc onPeerDisconnected(c: ConnManager, peerId: PeerId) {.async: (raises: []).} 
   c.clearPeerReadyState(peerId)
   c.connectedAt.del(peerId)
   if not c.peerStore.isNil:
+    c.peerStore.markPeerDisconnected(peerId)
     c.peerStore.cleanup(peerId)
   libp2p_peers.set(c.muxerStore.countPeers.int64)
   await noCancel c.triggerPeerEvents(peerId, PeerEvent(kind: PeerEventKind.Left))
@@ -463,6 +464,9 @@ proc storeMuxer*(
     raise newException(LPError, "muxer already stored")
 
   libp2p_peers.set(c.muxerStore.countPeers().int64)
+
+  if isNewPeer and not c.peerStore.isNil:
+    c.peerStore.markPeerConnected(peerId)
 
   c.onCloseFuts.trackFut(c.onClose(muxer))
 

--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -90,6 +90,7 @@ type
 
   AddressBook* = ref object of PeerBook[seq[AddressEntry]]
     ttls*: AddressConfidenceTtls
+    connectedPeers: HashSet[PeerId]
 
   KeyBook* = ref object of PeerBook[PublicKey]
 
@@ -230,6 +231,23 @@ proc mergeAddressEntry(entries: var seq[AddressEntry], entry: AddressEntry) =
   else:
     entries.add(entry)
 
+proc refreshExpired(addressBook: AddressBook, peerId: PeerId, now = Moment.now()) =
+  var entries = addressBook.book.getOrDefault(peerId)
+  if entries.len == 0:
+    return
+
+  var refreshed = false
+  for entry in entries.mitems:
+    if entry.isExpired(addressBook.ttls):
+      entry.lastUpdated = now
+      refreshed = true
+
+  if refreshed:
+    addressBook.book[peerId] = entries
+
+proc isLive(addressBook: AddressBook, peerId: PeerId, entry: AddressEntry): bool =
+  peerId in addressBook.connectedPeers or not entry.isExpired(addressBook.ttls)
+
 proc set*(
     addressBook: AddressBook,
     peerId: PeerId,
@@ -281,10 +299,10 @@ proc `[]=`*(addressBook: AddressBook, peerId: PeerId, addrs: seq[MultiAddress]) 
 
 proc `[]`*(addressBook: AddressBook, peerId: PeerId): seq[MultiAddress] =
   ## Return non-expired addresses for `peerId`.
-  addressBook.book
-    .getOrDefault(peerId)
-    .filterIt(not it.isExpired(addressBook.ttls))
-    .mapIt(it.address)
+  ## Connected peers keep their known addresses visible until disconnect.
+  addressBook.book.getOrDefault(peerId).filterIt(addressBook.isLive(peerId, it)).mapIt(
+    it.address
+  )
 
 proc entries*(addressBook: AddressBook, peerId: PeerId): seq[AddressEntry] =
   ## Return the raw entry list for `peerId`, including expired entries.
@@ -292,7 +310,7 @@ proc entries*(addressBook: AddressBook, peerId: PeerId): seq[AddressEntry] =
 
 proc contains*(addressBook: AddressBook, peerId: PeerId): bool =
   for entry in addressBook.book.getOrDefault(peerId):
-    if not entry.isExpired(addressBook.ttls):
+    if addressBook.isLive(peerId, entry):
       return true
   return false
 
@@ -330,13 +348,24 @@ proc extend*(
 
 proc pruneExpired*(addressBook: AddressBook) =
   ## Remove all per-address entries whose TTL has elapsed.
+  ## Connected peers keep their entries fresh while they remain connected.
   ## Peers whose last address expires are removed from the AddressBook only;
   ## other peer metadata (keys, protocols, agent version, etc.) is left intact.
   var pending: seq[(PeerId, seq[AddressEntry])]
+  var refresh: seq[PeerId]
   for peerId, entries in addressBook.book:
+    if peerId in addressBook.connectedPeers:
+      if entries.anyIt(it.isExpired(addressBook.ttls)):
+        refresh.add(peerId)
+      continue
+
     let alive = entries.filterIt(not it.isExpired(addressBook.ttls))
     if alive.len < entries.len:
       pending.add((peerId, alive))
+
+  let now = Moment.now()
+  for peerId in refresh:
+    addressBook.refreshExpired(peerId, now)
 
   for (peerId, alive) in pending:
     if alive.len > 0:
@@ -396,10 +425,31 @@ proc `[]`*[T](p: PeerStore, typ: type[T]): T =
   p.books[name] = book
   book
 
+proc removeFromCleanupQueue(peerStore: PeerStore, peerId: PeerId) =
+  let cleanupPos = peerStore.toClean.find(peerId)
+  if cleanupPos >= 0:
+    peerStore.toClean.delete(cleanupPos)
+
 proc del*(peerStore: PeerStore, peerId: PeerId) =
   ## Delete the provided peer from every book.
+  peerStore.removeFromCleanupQueue(peerId)
+
+  peerStore.books.withValue(getTypeName(AddressBook), bookPtr):
+    AddressBook(bookPtr[]).connectedPeers.excl(peerId)
+
   for _, book in peerStore.books:
     book.deletor(peerId)
+
+proc markPeerConnected*(peerStore: PeerStore, peerId: PeerId) =
+  ## Mark `peerId` as actively connected so known addresses do not TTL-expire.
+  peerStore[AddressBook].connectedPeers.incl(peerId)
+  peerStore.removeFromCleanupQueue(peerId)
+
+proc markPeerDisconnected*(peerStore: PeerStore, peerId: PeerId) =
+  ## Drop active connection state after refreshing known addresses for redial.
+  let addressBook = peerStore[AddressBook]
+  addressBook.refreshExpired(peerId)
+  addressBook.connectedPeers.excl(peerId)
 
 proc addressPruneLoop(
     peerStore: PeerStore, interval: Duration
@@ -466,9 +516,7 @@ proc updatePeerInfo*(
     if sprBook.shouldStoreSignedPeerRecord(info.peerId, signedPeerRecord):
       sprBook[info.peerId] = signedPeerRecord
 
-  let cleanupPos = peerStore.toClean.find(info.peerId)
-  if cleanupPos >= 0:
-    peerStore.toClean.delete(cleanupPos)
+  peerStore.removeFromCleanupQueue(info.peerId)
 
 proc cleanup*(peerStore: PeerStore, peerId: PeerId) =
   if peerStore.capacity == 0:
@@ -477,11 +525,11 @@ proc cleanup*(peerStore: PeerStore, peerId: PeerId) =
   elif peerStore.capacity < 0:
     #infinite capacity
     return
+  peerStore.removeFromCleanupQueue(peerId)
 
   peerStore.toClean.add(peerId)
   while peerStore.toClean.len > peerStore.capacity:
     peerStore.del(peerStore.toClean[0])
-    peerStore.toClean.delete(0)
 
 proc identify*(
     peerStore: PeerStore, muxer: Muxer, dir: Direction

--- a/tests/libp2p/test_peer_store.nim
+++ b/tests/libp2p/test_peer_store.nim
@@ -229,6 +229,11 @@ suite "AddressBook TTL / confidence":
     b.ttls = AddressConfidenceTtls(low: low, medium: medium, high: high)
     b
 
+  proc makeStore(low, medium, high: Duration): PeerStore =
+    PeerStore.new(
+      nil, addressTtls = AddressConfidenceTtls(low: low, medium: medium, high: high)
+    )
+
   proc newRecorder(book: AddressBook): ref seq[PeerId] =
     ## Record the peerId of every change-handler notification.
     var recorded: ref seq[PeerId]
@@ -448,6 +453,58 @@ suite "AddressBook TTL / confidence":
       # All expired entries makes 'contains' false, the raw entry remains.
       peerId2 notin book
       book.entries(peerId2).len == 1
+
+  test "connected peer reads include expired entries":
+    let peerStore = makeStore(1.seconds, 1.hours, 24.hours)
+    peerStore[AddressBook].set(peerId1, @[addr1], AddressConfidence.Low)
+    peerStore[AddressBook].book[peerId1][0].lastUpdated = Moment.now() - 2.seconds
+
+    check:
+      peerStore[AddressBook][peerId1].len == 0
+      peerId1 notin peerStore[AddressBook]
+
+    peerStore.markPeerConnected(peerId1)
+
+    check:
+      peerStore[AddressBook][peerId1] == @[addr1]
+      peerId1 in peerStore[AddressBook]
+
+  test "pruneExpired refreshes connected expired entries without notifying":
+    let peerStore = makeStore(1.seconds, 1.hours, 24.hours)
+    let book = peerStore[AddressBook]
+    book.set(peerId1, @[addr1], AddressConfidence.Low)
+    book.book[peerId1][0].lastUpdated = Moment.now() - 2.seconds
+
+    let recorded = newRecorder(book)
+    peerStore.markPeerConnected(peerId1)
+    book.pruneExpired()
+
+    check:
+      book.entries(peerId1).len == 1
+      not book.entries(peerId1)[0].isExpired(book.ttls)
+      book[peerId1] == @[addr1]
+      recorded[].len == 0
+
+  test "markPeerDisconnected refreshes stale entries before unpinning":
+    let peerStore = makeStore(1.seconds, 1.hours, 24.hours)
+    let book = peerStore[AddressBook]
+    book.set(peerId1, @[addr1], AddressConfidence.Low)
+
+    peerStore.markPeerConnected(peerId1)
+    book.book[peerId1][0].lastUpdated = Moment.now() - 2.seconds
+    peerStore.markPeerDisconnected(peerId1)
+
+    check:
+      book[peerId1] == @[addr1]
+      peerId1 in book
+      not book.entries(peerId1)[0].isExpired(book.ttls)
+
+    book.book[peerId1][0].lastUpdated = Moment.now() - 2.seconds
+    book.pruneExpired()
+
+    check:
+      book.entries(peerId1).len == 0
+      peerId1 notin book
 
   test "reads on an absent peer return empty and do not crash":
     let book = makeBook(1.hours, 1.hours, 24.hours)

--- a/tests/libp2p/test_peer_store_component.nim
+++ b/tests/libp2p/test_peer_store_component.nim
@@ -186,11 +186,9 @@ suite "PeerStore Address TTL - Component":
       switch.peerStore[AddressBook].entries(zeroTtlPeer).len == 1
       switch.peerStore[AddressBook].entries(infinitePeer).len == 1
 
-  asyncTest "connected-but-idle address expires while still connected":
-    # An address only gets a fresh timestamp when it is written again:
-    # on a re-dial, an identify, or an identify push from the peer.
-    # If a connection does none of these, the address gets stale and the
-    # prune loop drops it while we are still connected to the peer.
+  asyncTest "connected-but-idle address stays fresh while still connected":
+    # Connected peers keep already-known addresses visible and periodically
+    # refreshed, so an idle long-lived connection stays redialable.
     let
       listener = makeStandardSwitch()
       # low is small so the prune loop runs often.
@@ -209,13 +207,26 @@ suite "PeerStore Address TTL - Component":
     checkUntilTimeout:
       dialer.peerStore[AddressBook].entries(peerId).len > 0
 
-    # Nothing refreshes the address.
-    # Back-date the entries beyond the TTL.
+    # Back-date the entries beyond the TTL to emulate an idle connection.
     for i in 0 ..< dialer.peerStore[AddressBook].book[peerId].len:
       dialer.peerStore[AddressBook].book[peerId][i].lastUpdated = Moment.now() - 2.hours
 
-    # The prune loop drops the old address while the connection is still open.
-    checkUntilTimeout:
-      dialer.peerStore[AddressBook].entries(peerId).len == 0
-
     check dialer.isConnected(peerId)
+    check dialer.peerStore[AddressBook][peerId].len > 0
+
+    # The prune loop refreshes the old address while the connection is still open.
+    checkUntilTimeout:
+      dialer.peerStore[AddressBook].entries(peerId).len > 0
+      dialer.peerStore[AddressBook].entries(peerId).allIt(
+        not it.isExpired(dialer.peerStore[AddressBook].ttls)
+      )
+      dialer.peerStore[AddressBook][peerId].len > 0
+
+    await dialer.disconnect(peerId)
+
+    checkUntilTimeout:
+      not dialer.isConnected(peerId)
+
+    check:
+      dialer.peerStore[AddressBook][peerId].len > 0
+      peerId in dialer.peerStore[AddressBook]


### PR DESCRIPTION
## Summary

Keep known peer addresses available while the peer is still connected.

Previously, AddressBook TTL pruning could expire a peer's addresses even while an active connection existed. This made connected peers appear addressless to peerstore readers and could leave no address available immediately after disconnect. This PR tracks connected peers in the peerstore, keeps their existing addresses live while connected, and refreshes stale entries before removing the connected state on disconnect.

## Affected Areas
- [x] Peer Management / Discovery

## Impact on Library Users
Connected peers no longer lose their known addresses due to TTL expiry while the connection is active. After the last disconnect, those addresses return to normal TTL-based expiry behavior.

This adds peerstore lifecycle hooks used by the connection manager; no migration is required for existing callers.

## References

- Fixes #2684