### PR TITLE
ci(daily-report): add runnable examples to report

### DIFF
--- a/.github/workflows/daily_ci_report.yml
+++ b/.github/workflows/daily_ci_report.yml
@@ -42,6 +42,7 @@ jobs:
               ("Daily amd64", "daily_amd64.yml"),
               ("Daily i386", "daily_i386.yml"),
               ("Daily without feature flags", "daily_tests_no_flags.yml"),
+              ("Daily runnable examples", "daily_runnable_examples.yml"),
           ]
 
           LABEL_NAME = "daily-ci-failure"


### PR DESCRIPTION
`daily_runnable_examples` is workflows that daily checks if runnable examples (from comments) are compiling. it should also be included in the daily report.