### PR TITLE
chore(cbind): nim-ffi migration [2/9] — new-library scaffold + CI

### DIFF
--- a/.github/workflows/cbindings.yml
+++ b/.github/workflows/cbindings.yml
@@ -69,7 +69,13 @@ jobs:
   # Temporary parallel job: builds the new nim-ffi library (cbind/libp2p_ffi.nim)
   # and generates its C/CDDL bindings. Folded into the main flow at the flip PR,
   # when libp2p_ffi.nim replaces the legacy libp2p.nim.
+  #
+  # Disabled until the final PR of the nim-ffi migration series: libp2p_ffi.nim is
+  # built up incrementally across PRs 2..9 and only compiles end-to-end at the
+  # flip. Re-enable (drop `if: false`) once the library is complete and expected
+  # to pass.
   c-bindings-ffi:
+    if: false
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -81,7 +87,7 @@ jobs:
         shell: bash
 
     name: "Build FFI library (nim-ffi)"
-    runs-on: ubuntu-22.04
+    runs-on: macos-15 # fastest to compile and run; see daily_tests_no_flags.yml
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -92,8 +98,8 @@ jobs:
         uses: "./.github/actions/install_nim"
         with:
           shell: bash
-          os: linux
-          cpu: amd64
+          os: macos-15
+          cpu: arm64
           nim_ref: v2.2.10
 
       - name: Restore deps from cache
@@ -101,7 +107,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: nimbledeps
-          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned', 'cbind/.pinned') }}
+          key: nimbledeps-macos-15-arm64-clang-${{ hashFiles('.pinned', 'cbind/.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
@@ -112,12 +118,13 @@ jobs:
         run: |
           nim --version
           nimble --version
-          gcc --version
+          clang --version
 
           nimble setup
           cd cbind
           nimble install_pinned
           nimble setup
+          make -C .. nat_libs
           nimble buildffi
           nimble genbindings_c
           nimble genbindings_cddl

--- a/.github/workflows/cbindings.yml
+++ b/.github/workflows/cbindings.yml
@@ -101,7 +101,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: nimbledeps
-          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned') }}
+          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned', 'cbind/.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/cbindings.yml
+++ b/.github/workflows/cbindings.yml
@@ -65,3 +65,59 @@ jobs:
           nimble install_pinned
           nimble setup
           nimble examples
+
+  # Temporary parallel job: builds the new nim-ffi library (cbind/libp2p_ffi.nim)
+  # and generates its C/CDDL bindings. Folded into the main flow at the flip PR,
+  # when libp2p_ffi.nim replaces the legacy libp2p.nim.
+  c-bindings-ffi:
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+    env:
+      NIMBLE_COMMIT: 9207e8b2bbdf66b5a4d1020214cff44d2d30df92 # v0.20.1
+
+    defaults:
+      run:
+        shell: bash
+
+    name: "Build FFI library (nim-ffi)"
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Setup Nim
+        uses: "./.github/actions/install_nim"
+        with:
+          shell: bash
+          os: linux
+          cpu: amd64
+          nim_ref: v2.2.10
+
+      - name: Restore deps from cache
+        id: deps-cache
+        uses: actions/cache@v5
+        with:
+          path: nimbledeps
+          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned') }}
+
+      - name: Install deps
+        if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
+        run: |
+          nimble install_pinned
+
+      - name: Build FFI library and generate C/CDDL bindings
+        run: |
+          nim --version
+          nimble --version
+          gcc --version
+
+          nimble setup
+          cd cbind
+          nimble install_pinned
+          nimble setup
+          nimble buildffi
+          nimble genbindings_c
+          nimble genbindings_cddl

--- a/cbind/.gitignore
+++ b/cbind/.gitignore
@@ -1,3 +1,9 @@
 nimble.develop
 nimble.paths
 nimbledeps
+nimble.lock
+nimcache
+nimcache_c
+nimcache_cddl
+c_bindings
+cddl_bindings

--- a/cbind/.pinned
+++ b/cbind/.pinned
@@ -1,3 +1,3 @@
 taskpools;https://github.com/status-im/nim-taskpools@#9e8ccc754631ac55ac2fd495e167e74e86293edb
 cbor_serialization;https://github.com/vacp2p/nim-cbor-serialization@#1664160e04d153573373afddc552b9cbf6fbe4dc
-ffi;https://github.com/logos-messaging/nim-ffi@#7e3fd96e7417528fecdd0d685fc8fd29a3fd6bfd
+ffi;https://github.com/logos-messaging/nim-ffi@#d1575f08d104634a85e421b8480fd2605cd0556f

--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -16,8 +16,6 @@ requires "taskpools >= 0.1.0"
 task install_pinned,
   "Install cbind's pinned deps (taskpools, cbor_serialization, nim-ffi)":
   # cbind-scoped lock; kept out of the root .pinned so the Nim 2.2.4 CI job stays green.
-  if not dirExists("nimbledeps"):
-    mkDir("nimbledeps")
   let deps = readFile(".pinned").splitWhitespace().mapIt(it.split(";", 1)[1])
   exec "nimble install -y " & deps.join(" ")
 

--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -16,7 +16,8 @@ requires "taskpools >= 0.1.0"
 task install_pinned,
   "Install cbind's pinned deps (taskpools, cbor_serialization, nim-ffi)":
   # cbind-scoped lock; kept out of the root .pinned so the Nim 2.2.4 CI job stays green.
-  if not dirExists("nimbledeps"): mkDir("nimbledeps")
+  if not dirExists("nimbledeps"):
+    mkDir("nimbledeps")
   let deps = readFile(".pinned").splitWhitespace().mapIt(it.split(";", 1)[1])
   exec "nimble install -y " & deps.join(" ")
 

--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -16,6 +16,7 @@ requires "taskpools >= 0.1.0"
 task install_pinned,
   "Install cbind's pinned deps (taskpools, cbor_serialization, nim-ffi)":
   # cbind-scoped lock; kept out of the root .pinned so the Nim 2.2.4 CI job stays green.
+  if not dirExists("nimbledeps"): mkDir("nimbledeps")
   let deps = readFile(".pinned").splitWhitespace().mapIt(it.split(";", 1)[1])
   exec "nimble install -y " & deps.join(" ")
 

--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -87,3 +87,40 @@ task examples, "Build and run C bindings examples":
     " -pthread"
   exec "../build/cbindings"
   exec "../build/echo"
+
+# nim-ffi library, built in parallel to the legacy cbind above (see libp2p_ffi.nim).
+# Renamed over libp2p.nim at the flip PR, which drops everything above this line.
+
+proc ffiLibExt(): string =
+  when defined(windows):
+    "dll"
+  elif defined(macosx):
+    "dylib"
+  else:
+    "so"
+
+proc buildFfiLib() =
+  let buildDir = "../build"
+  if not dirExists(buildDir):
+    mkDir(buildDir)
+  # Name the output `lib<name>` so the file matches the soname nim derives from
+  # the module; `--nimMainPrefix:liblibp2p` matches the `liblibp2pNimMain` symbol
+  # nim-ffi's `declareLibrary` imports.
+  exec "nim c --out:" & buildDir & "/liblibp2p." & ffiLibExt() &
+    " --threads:on --app:lib --opt:size --noMain --mm:refc -d:metrics" &
+    " --nimMainPrefix:liblibp2p --nimcache:nimcache libp2p_ffi.nim"
+
+task buildffi, "Build the FFI shared library":
+  buildFfiLib()
+
+proc genBindingsFor(lang, outDir: string) =
+  exec "nim c --threads:on --app:lib --noMain --mm:refc -d:metrics" &
+    " --nimMainPrefix:liblibp2p -d:ffiGenBindings -d:targetLang=" & lang &
+    " -d:ffiOutputDir=" & outDir & " -d:ffiSrcPath=libp2p_ffi.nim" &
+    " --nimcache:nimcache_" & lang & " -o:/dev/null libp2p_ffi.nim"
+
+task genbindings_c, "Generate C bindings (cbind/c_bindings)":
+  genBindingsFor("c", "c_bindings")
+
+task genbindings_cddl, "Generate CDDL schema (cbind/cddl_bindings)":
+  genBindingsFor("cddl", "cddl_bindings")

--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -106,8 +106,11 @@ proc buildFfiLib() =
   # Name the output `lib<name>` so the file matches the soname nim derives from
   # the module; `--nimMainPrefix:liblibp2p` matches the `liblibp2pNimMain` symbol
   # nim-ffi's `declareLibrary` imports.
+  # ffiThreadExitTimeoutMs: bound the FFI thread's graceful-shutdown wait; the
+  # 1500ms default is too tight for libp2pDestroy's switch.stop() over many conns.
   exec "nim c --out:" & buildDir & "/liblibp2p." & ffiLibExt() &
     " --threads:on --app:lib --opt:size --noMain --mm:refc -d:metrics" &
+    " -d:ffiThreadExitTimeoutMs=5000" &
     " --nimMainPrefix:liblibp2p --nimcache:nimcache libp2p_ffi.nim"
 
 task buildffi, "Build the FFI shared library":

--- a/cbind/libp2p_ffi.nim
+++ b/cbind/libp2p_ffi.nim
@@ -198,21 +198,53 @@ proc createLibp2pNode(config: Libp2pConfig): Result[LibP2P, string] =
 proc libp2pNew*(config: Libp2pConfig): Future[Result[LibP2P, string]] {.ffiCtor.} =
   try:
     return createLibp2pNode(config)
-  except CatchableError as e:
+  except LPError as e:
     return err("could not create libp2p node: " & e.msg)
 
 proc libp2pDestroy*(lib: LibP2P) {.ffiDtor.} =
   discard
 
-proc libp2pStart*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} =
+proc libp2pStart*(lib: LibP2P): Future[Result[void, string]] {.ffi.} =
   try:
     await lib.switch.start()
   except LPError as e:
     return err(e.msg)
-  ok(true)
+  ok()
 
-proc libp2pStop*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} =
+proc libp2pStop*(lib: LibP2P): Future[Result[void, string]] {.ffi.} =
   await lib.switch.stop()
-  ok(true)
+  ok()
+
+# Legacy compatibility: hosts still calling `libp2p_new_default_config()` get a
+# zero-initialized config with the correct C layout, matching the old behavior.
+# `CLibp2pConfig` is a hand-maintained C-ABI mirror of `Libp2pConfig` — it must
+# be kept in sync by hand because the `{.ffi.}` config crosses the boundary as
+# CBOR, not as a C struct, so it isn't part of the generated bindings.
+type CLibp2pConfig {.exportc: "libp2p_config", bycopy.} = object
+  mountGossipsub: cint
+  gossipsubTriggerSelf: cint
+  mountKad: cint
+  mountServiceDiscovery: cint
+  dnsResolver: cstring
+  addrs: ptr cstring
+  addrsLen: csize_t
+  muxer: cint
+  transport: cint
+  bootstrapNodes: pointer
+  bootstrapNodesLen: csize_t
+  privKey: ptr byte
+  privKeyLen: csize_t
+  maxConnections: cint
+  maxIn: cint
+  maxOut: cint
+  maxConnsPerPeer: cint
+  circuitRelay: cint
+  circuitRelayClient: cint
+  autonat: cint
+  autonatV2: cint
+  autonatV2Server: cint
+
+proc libp2p_new_default_config(): CLibp2pConfig {.exportc, cdecl, dynlib.} =
+  CLibp2pConfig()
 
 genBindings()

--- a/cbind/libp2p_ffi.nim
+++ b/cbind/libp2p_ffi.nim
@@ -44,6 +44,7 @@ type LibP2P* = ref object
   topicHandlers: Table[string, TopicHandler]
   customProtocols: Table[string, LPProtocol]
   streams: StreamRegistry
+  stopped: bool ## Guards shutdownSwitch so stop-then-destroy doesn't double-stop.
 
 declareLibrary("libp2p", LibP2P)
 
@@ -197,12 +198,17 @@ proc createLibp2pNode(config: Libp2pConfig): Result[LibP2P, string] =
 
 proc libp2pNew*(config: Libp2pConfig): Future[Result[LibP2P, string]] {.ffiCtor.} =
   try:
-    return createLibp2pNode(config)
+    createLibp2pNode(config)
   except LPError as e:
-    return err("could not create libp2p node: " & e.msg)
+    err("could not create libp2p node: " & e.msg)
 
-proc libp2pDestroy*(lib: LibP2P) {.ffiDtor.} =
-  discard
+proc shutdownSwitch(lib: LibP2P) {.async.} =
+  ## Single source of truth for graceful shutdown. Idempotent: safe to call from
+  ## both an explicit `libp2pStop` and `libp2pDestroy`'s teardown.
+  if lib.stopped:
+    return
+  lib.stopped = true
+  await lib.switch.stop()
 
 proc libp2pStart*(lib: LibP2P): Future[Result[void, string]] {.ffi.} =
   try:
@@ -212,14 +218,18 @@ proc libp2pStart*(lib: LibP2P): Future[Result[void, string]] {.ffi.} =
   ok()
 
 proc libp2pStop*(lib: LibP2P): Future[Result[void, string]] {.ffi.} =
-  await lib.switch.stop()
+  await shutdownSwitch(lib)
   ok()
 
-# Legacy compatibility: hosts still calling `libp2p_new_default_config()` get a
-# zero-initialized config with the correct C layout, matching the old behavior.
-# `CLibp2pConfig` is a hand-maintained C-ABI mirror of `Libp2pConfig` — it must
-# be kept in sync by hand because the `{.ffi.}` config crosses the boundary as
-# CBOR, not as a C struct, so it isn't part of the generated bindings.
+proc libp2pDestroy*(lib: LibP2P): Future[void] {.ffiDtor.} =
+  ## Owns the full teardown: the FFI runtime runs this on the worker loop at
+  ## shutdown, so the switch is gracefully stopped before the threads are joined
+  ## and the context is freed. Destroy alone is sufficient; libp2pStop is
+  ## optional and only useful for an explicit, error-reporting shutdown.
+  await shutdownSwitch(lib)
+
+# Hand-maintained C-ABI mirror of `Libp2pConfig`: the `{.ffi.}` config crosses as
+# CBOR, not a C struct, so it's absent from the generated bindings. Keep in sync.
 type CLibp2pConfig {.exportc: "libp2p_config", bycopy.} = object
   mountGossipsub: cint
   gossipsubTriggerSelf: cint
@@ -244,7 +254,9 @@ type CLibp2pConfig {.exportc: "libp2p_config", bycopy.} = object
   autonatV2: cint
   autonatV2Server: cint
 
-proc libp2p_new_default_config(): CLibp2pConfig {.exportc, cdecl, dynlib.} =
+proc libp2pNewDefaultConfig(): CLibp2pConfig {.
+    exportc: "libp2p_new_default_config", cdecl, dynlib
+.} =
   CLibp2pConfig()
 
 genBindings()

--- a/cbind/libp2p_ffi.nim
+++ b/cbind/libp2p_ffi.nim
@@ -217,6 +217,7 @@ proc libp2pStart*(lib: LibP2P): Future[Result[void, string]] {.ffi.} =
     await lib.switch.start()
   except LPError as e:
     return err(e.msg)
+  lib.stopped = false
   ok()
 
 proc libp2pStop*(lib: LibP2P): Future[Result[void, string]] {.ffi.} =

--- a/cbind/libp2p_ffi.nim
+++ b/cbind/libp2p_ffi.nim
@@ -186,7 +186,7 @@ proc createLibp2pNode(config: Libp2pConfig): Result[LibP2P, string] =
   let switch =
     try:
       switchBuilder.build()
-    except CatchableError as e:
+    except LPError as e:
       return err("could not create libp2p node: " & e.msg)
 
   let lib = LibP2P(switch: switch, rng: rng, relayClient: relayClientOpt)

--- a/cbind/libp2p_ffi.nim
+++ b/cbind/libp2p_ffi.nim
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## C FFI bindings for nim-libp2p, built on top of `nim-ffi`.
+##
+## `nim-ffi` provides the FFI runtime and generates the C/CDDL bindings. This
+## file only declares the library state, the request/response shapes and the
+## libp2p-specific bodies; `genBindings()` at the bottom emits the foreign
+## bindings consumed by `logos-co/logos-libp2p-module`.
+##
+## The `{.ffi.}` config types and all of their parsing live in
+## `libp2p_ffi/config.nim`, `include`d below — see that file for the
+## `config.parse()` entry point and for why it is included rather than imported.
+
+import ffi
+
+import std/tables
+
+import ../libp2p
+import ../libp2p/[multiaddress, peerid]
+import ../libp2p/crypto/crypto
+import ../libp2p/nameresolving/dnsresolver
+import ../libp2p/protocols/pubsub/gossipsub
+import ../libp2p/protocols/protocol
+import ../libp2p/protocols/ping
+import ../libp2p/protocols/kademlia
+import ../libp2p/protocols/service_discovery
+import ../libp2p/protocols/service_discovery/types
+import ../libp2p/protocols/connectivity/relay/client
+
+type StreamRegistry = object
+  ## Owns the live streams handed out across the FFI boundary.
+  streams: Table[uint64, Stream]
+  nextStreamId: uint64
+
+type LibP2P* = ref object
+  ## Main library state. The FFI context owns one instance; its tables mutate
+  ## through the `lib` receiver of every `{.ffi.}` proc.
+  switch: Switch
+  rng: Rng
+  gossipSub: Opt[GossipSub]
+  kad: Opt[KadDHT]
+  relayClient: Opt[RelayClient]
+  topicHandlers: Table[string, TopicHandler]
+  customProtocols: Table[string, LPProtocol]
+  streams: StreamRegistry
+
+declareLibrary("libp2p", LibP2P)
+
+include "libp2p_ffi/config"
+
+proc register(reg: var StreamRegistry, stream: Stream): uint64 =
+  reg.nextStreamId.inc()
+  let id = reg.nextStreamId
+  reg.streams[id] = stream
+  id
+
+func get(reg: StreamRegistry, id: uint64): Result[Stream, string] =
+  let stream = reg.streams.getOrDefault(id, nil)
+  if stream.isNil():
+    return err("unknown stream handle")
+  ok(stream)
+
+const MaxReadBytes = 64 * 1024 * 1024
+  ## Upper bound on a single stream read. Caps the buffer an untrusted peer can
+  ## make us pre-allocate before any byte arrives; well above libp2p's largest
+  ## framed messages, so legitimate reads are unaffected.
+
+proc mountGossipsub(lib: LibP2P, triggerSelf: bool): Result[void, string] =
+  let gs = GossipSub.init(switch = lib.switch, triggerSelf = triggerSelf, rng = lib.rng)
+  try:
+    lib.switch.mount(gs)
+  except LPError as e:
+    return err(e.msg)
+  lib.gossipSub = Opt.some(gs)
+  ok()
+
+proc defaultKadConfig(): KadDHTConfig =
+  # Validator/selector are host callbacks that can't cross the FFI boundary, so
+  # fall back to the defaults.
+  KadDHTConfig.new(
+    validator = DefaultEntryValidator(), selector = DefaultEntrySelector()
+  )
+
+proc mountKad(
+    lib: LibP2P, bootstrapNodes: seq[(PeerId, seq[MultiAddress])]
+): Result[void, string] =
+  try:
+    let k = KadDHT.new(
+      lib.switch,
+      bootstrapNodes = bootstrapNodes,
+      config = defaultKadConfig(),
+      rng = lib.rng,
+    )
+    lib.switch.mount(k)
+    lib.kad = Opt.some(k)
+  except LPError as e:
+    return err(e.msg)
+  ok()
+
+proc mountServiceDiscovery(
+    lib: LibP2P, bootstrapNodes: seq[(PeerId, seq[MultiAddress])]
+): Result[void, string] =
+  try:
+    let sd = ServiceDiscovery.new(
+      lib.switch,
+      bootstrapNodes = bootstrapNodes,
+      config = defaultKadConfig(),
+      rng = lib.rng,
+      codec = ExtendedServiceDiscoveryCodec,
+    )
+    lib.switch.mount(sd)
+    lib.kad = Opt.some(KadDHT(sd))
+  except LPError as e:
+    return err(e.msg)
+  ok()
+
+proc mountProtocols(lib: LibP2P, cfg: ParsedConfig): Result[void, string] =
+  if cfg.mountGossipsub:
+    ?mountGossipsub(lib, cfg.gossipsubTriggerSelf)
+
+  if cfg.mountServiceDiscovery:
+    ?mountServiceDiscovery(lib, cfg.bootstrapNodes)
+  elif cfg.mountKad:
+    ?mountKad(lib, cfg.bootstrapNodes)
+
+  try:
+    lib.switch.mount(Ping.new(rng = lib.rng))
+  except LPError as e:
+    return err(e.msg)
+  ok()
+
+proc withConfiguredTransport(
+    builder: SwitchBuilder, transport: ParsedTransport
+): SwitchBuilder =
+  case transport.kind
+  of TransportType.QUIC:
+    builder.withQuicTransport()
+  of TransportType.TCP:
+    let tcp = builder.withTcpTransport()
+    case transport.muxer
+    of MuxerType.MPLEX:
+      tcp.withMplex()
+    of MuxerType.YAMUX:
+      tcp.withYamux()
+
+proc createLibp2pNode(config: Libp2pConfig): Result[LibP2P, string] =
+  let cfg = ?config.parse()
+  let rng = newRng()
+
+  var switchBuilder = SwitchBuilder
+    .new()
+    .withRng(rng)
+    .withMaxConnsPerPeer(cfg.maxConnsPerPeer)
+    .withNameResolver(DnsResolver.new(cfg.dnsServers))
+    .withNoise()
+    .withPrivateKey(cfg.privKey)
+    .withAddresses(cfg.addrs)
+    .withConfiguredTransport(cfg.transport)
+
+  if cfg.maxIn > 0 and cfg.maxOut > 0:
+    switchBuilder = switchBuilder.withConnectionLimits(
+      ConnectionLimits.maxInOut(cfg.maxIn, cfg.maxOut)
+    )
+  elif cfg.maxConnections > 0:
+    switchBuilder =
+      switchBuilder.withConnectionLimits(ConnectionLimits.maxTotal(cfg.maxConnections))
+
+  var relayClientOpt = Opt.none(RelayClient)
+  if cfg.circuitRelayClient:
+    let cl = RelayClient.new()
+    switchBuilder = switchBuilder.withCircuitRelay(cl)
+    relayClientOpt = Opt.some(cl)
+  elif cfg.circuitRelay:
+    switchBuilder = switchBuilder.withCircuitRelay()
+
+  if cfg.autonat:
+    switchBuilder = switchBuilder.withAutonat()
+
+  if cfg.autonatV2:
+    switchBuilder = switchBuilder.withNAT(autonatConfig(AutonatV2))
+
+  if cfg.autonatV2Server:
+    switchBuilder = switchBuilder.withAutonatV2Server()
+
+  let switch =
+    try:
+      switchBuilder.build()
+    except CatchableError as e:
+      return err("could not create libp2p node: " & e.msg)
+
+  let lib = LibP2P(switch: switch, rng: rng, relayClient: relayClientOpt)
+
+  ?mountProtocols(lib, cfg)
+
+  ok(lib)
+
+proc libp2pNew*(config: Libp2pConfig): Future[Result[LibP2P, string]] {.ffiCtor.} =
+  try:
+    return createLibp2pNode(config)
+  except CatchableError as e:
+    return err("could not create libp2p node: " & e.msg)
+
+proc libp2pDestroy*(lib: LibP2P) {.ffiDtor.} =
+  discard
+
+proc libp2pStart*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} =
+  try:
+    await lib.switch.start()
+  except LPError as e:
+    return err(e.msg)
+  ok(true)
+
+proc libp2pStop*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} =
+  await lib.switch.stop()
+  ok(true)
+
+genBindings()

--- a/cbind/libp2p_ffi.nim
+++ b/cbind/libp2p_ffi.nim
@@ -211,6 +211,8 @@ proc shutdownSwitch(lib: LibP2P) {.async.} =
   await lib.switch.stop()
 
 proc libp2pStart*(lib: LibP2P): Future[Result[void, string]] {.ffi.} =
+  if not lib.stopped:
+    return
   try:
     await lib.switch.start()
   except LPError as e:

--- a/cbind/libp2p_ffi/config.nim
+++ b/cbind/libp2p_ffi/config.nim
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## Config crossing the FFI boundary and its parsing, `include`d into
+## `../libp2p_ffi.nim`.
+##
+## `Libp2pConfig` is the raw, wire-friendly shape the host fills in; `parse`
+## validates it once and returns a `ParsedConfig` of ready-to-use Nim values, so
+## the node builder never touches a raw string or ordinal again:
+##
+##   let cfg = ?config.parse()
+##   ... cfg.privKey, cfg.transport, cfg.bootstrapNodes ...
+##
+## The `{.ffi.}` types share this module with `genBindings()` on purpose: nim-ffi
+## reads the object fields straight from the AST, and an exported field would
+## leak its `*` into the generated field name. `include` (not `import`) keeps the
+## fields unexported and the emitted bindings clean.
+
+type TransportType {.pure.} = enum
+  QUIC
+  TCP
+
+type MuxerType {.pure.} = enum
+  MPLEX
+  YAMUX
+
+type BootstrapNode {.ffi.} = object
+  peerId: string
+  multiaddrs: seq[string]
+
+type Libp2pConfig {.ffi.} = object
+  mountGossipsub: bool
+  gossipsubTriggerSelf: bool
+  mountKad: bool
+  mountServiceDiscovery: bool
+  dnsResolver: string
+  addrs: seq[string]
+  # `MuxerType`/`TransportType` ordinals, passed as `int` because nim-ffi can't
+  # yet carry a Nim enum across the wire (see parseMuxer/parseTransport).
+  muxer: int
+  transport: int
+  bootstrapNodes: seq[BootstrapNode]
+  privKey: seq[byte]
+  maxConnections: int
+  maxIn: int
+  maxOut: int
+  maxConnsPerPeer: int
+  circuitRelay: bool
+  circuitRelayClient: bool
+  autonat: bool
+  autonatV2: bool
+  autonatV2Server: bool
+
+type ParsedTransport = object
+  ## The transport to build, plus the muxer it needs. A muxer is only used with
+  ## TCP, so the variant makes "no muxer for QUIC" unrepresentable rather than
+  ## carrying a meaningless default.
+  case kind: TransportType
+  of TransportType.TCP:
+    muxer: MuxerType
+  of TransportType.QUIC:
+    discard
+
+type ParsedConfig = object
+  ## `Libp2pConfig` with every field validated and decoded once. Consumed by the
+  ## node builder; carries no raw strings or ordinals.
+  dnsServers: seq[TransportAddress]
+  addrs: seq[MultiAddress]
+  transport: ParsedTransport
+  privKey: Opt[PrivateKey]
+  bootstrapNodes: seq[(PeerId, seq[MultiAddress])]
+  maxConnections: int
+  maxIn: int
+  maxOut: int
+  maxConnsPerPeer: int
+  circuitRelay: bool
+  circuitRelayClient: bool
+  autonat: bool
+  autonatV2: bool
+  autonatV2Server: bool
+  mountGossipsub: bool
+  gossipsubTriggerSelf: bool
+  mountKad: bool
+  mountServiceDiscovery: bool
+
+func parseTransport(v: int): Result[TransportType, string] =
+  case v
+  of ord(TransportType.QUIC):
+    ok(TransportType.QUIC)
+  of ord(TransportType.TCP):
+    ok(TransportType.TCP)
+  else:
+    err("invalid transport")
+
+func parseMuxer(v: int): Result[MuxerType, string] =
+  case v
+  of ord(MuxerType.MPLEX):
+    ok(MuxerType.MPLEX)
+  of ord(MuxerType.YAMUX):
+    ok(MuxerType.YAMUX)
+  else:
+    err("invalid muxer")
+
+proc parseBootstrapNodes(
+    nodes: openArray[BootstrapNode]
+): Result[seq[(PeerId, seq[MultiAddress])], string] =
+  var parsed: seq[(PeerId, seq[MultiAddress])]
+  for node in nodes:
+    let peerId = PeerId.init(node.peerId).valueOr:
+      return err("invalid bootstrap peer id: " & $error)
+    var addrs: seq[MultiAddress]
+    for a in node.multiaddrs:
+      let ma = MultiAddress.init(a).valueOr:
+        return err("invalid bootstrap multiaddr: " & $error)
+      addrs.add(ma)
+    parsed.add((peerId, addrs))
+  ok(parsed)
+
+proc resolveDnsServers(dnsResolver: string): Result[seq[TransportAddress], string] =
+  if dnsResolver.len == 0:
+    return ok(DefaultDnsServers)
+  try:
+    ok(@[initTAddress(dnsResolver)])
+  except TransportAddressError as e:
+    err("invalid dnsResolver address: " & e.msg)
+
+proc parsePrivateKey(raw: seq[byte]): Result[Opt[PrivateKey], string] =
+  if raw.len == 0:
+    return ok(Opt.none(PrivateKey))
+  let key = PrivateKey.init(raw).valueOr:
+    return err("invalid private key: " & $error)
+  ok(Opt.some(key))
+
+proc parseListenAddrs(raw: openArray[string]): Result[seq[MultiAddress], string] =
+  var addrs: seq[MultiAddress]
+  for a in raw:
+    let address = MultiAddress.init(a).valueOr:
+      return err("invalid listen address: " & $error)
+    addrs.add(address)
+  ok(addrs)
+
+proc parseTransportConfig(config: Libp2pConfig): Result[ParsedTransport, string] =
+  # A muxer is only used with TCP; a QUIC config's `muxer` ordinal is left
+  # unvalidated, matching the transport it applies to.
+  let transport = ?parseTransport(config.transport)
+  case transport
+  of TransportType.QUIC:
+    ok(ParsedTransport(kind: TransportType.QUIC))
+  of TransportType.TCP:
+    let muxer = ?parseMuxer(config.muxer)
+    ok(ParsedTransport(kind: TransportType.TCP, muxer: muxer))
+
+proc parse(config: Libp2pConfig): Result[ParsedConfig, string] =
+  let transport = ?parseTransportConfig(config)
+  let dnsServers = ?resolveDnsServers(config.dnsResolver)
+  let addrs = ?parseListenAddrs(config.addrs)
+  let privKey = ?parsePrivateKey(config.privKey)
+  let bootstrapNodes = ?parseBootstrapNodes(config.bootstrapNodes)
+
+  ok(
+    ParsedConfig(
+      dnsServers: dnsServers,
+      addrs: addrs,
+      transport: transport,
+      privKey: privKey,
+      bootstrapNodes: bootstrapNodes,
+      maxConnections: config.maxConnections,
+      maxIn: config.maxIn,
+      maxOut: config.maxOut,
+      maxConnsPerPeer: config.maxConnsPerPeer,
+      circuitRelay: config.circuitRelay,
+      circuitRelayClient: config.circuitRelayClient,
+      autonat: config.autonat,
+      autonatV2: config.autonatV2,
+      autonatV2Server: config.autonatV2Server,
+      mountGossipsub: config.mountGossipsub,
+      gossipsubTriggerSelf: config.gossipsubTriggerSelf,
+      mountKad: config.mountKad,
+      mountServiceDiscovery: config.mountServiceDiscovery,
+    )
+  )

--- a/cbind/libp2p_ffi/config.nim
+++ b/cbind/libp2p_ffi/config.nim
@@ -99,7 +99,7 @@ func parseMuxer(v: int): Result[MuxerType, string] =
   of ord(MuxerType.YAMUX):
     ok(MuxerType.YAMUX)
   else:
-    err("invalid muxer")
+    err("invalid muxer ordinal: " & $v)
 
 proc parseBootstrapNodes(
     nodes: openArray[BootstrapNode]

--- a/cbind/libp2p_ffi/config.nim
+++ b/cbind/libp2p_ffi/config.nim
@@ -90,7 +90,7 @@ func parseTransport(v: int): Result[TransportType, string] =
   of ord(TransportType.TCP):
     ok(TransportType.TCP)
   else:
-    err("invalid transport")
+    err("invalid transport ordinal: " & $v)
 
 func parseMuxer(v: int): Result[MuxerType, string] =
   case v

--- a/cbind/libp2p_ffi/config.nim
+++ b/cbind/libp2p_ffi/config.nim
@@ -139,7 +139,7 @@ proc parseListenAddrs(raw: openArray[string]): Result[seq[MultiAddress], string]
     addrs.add(address)
   ok(addrs)
 
-proc parseTransportConfig(config: Libp2pConfig): Result[ParsedTransport, string] =
+func parseTransportConfig(config: Libp2pConfig): Result[ParsedTransport, string] =
   # A muxer is only used with TCP; a QUIC config's `muxer` ordinal is left
   # unvalidated, matching the transport it applies to.
   let transport = ?parseTransport(config.transport)

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,14 @@
             inherit pkgs;
             src = ./.;
           };
+
+          # Temporary target for the nim-ffi library (cbind/libp2p_ffi.nim),
+          # built in parallel to `.#cbind` during the PR-train migration.
+          # Removed at the flip PR, when libp2p_ffi.nim replaces libp2p.nim.
+          cbind-ffi = import ./nix/cbind-ffi.nix {
+            inherit pkgs;
+            src = ./.;
+          };
         }
       );
 
@@ -56,4 +64,3 @@
       );
     };
 }
-

--- a/nix/cbind-deps.nix
+++ b/nix/cbind-deps.nix
@@ -22,8 +22,8 @@
 
   ffi = pkgs.fetchgit {
     url = "https://github.com/logos-messaging/nim-ffi";
-    rev = "7e3fd96e7417528fecdd0d685fc8fd29a3fd6bfd";
-    sha256 = "1zy1r7zpkmgzc010g839w9p2gl6zm19b52bhq7rbpg82l83vrcz7";
+    rev = "d1575f08d104634a85e421b8480fd2605cd0556f";
+    sha256 = "08ql2sjj656bjmqbj7mkky4mg1zfjdqarxygrgxk3s5cizznymxc";
     fetchSubmodules = true;
   };
 

--- a/nix/cbind-ffi.nix
+++ b/nix/cbind-ffi.nix
@@ -1,0 +1,95 @@
+{ pkgs, src }:
+
+# Temporary parallel derivation for the nim-ffi library (cbind/libp2p_ffi.nim),
+# built alongside the legacy `.#cbind` while the PR train migrates domain by
+# domain. Collapsed back into `nix/cbind.nix` at the flip PR, when
+# libp2p_ffi.nim replaces the legacy libp2p.nim.
+let
+  deps = import ./deps.nix { inherit pkgs; };
+  cbindDeps = import ./cbind-deps.nix { inherit pkgs; };
+
+  # nat_traversal is resolved from a writable copy (see buildPhase), not the store.
+  depsWithoutNat = builtins.removeAttrs deps [ "nat_traversal" ];
+
+  pathArgs =
+    builtins.concatStringsSep " "
+      (map (p: "--path:${p}") (builtins.attrValues depsWithoutNat));
+
+  cbindPathArgs =
+    builtins.concatStringsSep " "
+      (map (p: "--path:${p}") (builtins.attrValues cbindDeps));
+
+  libExt =
+    if pkgs.stdenv.hostPlatform.isWindows then "dll"
+    else if pkgs.stdenv.hostPlatform.isDarwin then "dylib"
+    else "so";
+in
+pkgs.stdenv.mkDerivation {
+  pname = "nim-libp2p-cbind-ffi";
+  version = "dev";
+
+  inherit src;
+
+  nativeBuildInputs = [
+    pkgs.nim-2_2
+    pkgs.git
+    pkgs.nimble
+  ] ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
+    # miniupnpc's Darwin Makefile archives via `LIBTOOL ?= $(shell which libtool)`; cctools supplies it, which resolves it.
+    pkgs.cctools
+    pkgs.which
+  ];
+
+  buildPhase = ''
+    export HOME=$TMPDIR
+    export XDG_CACHE_HOME=$TMPDIR/.cache
+    export NIMBLE_DIR=$TMPDIR/.nimble
+    export NIMCACHE=$TMPDIR/nimcache
+
+    mkdir -p build $NIMCACHE
+
+    echo "== Building nat_traversal vendored C libs =="
+    # nat_traversal's {.passl: <pkgRoot>/vendor/.../lib*.a.} needs a writable copy: the store is read-only.
+    NAT_PKG=$TMPDIR/nat_traversal
+    cp -r ${deps.nat_traversal} $NAT_PKG
+    chmod -R +w $NAT_PKG
+    # Reuse the repo Makefile's `nat_libs` target (the same recipe the nimble
+    # `examples` task drives) rather than re-deriving the per-OS make args here.
+    # NAT_PKG_DIR points it at the writable copy; NAT_CC forwards the nix $CC,
+    # since the vendored Makefiles default to CC=gcc, absent on the Darwin stdenv.
+    make nat_libs NAT_PKG_DIR="$NAT_PKG" NAT_CC="$CC"
+
+    commonArgs="--noNimblePath ${cbindPathArgs} ${pathArgs} --path:$NAT_PKG \
+      --threads:on --opt:size --noMain --mm:refc --d:metrics \
+      --nimMainPrefix:liblibp2p --nimcache:$NIMCACHE"
+
+    echo "== Building FFI library (dynamic/shared) =="
+    nim c $commonArgs --app:lib --out:build/liblibp2p.${libExt} cbind/libp2p_ffi.nim
+
+    echo "== Building FFI library (static) =="
+    nim c $commonArgs --app:staticlib --out:build/liblibp2p.a cbind/libp2p_ffi.nim
+
+    echo "== Generating C bindings =="
+    nim c $commonArgs --app:lib -d:ffiGenBindings -d:targetLang=c \
+      -d:ffiOutputDir=cbind/c_bindings -d:ffiSrcPath=libp2p_ffi.nim \
+      -o:/dev/null cbind/libp2p_ffi.nim
+
+    echo "== Generating CDDL schema =="
+    nim c $commonArgs --app:lib -d:ffiGenBindings -d:targetLang=cddl \
+      -d:ffiOutputDir=cbind/cddl_bindings -d:ffiSrcPath=libp2p_ffi.nim \
+      -o:/dev/null cbind/libp2p_ffi.nim
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib $out/include
+    cp build/liblibp2p.${libExt} $out/lib
+    cp build/liblibp2p.a         $out/lib
+    # libp2p.a references these via {.passl.}; install them so static linking resolves.
+    cp $NAT_PKG/vendor/miniupnp/miniupnpc/build/libminiupnpc.a $out/lib
+    cp $NAT_PKG/vendor/libnatpmp-upstream/libnatpmp.a          $out/lib
+    # Install nim-ffi's headers (libp2p.h + companions) flat: consumers stage
+    # them via `cp $out/include/*.h`, so a nested dir would be missed.
+    cp cbind/c_bindings/*.h   $out/include/
+    cp -r cbind/cddl_bindings $out/include/
+  '';
+}

--- a/nix/cbind-ffi.nix
+++ b/nix/cbind-ffi.nix
@@ -59,8 +59,11 @@ pkgs.stdenv.mkDerivation {
     # since the vendored Makefiles default to CC=gcc, absent on the Darwin stdenv.
     make nat_libs NAT_PKG_DIR="$NAT_PKG" NAT_CC="$CC"
 
+    # ffiThreadExitTimeoutMs: bound the FFI thread's graceful-shutdown wait; the
+    # 1500ms default is too tight for libp2pDestroy's switch.stop() over many conns.
     commonArgs="--noNimblePath ${cbindPathArgs} ${pathArgs} --path:$NAT_PKG \
       --threads:on --opt:size --noMain --mm:refc --d:metrics \
+      -d:ffiThreadExitTimeoutMs=5000 \
       --nimMainPrefix:liblibp2p --nimcache:$NIMCACHE"
 
     echo "== Building FFI library (dynamic/shared) =="


### PR DESCRIPTION
**nim-ffi cbind migration — PR train**

1. #2772 — deps + pinning
2. #2773 — scaffold + CI ← this PR
3. #2774 — connectivity
4. #2775 — streams (+ echo)
5. #2776 — pubsub (+ gossipsub)
6. #2777 — kad + CID + crypto
7. #2778 — service discovery
8. #2779 — relay / peerstore / metrics
9. #2780 — flip + delete legacy

---
Part 2 of a 9-PR train that replaces the hand-rolled `cbind/` C bindings with the generated **nim-ffi** codegen, landing it domain by domain so each PR stays reviewable. Targets `chore/cbind/ffi/01-deps-pinning` (stacked).

**This PR adds**
- `cbind/libp2p_ffi.nim`, the new nim-ffi library, developed **in parallel** to the legacy `cbind/libp2p.nim` so the old bindings keep shipping until the final flip. It carries the library state (`LibP2P`, `StreamRegistry`), `declareLibrary`, the `MaxReadBytes` read-ceiling reserved for the stream reads landing in a later PR, the node builder, the lifecycle entry points, and `genBindings()`.
- The `{.ffi.}` config types (`Libp2pConfig`, `BootstrapNode`, the transport/muxer enums) and their parsing live in `cbind/libp2p_ffi/config.nim`. `config.parse()` validates the raw config once and returns a `ParsedConfig` of ready-to-use Nim values, so the node builder never touches a raw string or ordinal. The file is `include`d rather than imported: nim-ffi reads `{.ffi.}` object fields from the AST, and exporting the fields would leak their `*` into the generated field names.
- Protocol mounting orchestrated by `mountProtocols`, with Kademlia and service discovery mounting through separate helpers instead of one function branching on config flags.
- `buildffi`/`genbindings_c`/`genbindings_cddl` nimble tasks, a temporary `.#cbind-ffi` nix target (which reuses the repo Makefile's `nat_libs` target), and a temporary `c-bindings-ffi` CI job — all pointed at the new file. The old `.#cbind` target and job are untouched.

**Lifecycle & shutdown**
- `libp2pNew` / `libp2pStart` / `libp2pStop` / `libp2pDestroy`. `libp2pDestroy` **owns graceful shutdown**: it stops the switch on the FFI worker loop before the threads are joined and the context is freed, so destroy alone is sufficient. `libp2pStop` is a thin, idempotent wrapper over the same `shutdownSwitch` path, kept for an explicit, error-reporting stop. A `stopped` flag makes stop-then-destroy a no-op.
- This relies on nim-ffi's async teardown hook for `{.ffiDtor.}`; the `ffi` dep is re-pinned to logos-messaging/nim-ffi#115 (`d1575f0`). The FFI build compiles with `-d:ffiThreadExitTimeoutMs=5000` to give a graceful `switch.stop()` room beyond the 1500 ms default before the context is leaked.
- `libp2p_new_default_config()` is preserved for hosts that still call it, as a hand-maintained C-ABI mirror struct (the `{.ffi.}` config crosses as CBOR, not a C struct, so it isn't in the generated bindings).

**CI status**
- The `c-bindings-ffi` job runs on macOS (`macos-15` / arm64 / clang) but is **currently disabled** (`if: false`): `libp2p_ffi.nim` is built up domain by domain across PRs 2–9 and only compiles end-to-end at the flip, so a green run isn't meaningful until then. It's re-enabled (drop `if: false`) in the final PR. The legacy `c-bindings` job is unchanged and stays green throughout.

**Review artifact:** the generated `libp2p.h` appears for the first time here, with just the lifecycle entry points.
