### PR TITLE
test(mplex): make tests teardown more robust

### DIFF
--- a/tests/libp2p/muxers/test_mplex.nim
+++ b/tests/libp2p/muxers/test_mplex.nim
@@ -403,10 +403,10 @@ suite "Mplex":
       await stream.close()
 
       await conn.close()
-      await acceptFut.wait(1.seconds)
-      await mplexDialFut.wait(1.seconds)
       await allFuturesRaising(transport1.stop(), transport2.stop())
+      await acceptFut
       await listenFut
+      await mplexDialFut
 
     asyncTest "read/write receiver lazy":
       let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
@@ -442,10 +442,10 @@ suite "Mplex":
       await stream.close()
 
       await conn.close()
-      await acceptFut.wait(1.seconds)
-      await mplexDialFut
       await allFuturesRaising(transport1.stop(), transport2.stop())
+      await acceptFut
       await listenFut
+      await mplexDialFut
 
     asyncTest "write fragmented":
       let
@@ -496,10 +496,11 @@ suite "Mplex":
       await listenJob.wait(10.seconds)
 
       await stream.close()
+      await mplexDial.close()
       await conn.close()
+      await allFuturesRaising(transport1.stop(), transport2.stop())
       await acceptFut
       await mplexDialFut
-      await allFuturesRaising(transport1.stop(), transport2.stop())
 
       await listenFut
 
@@ -535,9 +536,9 @@ suite "Mplex":
       check msg == "Hello from stream!"
 
       await conn.close()
-      await acceptFut.wait(1.seconds)
-      await mplexDialFut
       await allFuturesRaising(transport1.stop(), transport2.stop())
+      await acceptFut
+      await mplexDialFut
       await listenFut
 
     asyncTest "multiple streams":
@@ -633,10 +634,10 @@ suite "Mplex":
 
       await done.wait(5.seconds)
       await conn.close()
-      await acceptFut.wait(1.seconds)
-      await mplexDialFut
       await mplexDial.close()
       await allFuturesRaising(transport1.stop(), transport2.stop())
+      await acceptFut
+      await mplexDialFut
       await listenFut
 
     asyncTest "channel closes listener with EOF":
@@ -738,8 +739,8 @@ suite "Mplex":
       checkTracker(LPChannelTrackerName)
 
       await conn.close()
-      await mplexDialFut
       await allFuturesRaising(transport1.stop(), transport2.stop())
+      await mplexDialFut
       await acceptFut
 
     asyncTest "Connection.reset aborts the dialer stream":
@@ -775,8 +776,8 @@ suite "Mplex":
       checkTracker(LPChannelTrackerName)
 
       await conn.close()
-      await mplexDialFut
       await allFuturesRaising(transport1.stop(), transport2.stop())
+      await mplexDialFut
       await acceptFut
 
     asyncTest "dialing mplex closes both ends":
@@ -813,8 +814,8 @@ suite "Mplex":
       checkTracker(LPChannelTrackerName)
 
       await conn.close()
-      await mplexDialFut
       await allFuturesRaising(transport1.stop(), transport2.stop())
+      await mplexDialFut
       await acceptFut
 
     asyncTest "listening mplex closes both ends":
@@ -855,8 +856,8 @@ suite "Mplex":
       checkTracker(LPChannelTrackerName)
 
       await conn.close()
-      await mplexDialFut
       await allFuturesRaising(transport1.stop(), transport2.stop())
+      await mplexDialFut
       await acceptFut
 
     asyncTest "canceling mplex handler closes both ends":
@@ -898,8 +899,8 @@ suite "Mplex":
       checkTracker(LPChannelTrackerName)
 
       await conn.close()
-      await mplexDialFut
       await allFuturesRaising(transport1.stop(), transport2.stop())
+      await mplexDialFut
 
     asyncTest "closing dialing connection should close both ends":
       let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
@@ -938,8 +939,8 @@ suite "Mplex":
       checkTracker(LPChannelTrackerName)
 
       await conn.closeWithEOF()
-      await mplexDialFut
       await allFuturesRaising(transport1.stop(), transport2.stop())
+      await mplexDialFut
       await acceptFut
 
     asyncTest "canceling listening connection should close both ends":
@@ -980,8 +981,8 @@ suite "Mplex":
       checkTracker(LPChannelTrackerName)
 
       await conn.close()
-      await mplexDialFut
       await allFuturesRaising(transport1.stop(), transport2.stop())
+      await mplexDialFut
       await acceptFut
 
     suite "jitter":
@@ -1051,11 +1052,12 @@ suite "Mplex":
         await writer()
         await complete.wait(1.seconds)
         await stream.close()
+        await mplexDial.close()
         await conn.close()
+        await allFuturesRaising(transport1.stop(), transport2.stop())
         await acceptFut
         await mplexDialFut
 
-        await allFuturesRaising(transport1.stop(), transport2.stop())
         await listenFut
 
       asyncTest "channel should handle 1 byte read/write":
@@ -1114,8 +1116,9 @@ suite "Mplex":
 
         await complete.wait(5.seconds)
         await stream.close()
+        await mplexDial.close()
         await conn.close()
+        await allFuturesRaising(transport1.stop(), transport2.stop())
         await acceptFut
         await mplexDialFut
-        await allFuturesRaising(transport1.stop(), transport2.stop())
         await listenFut

--- a/tests/libp2p/muxers/test_mplex.nim
+++ b/tests/libp2p/muxers/test_mplex.nim
@@ -1058,7 +1058,6 @@ suite "Mplex":
         await allFuturesRaising(transport1.stop(), transport2.stop())
         await acceptFut
         await mplexDialFut
-
         await listenFut
 
       asyncTest "channel should handle 1 byte read/write":

--- a/tests/libp2p/muxers/test_mplex.nim
+++ b/tests/libp2p/muxers/test_mplex.nim
@@ -585,8 +585,8 @@ suite "Mplex":
       await done.wait(10.seconds)
       await conn.close()
       await acceptFut.wait(1.seconds)
-      await mplexDialFut
       await allFuturesRaising(transport1.stop(), transport2.stop())
+      await mplexDialFut
       await listenFut
 
     asyncTest "multiple read/write streams":
@@ -683,8 +683,8 @@ suite "Mplex":
       checkTracker(LPChannelTrackerName)
 
       await conn.close()
-      await mplexDialFut
       await allFuturesRaising(transport1.stop(), transport2.stop())
+      await mplexDialFut
       await acceptFut
 
     asyncTest "channel closes dialer with EOF":
@@ -878,7 +878,7 @@ suite "Mplex":
         await mplexListen.close()
 
       await transport1.start(ma)
-      let _ = acceptHandler()
+      let acceptFut = acceptHandler()
 
       let transport2: TcpTransport = TcpTransport.new(upgrade = Upgrade())
       let conn = await transport2.dial(transport1.addrs[0])
@@ -901,6 +901,7 @@ suite "Mplex":
       await conn.close()
       await allFuturesRaising(transport1.stop(), transport2.stop())
       await mplexDialFut
+      await acceptFut
 
     asyncTest "closing dialing connection should close both ends":
       let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]


### PR DESCRIPTION
first close muxers/transports before awaiting their handle futures

should fix class of issues: #2749 and #2748