### PR TITLE
test(transports): accept fails

### DIFF
--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -311,6 +311,10 @@ proc accept(s: Switch, transport: Transport) {.async: (raises: []).} =
         await conn.close()
       return
 
+when defined(libp2p_testing):
+  proc acceptFuts*(s: Switch): seq[Future[void]] =
+    s.acceptFuts
+
 proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
   ## Stop listening on every transport, and
   ## close every active connections

--- a/libp2p/transports/memorytransport.nim
+++ b/libp2p/transports/memorytransport.nim
@@ -22,7 +22,7 @@ logScope:
   topics = "libp2p memorytransport"
 
 type MemoryTransport* = ref object of Transport
-  rng: Rng
+  rng*: Rng
   connections: seq[RawConn]
   listener: Opt[MemoryListener]
 

--- a/tests/libp2p/test_switch_accept.nim
+++ b/tests/libp2p/test_switch_accept.nim
@@ -12,7 +12,7 @@ import
 import ../stubs/transportstub
 import ../tools/[unittest, crypto, lifecycle, multiaddress, switch_builder]
 
-proc newStubServer(
+proc newStubAcceptSwitch(
     behavior: StubAcceptBehavior, nilCount = 0, withTcp = false, maxIn = 0
 ): (Switch, MemoryTransportStub) =
   var addrs = @[MemoryAutoAddress()]
@@ -43,32 +43,32 @@ suite "Switch accept-loop failure handling":
 
   asyncTest "accept raising exits the loop while the transport still looks reachable":
     # a single inbound slot lets us check the loop hands it back when accept fails
-    let (switch, stub) = newStubServer(RaiseAlways, maxIn = 1)
-    startAndDeferStop(@[switch])
+    let (server, stub) = newStubAcceptSwitch(RaiseAlways, maxIn = 1)
+    startAndDeferStop(@[server])
 
     # the loop calls accept, it raises, and the loop returns and is not respawned
     checkUntilTimeout:
-      switch.acceptFuts[0].finished
+      server.acceptFuts[0].finished
     check stub.acceptCalls == 1
 
     # yet the transport still reports running and its address stays advertised,
     # so the switch keeps looking reachable while nothing is accepting
     check stub.running
-    check stub.addrs[0] in switch.peerInfo.listenAddrs
+    check stub.addrs[0] in server.peerInfo.listenAddrs
 
-    check switch.connManager.availableSlots(Direction.In) == 1
+    check server.connManager.availableSlots(Direction.In) == 1
 
   asyncTest "accept returning nil is non-fatal and the loop keeps retrying":
-    let (switch, stub) = newStubServer(NilAlways)
-    startAndDeferStop(@[switch])
+    let (server, stub) = newStubAcceptSwitch(NilAlways)
+    startAndDeferStop(@[server])
 
     # nil is treated as a transient miss, so the loop keeps calling accept
     checkUntilTimeout:
       stub.acceptCalls >= 5
-    check not switch.acceptFuts[0].finished
+    check not server.acceptFuts[0].finished
 
   asyncTest "inbound connections are dropped after a transport's accept loop dies":
-    let (server, stub) = newStubServer(RaiseAlways)
+    let (server, stub) = newStubAcceptSwitch(RaiseAlways)
     let client = makeStandardSwitch(MemoryAutoAddress())
     startAndDeferStop(@[server, client])
 
@@ -82,40 +82,25 @@ suite "Switch accept-loop failure handling":
     expect DialFailedError:
       await client.connect(server.peerInfo.peerId, server.peerInfo.addrs)
 
-  asyncTest "a transport recovers and accepts connections after transient nil failures":
-    const nilCount = 3
-    let (server, stub) = newStubServer(NilThenAccept, nilCount = nilCount)
-    let client = makeStandardSwitch(MemoryAutoAddress())
-    startAndDeferStop(@[server, client])
-
-    # once it has returned nil `nilCount` times the loop enters the base accept,
-    # registers the listener, and awaits an inbound connection
-    checkUntilTimeout:
-      stub.acceptCalls > nilCount
-
-    # a real inbound connection is now accepted end-to-end
-    await client.connect(server.peerInfo.peerId, server.peerInfo.addrs)
-    check client.isConnected(server.peerInfo.peerId)
-
   asyncTest "the accept loop releases its slot on each nil so a one-slot transport recovers":
     const nilCount = 3
     # only one inbound slot and the loop pre-acquires it before every accept.
-    # if the nil branch forgot to release it, the second accept would
-    # block on getIncomingSlot and the transport could never recover
-    let (server, stub) = newStubServer(NilThenAccept, nilCount = nilCount, maxIn = 1)
+    # reaching a real accept after nilCount nils is possible only if each
+    # nil released that slot, else the next getIncomingSlot would block forever
+    let (server, stub) = newStubAcceptSwitch(NilThenAccept, nilCount = nilCount, maxIn = 1)
     let client = makeStandardSwitch(MemoryAutoAddress())
     startAndDeferStop(@[server, client])
 
     checkUntilTimeout:
       stub.acceptCalls > nilCount
 
-    # and a real inbound connection is still accepted end-to-end and slot is used
+    # the recovered accept serves a real inbound connection, and the one slot is used
     await client.connect(server.peerInfo.peerId, server.peerInfo.addrs)
     check client.isConnected(server.peerInfo.peerId)
     check server.connManager.availableSlots(Direction.In) == 0
 
   asyncTest "one transport's accept failure does not stop other transports from accepting":
-    let (server, _) = newStubServer(RaiseAlways, withTcp = true)
+    let (server, _) = newStubAcceptSwitch(RaiseAlways, withTcp = true)
     let client = makeStandardSwitch(TcpAutoAddress)
     startAndDeferStop(@[server, client])
 

--- a/tests/libp2p/test_switch_accept.nim
+++ b/tests/libp2p/test_switch_accept.nim
@@ -42,32 +42,32 @@ suite "Switch accept-loop failure handling":
 
   asyncTest "accept raising exits the loop while the transport still looks reachable":
     # a single inbound slot lets us check the loop hands it back when accept fails
-    let (server, stub) = newStubAcceptSwitch(RaiseAlways, maxIn = 1)
+    let (server, transport) = newStubAcceptSwitch(RaiseAlways, maxIn = 1)
     startAndDeferStop(@[server])
 
     # the loop calls accept, it raises, and the loop returns and is not respawned
     checkUntilTimeout:
       server.acceptFuts[0].finished
-    check stub.acceptCalls == 1
+    check transport.acceptCalls == 1
 
     # yet the transport still reports running and its address stays advertised,
     # so the switch keeps looking reachable while nothing is accepting
-    check stub.running
-    check stub.addrs[0] in server.peerInfo.listenAddrs
+    check transport.running
+    check transport.addrs[0] in server.peerInfo.listenAddrs
 
     check server.connManager.availableSlots(Direction.In) == 1
 
   asyncTest "accept returning nil is non-fatal and the loop keeps retrying":
-    let (server, stub) = newStubAcceptSwitch(NilAlways)
+    let (server, transport) = newStubAcceptSwitch(NilAlways)
     startAndDeferStop(@[server])
 
-    # nil is treated as a transient miss, so the loop keeps calling accept
+    # nil is treated as a transient miss, so the loop keeps calling accept indefinitely
     checkUntilTimeout:
-      stub.acceptCalls >= 5
+      transport.acceptCalls >= 5 # arbitrary count
     check not server.acceptFuts[0].finished
 
   asyncTest "inbound connections are dropped after a transport's accept loop dies":
-    let (server, stub) = newStubAcceptSwitch(RaiseAlways)
+    let (server, transport) = newStubAcceptSwitch(RaiseAlways)
     let client = makeStandardSwitch(MemoryAutoAddress())
     startAndDeferStop(@[server, client])
 
@@ -76,7 +76,7 @@ suite "Switch accept-loop failure handling":
       server.acceptFuts[0].finished
 
     # the server still advertises its address
-    check stub.addrs[0] in server.peerInfo.listenAddrs
+    check transport.addrs[0] in server.peerInfo.listenAddrs
     # but nothing is accepting, so an inbound dial fails
     expect DialFailedError:
       await client.connect(server.peerInfo.peerId, server.peerInfo.addrs)
@@ -86,13 +86,13 @@ suite "Switch accept-loop failure handling":
     # only one inbound slot and the loop pre-acquires it before every accept.
     # reaching a real accept after nilCount nils is possible only if each
     # nil released that slot, else the next getIncomingSlot would block forever
-    let (server, stub) =
+    let (server, transport) =
       newStubAcceptSwitch(NilThenAccept, nilCount = nilCount, maxIn = 1)
     let client = makeStandardSwitch(MemoryAutoAddress())
     startAndDeferStop(@[server, client])
 
     checkUntilTimeout:
-      stub.acceptCalls > nilCount
+      transport.acceptCalls > nilCount
 
     # the recovered accept serves a real inbound connection, and the one slot is used
     await client.connect(server.peerInfo.peerId, server.peerInfo.addrs)

--- a/tests/libp2p/test_switch_accept.nim
+++ b/tests/libp2p/test_switch_accept.nim
@@ -5,14 +5,7 @@
 
 import sequtils
 import chronos
-import
-  ../../libp2p/[
-    builders,
-    switch,
-    dial,
-    multiaddress,
-    transports/transport,
-  ]
+import ../../libp2p/[builders, switch, dial, multiaddress, transports/transport]
 import ../stubs/transportstub
 import ../tools/[unittest, crypto, lifecycle, multiaddress, switch_builder]
 

--- a/tests/libp2p/test_switch_accept.nim
+++ b/tests/libp2p/test_switch_accept.nim
@@ -6,9 +6,8 @@
 import sequtils
 import chronos
 import
-  ../../libp2p/[
-    builders, switch, dial, multiaddress, transports/transport, stream/connection
-  ]
+  ../../libp2p/
+    [builders, switch, dial, multiaddress, transports/transport, stream/connection]
 import ../stubs/transportstub
 import ../tools/[unittest, crypto, lifecycle, multiaddress, switch_builder]
 
@@ -87,7 +86,8 @@ suite "Switch accept-loop failure handling":
     # only one inbound slot and the loop pre-acquires it before every accept.
     # reaching a real accept after nilCount nils is possible only if each
     # nil released that slot, else the next getIncomingSlot would block forever
-    let (server, stub) = newStubAcceptSwitch(NilThenAccept, nilCount = nilCount, maxIn = 1)
+    let (server, stub) =
+      newStubAcceptSwitch(NilThenAccept, nilCount = nilCount, maxIn = 1)
     let client = makeStandardSwitch(MemoryAutoAddress())
     startAndDeferStop(@[server, client])
 

--- a/tests/libp2p/test_switch_accept.nim
+++ b/tests/libp2p/test_switch_accept.nim
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import sequtils
+import chronos
+import
+  ../../libp2p/[
+    builders,
+    switch,
+    dial,
+    multiaddress,
+    transports/transport,
+  ]
+import ../stubs/transportstub
+import ../tools/[unittest, crypto, lifecycle, multiaddress, switch_builder]
+
+var memoryAddressCounter {.threadvar.}: int
+
+proc uniqueMemoryAddress(): MultiAddress =
+  # a concrete memory address per switch, so the shared memory registry never
+  # collides across tests, and so `start`/`accept` never need the wildcard rng
+  inc memoryAddressCounter
+  MultiAddress.init("/memorytransport/stub-" & $memoryAddressCounter).get()
+
+proc newStubServer(
+    behavior: StubAcceptBehavior, nilCount = 0, withTcp = false
+): (Switch, MemoryTransportStub) =
+  var addrs = @[uniqueMemoryAddress()]
+  if withTcp:
+    addrs.add(TcpAutoAddress)
+
+  var b = SwitchBuilder
+    .new()
+    .withRng(rng())
+    .withNoise()
+    .withMplex()
+    .withAddresses(addrs)
+    .withTransport(
+      proc(config: TransportConfig): Transport =
+        MemoryTransportStub.new(config.upgr, behavior, nilCount)
+    )
+  if withTcp:
+    b = b.withTcpTransport()
+
+  let switch = b.build()
+  (switch, MemoryTransportStub(switch.transports[0]))
+
+suite "Switch accept-loop failure handling":
+  teardown:
+    checkTrackers()
+
+  asyncTest "accept raising exits the loop while the transport still looks reachable":
+    let (switch, stub) = newStubServer(RaiseAlways)
+    startAndDeferStop(@[switch])
+
+    # the loop calls accept, it raises, and the loop returns and is not respawned
+    checkUntilTimeout:
+      switch.acceptFuts[0].finished
+    check stub.acceptCalls == 1
+
+    # yet the transport still reports running and its address stays advertised,
+    # so the switch keeps looking reachable while nothing is accepting
+    check stub.running
+    check stub.addrs[0] in switch.peerInfo.listenAddrs
+
+  asyncTest "accept returning nil is non-fatal and the loop keeps retrying":
+    let (switch, stub) = newStubServer(NilAlways)
+    startAndDeferStop(@[switch])
+
+    # nil is treated as a transient miss, so the loop keeps calling accept
+    checkUntilTimeout:
+      stub.acceptCalls >= 5
+    check not switch.acceptFuts[0].finished
+
+  asyncTest "inbound connections are dropped after a transport's accept loop dies":
+    let (server, stub) = newStubServer(RaiseAlways)
+    let client = makeStandardSwitch(MemoryAutoAddress())
+    startAndDeferStop(@[server, client])
+
+    # wait until the server's accept loop has given up
+    checkUntilTimeout:
+      server.acceptFuts[0].finished
+
+    # the server still advertises its address
+    check stub.addrs[0] in server.peerInfo.listenAddrs
+    # but nothing is accepting, so an inbound dial fails
+    expect DialFailedError:
+      await client.connect(server.peerInfo.peerId, server.peerInfo.addrs)
+
+  asyncTest "a transport recovers and accepts connections after transient nil failures":
+    const nilCount = 3
+    let (server, stub) = newStubServer(NilThenAccept, nilCount = nilCount)
+    let client = makeStandardSwitch(MemoryAutoAddress())
+    startAndDeferStop(@[server, client])
+
+    # once it has returned nil `nilCount` times the loop enters the base accept,
+    # registers the listener, and awaits an inbound connection
+    checkUntilTimeout:
+      stub.acceptCalls > nilCount
+
+    # a real inbound connection is now accepted end-to-end
+    await client.connect(server.peerInfo.peerId, server.peerInfo.addrs)
+    check client.isConnected(server.peerInfo.peerId)
+
+  asyncTest "one transport's accept failure does not stop other transports from accepting":
+    let (server, stub) = newStubServer(RaiseAlways, withTcp = true)
+    let client = makeStandardSwitch(TcpAutoAddress)
+    startAndDeferStop(@[server, client])
+
+    # the memory transport's accept loop has died
+    checkUntilTimeout:
+      server.acceptFuts[0].finished
+
+    # but the TCP transport still accepts connections
+    let tcpAddrs = server.peerInfo.addrs.filterIt(TCP.match(it))
+    await client.connect(server.peerInfo.peerId, tcpAddrs)
+    check client.isConnected(server.peerInfo.peerId)

--- a/tests/libp2p/test_switch_accept.nim
+++ b/tests/libp2p/test_switch_accept.nim
@@ -5,22 +5,17 @@
 
 import sequtils
 import chronos
-import ../../libp2p/[builders, switch, dial, multiaddress, transports/transport]
+import
+  ../../libp2p/[
+    builders, switch, dial, multiaddress, transports/transport, stream/connection
+  ]
 import ../stubs/transportstub
 import ../tools/[unittest, crypto, lifecycle, multiaddress, switch_builder]
 
-var memoryAddressCounter {.threadvar.}: int
-
-proc uniqueMemoryAddress(): MultiAddress =
-  # a concrete memory address per switch, so the shared memory registry never
-  # collides across tests, and so `start`/`accept` never need the wildcard rng
-  inc memoryAddressCounter
-  MultiAddress.init("/memorytransport/stub-" & $memoryAddressCounter).get()
-
 proc newStubServer(
-    behavior: StubAcceptBehavior, nilCount = 0, withTcp = false
+    behavior: StubAcceptBehavior, nilCount = 0, withTcp = false, maxIn = 0
 ): (Switch, MemoryTransportStub) =
-  var addrs = @[uniqueMemoryAddress()]
+  var addrs = @[MemoryAutoAddress()]
   if withTcp:
     addrs.add(TcpAutoAddress)
 
@@ -32,10 +27,12 @@ proc newStubServer(
     .withAddresses(addrs)
     .withTransport(
       proc(config: TransportConfig): Transport =
-        MemoryTransportStub.new(config.upgr, behavior, nilCount)
+        MemoryTransportStub.new(config.upgr, rng(), behavior, nilCount)
     )
   if withTcp:
     b = b.withTcpTransport()
+  if maxIn > 0:
+    b = b.withMaxInOut(maxIn, 8)
 
   let switch = b.build()
   (switch, MemoryTransportStub(switch.transports[0]))
@@ -45,7 +42,8 @@ suite "Switch accept-loop failure handling":
     checkTrackers()
 
   asyncTest "accept raising exits the loop while the transport still looks reachable":
-    let (switch, stub) = newStubServer(RaiseAlways)
+    # a single inbound slot lets us check the loop hands it back when accept fails
+    let (switch, stub) = newStubServer(RaiseAlways, maxIn = 1)
     startAndDeferStop(@[switch])
 
     # the loop calls accept, it raises, and the loop returns and is not respawned
@@ -57,6 +55,8 @@ suite "Switch accept-loop failure handling":
     # so the switch keeps looking reachable while nothing is accepting
     check stub.running
     check stub.addrs[0] in switch.peerInfo.listenAddrs
+
+    check switch.connManager.availableSlots(Direction.In) == 1
 
   asyncTest "accept returning nil is non-fatal and the loop keeps retrying":
     let (switch, stub) = newStubServer(NilAlways)
@@ -97,8 +97,25 @@ suite "Switch accept-loop failure handling":
     await client.connect(server.peerInfo.peerId, server.peerInfo.addrs)
     check client.isConnected(server.peerInfo.peerId)
 
+  asyncTest "the accept loop releases its slot on each nil so a one-slot transport recovers":
+    const nilCount = 3
+    # only one inbound slot and the loop pre-acquires it before every accept.
+    # if the nil branch forgot to release it, the second accept would
+    # block on getIncomingSlot and the transport could never recover
+    let (server, stub) = newStubServer(NilThenAccept, nilCount = nilCount, maxIn = 1)
+    let client = makeStandardSwitch(MemoryAutoAddress())
+    startAndDeferStop(@[server, client])
+
+    checkUntilTimeout:
+      stub.acceptCalls > nilCount
+
+    # and a real inbound connection is still accepted end-to-end and slot is used
+    await client.connect(server.peerInfo.peerId, server.peerInfo.addrs)
+    check client.isConnected(server.peerInfo.peerId)
+    check server.connManager.availableSlots(Direction.In) == 0
+
   asyncTest "one transport's accept failure does not stop other transports from accepting":
-    let (server, stub) = newStubServer(RaiseAlways, withTcp = true)
+    let (server, _) = newStubServer(RaiseAlways, withTcp = true)
     let client = makeStandardSwitch(TcpAutoAddress)
     startAndDeferStop(@[server, client])
 

--- a/tests/stubs/transportstub.nim
+++ b/tests/stubs/transportstub.nim
@@ -7,7 +7,10 @@
 
 import chronos
 import
-  ../../libp2p/[transports/transport, transports/memorytransport, upgrademngrs/upgrade]
+  ../../libp2p/[
+    transports/transport, transports/memorytransport, upgrademngrs/upgrade,
+    crypto/crypto,
+  ]
 
 type
   StubAcceptBehavior* = enum
@@ -23,10 +26,12 @@ type
 proc new*(
     T: typedesc[MemoryTransportStub],
     upgrade: Upgrade,
+    rng: Rng,
     behavior: StubAcceptBehavior,
     nilCount: int = 0,
 ): T =
-  let self = T(upgrader: upgrade, behavior: behavior, nilCount: nilCount)
+  let self =
+    T(upgrader: upgrade, rng: rng, behavior: behavior, nilCount: nilCount)
   procCall Transport(self).initialize()
   self
 

--- a/tests/stubs/transportstub.nim
+++ b/tests/stubs/transportstub.nim
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+{.push raises: [].}
+
+import chronos
+import
+  ../../libp2p/[
+    transports/transport,
+    transports/memorytransport,
+    upgrademngrs/upgrade,
+  ]
+
+type
+  StubAcceptBehavior* = enum
+    RaiseAlways ## every accept raises: the transport can never accept
+    NilAlways ## every accept returns nil: the switch's non-fatal branch
+    NilThenAccept ## return nil `nilCount` times, then accept normally
+
+  MemoryTransportStub* = ref object of MemoryTransport
+    behavior: StubAcceptBehavior
+    nilCount: int ## for NilThenAccept: how many nils before accepting normally
+    acceptCalls*: int ## number of times accept was invoked
+
+proc new*(
+    T: typedesc[MemoryTransportStub],
+    upgrade: Upgrade,
+    behavior: StubAcceptBehavior,
+    nilCount: int = 0,
+): T =
+  let self = T(upgrader: upgrade, behavior: behavior, nilCount: nilCount)
+  procCall Transport(self).initialize()
+  self
+
+method accept*(
+    self: MemoryTransportStub
+): Future[RawConn] {.
+    async: (raises: [transport.TransportError, CancelledError])
+.} =
+  inc self.acceptCalls
+
+  case self.behavior
+  of RaiseAlways:
+    raise newException(MemoryTransportError, "stub accept always fails")
+  of NilAlways:
+    # the switch retries immediately whenever accept returns nil.
+    # without an await here, that retry loop would run non-stop and never let any
+    # other async task run, so the test would hang.
+    # sleepAsync(0) pauses this task for an instant each retry, letting the rest
+    # of the test run. a real transport's accept pauses here anyway while it waits
+    # for a connection.
+    await sleepAsync(0.milliseconds)
+    return nil
+  of NilThenAccept:
+    if self.acceptCalls <= self.nilCount:
+      # pause an instant each retry, else this loop runs non-stop and hangs the test
+      await sleepAsync(0.milliseconds)
+      return nil
+    # accept normally by delegating to the base transport
+    return await procCall MemoryTransport(self).accept()

--- a/tests/stubs/transportstub.nim
+++ b/tests/stubs/transportstub.nim
@@ -7,11 +7,7 @@
 
 import chronos
 import
-  ../../libp2p/[
-    transports/transport,
-    transports/memorytransport,
-    upgrademngrs/upgrade,
-  ]
+  ../../libp2p/[transports/transport, transports/memorytransport, upgrademngrs/upgrade]
 
 type
   StubAcceptBehavior* = enum
@@ -36,9 +32,7 @@ proc new*(
 
 method accept*(
     self: MemoryTransportStub
-): Future[RawConn] {.
-    async: (raises: [transport.TransportError, CancelledError])
-.} =
+): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =
   inc self.acceptCalls
 
   case self.behavior

--- a/tests/stubs/transportstub.nim
+++ b/tests/stubs/transportstub.nim
@@ -8,7 +8,9 @@
 import chronos
 import
   ../../libp2p/[
-    transports/transport, transports/memorytransport, upgrademngrs/upgrade,
+    transports/transport,
+    transports/memorytransport,
+    upgrademngrs/upgrade,
     crypto/crypto,
   ]
 
@@ -30,8 +32,7 @@ proc new*(
     behavior: StubAcceptBehavior,
     nilCount: int = 0,
 ): T =
-  let self =
-    T(upgrader: upgrade, rng: rng, behavior: behavior, nilCount: nilCount)
+  let self = T(upgrader: upgrade, rng: rng, behavior: behavior, nilCount: nilCount)
   procCall Transport(self).initialize()
   self
 


### PR DESCRIPTION
## Summary

Addresses #2755

Adds test coverage for what happens when a transport's `accept` fails.

The switch runs one accept loop per transport. Today the two failure modes behave differently and neither was pinned by a test:
  - `accept` returns `nil`: treated as a transient miss, the loop retries.
  - `accept` raises: the loop logs "Exception in accept loop, exiting" and returns for good. The transport stays `running` with its address still advertised, so the node looks reachable while nothing is accepting.

This PR documents current behavior only. Any refactor is tracked in #666.

New `tests/libp2p/test_switch_accept.nim` covers:
  - accept raising exits the loop while the transport still reports running and advertised
  - accept returning nil is non-fatal and the loop keeps retrying
  - inbound dials are dropped once a transport's accept loop has died
  - a transport recovers and serves a real connection after transient nil failures
  - one transport's accept failure does not stop other transports from accepting

## Affected Areas

- [x] Tests

## Impact on Library Users

Two minor surface changes, both for tests only:
- `MemoryTransport.rng` is now an exported field.
- `Switch.acceptFuts` accessor added under `when defined(libp2p_testing)`