### PR TITLE
fix(test): use captured variable for closure

### DIFF
--- a/tests/libp2p/muxers/test_yamux.nim
+++ b/tests/libp2p/muxers/test_yamux.nim
@@ -578,6 +578,7 @@ suite "Yamux":
       yamuxb.maxChannCount = 2
 
       for streamId in [11'u32, 13'u32, 15'u32]:
+        let streamId = streamId # capture loop var for the asyncTest closure
         let stream =
           yamuxb.createStream(streamId, false, YamuxDefaultWindowSize, MaxSendQueueSize)
         stream.isReset = true


### PR DESCRIPTION
fix for compile error happening on `devel` nim version
> /home/runner/work/nim-libp2p/nim-libp2p/tests/libp2p/muxers/test_yamux.nim(589, 11) Error: 'streamId' is of type <lent uint32> which cannot be captured as it would violate memory safety, declared here: /home/runner/work/nim-libp2p/nim-libp2p/tests/libp2p/muxers/test_yamux.nim(580, 11); using '-d:nimNoLentIterators' helps in some cases. Consider using a <ref T> which can be captured.
https://github.com/vacp2p/nim-libp2p/actions/runs/28651871282/job/84971657866?pr=2739