### PR TITLE
chore(cbind): nim-ffi migration [6/9] — kademlia + CID + crypto

### DIFF
--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -152,7 +152,7 @@ task examples, "Build and run the C bindings examples":
     cborObjs.add obj
   let cborObjsStr = cborObjs.join(" ")
 
-  for example in ["echo", "gossipsub"]:
+  for example in ["echo", "gossipsub", "kad"]:
     let outBin = "../build/" & example
     exec "gcc -std=c11 -O2 -I c_bindings -I " & vendor & " examples/" & example & ".c " &
       cborObjsStr & " " & lib & " -pthread -Wl,-rpath,'$ORIGIN' -o " & outBin

--- a/cbind/examples/CMakeLists.txt
+++ b/cbind/examples/CMakeLists.txt
@@ -62,7 +62,7 @@ set_property(TARGET tinycbor PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 find_package(Threads REQUIRED)
 
-foreach(example echo gossipsub)
+foreach(example echo gossipsub kad)
   add_executable(${example} "${example}.c")
   target_include_directories(${example} PRIVATE "${GEN_DIR}")
   target_link_libraries(${example} PRIVATE "${LIB_FILE}" tinycbor Threads::Threads)

--- a/cbind/examples/README.md
+++ b/cbind/examples/README.md
@@ -5,6 +5,8 @@ Worked examples of consuming nim-libp2p from C through the FFI bindings generate
 The bindings are a header-only C API over a C ABI. Every generated method is asynchronous: it takes a result callback and returns immediately, and the callback fires from the library's dispatch thread. Library-initiated events (incoming streams, pub/sub messages) arrive through `libp2p_ctx_add_on_…_listener` callbacks. The examples turn each async call back into a blocking step with the small helpers in `common.h`.
 
 - `echo.c` — two TCP nodes; the server mounts a custom `/cbind/echo/1.0.0` protocol and echoes the bytes it reads, the client dials it and verifies the round-trip. The incoming-stream handler only hands the stream id to `main`, which serves it inline, since calling back into the library from the dispatch thread would deadlock.
+- `gossipsub.c` — two TCP nodes join a shared topic and exchange one message, delivered to the subscriber through its pub/sub-message listener.
+- `kad.c` — two TCP nodes form a Kademlia DHT (a server, and a client that lists the server as its bootstrap node), then round-trip a value (`kad_put_value` / `kad_get_value`) and a provider record (`create_cid`, `kad_start_providing` / `kad_get_providers`) over the wire.
 
 ## Build
 
@@ -34,6 +36,8 @@ cmake -S . -B build -DTINYCBOR_VENDOR=$(nimble path ffi)/ffi/codegen/templates/c
 
 ```sh
 ./build/echo
+./build/gossipsub
+./build/kad
 ```
 
-Each program exits `0` on success and prints what it sent and received.
+Each program exits `0` on success and prints the values it exchanged over the wire.

--- a/cbind/examples/kad.c
+++ b/cbind/examples/kad.c
@@ -1,0 +1,226 @@
+// Kademlia DHT: two TCP nodes form a DHT (a server, and a client that lists the
+// server as its bootstrap node), then round-trip a value and a provider record
+// over the wire. The generated bindings are asynchronous, so every call is
+// wrapped with the blocking helpers in common.h.
+//
+// The client learns the server through its `bootstrapNodes` config: at
+// construction the DHT inserts each bootstrap peer (with its addresses) into
+// the routing table, so the client can reach the server without any prior
+// lookup. All DHT queries here originate at the client and travel to the
+// server, which is why only the client needs to know the server.
+#include "common.h"
+
+// TransportType / MuxerType ordinals, mirrored from libp2p_ffi/config.nim.
+static const int64_t TransportTcp = 1;
+static const int64_t MuxerMplex = 0;
+
+// A key is just bytes for the DHT; the value is stored and fetched verbatim.
+static const char *ValueKey = "/cbind/kad/demo-key";
+static const char *ValueData = "hello kademlia";
+
+// libp2p_ctx_create_cid returns the CID string, so it needs its own waiter.
+typedef struct {
+  atomic_int done;
+  int err_code;
+  char err[256];
+  char cid[256];
+} CidWaiter;
+
+static void on_cid(int ec, const NimFfiStr *reply, const char *em, void *ud) {
+  CidWaiter *w = (CidWaiter *)ud;
+  w->err_code = ec;
+  if (reply && reply->data)
+    snprintf(w->cid, sizeof(w->cid), "%.*s", (int)reply->len, reply->data);
+  if (em)
+    snprintf(w->err, sizeof(w->err), "%s", em);
+  atomic_store(&w->done, 1);
+}
+
+// kad_get_value replies with a ReadResponse carrying the stored bytes.
+typedef struct {
+  atomic_int done;
+  int err_code;
+  char err[256];
+  uint8_t data[512];
+  size_t len;
+} ValueWaiter;
+
+static void on_value(int ec, const ReadResponse *reply, const char *em,
+                     void *ud) {
+  ValueWaiter *w = (ValueWaiter *)ud;
+  w->err_code = ec;
+  if (reply && reply->data.data) {
+    w->len =
+        reply->data.len < sizeof(w->data) ? reply->data.len : sizeof(w->data);
+    memcpy(w->data, reply->data.data, w->len);
+  }
+  if (em)
+    snprintf(w->err, sizeof(w->err), "%s", em);
+  atomic_store(&w->done, 1);
+}
+
+// kad_get_providers replies with the peers that announced the CID.
+#define MAX_PROVIDERS 8
+typedef struct {
+  atomic_int done;
+  int err_code;
+  char err[256];
+  char peerIds[MAX_PROVIDERS][128];
+  size_t n;
+} ProvidersWaiter;
+
+static void on_providers(int ec, const ProvidersResponse *reply, const char *em,
+                         void *ud) {
+  ProvidersWaiter *w = (ProvidersWaiter *)ud;
+  w->err_code = ec;
+  if (reply) {
+    w->n = reply->providers.len < MAX_PROVIDERS ? reply->providers.len
+                                                : MAX_PROVIDERS;
+    for (size_t i = 0; i < w->n; i++)
+      if (reply->providers.data[i].peerId.data)
+        snprintf(w->peerIds[i], sizeof(w->peerIds[i]), "%s",
+                 reply->providers.data[i].peerId.data);
+  }
+  if (em)
+    snprintf(w->err, sizeof(w->err), "%s", em);
+  atomic_store(&w->done, 1);
+}
+
+// Builds a kad-dht node. `boot` is NULL for the server (no bootstrap peers) or
+// the server's PeerInfo for the client, whose DHT then knows how to reach it.
+static LibP2PCtx *kadNode(const char *listenAddr, const char *label,
+                          const PeerInfoWaiter *boot) {
+  NimFfiStr addrSlot = nimffi_str(listenAddr);
+  Libp2pConfig cfg;
+  memset(&cfg, 0, sizeof(cfg));
+  cfg.mountKad = true;
+  cfg.addrs.data = &addrSlot;
+  cfg.addrs.len = 1;
+  cfg.muxer = MuxerMplex;
+  cfg.transport = TransportTcp;
+
+  NimFfiStr bootAddrs[MAX_ADDRS];
+  BootstrapNode bootNode;
+  if (boot) {
+    for (size_t i = 0; i < boot->naddrs; i++)
+      bootAddrs[i] = nimffi_str(boot->addrs[i]);
+    bootNode.peerId = nimffi_str(boot->peerId);
+    bootNode.multiaddrs.data = bootAddrs;
+    bootNode.multiaddrs.len = boot->naddrs;
+    cfg.bootstrapNodes.data = &bootNode;
+    cfg.bootstrapNodes.len = 1;
+  }
+  // await_create only reads cfg while encoding, so the stack-local bootstrap
+  // views above stay valid for the whole call.
+  return await_create(&cfg, label);
+}
+
+// Dials `to` from `from` so identify runs and a live connection backs the DHT
+// RPCs that follow.
+static bool dial(LibP2PCtx *from, const PeerInfoWaiter *to) {
+  NimFfiStr connAddrs[MAX_ADDRS];
+  for (size_t i = 0; i < to->naddrs; i++)
+    connAddrs[i] = nimffi_str(to->addrs[i]);
+  ConnectRequest req = {nimffi_str(to->peerId), {connAddrs, to->naddrs}, 0};
+  BoolWaiter bw;
+  return AWAIT_BOOL(bw, libp2p_ctx_connect(from, &req, on_bool, &bw),
+                    "connect");
+}
+
+int main(void) {
+  int status = 1;
+  BoolWaiter bw;
+  PeerInfoWaiter serverInfo;
+
+  LibP2PCtx *server = kadNode("/ip4/127.0.0.1/tcp/5031", "server", NULL);
+  if (!server)
+    return 1;
+  if (!AWAIT_BOOL(bw, libp2p_ctx_start(server, on_bool, &bw), "start server"))
+    goto cleanup_server;
+  if (!await_peerinfo(server, &serverInfo, "server peerinfo"))
+    goto cleanup_server;
+  printf("Server: %s\n", serverInfo.peerId);
+
+  LibP2PCtx *client = kadNode("/ip4/127.0.0.1/tcp/5032", "client", &serverInfo);
+  if (!client)
+    goto cleanup_server;
+  if (!AWAIT_BOOL(bw, libp2p_ctx_start(client, on_bool, &bw), "start client") ||
+      !dial(client, &serverInfo))
+    goto cleanup_client;
+
+  // ── Value round-trip: server stores, client fetches over the DHT ──────────
+  NimFfiBytes key = {(uint8_t *)ValueKey, strlen(ValueKey)};
+  NimFfiBytes value = {(uint8_t *)ValueData, strlen(ValueData)};
+  KadPutValueRequest putReq = {key, value};
+  if (!AWAIT_BOOL(bw, libp2p_ctx_kad_put_value(server, &putReq, on_bool, &bw),
+                  "put_value"))
+    goto cleanup_client;
+  printf("Server stored %zu bytes under '%s'\n", value.len, ValueKey);
+
+  ValueWaiter vw;
+  memset(&vw, 0, sizeof(vw));
+  // quorum 1: this two-node DHT has a single holder (the server), so one valid
+  // response is enough. A negative value would ask for the default quorum (5),
+  // which this topology can never reach; 0 is rejected by the binding.
+  KadGetValueRequest getReq = {key, 1};
+  libp2p_ctx_kad_get_value(client, &getReq, on_value, &vw);
+  if (!wait_done(&vw.done) || vw.err_code != 0) {
+    fprintf(stderr, "get_value: %s\n", vw.err[0] ? vw.err : "unknown");
+    goto cleanup_client;
+  }
+  printf("Client fetched: %.*s\n", (int)vw.len, vw.data);
+  if (vw.len != value.len || memcmp(vw.data, ValueData, vw.len) != 0) {
+    fprintf(stderr, "Error: fetched value does not match\n");
+    goto cleanup_client;
+  }
+
+  // ── Provider round-trip: server advertises a CID, client discovers it ─────
+  CidWaiter cw;
+  memset(&cw, 0, sizeof(cw));
+  const char *cidData = "cbind-kad";
+  CreateCidRequest cidReq = {1,
+                             nimffi_str("raw"),
+                             nimffi_str("sha2-256"),
+                             {(uint8_t *)cidData, strlen(cidData)}};
+  libp2p_ctx_create_cid(client, &cidReq, on_cid, &cw);
+  if (!wait_done(&cw.done) || cw.err_code != 0) {
+    fprintf(stderr, "create_cid: %s\n", cw.err[0] ? cw.err : "unknown");
+    goto cleanup_client;
+  }
+  printf("CID: %s\n", cw.cid);
+
+  if (!AWAIT_BOOL(bw,
+                  libp2p_ctx_kad_start_providing(server, nimffi_str(cw.cid),
+                                                 on_bool, &bw),
+                  "start_providing"))
+    goto cleanup_client;
+  printf("Server is providing %s\n", cw.cid);
+
+  ProvidersWaiter pw;
+  memset(&pw, 0, sizeof(pw));
+  libp2p_ctx_kad_get_providers(client, nimffi_str(cw.cid), on_providers, &pw);
+  if (!wait_done(&pw.done) || pw.err_code != 0) {
+    fprintf(stderr, "get_providers: %s\n", pw.err[0] ? pw.err : "unknown");
+    goto cleanup_client;
+  }
+  printf("Client found %zu provider(s)\n", pw.n);
+
+  bool serverIsProvider = false;
+  for (size_t i = 0; i < pw.n; i++) {
+    printf("  provider: %s\n", pw.peerIds[i]);
+    if (strcmp(pw.peerIds[i], serverInfo.peerId) == 0)
+      serverIsProvider = true;
+  }
+  if (serverIsProvider)
+    status = 0;
+  else
+    fprintf(stderr, "Error: server not found among providers\n");
+
+cleanup_client:
+  AWAIT_BOOL(bw, libp2p_ctx_stop(client, on_bool, &bw), "stop client");
+  libp2p_ctx_destroy(client);
+cleanup_server:
+  AWAIT_BOOL(bw, libp2p_ctx_stop(server, on_bool, &bw), "stop server");
+  libp2p_ctx_destroy(server);
+  return status;
+}

--- a/cbind/libp2p_ffi.nim
+++ b/cbind/libp2p_ffi.nim
@@ -25,8 +25,9 @@ import ../libp2p/protocols/protocol
 import ../libp2p/protocols/ping
 import ../libp2p/protocols/kademlia
 import ../libp2p/protocols/service_discovery
-import ../libp2p/protocols/service_discovery/types
+import ../libp2p/protocols/service_discovery/[random_find, types]
 import ../libp2p/protocols/connectivity/relay/client
+import ../libp2p/extended_peer_record
 
 type StreamRegistry = ref object
   ## Owns the live streams handed out across the FFI boundary and the
@@ -102,6 +103,43 @@ type PublishResponse {.ffi.} = object
 
 type ReadResponse {.ffi.} = object
   data: seq[byte]
+
+type CreateCidRequest {.ffi.} = object
+  version: int
+  multicodec: string
+  hash: string
+  data: seq[byte]
+
+type NewPrivateKeyRequest {.ffi.} = object
+  scheme: int
+
+type KadPutValueRequest {.ffi.} = object
+  key: seq[byte]
+  value: seq[byte]
+
+type KadGetValueRequest {.ffi.} = object
+  key: seq[byte]
+  quorum: int
+
+type ProviderInfo {.ffi.} = object
+  peerId: string
+  addrs: seq[string]
+
+type ProvidersResponse {.ffi.} = object
+  providers: seq[ProviderInfo]
+
+type ServiceInfoEntry {.ffi.} = object
+  id: string
+  data: seq[byte]
+
+type ExtendedPeerRecordEntry {.ffi.} = object
+  peerId: string
+  seqNo: uint64
+  addrs: seq[string]
+  services: seq[ServiceInfoEntry]
+
+type ExtendedRecordsResponse {.ffi.} = object
+  records: seq[ExtendedPeerRecordEntry]
 
 type IncomingStreamEvent {.ffi.} = object
   proto: string
@@ -601,5 +639,168 @@ proc libp2pGossipsubUnsubscribe*(
     lib.topicHandlers.del(topic)
     gossipSub.unsubscribe(topic, handler)
   ok(true)
+
+func toExtendedRecordEntry(record: ExtendedPeerRecord): ExtendedPeerRecordEntry =
+  ExtendedPeerRecordEntry(
+    peerId: $record.peerId,
+    seqNo: record.seqNo,
+    addrs: record.addresses.mapIt($it.address),
+    services: record.services.mapIt(ServiceInfoEntry(id: it.id, data: it.data.get(@[]))),
+  )
+
+func toExtendedRecordsResponse(
+    records: seq[ExtendedPeerRecord]
+): ExtendedRecordsResponse =
+  ExtendedRecordsResponse(records: records.mapIt(toExtendedRecordEntry(it)))
+
+proc libp2pKadFindNode*(
+    lib: LibP2P, peerId: string
+): Future[Result[PeersResponse, string]] {.ffi.} =
+  let kad = lib.kad.valueOr:
+    return err("kad-dht not initialized")
+  let target = PeerId.init(peerId).valueOr:
+    return err($error)
+  let peers =
+    try:
+      await kad.findNode(target.toKey())
+    except LPError as e:
+      return err(e.msg)
+  ok(PeersResponse(peerIds: peers.mapIt($it)))
+
+proc libp2pKadPutValue*(
+    lib: LibP2P, req: KadPutValueRequest
+): Future[Result[bool, string]] {.ffi.} =
+  let kad = lib.kad.valueOr:
+    return err("kad-dht not initialized")
+  let res = await kad.putValue(req.key, req.value)
+  if res.isErr():
+    return err(res.error)
+  ok(true)
+
+proc libp2pKadGetValue*(
+    lib: LibP2P, req: KadGetValueRequest
+): Future[Result[ReadResponse, string]] {.ffi.} =
+  let kad = lib.kad.valueOr:
+    return err("kad-dht not initialized")
+  if req.quorum == 0:
+    return err("quorum must be greater than 0 (use a negative value for the default)")
+  let quorum =
+    if req.quorum < 0:
+      Opt.none(int)
+    else:
+      Opt.some(req.quorum)
+  let res =
+    try:
+      await kad.getValue(req.key, quorum)
+    except LPError as e:
+      return err(e.msg)
+  let entry = res.valueOr:
+    return err(res.error)
+  ok(ReadResponse(data: entry.value))
+
+proc kadAndCid(lib: LibP2P, cid: string): Result[(KadDHT, Cid), string] =
+  let kad = lib.kad.valueOr:
+    return err("kad-dht not initialized")
+  let c = Cid.init(cid).valueOr:
+    return err("invalid cid: " & $error)
+  ok((kad, c))
+
+proc libp2pKadAddProvider*(
+    lib: LibP2P, cid: string
+): Future[Result[bool, string]] {.ffi.} =
+  let (kad, c) = kadAndCid(lib, cid).valueOr:
+    return err(error)
+  await kad.addProvider(c)
+  ok(true)
+
+proc libp2pKadStartProviding*(
+    lib: LibP2P, cid: string
+): Future[Result[bool, string]] {.ffi.} =
+  let (kad, c) = kadAndCid(lib, cid).valueOr:
+    return err(error)
+  await kad.startProviding(c)
+  ok(true)
+
+proc libp2pKadStopProviding*(
+    lib: LibP2P, cid: string
+): Future[Result[bool, string]] {.ffi.} =
+  let (kad, c) = kadAndCid(lib, cid).valueOr:
+    return err(error)
+  kad.stopProviding(c)
+  ok(true)
+
+proc libp2pKadGetProviders*(
+    lib: LibP2P, cid: string
+): Future[Result[ProvidersResponse, string]] {.ffi.} =
+  let (kad, c) = kadAndCid(lib, cid).valueOr:
+    return err(error)
+  let providersSet =
+    try:
+      await kad.getProviders(c.toKey())
+    except LPError as e:
+      return err(e.msg)
+
+  var providers: seq[ProviderInfo]
+  for provider in providersSet.toSeq():
+    let providerId = provider.id.valueOr:
+      continue
+    let peerId = PeerId.init(providerId).valueOr:
+      continue
+    providers.add(ProviderInfo(peerId: $peerId, addrs: provider.addrs.mapIt($it)))
+  ok(ProvidersResponse(providers: providers))
+
+proc resolveServiceDiscovery(lib: LibP2P): Result[ServiceDiscovery, string] =
+  let kad = lib.kad.valueOr:
+    return err("service discovery not initialized")
+  if not (kad of ServiceDiscovery):
+    return err("service discovery not mounted")
+  ok(ServiceDiscovery(kad))
+
+proc libp2pKadRandomRecords*(
+    lib: LibP2P
+): Future[Result[ExtendedRecordsResponse, string]] {.ffi.} =
+  let disco = resolveServiceDiscovery(lib).valueOr:
+    return err(error)
+  let records = await disco.lookupRandom()
+  ok(toExtendedRecordsResponse(records))
+
+proc libp2pCreateCid*(
+    lib: LibP2P, req: CreateCidRequest
+): Future[Result[string, string]] {.ffi.} =
+  let cidVer =
+    case req.version
+    of 0:
+      CIDv0
+    of 1:
+      CIDv1
+    else:
+      return err("cid version must be 0 or 1")
+
+  let mc = MultiCodec.codec(req.multicodec)
+  if mc == InvalidMultiCodec:
+    return err("invalid multicodec: " & req.multicodec)
+
+  let mh = MultiHash.digest(req.hash, req.data).valueOr:
+    return err("multihash error: " & $error)
+
+  let cid = Cid.init(cidVer, mc, mh).valueOr:
+    return err("cid init error: " & $error)
+
+  ok($cid)
+
+proc libp2pNewPrivateKey*(
+    lib: LibP2P, req: NewPrivateKeyRequest
+): Future[Result[seq[byte], string]] {.ffi.} =
+  if req.scheme < ord(low(PKScheme)) or req.scheme > ord(high(PKScheme)):
+    return err("invalid key scheme")
+  let scheme = PKScheme(req.scheme)
+
+  let key = PrivateKey.random(scheme, lib.rng).valueOr:
+    return err("could not generate private key")
+
+  let keyData = key.getBytes().valueOr:
+    return err("could not get bytes for private key")
+
+  ok(keyData)
 
 genBindings()


### PR DESCRIPTION
**nim-ffi cbind migration — PR train**

1. #2772 — deps + pinning
2. #2773 — scaffold + CI
3. #2774 — connectivity
4. #2775 — streams (+ echo)
5. #2776 — pubsub (+ gossipsub)
6. #2777 — kad + CID + crypto ← this PR
7. #2778 — service discovery
8. #2779 — relay / peerstore / metrics
9. #2780 — flip + delete legacy

---
Part 6 of a 9-PR train that replaces the hand-rolled `cbind/` C bindings with the generated **nim-ffi** codegen, landing it domain by domain so each PR stays reviewable and CI-green (build the FFI lib + generate bindings + build/run examples).

Targets `chore/cbind/ffi/05-pubsub` (stacked).

**This PR adds**
- Kademlia: `findNode`, `putValue`, `getValue`, `addProvider`, `getProviders`, `startProviding`, `stopProviding`, `randomRecords`.
- `libp2pCreateCid` and `libp2pNewPrivateKey`.
- Their request/response types plus the extended-peer-record marshalling helpers used by `randomRecords`.

**Review artifact:** Header diff shows the kad + CID + crypto entry points.
