### PR TITLE
fix(memory-transport): serialize concurrent writes

### DIFF
--- a/libp2p/stream/bridgestream.nim
+++ b/libp2p/stream/bridgestream.nim
@@ -3,6 +3,7 @@
 
 import pkg/chronos
 import connection, bufferstream
+import ../utils/lock
 
 export connection
 
@@ -16,25 +17,14 @@ type
     closeHandler: proc(): Future[void] {.async: (raises: []).}
     writeLock: AsyncLock
 
-proc writeLocked(
-    s: BridgeStream, msg: sink seq[byte]
-): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
-  await s.writeLock.acquire()
-  try:
-    await s.writeHandler(move(msg))
-  finally:
-    try:
-      s.writeLock.release()
-    except AsyncLockError as exc:
-      raiseAssert "BridgeStream write lock release failed: " & exc.msg
-
 method write*(
     s: BridgeStream, msg: sink seq[byte]
-): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
+): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
   if s.writeLock.isNil:
-    s.writeHandler(move(msg))
+    await s.writeHandler(move(msg))
   else:
-    s.writeLocked(move(msg))
+    s.writeLock.withLock:
+      await s.writeHandler(move(msg))
 
 method closeImpl*(s: BridgeStream): Future[void] {.async: (raises: [], raw: true).} =
   if not isNil(s.closeHandler):

--- a/libp2p/stream/bridgestream.nim
+++ b/libp2p/stream/bridgestream.nim
@@ -16,7 +16,7 @@ type
     closeHandler: proc(): Future[void] {.async: (raises: []).}
     writeLock: AsyncLock
 
-method write*(
+proc writeLocked(
     s: BridgeStream, msg: sink seq[byte]
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
   await s.writeLock.acquire()
@@ -28,6 +28,14 @@ method write*(
     except AsyncLockError as exc:
       raiseAssert "BridgeStream write lock release failed: " & exc.msg
 
+method write*(
+    s: BridgeStream, msg: sink seq[byte]
+): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
+  if s.writeLock.isNil:
+    s.writeHandler(move(msg))
+  else:
+    s.writeLocked(move(msg))
+
 method closeImpl*(s: BridgeStream): Future[void] {.async: (raises: [], raw: true).} =
   if not isNil(s.closeHandler):
     discard s.closeHandler()
@@ -38,14 +46,18 @@ method getWrapped*(s: BridgeStream): Connection =
   nil
 
 proc bridgedConnections*(
-    closeTogether: bool = true, dirA = Direction.In, dirB = Direction.In
+    closeTogether: bool = true,
+    dirA = Direction.In,
+    dirB = Direction.In,
+    serializeWrites = false,
 ): (BridgeStream, BridgeStream) =
   let connA = BridgeStream()
   let connB = BridgeStream()
   connA.dir = dirA
   connB.dir = dirB
-  connA.writeLock = newAsyncLock()
-  connB.writeLock = newAsyncLock()
+  if serializeWrites:
+    connA.writeLock = newAsyncLock()
+    connB.writeLock = newAsyncLock()
   connA.initStream()
   connB.initStream()
 

--- a/libp2p/stream/bridgestream.nim
+++ b/libp2p/stream/bridgestream.nim
@@ -14,11 +14,19 @@ type
   BridgeStream* = ref object of BufferStream
     writeHandler: WriteHandler
     closeHandler: proc(): Future[void] {.async: (raises: []).}
+    writeLock: AsyncLock
 
 method write*(
     s: BridgeStream, msg: sink seq[byte]
-): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
-  s.writeHandler(move(msg))
+): Future[void] {.async: (raises: [CancelledError, LPStreamError]).} =
+  await s.writeLock.acquire()
+  try:
+    await s.writeHandler(move(msg))
+  finally:
+    try:
+      s.writeLock.release()
+    except AsyncLockError as exc:
+      raiseAssert "BridgeStream write lock release failed: " & exc.msg
 
 method closeImpl*(s: BridgeStream): Future[void] {.async: (raises: [], raw: true).} =
   if not isNil(s.closeHandler):
@@ -36,6 +44,8 @@ proc bridgedConnections*(
   let connB = BridgeStream()
   connA.dir = dirA
   connB.dir = dirB
+  connA.writeLock = newAsyncLock()
+  connB.writeLock = newAsyncLock()
   connA.initStream()
   connB.initStream()
 

--- a/libp2p/transports/memorymanager.nim
+++ b/libp2p/transports/memorymanager.nim
@@ -38,7 +38,7 @@ proc accept*(self: MemoryListener): Future[RawConn] {.gcsafe, raises: [].} =
   return self.accept
 
 proc dial*(self: MemoryListener): Future[RawConn] {.gcsafe, raises: [].} =
-  let (connA, connB) = bridgedConnections()
+  let (connA, connB) = bridgedConnections(serializeWrites = true)
 
   self.onListenerEnd(self.address)
   self.accept.complete(connA)

--- a/libp2p/utils/lock.nim
+++ b/libp2p/utils/lock.nim
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
 import chronos
 
 template withLock*(a: AsyncLock, body: untyped) =

--- a/libp2p/utils/lock.nim
+++ b/libp2p/utils/lock.nim
@@ -1,0 +1,13 @@
+import chronos
+
+template withLock*(a: AsyncLock, body: untyped) =
+  ## Acquires the given lock, executes the statements in body and
+  ## releases the lock after the statements finish executing.
+  await a.acquire()
+  try:
+    body
+  finally:
+    try:
+      a.release()
+    except AsyncLockError as exc:
+      raiseAssert "AsyncLock release failed: " & exc.msg

--- a/tests/libp2p/stream/test_bridgestream.nim
+++ b/tests/libp2p/stream/test_bridgestream.nim
@@ -26,7 +26,7 @@ suite "BridgeStream":
     await c2.close()
 
   asyncTest "serializes concurrent writes to peer buffer":
-    let (c1, c2) = bridgedConnections()
+    let (c1, c2) = bridgedConnections(serializeWrites = true)
     var msg: array[5, byte]
 
     await c1.write("first")

--- a/tests/libp2p/stream/test_bridgestream.nim
+++ b/tests/libp2p/stream/test_bridgestream.nim
@@ -25,6 +25,28 @@ suite "BridgeStream":
     await c1.close()
     await c2.close()
 
+  asyncTest "serializes concurrent writes to peer buffer":
+    let (c1, c2) = bridgedConnections()
+    var msg: array[5, byte]
+
+    await c1.write("first")
+
+    let
+      write1 = c1.write("again")
+      write2 = c1.write("third")
+
+    await c2.readExactly(addr msg, msg.len)
+    check string.fromBytes(msg) == "first"
+    await c2.readExactly(addr msg, msg.len)
+    check string.fromBytes(msg) == "again"
+    await c2.readExactly(addr msg, msg.len)
+    check string.fromBytes(msg) == "third"
+
+    check await allFutures(write1, write2).withTimeout(1.seconds)
+
+    await c1.close()
+    await c2.close()
+
   asyncTest "closing":
     # closing c1, should also close c2
     var (c1, c2) = bridgedConnections()


### PR DESCRIPTION
adding serialization to concurrent writes in memory transports. 

previously rendezvous tests could fail because rendezvous calls  `conn.writeMsg(...)` on the same raw connection from many call sites and memory transport was not safe for concurrent writes.

closes: #2744