### PR TITLE
test(pubsub): cover stale peer cleanup after dropped connection

### DIFF
--- a/tests/libp2p/pubsub/test_gossipsub.nim
+++ b/tests/libp2p/pubsub/test_gossipsub.nim
@@ -6,6 +6,7 @@
 import chronos, chronos/rateLimit, stew/byteutils, utils, sequtils
 import ../../../libp2p/[muxers/muxer, connmanager, switch]
 import ../../../libp2p/stream/connection
+import ../../../libp2p/utils/future
 import
   ../../../libp2p/protocols/pubsub/[
     floodsub,
@@ -128,23 +129,22 @@ suite "GossipSub":
       peerId = randomPeerId()
       muxer = Muxer(connection: Connection.new(peerId, Direction.In))
       unblockConnected = newAsyncEvent()
-    var connectedStarted = false
+      connectedStartedFut = newFuture[void]("connectedStarted")
 
     defer:
-      await connMngr.close()
+      await gossipSub.switch.stop()
 
     proc connectedHandler(
         handlerPeerId: PeerId, event: ConnEvent
     ) {.async: (raises: [CancelledError]).} =
       if handlerPeerId == peerId:
-        connectedStarted = true
+        connectedStartedFut.completeOnce()
         await unblockConnected.wait()
 
     connMngr.addConnEventHandler(connectedHandler, ConnEventKind.Connected)
 
     let storeFut = connMngr.storeMuxer(muxer)
-    checkUntilTimeout:
-      connectedStarted
+    await connectedStartedFut
 
     check:
       peerId in connMngr

--- a/tests/libp2p/pubsub/test_gossipsub.nim
+++ b/tests/libp2p/pubsub/test_gossipsub.nim
@@ -5,6 +5,7 @@
 
 import chronos, chronos/rateLimit, stew/byteutils, utils, sequtils
 import ../../../libp2p/[muxers/muxer, connmanager, switch]
+import ../../../libp2p/stream/connection
 import
   ../../../libp2p/protocols/pubsub/[
     floodsub,
@@ -119,6 +120,47 @@ suite "GossipSub":
       not gossipSub.mesh.hasPeerId(topic, peer.peerId)
       not gossipSub.fanout.hasPeerId(topic, peer.peerId)
       not gossipSub.gossipsub.hasPeerId(topic, peer.peerId)
+
+  asyncTest "drop during Connected handlers does not leave stale pubsub peer":
+    let
+      gossipSub = TestGossipSub.init(makeStandardSwitch(), rng = rng())
+      connMngr = gossipSub.switch.connManager
+      peerId = randomPeerId()
+      muxer = Muxer(connection: Connection.new(peerId, Direction.In))
+      unblockConnected = newAsyncEvent()
+    var connectedStarted = false
+
+    defer:
+      await connMngr.close()
+
+    proc connectedHandler(
+        handlerPeerId: PeerId, event: ConnEvent
+    ) {.async: (raises: [CancelledError]).} =
+      if handlerPeerId == peerId:
+        connectedStarted = true
+        await unblockConnected.wait()
+
+    connMngr.addConnEventHandler(connectedHandler, ConnEventKind.Connected)
+
+    let storeFut = connMngr.storeMuxer(muxer)
+    checkUntilTimeout:
+      connectedStarted
+
+    check:
+      peerId in connMngr
+      peerId notin gossipSub.peers
+
+    await connMngr.dropPeer(peerId)
+    checkUntilTimeout:
+      peerId notin connMngr
+      peerId notin gossipSub.peers
+
+    unblockConnected.fire()
+    await storeFut
+
+    check:
+      peerId notin connMngr
+      peerId notin gossipSub.peers
 
   asyncTest "unsubscribePeer - handles nil peer gracefully":
     # Given a GossipSub instance


### PR DESCRIPTION
## Summary

Adds a GossipSub regression test for the case where a peer is dropped while `storeMuxer` is still waiting for `Connected` handlers to finish.

The test verifies that, after the connection is dropped and `storeMuxer` resumes, the peer is not left behind in `gossipSub.peers`.

## Affected Areas

- [x] Gossipsub  
  Adds regression coverage for stale pubsub peer state after connection drop.
- [x] Other  
  Test-only change in `tests/libp2p/pubsub/test_gossipsub.nim`.


## References

- vacp2p/nim-libp2p#2621
- status-im/nimbus-eth2#8687