### PR TITLE
test(misc): dual stack 5

### DIFF
--- a/libp2p/services/wildcardresolverservice.nim
+++ b/libp2p/services/wildcardresolverservice.nim
@@ -69,7 +69,7 @@ proc isWildcardIp(ip: IpAddress): bool =
   of IpAddressFamily.IPv6:
     ip.address_v6 == AnyAddress6.address_v6
 
-proc expandWildcardAddresses*(
+proc expandWildcardAddresses(
     networkInterfaceProvider: NetworkInterfaceProvider, listenAddrs: seq[MultiAddress]
 ): seq[MultiAddress] =
   ## Expand bound wildcard addresses (``0.0.0.0`` / ``::``) into one address
@@ -100,6 +100,9 @@ proc expandWildcardAddresses*(
         listenAddr.replaceIp(ifaddr.host.toIpAddress()).withValue(remapped):
           addresses.add(remapped)
   addresses
+
+when defined(libp2p_testing):
+  export expandWildcardAddresses
 
 method setup*(self: WildcardAddressResolverService, switch: Switch) {.raises: [].} =
   ## Sets up the `WildcardAddressResolverService`.

--- a/libp2p/services/wildcardresolverservice.nim
+++ b/libp2p/services/wildcardresolverservice.nim
@@ -69,7 +69,7 @@ proc isWildcardIp(ip: IpAddress): bool =
   of IpAddressFamily.IPv6:
     ip.address_v6 == AnyAddress6.address_v6
 
-proc expandWildcardAddresses(
+proc expandWildcardAddresses*(
     networkInterfaceProvider: NetworkInterfaceProvider, listenAddrs: seq[MultiAddress]
 ): seq[MultiAddress] =
   ## Expand bound wildcard addresses (``0.0.0.0`` / ``::``) into one address

--- a/tests/libp2p/service_discovery/component/test_advertise_discover.nim
+++ b/tests/libp2p/service_discovery/component/test_advertise_discover.nim
@@ -15,7 +15,7 @@ import
     protocols/service_discovery/types,
     switch,
   ]
-import ../../../tools/[crypto, lifecycle, unittest, topology]
+import ../../../tools/[crypto, lifecycle, multiaddress, unittest, topology]
 import ../utils
 
 suite "Service Discovery Component - Advertise Discover":
@@ -390,3 +390,43 @@ suite "Service Discovery Component - Advertise Discover":
     # The maintenance loop rotates the new bucket peer in and registers with it.
     checkUntilTimeout:
       lateRegistrar.countAdsInCache(serviceId) == 1
+
+  asyncTest "an IPv6 node registers three services one after another":
+    # A node listening only on IPv6 advertises only IPv6 addresses, which never
+    # enter the IPv4-only IP tree, so its advertisements draw no IP-similarity
+    # waiting time: each is Confirmed and cached, even under default settings.
+    let registrarNode = setupServiceDiscoveryNode()
+    let advertiserNode = setupServiceDiscoveryNode(addresses = @[TcpAutoAddressIP6()])
+    startAndDeferStop(@[registrarNode, advertiserNode])
+    await connect(registrarNode, advertiserNode)
+
+    for i in 1 .. 3:
+      let service = makeServiceInfo("ipv6-service-" & $i)
+      let serviceId = service.id.hashServiceId()
+      advertiserNode.addProvidedService(service)
+      checkUntilTimeout:
+        registrarNode.countAdsInCache(serviceId) == 1
+
+  asyncTest "a dual-stack node is told to Wait on its second advertisement":
+    # A dual-stack node advertises its IPv4 address, which enters the IP tree on
+    # its first, Confirmed advertisement. Its second advertisement is scored
+    # against that address, so it is told to Wait and never reaches the cache.
+    let registrarNode = setupServiceDiscoveryNode()
+    let advertiserNode =
+      setupServiceDiscoveryNode(addresses = @[TcpAutoAddressIP4(), TcpAutoAddressIP6()])
+    startAndDeferStop(@[registrarNode, advertiserNode])
+    await connect(registrarNode, advertiserNode)
+
+    let firstService = makeServiceInfo("dual-stack-service-1")
+    let firstServiceId = firstService.id.hashServiceId()
+    advertiserNode.addProvidedService(firstService)
+    checkUntilTimeout:
+      registrarNode.countAdsInCache(firstServiceId) == 1
+
+    let secondService = makeServiceInfo("dual-stack-service-2")
+    let secondServiceId = secondService.id.hashServiceId()
+    advertiserNode.addProvidedService(secondService)
+    # A Wait records a service lower bound, the ad never reaches the cache.
+    checkUntilTimeout:
+      registrarNode.registrar.boundService.hasKey(secondServiceId)
+    check registrarNode.countAdsInCache(secondServiceId) == 0

--- a/tests/libp2p/service_discovery/component/test_advertise_discover.nim
+++ b/tests/libp2p/service_discovery/component/test_advertise_discover.nim
@@ -392,6 +392,7 @@ suite "Service Discovery Component - Advertise Discover":
       lateRegistrar.countAdsInCache(serviceId) == 1
 
   asyncTest "an IPv6 node registers three services one after another":
+    # TODO: vacp2p/nim-libp2p#2756
     # A node listening only on IPv6 advertises only IPv6 addresses, which never
     # enter the IPv4-only IP tree, so its advertisements draw no IP-similarity
     # waiting time: each is Confirmed and cached, even under default settings.
@@ -407,10 +408,7 @@ suite "Service Discovery Component - Advertise Discover":
       checkUntilTimeout:
         registrarNode.countAdsInCache(serviceId) == 1
 
-  asyncTest "a dual-stack node is told to Wait on its second advertisement":
-    # A dual-stack node advertises its IPv4 address, which enters the IP tree on
-    # its first, Confirmed advertisement. Its second advertisement is scored
-    # against that address, so it is told to Wait and never reaches the cache.
+  asyncTest "a dual-stack node follows the normal path and is told to Wait":
     let registrarNode = setupServiceDiscoveryNode()
     let advertiserNode =
       setupServiceDiscoveryNode(addresses = @[TcpAutoAddressIP4(), TcpAutoAddressIP6()])
@@ -426,7 +424,8 @@ suite "Service Discovery Component - Advertise Discover":
     let secondService = makeServiceInfo("dual-stack-service-2")
     let secondServiceId = secondService.id.hashServiceId()
     advertiserNode.addProvidedService(secondService)
-    # A Wait records a service lower bound, the ad never reaches the cache.
+    # The registrar answered Wait, not Confirmed: it records the Wait in
+    # boundService and does not admit the second ad to the cache.
     checkUntilTimeout:
       registrarNode.registrar.boundService.hasKey(secondServiceId)
     check registrarNode.countAdsInCache(secondServiceId) == 0

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -81,8 +81,11 @@ proc makeAdvertisement*(
   )
   SignedExtendedPeerRecord.init(privateKey, extRecord).get()
 
-proc createSwitch*(privateKey: Opt[PrivateKey] = Opt.none(PrivateKey)): Switch =
-  makeStandardSwitchBuilder(TcpAutoAddress).withPrivateKey(privateKey).build()
+proc createSwitch*(
+    privateKey: Opt[PrivateKey] = Opt.none(PrivateKey),
+    addresses: seq[MultiAddress] = @[TcpAutoAddress()],
+): Switch =
+  makeStandardSwitchBuilder(addresses).withPrivateKey(privateKey).build()
 
 proc testKadDHTConfig(): KadDHTConfig =
   KadDHTConfig.new(
@@ -102,8 +105,9 @@ proc setupServiceDiscoveryNode*(
     client: bool = false,
     privateKey: Opt[PrivateKey] = Opt.none(PrivateKey),
     kadConfig: KadDHTConfig = testKadDHTConfig(),
+    addresses: seq[MultiAddress] = @[TcpAutoAddress()],
 ): ServiceDiscovery =
-  let switch = createSwitch(privateKey)
+  let switch = createSwitch(privateKey, addresses)
   let node = ServiceDiscovery.new(
     switch,
     bootstrapNodes = bootstrapNodes,

--- a/tests/libp2p/services/test_natservice.nim
+++ b/tests/libp2p/services/test_natservice.nim
@@ -660,6 +660,25 @@ suite "NATService (setupMappings)":
     check svc.externalIp.isSome
     check svc.externalIp.get() == externalIp
 
+  asyncTest "an external IPv6 from the IGD maps the port but announces nothing":
+    # the port mapping still succeeds, but a v6 external IP has no announced form
+    # on a v4 listen address, so the mapping produces no announced address
+    let
+      externalIp = parseIpAddress("2001:db8::1")
+      mapper = newRecordingOk(externalIp)
+      factory = recordingFactory(mapper)
+      cfg = upnpConfig()
+      switch = makeSwitch(cfg, @[loopbackAddr()], factory)
+      svc = findNatService(switch)
+
+    await switch.start()
+    defer:
+      await switch.stop()
+
+    let announced = await svc.setupMappings(@[privateAddr(9000)])
+    check announced.len == 0
+    check mapper.mapCalls.len == 1
+
   asyncTest "non-private listen addresses are skipped":
     let
       externalIp = parseIpAddress("203.0.113.1")

--- a/tests/libp2p/services/test_wildcard_resolver.nim
+++ b/tests/libp2p/services/test_wildcard_resolver.nim
@@ -79,3 +79,39 @@ suite "WildcardAddressResolverService":
         MultiAddress.init("/ip4/0.0.0.0" & $tcpIp4Wildcard).get,
         MultiAddress.init("/ip6/::" & $tcpIp6).get,
       ]
+
+  test "expandWildcardAddresses expands an IPv4 wildcard to IPv4 interfaces only":
+    # an IPv4 wildcard expands only to the IPv4 interfaces
+    let expanded = expandWildcardAddresses(
+      getAddressesMock, @[MultiAddress.init("/ip4/0.0.0.0/tcp/4001").tryGet()]
+    )
+    check expanded ==
+      @[
+        MultiAddress.init("/ip4/127.0.0.1/tcp/4001").tryGet(),
+        MultiAddress.init("/ip4/192.168.1.22/tcp/4001").tryGet(),
+      ]
+
+  test "expandWildcardAddresses expands an IPv6 wildcard to both IPv6 and IPv4 interfaces":
+    # an IPv6 wildcard expands to the IPv6 interfaces
+    # and additionally to every IPv4 interface the provider offers
+    let expanded = expandWildcardAddresses(
+      getAddressesMock, @[MultiAddress.init("/ip6/::/tcp/4001").tryGet()]
+    )
+    check expanded ==
+      @[
+        MultiAddress.init("/ip6/::1/tcp/4001").tryGet(),
+        MultiAddress.init("/ip6/fe80::1/tcp/4001").tryGet(),
+        MultiAddress.init("/ip4/127.0.0.1/tcp/4001").tryGet(),
+        MultiAddress.init("/ip4/192.168.1.22/tcp/4001").tryGet(),
+      ]
+
+  test "expandWildcardAddresses passes non-wildcard and non-IP addresses through unchanged":
+    # a concrete IP is not a wildcard, and a DNS or memory address carries no IP
+    # each is returned identical and unduplicated
+    let inputs = @[
+      MultiAddress.init("/ip4/1.2.3.4/tcp/4001").tryGet(),
+      MultiAddress.init("/dns4/example.com/tcp/4001").tryGet(),
+      MultiAddress.init("/memorytransport/addr-1").tryGet(),
+    ]
+    let expanded = expandWildcardAddresses(getAddressesMock, inputs)
+    check expanded == inputs

--- a/tests/libp2p/services/test_wildcard_resolver.nim
+++ b/tests/libp2p/services/test_wildcard_resolver.nim
@@ -92,6 +92,7 @@ suite "WildcardAddressResolverService":
       ]
 
   test "expandWildcardAddresses expands an IPv6 wildcard to both IPv6 and IPv4 interfaces":
+    # TODO: vacp2p/nim-libp2p#2757
     # an IPv6 wildcard expands to the IPv6 interfaces
     # and additionally to every IPv4 interface the provider offers
     let expanded = expandWildcardAddresses(


### PR DESCRIPTION
## Summary

Adds test coverage for IPv4/IPv6 dual-stack behavior across three areas: service-discovery IP-similarity scoring, the wildcard address resolver, and the NAT service.

Two of the pinned behaviors got their own issues:

  - #2756
  - #2757

The rest is new tests: NAT service drops a v6 external from the IGD (maps the port, announces nothing), and the wildcard resolver's per-family expansion and passthrough of non-wildcard / non-IP addresses.

The only non-test change is making `expandWildcardAddresses` public in tests so it can be tested directly.

 ## Affected Areas

- [x] Tests
