### PR TITLE
chore(cbind): nim-ffi migration [7/9] — service discovery + extended peer records

### DIFF
--- a/cbind/libp2p_ffi.nim
+++ b/cbind/libp2p_ffi.nim
@@ -14,7 +14,8 @@
 
 import ffi
 
-import std/[tables, sequtils, times]
+import std/[tables, sequtils]
+from std/times import getTime, toUnix
 
 import ../libp2p
 import ../libp2p/[multiaddress, peerid]

--- a/cbind/libp2p_ffi.nim
+++ b/cbind/libp2p_ffi.nim
@@ -864,9 +864,7 @@ proc libp2pCreateXpr*(
   for s in req.services:
     services.add(ServiceInfo(id: s.id, data: Opt.some(s.data)))
 
-  let peerRecord = ExtendedPeerRecord.init(
-    peerId = peerInfo.peerId, addresses = addresses, seqNo = seqNo, services = services
-  )
+  let peerRecord = ExtendedPeerRecord.init(peerInfo.peerId, addresses, seqNo, services)
 
   let xpr = SignedExtendedPeerRecord.build(peerInfo.privateKey, peerRecord).valueOr:
     return err(error)

--- a/cbind/libp2p_ffi.nim
+++ b/cbind/libp2p_ffi.nim
@@ -14,7 +14,7 @@
 
 import ffi
 
-import std/[tables, sequtils]
+import std/[tables, sequtils, times]
 
 import ../libp2p
 import ../libp2p/[multiaddress, peerid]
@@ -140,6 +140,22 @@ type ExtendedPeerRecordEntry {.ffi.} = object
 
 type ExtendedRecordsResponse {.ffi.} = object
   records: seq[ExtendedPeerRecordEntry]
+
+type StartAdvertisingRequest {.ffi.} = object
+  serviceId: string
+  serviceData: seq[byte]
+
+type CreateXprRequest {.ffi.} = object
+  addrs: seq[string]
+  services: seq[ServiceInfoEntry]
+  seqNo: uint64
+
+type DecodeXprRequest {.ffi.} = object
+  encoded: seq[byte]
+
+type LookupRequest {.ffi.} = object
+  serviceId: string
+  serviceData: seq[byte]
 
 type IncomingStreamEvent {.ffi.} = object
   proto: string
@@ -763,6 +779,113 @@ proc libp2pKadRandomRecords*(
     return err(error)
   let records = await disco.lookupRandom()
   ok(toExtendedRecordsResponse(records))
+
+proc libp2pServiceDiscoStart*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} =
+  let disco = resolveServiceDiscovery(lib).valueOr:
+    return err(error)
+  await disco.start()
+  ok(true)
+
+proc libp2pServiceDiscoStop*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} =
+  let disco = resolveServiceDiscovery(lib).valueOr:
+    return err(error)
+  await disco.stop()
+  ok(true)
+
+proc libp2pServiceDiscoStartAdvertising*(
+    lib: LibP2P, req: StartAdvertisingRequest
+): Future[Result[bool, string]] {.ffi.} =
+  let disco = resolveServiceDiscovery(lib).valueOr:
+    return err(error)
+  disco.startAdvertising(
+    ServiceInfo(id: req.serviceId, data: Opt.some(req.serviceData))
+  )
+  ok(true)
+
+proc libp2pServiceDiscoStopAdvertising*(
+    lib: LibP2P, serviceId: string
+): Future[Result[bool, string]] {.ffi.} =
+  let disco = resolveServiceDiscovery(lib).valueOr:
+    return err(error)
+  await disco.stopAdvertising(serviceId)
+  ok(true)
+
+proc libp2pServiceDiscoRegisterInterest*(
+    lib: LibP2P, serviceId: string
+): Future[Result[bool, string]] {.ffi.} =
+  let disco = resolveServiceDiscovery(lib).valueOr:
+    return err(error)
+  discard disco.registerInterest(serviceId)
+  ok(true)
+
+proc libp2pServiceDiscoUnregisterInterest*(
+    lib: LibP2P, serviceId: string
+): Future[Result[bool, string]] {.ffi.} =
+  let disco = resolveServiceDiscovery(lib).valueOr:
+    return err(error)
+  disco.unregisterInterest(serviceId)
+  ok(true)
+
+proc libp2pServiceDiscoLookup*(
+    lib: LibP2P, req: LookupRequest
+): Future[Result[ExtendedRecordsResponse, string]] {.ffi.} =
+  let disco = resolveServiceDiscovery(lib).valueOr:
+    return err(error)
+  let service = ServiceInfo(id: req.serviceId, data: Opt.some(req.serviceData))
+  let res = await disco.lookup(service)
+  let ads = res.valueOr:
+    return err($error)
+  ok(toExtendedRecordsResponse(ads.mapIt(it.data)))
+
+proc libp2pServiceDiscoRandomLookup*(
+    lib: LibP2P
+): Future[Result[ExtendedRecordsResponse, string]] {.ffi.} =
+  let disco = resolveServiceDiscovery(lib).valueOr:
+    return err(error)
+  let records = await disco.lookupRandom()
+  ok(toExtendedRecordsResponse(records))
+
+proc libp2pCreateXpr*(
+    lib: LibP2P, req: CreateXprRequest
+): Future[Result[seq[byte], string]] {.ffi.} =
+  let peerInfo = lib.switch.peerInfo
+  if peerInfo.isNil():
+    return err("switch peerInfo is nil")
+
+  var addresses = parseMultiaddrs(req.addrs).valueOr:
+    return err(error)
+  if addresses.len == 0:
+    addresses = peerInfo.addrs
+
+  let seqNo =
+    if req.seqNo == 0:
+      getTime().toUnix().uint64
+    else:
+      req.seqNo
+
+  var services: seq[ServiceInfo]
+  for s in req.services:
+    services.add(ServiceInfo(id: s.id, data: Opt.some(s.data)))
+
+  let peerRecord = ExtendedPeerRecord.init(
+    peerId = peerInfo.peerId, addresses = addresses, seqNo = seqNo, services = services
+  )
+
+  let xpr = SignedExtendedPeerRecord.build(peerInfo.privateKey, peerRecord).valueOr:
+    return err(error)
+
+  ok(xpr.encode())
+
+proc libp2pDecodeXpr*(
+    lib: LibP2P, req: DecodeXprRequest
+): Future[Result[ExtendedPeerRecordEntry, string]] {.ffi.} =
+  let sxpr = SignedExtendedPeerRecord.decode(req.encoded).valueOr:
+    return err("failed to decode signed extended peer record: " & $error)
+
+  sxpr.checkValid().isOkOr:
+    return err("invalid XPR signature: " & $error)
+
+  ok(toExtendedRecordEntry(sxpr.data))
 
 proc libp2pCreateCid*(
     lib: LibP2P, req: CreateCidRequest


### PR DESCRIPTION
**nim-ffi cbind migration — PR train**

1. #2772 — deps + pinning
2. #2773 — scaffold + CI
3. #2774 — connectivity
4. #2775 — streams (+ echo)
5. #2776 — pubsub (+ gossipsub)
6. #2777 — kad + CID + crypto
7. #2778 — service discovery ← this PR
8. #2779 — relay / peerstore / metrics
9. #2780 — flip + delete legacy

---
Part 7 of a 9-PR train that replaces the hand-rolled `cbind/` C bindings with the generated **nim-ffi** codegen, landing it domain by domain so each PR stays reviewable and CI-green (build the FFI lib + generate bindings + build/run examples).

Targets `chore/cbind/ffi/06-kad-crypto` (stacked).

**This PR adds**
- Service discovery: `start`, `stop`, `startAdvertising`, `stopAdvertising`, `lookup`, `randomLookup`, `registerInterest`, `unregisterInterest`.
- `libp2pCreateXpr` and `libp2pDecodeXpr` (the extended-peer-record encode/decode, including the previously-missing `decode_xpr` path).
- Their `{.ffi.}` request/response types.

**Review artifact:** Header diff shows the service-discovery + xpr entry points; verify `libp2p_ctx_decode_xpr` is present.
