### PR TITLE
fix: avoid deadlock when dropping peers from stream handler

### DIFF
--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -601,7 +601,12 @@ proc dropPeer*(c: ConnManager, peerId: PeerId) {.async: (raises: [CancelledError
   let muxers = c.muxerStore.remove(peerId)
   if muxers.len > 0:
     try:
-      await allFutures(muxers.mapIt(closeMuxer(it)))
+      # Drain the muxers in the background: `dropPeer` may be awaited from one
+      # of this peer's own stream handlers, which `closeMuxer` in turn awaits,
+      # so awaiting it here can deadlock and `PeerEvent.Left` would never fire.
+      for mux in muxers:
+        c.onCloseFuts.trackFut(closeMuxer(mux))
+      await allFutures(muxers.mapIt(it.connection.close()))
     finally:
       await noCancel c.onPeerDisconnected(peerId)
 

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -419,6 +419,13 @@ method getOrCreatePeer*(
   # metrics
   libp2p_pubsub_peers.set(p.peers.len.int64)
 
+  if not p.switch.isConnected(peerId):
+    # The peer was dropped while this stream was being negotiated, so
+    # `PeerEvent.Left` has already fired (or never will for this peer) and
+    # nothing else would remove the peer.
+    debug "created pubsub peer for disconnected peer, removing", peerId
+    p.unsubscribePeer(peerId)
+
   return pubSubPeer
 
 proc handleData*(

--- a/tests/libp2p/pubsub/test_gossipsub.nim
+++ b/tests/libp2p/pubsub/test_gossipsub.nim
@@ -313,6 +313,19 @@ suite "GossipSub":
     check:
       not gossipSub.gossipsub.hasPeer(topic, peer)
 
+  asyncTest "getOrCreatePeer removes peer created without a live connection":
+    let (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
+    defer:
+      await teardownGossipSub(gossipSub, conns)
+
+    let disconnectedPeer = randomPeerId()
+    discard gossipSub.getOrCreatePeer(disconnectedPeer, @[], GossipSubCodec_12)
+
+    check:
+      disconnectedPeer notin gossipSub.peers
+      # peers created by other means are untouched
+      peers[0].peerId in gossipSub.peers
+
   asyncTest "subscribe and unsubscribeAll":
     let (gossipSub, conns, _) =
       setupGossipSubWithPeers(15, topic, populateGossipsub = true, populateMesh = true)

--- a/tests/libp2p/test_switch.nim
+++ b/tests/libp2p/test_switch.nim
@@ -640,6 +640,50 @@ suite "Switch":
 
     await allFuturesRaising(switches[0].stop())
 
+  asyncTest "e2e drop peer from inside its own stream handler":
+    let disconnected = newWaitGroup(1)
+    var events: set[PeerEventKind]
+
+    let switch1 = makeStandardSwitch(TcpAutoAddress)
+    let switch2 = makeStandardSwitch(TcpAutoAddress)
+
+    proc handle(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
+      try:
+        await switch1.disconnect(stream.peerId)
+        disconnected.done()
+      finally:
+        await stream.close()
+
+    let testProto = new TestProto
+    testProto.codec = TestCodec
+    testProto.handler = handle
+    switch1.mount(testProto)
+
+    proc peerHandler(
+        peerId: PeerId, event: PeerEvent
+    ) {.async: (raises: [CancelledError]).} =
+      events.incl(event.kind)
+
+    switch1.addPeerEventHandler(peerHandler, PeerEventKind.Joined)
+    switch1.addPeerEventHandler(peerHandler, PeerEventKind.Left)
+
+    await switch1.start()
+    await switch2.start()
+
+    let stream =
+      await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, TestCodec)
+
+    # with the deadlock, the disconnect never completes and this times out
+    await disconnected.wait(5.seconds)
+
+    checkUntilTimeout:
+      not switch1.isConnected(switch2.peerInfo.peerId)
+      not switch2.isConnected(switch1.peerInfo.peerId)
+      PeerEventKind.Left in events
+
+    await stream.closeWithEOF()
+    await allFuturesRaising(switch1.stop(), switch2.stop())
+
   asyncTest "e2e closing remote raw connection should not leak":
     let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
 


### PR DESCRIPTION
## Summary

Fixes a disconnect deadlock when a stream handler awaits disconnecting its own peer.

Previously, `dropPeer` awaited muxer shutdown, while mplex shutdown could await the same handler future that was blocked on `dropPeer`. That circular wait prevented `PeerEvent.Left` from firing and could leave PubSub peers retained after the connection was gone.

This PR decouples peer-left notification from muxer drain (connections are closed and PeerEvent.Left is emitted, while the muxer/handler drain completes in the background), and removes PubSub peers created after their switch connection is already gone.

cc: @tersec 

## Affected Areas

- [x] Gossipsub  
  Removes PubSub peers created for disconnected peers during teardown.
- [ ] Transports
- [x] Peer Management / Discovery  
  Changes peer drop/disconnect cleanup ordering.
- [ ] Protocol Logic  
- [ ] Build / Tooling
- [ ] Other

## Impact on Library Users

Disconnects awaited from protocol stream handlers can now complete, and `PeerEvent.Left` is emitted without waiting for muxer handler drain to finish. PubSub peer accounting should no longer keep peers that are already disconnected.

## Risk Assessment

The main behavior change is in dropPeer: it now returns once the transport connections are closed and PeerEvent.Left has fired, without waiting for muxer stream handlers to drain. The drain still completes. It is tracked in the connection manager and awaited on   ConnManager.close — but callers of disconnect no longer block on it. Handler futures are never cancelled, so handler semantics are unchanged

## References

- Regression from #2605
