### PR TITLE
test: remove unnecessary test that takes too much time

### DIFF
--- a/tests/tools/test_unittest.nim
+++ b/tests/tools/test_unittest.nim
@@ -71,10 +71,6 @@ suite "checkUntilTimeout helpers - failed":
       # if before out test program result was not success, leave it as failed
       exitProcs.setProgramResult(QuitSuccess)
 
-  asyncTest "checkUntilTimeout should timeout if condition is never true":
-    checkUntilTimeout:
-      false
-
   asyncTest "checkUntilTimeoutCustom should timeout if condition is never true":
     checkUntilTimeoutCustom(100.milliseconds, 10.milliseconds):
       false


### PR DESCRIPTION
test ` "checkUntilTimeout should timeout if condition is never true"` is the same as `"checkUntilTimeoutCustom should timeout if condition is never true"` but with different timeout values (it uses defaults).

since default values is 30s for timeout, it makes this test case too much time spent waiting doing nothing.
it is unnecessary spending 30s per each job and each commit = 9m total CI time per commit wasted. also 30s gain on current job individually is noticeable.