### PR TITLE
ci: force save cache

### DIFF
--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -164,7 +164,9 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: nimcache
-          key: nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}
+          key: nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}-${{ github.run_id }}
+          restore-keys: |
+            nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}-
 
       - name: Build test_all
         id: build-test-all
@@ -192,6 +194,17 @@ jobs:
         with:
           path: nimcache
           key: ${{ steps.nimcache-restore.outputs.cache-primary-key }}
+
+      - name: Prune old nimcache entries
+        if: github.ref_name == 'master'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREFIX="nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}"
+          KEEP="${{ steps.nimcache-restore.outputs.cache-primary-key }}"
+          gh cache list --ref "${{ github.ref }}" --limit 100 --json id,key \
+            --jq ".[] | select(.key | startswith(\"$PREFIX\")) | select(.key != \"$KEEP\") | .id" \
+            | xargs -r -n1 gh cache delete
 
       - name: Run tests
         id: run-tests

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -166,7 +166,7 @@ jobs:
           path: nimcache
           key: nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}-${{ github.run_id }}
           restore-keys: |
-            nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}-
+            nimcache-test_all-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ matrix.nim.ref }}-${{ matrix.nim.memory_management }}
 
       - name: Build test_all
         id: build-test-all


### PR DESCRIPTION
save build cache jobs have not been saving cache:
<img width="1222" height="131" alt="image" src="https://github.com/user-attachments/assets/5ace4a63-10cd-4b63-8dd5-0c87ece4020e" />
https://github.com/vacp2p/nim-libp2p/actions/runs/28608449418/job/84884088484

in order to avoid this all master commits will create cache under unique id. prefix will be used to restore key ensuring all jobs will get cache. and additional steps is added that will remove all earlier cache entries 