### PR TITLE
chore(cbind): nim-ffi migration [8/9] — relay, peerstore, metrics (API parity)

### DIFF
--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -151,7 +151,7 @@ task examples, "Build and run the C bindings examples":
     cborObjs.add obj
   let cborObjsStr = cborObjs.join(" ")
 
-  for example in ["echo", "gossipsub", "kad"]:
+  for example in ["echo", "gossipsub", "kad", "relay", "peerstore", "metrics"]:
     let outBin = "../build/" & example
     exec "gcc -std=c11 -O2 -I c_bindings -I " & vendor & " examples/" & example & ".c " &
       cborObjsStr & " " & lib & " -pthread -Wl,-rpath,'$ORIGIN' -o " & outBin

--- a/cbind/examples/CMakeLists.txt
+++ b/cbind/examples/CMakeLists.txt
@@ -62,7 +62,7 @@ set_property(TARGET tinycbor PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 find_package(Threads REQUIRED)
 
-foreach(example echo gossipsub kad)
+foreach(example echo gossipsub kad relay peerstore metrics)
   add_executable(${example} "${example}.c")
   target_include_directories(${example} PRIVATE "${GEN_DIR}")
   target_link_libraries(${example} PRIVATE "${LIB_FILE}" tinycbor Threads::Threads)

--- a/cbind/examples/README.md
+++ b/cbind/examples/README.md
@@ -7,6 +7,9 @@ The bindings are a header-only C API over a C ABI. Every generated method is asy
 - `echo.c` — two TCP nodes; the server mounts a custom `/cbind/echo/1.0.0` protocol and echoes the bytes it reads, the client dials it and verifies the round-trip. The incoming-stream handler only hands the stream id to `main`, which serves it inline, since calling back into the library from the dispatch thread would deadlock.
 - `gossipsub.c` — two TCP nodes join a shared topic and exchange one message, delivered to the subscriber through its pub/sub-message listener.
 - `kad.c` — two TCP nodes form a Kademlia DHT (a server, and a client that lists the server as its bootstrap node), then round-trip a value (`kad_put_value` / `kad_get_value`) and a provider record (`create_cid`, `kad_start_providing` / `kad_get_providers`) over the wire.
+- `relay.c` — three TCP nodes: a relay, a destination and a source. The destination reserves a slot on the relay (`circuit_relay_reserve`); the source reaches it over a `/p2p-circuit` address (`dial_circuit_relay`) and runs the echo exchange relayed instead of direct.
+- `peerstore.c` — drives one node's peerstore directly from a second node's PeerInfo: `peerstore_add_peer`, `peerstore_get_peers`, `peerstore_get_peer_info`, `peerstore_set_peer_protocols`, then `peerstore_delete_peer`. No dialing required.
+- `metrics.c` — two TCP nodes connect, then one dumps the process-wide Prometheus registry as JSON via `collect_metrics`.
 
 ## Build
 
@@ -38,6 +41,9 @@ cmake -S . -B build -DTINYCBOR_VENDOR=$(nimble path ffi)/ffi/codegen/templates/c
 ./build/echo
 ./build/gossipsub
 ./build/kad
+./build/relay
+./build/peerstore
+./build/metrics
 ```
 
 Each program exits `0` on success and prints the values it exchanged over the wire.

--- a/cbind/examples/README.md
+++ b/cbind/examples/README.md
@@ -7,9 +7,9 @@ The bindings are a header-only C API over a C ABI. Every generated method is asy
 - `echo.c` — two TCP nodes; the server mounts a custom `/cbind/echo/1.0.0` protocol and echoes the bytes it reads, the client dials it and verifies the round-trip. The incoming-stream handler only hands the stream id to `main`, which serves it inline, since calling back into the library from the dispatch thread would deadlock.
 - `gossipsub.c` — two TCP nodes join a shared topic and exchange one message, delivered to the subscriber through its pub/sub-message listener.
 - `kad.c` — two TCP nodes form a Kademlia DHT (a server, and a client that lists the server as its bootstrap node), then round-trip a value (`kad_put_value` / `kad_get_value`) and a provider record (`create_cid`, `kad_start_providing` / `kad_get_providers`) over the wire.
-- `relay.c` — three TCP nodes: a relay, a destination and a source. The destination reserves a slot on the relay (`circuit_relay_reserve`); the source reaches it over a `/p2p-circuit` address (`dial_circuit_relay`) and runs the echo exchange relayed instead of direct.
-- `peerstore.c` — drives one node's peerstore directly from a second node's PeerInfo: `peerstore_add_peer`, `peerstore_get_peers`, `peerstore_get_peer_info`, `peerstore_set_peer_protocols`, then `peerstore_delete_peer`. No dialing required.
-- `metrics.c` — two TCP nodes connect, then one dumps the process-wide Prometheus registry as JSON via `collect_metrics`.
+- `relay.c` — three TCP nodes: a relay, a destination and a source. The destination reserves a slot on the relay (`circuit_relay_reserve`); the source reaches it over a `/p2p-circuit` address (`dial_circuit_relay`) and sends a message the destination reads off its relayed stream.
+- `peerstore.c` — drives one node's peerstore directly from a second node's PeerInfo: `peerstore_add_peer`, `peerstore_get_peers`, `peerstore_get_peer_info`, then `peerstore_delete_peer`. No dialing required.
+- `metrics.c` — a running node dumps the process-wide Prometheus registry as JSON via `collect_metrics`.
 
 ## Build
 

--- a/cbind/examples/metrics.c
+++ b/cbind/examples/metrics.c
@@ -1,8 +1,6 @@
-// Metrics: two TCP nodes connect, then one dumps the process-wide Prometheus
-// registry as JSON via libp2p_ctx_collect_metrics. The registry is global (it
-// belongs to the `metrics` module, not a single node), so a running node with a
-// live connection is enough to populate real counters. The generated bindings
-// are asynchronous, so every call is wrapped with the blocking helpers in
+// Metrics: a running node dumps the process-wide Prometheus registry as JSON
+// via libp2p_ctx_collect_metrics. The registry is global, so one started node
+// is enough to populate it. Calls are made blocking with the helpers in
 // common.h.
 #include "common.h"
 
@@ -10,16 +8,13 @@
 static const int64_t TransportTcp = 1;
 static const int64_t MuxerMplex = 0;
 
-// collect_metrics replies with a JSON string (Result[string]), so it needs its
-// own waiter. The document can be large, so keep a generous buffer and record
-// whether it was truncated for display.
+// collect_metrics replies with a JSON string (Result[string]).
 typedef struct {
   atomic_int done;
   int err_code;
   char err[256];
   char json[1 << 16];
   size_t len;
-  bool truncated;
 } MetricsWaiter;
 
 static void on_metrics(int ec, const NimFfiStr *reply, const char *em,
@@ -27,9 +22,8 @@ static void on_metrics(int ec, const NimFfiStr *reply, const char *em,
   MetricsWaiter *w = (MetricsWaiter *)ud;
   w->err_code = ec;
   if (reply && reply->data) {
-    size_t cap = sizeof(w->json) - 1;
-    w->truncated = reply->len > cap;
-    w->len = w->truncated ? cap : reply->len;
+    w->len =
+        reply->len < sizeof(w->json) - 1 ? reply->len : sizeof(w->json) - 1;
     memcpy(w->json, reply->data, w->len);
     w->json[w->len] = '\0';
   }
@@ -38,72 +32,44 @@ static void on_metrics(int ec, const NimFfiStr *reply, const char *em,
   atomic_store(&w->done, 1);
 }
 
-static LibP2PCtx *createNode(const char *listenAddr, const char *label) {
-  NimFfiStr addrSlot = nimffi_str(listenAddr);
+int main(void) {
+  NimFfiStr addr = nimffi_str("/ip4/127.0.0.1/tcp/5041");
   Libp2pConfig cfg;
   memset(&cfg, 0, sizeof(cfg));
-  cfg.addrs.data = &addrSlot;
+  cfg.addrs.data = &addr;
   cfg.addrs.len = 1;
   cfg.muxer = MuxerMplex;
   cfg.transport = TransportTcp;
-  return await_create(&cfg, label);
-}
 
-int main(void) {
-  LibP2PCtx *server = createNode("/ip4/127.0.0.1/tcp/5041", "server");
-  LibP2PCtx *client = createNode("/ip4/127.0.0.1/tcp/5042", "client");
-  if (!server || !client) {
-    libp2p_ctx_destroy(server);
-    libp2p_ctx_destroy(client);
+  LibP2PCtx *node = await_create(&cfg, "node");
+  if (!node)
     return 1;
-  }
 
   int status = 1;
   BoolWaiter bw;
-  if (!AWAIT_BOOL(bw, libp2p_ctx_start(server, on_bool, &bw), "start server") ||
-      !AWAIT_BOOL(bw, libp2p_ctx_start(client, on_bool, &bw), "start client"))
+  if (!AWAIT_BOOL(bw, libp2p_ctx_start(node, on_bool, &bw), "start"))
     goto cleanup;
-
-  PeerInfoWaiter pw;
-  if (!await_peerinfo(server, &pw, "peerinfo"))
-    goto cleanup;
-
-  NimFfiStr connAddrs[MAX_ADDRS];
-  for (size_t i = 0; i < pw.naddrs; i++)
-    connAddrs[i] = nimffi_str(pw.addrs[i]);
-  ConnectRequest connReq = {nimffi_str(pw.peerId), {connAddrs, pw.naddrs}, 0};
-  if (!AWAIT_BOOL(bw, libp2p_ctx_connect(client, &connReq, on_bool, &bw),
-                  "connect"))
-    goto cleanup;
-
-  // Let identify and the muxer settle so their counters are non-zero.
-  sleep_ms(500);
 
   MetricsWaiter mw;
   memset(&mw, 0, sizeof(mw));
-  libp2p_ctx_collect_metrics(server, on_metrics, &mw);
+  libp2p_ctx_collect_metrics(node, on_metrics, &mw);
   if (!wait_done(&mw.done) || mw.err_code != 0) {
     fprintf(stderr, "collect_metrics: %s\n", mw.err[0] ? mw.err : "unknown");
     goto cleanup;
   }
 
-  // The payload is a JSON array of {name,type,help,labels,value,timestamp}
-  // objects. Print a short prefix rather than the whole document.
-  printf("Collected %zu bytes of metrics%s\n", mw.len,
-         mw.truncated ? " (truncated)" : "");
-  printf("%.512s%s\n", mw.json, mw.len > 512 ? " ..." : "");
+  // A JSON array of {name,type,help,labels,value,timestamp} objects; print a
+  // prefix rather than the whole document.
+  printf("Collected %zu bytes of metrics\n", mw.len);
+  printf("%.400s%s\n", mw.json, mw.len > 400 ? " ..." : "");
 
-  // A running node always registers libp2p collectors, so a well-formed,
-  // non-empty JSON array with at least one named metric is the success signal.
-  if (mw.len > 2 && mw.json[0] == '[' && strstr(mw.json, "\"name\""))
+  if (mw.json[0] == '[' && strstr(mw.json, "\"name\""))
     status = 0;
   else
     fprintf(stderr, "Error: metrics payload was empty or malformed\n");
 
 cleanup:
-  AWAIT_BOOL(bw, libp2p_ctx_stop(client, on_bool, &bw), "stop client");
-  AWAIT_BOOL(bw, libp2p_ctx_stop(server, on_bool, &bw), "stop server");
-  libp2p_ctx_destroy(client);
-  libp2p_ctx_destroy(server);
+  AWAIT_BOOL(bw, libp2p_ctx_stop(node, on_bool, &bw), "stop");
+  libp2p_ctx_destroy(node);
   return status;
 }

--- a/cbind/examples/metrics.c
+++ b/cbind/examples/metrics.c
@@ -1,0 +1,109 @@
+// Metrics: two TCP nodes connect, then one dumps the process-wide Prometheus
+// registry as JSON via libp2p_ctx_collect_metrics. The registry is global (it
+// belongs to the `metrics` module, not a single node), so a running node with a
+// live connection is enough to populate real counters. The generated bindings
+// are asynchronous, so every call is wrapped with the blocking helpers in
+// common.h.
+#include "common.h"
+
+// TransportType / MuxerType ordinals, mirrored from libp2p_ffi/config.nim.
+static const int64_t TransportTcp = 1;
+static const int64_t MuxerMplex = 0;
+
+// collect_metrics replies with a JSON string (Result[string]), so it needs its
+// own waiter. The document can be large, so keep a generous buffer and record
+// whether it was truncated for display.
+typedef struct {
+  atomic_int done;
+  int err_code;
+  char err[256];
+  char json[1 << 16];
+  size_t len;
+  bool truncated;
+} MetricsWaiter;
+
+static void on_metrics(int ec, const NimFfiStr *reply, const char *em,
+                       void *ud) {
+  MetricsWaiter *w = (MetricsWaiter *)ud;
+  w->err_code = ec;
+  if (reply && reply->data) {
+    size_t cap = sizeof(w->json) - 1;
+    w->truncated = reply->len > cap;
+    w->len = w->truncated ? cap : reply->len;
+    memcpy(w->json, reply->data, w->len);
+    w->json[w->len] = '\0';
+  }
+  if (em)
+    snprintf(w->err, sizeof(w->err), "%s", em);
+  atomic_store(&w->done, 1);
+}
+
+static LibP2PCtx *createNode(const char *listenAddr, const char *label) {
+  NimFfiStr addrSlot = nimffi_str(listenAddr);
+  Libp2pConfig cfg;
+  memset(&cfg, 0, sizeof(cfg));
+  cfg.addrs.data = &addrSlot;
+  cfg.addrs.len = 1;
+  cfg.muxer = MuxerMplex;
+  cfg.transport = TransportTcp;
+  return await_create(&cfg, label);
+}
+
+int main(void) {
+  LibP2PCtx *server = createNode("/ip4/127.0.0.1/tcp/5041", "server");
+  LibP2PCtx *client = createNode("/ip4/127.0.0.1/tcp/5042", "client");
+  if (!server || !client) {
+    libp2p_ctx_destroy(server);
+    libp2p_ctx_destroy(client);
+    return 1;
+  }
+
+  int status = 1;
+  BoolWaiter bw;
+  if (!AWAIT_BOOL(bw, libp2p_ctx_start(server, on_bool, &bw), "start server") ||
+      !AWAIT_BOOL(bw, libp2p_ctx_start(client, on_bool, &bw), "start client"))
+    goto cleanup;
+
+  PeerInfoWaiter pw;
+  if (!await_peerinfo(server, &pw, "peerinfo"))
+    goto cleanup;
+
+  NimFfiStr connAddrs[MAX_ADDRS];
+  for (size_t i = 0; i < pw.naddrs; i++)
+    connAddrs[i] = nimffi_str(pw.addrs[i]);
+  ConnectRequest connReq = {nimffi_str(pw.peerId), {connAddrs, pw.naddrs}, 0};
+  if (!AWAIT_BOOL(bw, libp2p_ctx_connect(client, &connReq, on_bool, &bw),
+                  "connect"))
+    goto cleanup;
+
+  // Let identify and the muxer settle so their counters are non-zero.
+  sleep_ms(500);
+
+  MetricsWaiter mw;
+  memset(&mw, 0, sizeof(mw));
+  libp2p_ctx_collect_metrics(server, on_metrics, &mw);
+  if (!wait_done(&mw.done) || mw.err_code != 0) {
+    fprintf(stderr, "collect_metrics: %s\n", mw.err[0] ? mw.err : "unknown");
+    goto cleanup;
+  }
+
+  // The payload is a JSON array of {name,type,help,labels,value,timestamp}
+  // objects. Print a short prefix rather than the whole document.
+  printf("Collected %zu bytes of metrics%s\n", mw.len,
+         mw.truncated ? " (truncated)" : "");
+  printf("%.512s%s\n", mw.json, mw.len > 512 ? " ..." : "");
+
+  // A running node always registers libp2p collectors, so a well-formed,
+  // non-empty JSON array with at least one named metric is the success signal.
+  if (mw.len > 2 && mw.json[0] == '[' && strstr(mw.json, "\"name\""))
+    status = 0;
+  else
+    fprintf(stderr, "Error: metrics payload was empty or malformed\n");
+
+cleanup:
+  AWAIT_BOOL(bw, libp2p_ctx_stop(client, on_bool, &bw), "stop client");
+  AWAIT_BOOL(bw, libp2p_ctx_stop(server, on_bool, &bw), "stop server");
+  libp2p_ctx_destroy(client);
+  libp2p_ctx_destroy(server);
+  return status;
+}

--- a/cbind/examples/peerstore.c
+++ b/cbind/examples/peerstore.c
@@ -1,0 +1,215 @@
+// Peerstore: a node's local book of what it knows about other peers. This
+// example drives the store directly — no dialing required — by taking a second
+// node's real PeerInfo and then adding, inspecting, updating and removing it
+// through the peerstore API. The generated bindings are asynchronous, so every
+// call is wrapped with the blocking helpers in common.h.
+#include "common.h"
+
+// TransportType / MuxerType ordinals, mirrored from libp2p_ffi/config.nim.
+static const int64_t TransportTcp = 1;
+static const int64_t MuxerMplex = 0;
+
+static const char *CustomProto = "/cbind/peerstore/1.0.0";
+
+// get_peers replies with a PeersResponse of peer-id strings.
+#define MAX_PEERS 16
+typedef struct {
+  atomic_int done;
+  int err_code;
+  char err[256];
+  char peerIds[MAX_PEERS][128];
+  size_t n;
+} PeersWaiter;
+
+static void on_peers(int ec, const PeersResponse *reply, const char *em,
+                     void *ud) {
+  PeersWaiter *w = (PeersWaiter *)ud;
+  w->err_code = ec;
+  if (reply) {
+    w->n = reply->peerIds.len < MAX_PEERS ? reply->peerIds.len : MAX_PEERS;
+    for (size_t i = 0; i < w->n; i++)
+      if (reply->peerIds.data[i].data)
+        snprintf(w->peerIds[i], sizeof(w->peerIds[i]), "%s",
+                 reply->peerIds.data[i].data);
+  }
+  if (em)
+    snprintf(w->err, sizeof(w->err), "%s", em);
+  atomic_store(&w->done, 1);
+}
+
+// get_peer_info replies with the full PeerStoreEntryResponse for one peer.
+typedef struct {
+  atomic_int done;
+  int err_code;
+  char err[256];
+  char addrs[MAX_ADDRS][256];
+  size_t naddrs;
+  char protocols[MAX_ADDRS][128];
+  size_t nprotocols;
+} PeerEntryWaiter;
+
+static void on_peer_entry(int ec, const PeerStoreEntryResponse *reply,
+                          const char *em, void *ud) {
+  PeerEntryWaiter *w = (PeerEntryWaiter *)ud;
+  w->err_code = ec;
+  if (reply) {
+    w->naddrs = reply->addrs.len < MAX_ADDRS ? reply->addrs.len : MAX_ADDRS;
+    for (size_t i = 0; i < w->naddrs; i++)
+      if (reply->addrs.data[i].data)
+        snprintf(w->addrs[i], sizeof(w->addrs[i]), "%s",
+                 reply->addrs.data[i].data);
+    w->nprotocols =
+        reply->protocols.len < MAX_ADDRS ? reply->protocols.len : MAX_ADDRS;
+    for (size_t i = 0; i < w->nprotocols; i++)
+      if (reply->protocols.data[i].data)
+        snprintf(w->protocols[i], sizeof(w->protocols[i]), "%s",
+                 reply->protocols.data[i].data);
+  }
+  if (em)
+    snprintf(w->err, sizeof(w->err), "%s", em);
+  atomic_store(&w->done, 1);
+}
+
+static bool get_entry(LibP2PCtx *ctx, const char *peerId, PeerEntryWaiter *w) {
+  memset(w, 0, sizeof(*w));
+  libp2p_ctx_peerstore_get_peer_info(ctx, nimffi_str(peerId), on_peer_entry, w);
+  if (!wait_done(&w->done) || w->err_code != 0) {
+    fprintf(stderr, "get_peer_info: %s\n", w->err[0] ? w->err : "unknown");
+    return false;
+  }
+  return true;
+}
+
+static bool has_protocol(const PeerEntryWaiter *w, const char *proto) {
+  for (size_t i = 0; i < w->nprotocols; i++)
+    if (strcmp(w->protocols[i], proto) == 0)
+      return true;
+  return false;
+}
+
+static LibP2PCtx *createNode(const char *listenAddr, const char *label) {
+  NimFfiStr addrSlot = nimffi_str(listenAddr);
+  Libp2pConfig cfg;
+  memset(&cfg, 0, sizeof(cfg));
+  cfg.addrs.data = &addrSlot;
+  cfg.addrs.len = 1;
+  cfg.muxer = MuxerMplex;
+  cfg.transport = TransportTcp;
+  return await_create(&cfg, label);
+}
+
+int main(void) {
+  int status = 1;
+  BoolWaiter bw;
+
+  // The "local" node owns the peerstore we drive. The "other" node only exists
+  // to hand us a real peer id and listen addresses to store.
+  LibP2PCtx *local = createNode("/ip4/127.0.0.1/tcp/5051", "local");
+  LibP2PCtx *other = createNode("/ip4/127.0.0.1/tcp/5052", "other");
+  if (!local || !other) {
+    libp2p_ctx_destroy(local);
+    libp2p_ctx_destroy(other);
+    return 1;
+  }
+
+  // Start `other` so its listen addresses are bound and reported by peer_info.
+  if (!AWAIT_BOOL(bw, libp2p_ctx_start(other, on_bool, &bw), "start other"))
+    goto cleanup;
+
+  PeerInfoWaiter other_info;
+  if (!await_peerinfo(other, &other_info, "other peerinfo"))
+    goto cleanup;
+  printf("Peer to store: %s\n", other_info.peerId);
+
+  // ── add_peer: merge addresses (and a protocol) into the address book ───────
+  NimFfiStr addrs[MAX_ADDRS];
+  for (size_t i = 0; i < other_info.naddrs; i++)
+    addrs[i] = nimffi_str(other_info.addrs[i]);
+  NimFfiStr protoSlot = nimffi_str(CustomProto);
+  AddPeerRequest addReq = {nimffi_str(other_info.peerId),
+                           {addrs, other_info.naddrs},
+                           {&protoSlot, 1}};
+  if (!AWAIT_BOOL(bw,
+                  libp2p_ctx_peerstore_add_peer(local, &addReq, on_bool, &bw),
+                  "add_peer"))
+    goto cleanup;
+  printf("Added %s with %zu address(es) and protocol %s\n", other_info.peerId,
+         other_info.naddrs, CustomProto);
+
+  // ── get_peers: the stored peer should now be listed ───────────────────────
+  PeersWaiter peers;
+  memset(&peers, 0, sizeof(peers));
+  libp2p_ctx_peerstore_get_peers(local, on_peers, &peers);
+  if (!wait_done(&peers.done) || peers.err_code != 0) {
+    fprintf(stderr, "get_peers: %s\n", peers.err[0] ? peers.err : "unknown");
+    goto cleanup;
+  }
+  bool listed = false;
+  printf("Peerstore holds %zu peer(s):\n", peers.n);
+  for (size_t i = 0; i < peers.n; i++) {
+    printf("  %s\n", peers.peerIds[i]);
+    if (strcmp(peers.peerIds[i], other_info.peerId) == 0)
+      listed = true;
+  }
+  if (!listed) {
+    fprintf(stderr, "Error: stored peer not found in get_peers\n");
+    goto cleanup;
+  }
+
+  // ── get_peer_info: read back the stored addresses and protocols ───────────
+  PeerEntryWaiter entry;
+  if (!get_entry(local, other_info.peerId, &entry))
+    goto cleanup;
+  printf("Stored entry: %zu address(es), %zu protocol(s)\n", entry.naddrs,
+         entry.nprotocols);
+  if (entry.naddrs == 0 || !has_protocol(&entry, CustomProto)) {
+    fprintf(stderr, "Error: stored entry is missing its address or protocol\n");
+    goto cleanup;
+  }
+
+  // ── set_peer_protocols: replace the protocol set, then verify the change ──
+  const char *NewProto = "/cbind/peerstore/2.0.0";
+  NimFfiStr newProtoSlot = nimffi_str(NewProto);
+  SetProtocolsRequest setReq = {nimffi_str(other_info.peerId),
+                                {&newProtoSlot, 1}};
+  if (!AWAIT_BOOL(
+          bw,
+          libp2p_ctx_peerstore_set_peer_protocols(local, &setReq, on_bool, &bw),
+          "set_peer_protocols"))
+    goto cleanup;
+  if (!get_entry(local, other_info.peerId, &entry))
+    goto cleanup;
+  if (has_protocol(&entry, CustomProto) || !has_protocol(&entry, NewProto)) {
+    fprintf(stderr,
+            "Error: set_peer_protocols did not replace the protocols\n");
+    goto cleanup;
+  }
+  printf("Protocols replaced with %s\n", NewProto);
+
+  // ── delete_peer: the store should be empty of it afterwards ───────────────
+  if (!AWAIT_BOOL(bw,
+                  libp2p_ctx_peerstore_delete_peer(
+                      local, nimffi_str(other_info.peerId), on_bool, &bw),
+                  "delete_peer"))
+    goto cleanup;
+  memset(&peers, 0, sizeof(peers));
+  libp2p_ctx_peerstore_get_peers(local, on_peers, &peers);
+  if (!wait_done(&peers.done) || peers.err_code != 0) {
+    fprintf(stderr, "get_peers: %s\n", peers.err[0] ? peers.err : "unknown");
+    goto cleanup;
+  }
+  for (size_t i = 0; i < peers.n; i++) {
+    if (strcmp(peers.peerIds[i], other_info.peerId) == 0) {
+      fprintf(stderr, "Error: peer still present after delete_peer\n");
+      goto cleanup;
+    }
+  }
+  printf("Deleted %s from the peerstore\n", other_info.peerId);
+  status = 0;
+
+cleanup:
+  AWAIT_BOOL(bw, libp2p_ctx_stop(other, on_bool, &bw), "stop other");
+  libp2p_ctx_destroy(other);
+  libp2p_ctx_destroy(local);
+  return status;
+}

--- a/cbind/examples/peerstore.c
+++ b/cbind/examples/peerstore.c
@@ -1,15 +1,13 @@
-// Peerstore: a node's local book of what it knows about other peers. This
-// example drives the store directly — no dialing required — by taking a second
-// node's real PeerInfo and then adding, inspecting, updating and removing it
-// through the peerstore API. The generated bindings are asynchronous, so every
-// call is wrapped with the blocking helpers in common.h.
+// Peerstore: a node's local record of other peers. This drives the store
+// directly — no dialing — using a second node's real PeerInfo: add the peer,
+// list it, read it back, then delete it. Calls are made blocking via common.h.
 #include "common.h"
 
 // TransportType / MuxerType ordinals, mirrored from libp2p_ffi/config.nim.
 static const int64_t TransportTcp = 1;
 static const int64_t MuxerMplex = 0;
 
-static const char *CustomProto = "/cbind/peerstore/1.0.0";
+static const char *Proto = "/cbind/peerstore/1.0.0";
 
 // get_peers replies with a PeersResponse of peer-id strings.
 #define MAX_PEERS 16
@@ -37,61 +35,49 @@ static void on_peers(int ec, const PeersResponse *reply, const char *em,
   atomic_store(&w->done, 1);
 }
 
-// get_peer_info replies with the full PeerStoreEntryResponse for one peer.
+static bool get_peers(LibP2PCtx *ctx, PeersWaiter *w) {
+  memset(w, 0, sizeof(*w));
+  libp2p_ctx_peerstore_get_peers(ctx, on_peers, w);
+  if (!wait_done(&w->done) || w->err_code != 0) {
+    fprintf(stderr, "get_peers: %s\n", w->err[0] ? w->err : "unknown");
+    return false;
+  }
+  return true;
+}
+
+static bool holds(const PeersWaiter *w, const char *peerId) {
+  for (size_t i = 0; i < w->n; i++)
+    if (strcmp(w->peerIds[i], peerId) == 0)
+      return true;
+  return false;
+}
+
+// get_peer_info replies with the full entry; we only report its counts here.
 typedef struct {
   atomic_int done;
   int err_code;
   char err[256];
-  char addrs[MAX_ADDRS][256];
-  size_t naddrs;
-  char protocols[MAX_ADDRS][128];
-  size_t nprotocols;
-} PeerEntryWaiter;
+  size_t naddrs, nprotocols;
+} EntryWaiter;
 
-static void on_peer_entry(int ec, const PeerStoreEntryResponse *reply,
-                          const char *em, void *ud) {
-  PeerEntryWaiter *w = (PeerEntryWaiter *)ud;
+static void on_entry(int ec, const PeerStoreEntryResponse *reply,
+                     const char *em, void *ud) {
+  EntryWaiter *w = (EntryWaiter *)ud;
   w->err_code = ec;
   if (reply) {
-    w->naddrs = reply->addrs.len < MAX_ADDRS ? reply->addrs.len : MAX_ADDRS;
-    for (size_t i = 0; i < w->naddrs; i++)
-      if (reply->addrs.data[i].data)
-        snprintf(w->addrs[i], sizeof(w->addrs[i]), "%s",
-                 reply->addrs.data[i].data);
-    w->nprotocols =
-        reply->protocols.len < MAX_ADDRS ? reply->protocols.len : MAX_ADDRS;
-    for (size_t i = 0; i < w->nprotocols; i++)
-      if (reply->protocols.data[i].data)
-        snprintf(w->protocols[i], sizeof(w->protocols[i]), "%s",
-                 reply->protocols.data[i].data);
+    w->naddrs = reply->addrs.len;
+    w->nprotocols = reply->protocols.len;
   }
   if (em)
     snprintf(w->err, sizeof(w->err), "%s", em);
   atomic_store(&w->done, 1);
 }
 
-static bool get_entry(LibP2PCtx *ctx, const char *peerId, PeerEntryWaiter *w) {
-  memset(w, 0, sizeof(*w));
-  libp2p_ctx_peerstore_get_peer_info(ctx, nimffi_str(peerId), on_peer_entry, w);
-  if (!wait_done(&w->done) || w->err_code != 0) {
-    fprintf(stderr, "get_peer_info: %s\n", w->err[0] ? w->err : "unknown");
-    return false;
-  }
-  return true;
-}
-
-static bool has_protocol(const PeerEntryWaiter *w, const char *proto) {
-  for (size_t i = 0; i < w->nprotocols; i++)
-    if (strcmp(w->protocols[i], proto) == 0)
-      return true;
-  return false;
-}
-
-static LibP2PCtx *createNode(const char *listenAddr, const char *label) {
-  NimFfiStr addrSlot = nimffi_str(listenAddr);
+static LibP2PCtx *createNode(const char *addr, const char *label) {
+  NimFfiStr slot = nimffi_str(addr);
   Libp2pConfig cfg;
   memset(&cfg, 0, sizeof(cfg));
-  cfg.addrs.data = &addrSlot;
+  cfg.addrs.data = &slot;
   cfg.addrs.len = 1;
   cfg.muxer = MuxerMplex;
   cfg.transport = TransportTcp;
@@ -102,8 +88,8 @@ int main(void) {
   int status = 1;
   BoolWaiter bw;
 
-  // The "local" node owns the peerstore we drive. The "other" node only exists
-  // to hand us a real peer id and listen addresses to store.
+  // `local` owns the peerstore we drive; `other` just hands us a real peer id
+  // and listen addresses to store.
   LibP2PCtx *local = createNode("/ip4/127.0.0.1/tcp/5051", "local");
   LibP2PCtx *other = createNode("/ip4/127.0.0.1/tcp/5052", "other");
   if (!local || !other) {
@@ -115,96 +101,56 @@ int main(void) {
   // Start `other` so its listen addresses are bound and reported by peer_info.
   if (!AWAIT_BOOL(bw, libp2p_ctx_start(other, on_bool, &bw), "start other"))
     goto cleanup;
-
-  PeerInfoWaiter other_info;
-  if (!await_peerinfo(other, &other_info, "other peerinfo"))
+  PeerInfoWaiter oi;
+  if (!await_peerinfo(other, &oi, "other peerinfo"))
     goto cleanup;
-  printf("Peer to store: %s\n", other_info.peerId);
+  printf("Peer to store: %s\n", oi.peerId);
 
-  // ── add_peer: merge addresses (and a protocol) into the address book ───────
+  // add_peer: merge the peer's addresses and a protocol into the store.
   NimFfiStr addrs[MAX_ADDRS];
-  for (size_t i = 0; i < other_info.naddrs; i++)
-    addrs[i] = nimffi_str(other_info.addrs[i]);
-  NimFfiStr protoSlot = nimffi_str(CustomProto);
-  AddPeerRequest addReq = {nimffi_str(other_info.peerId),
-                           {addrs, other_info.naddrs},
-                           {&protoSlot, 1}};
+  for (size_t i = 0; i < oi.naddrs; i++)
+    addrs[i] = nimffi_str(oi.addrs[i]);
+  NimFfiStr proto = nimffi_str(Proto);
+  AddPeerRequest addReq = {
+      nimffi_str(oi.peerId), {addrs, oi.naddrs}, {&proto, 1}};
   if (!AWAIT_BOOL(bw,
                   libp2p_ctx_peerstore_add_peer(local, &addReq, on_bool, &bw),
                   "add_peer"))
     goto cleanup;
-  printf("Added %s with %zu address(es) and protocol %s\n", other_info.peerId,
-         other_info.naddrs, CustomProto);
 
-  // ── get_peers: the stored peer should now be listed ───────────────────────
+  // get_peers + get_peer_info: the peer is now listed and readable.
   PeersWaiter peers;
-  memset(&peers, 0, sizeof(peers));
-  libp2p_ctx_peerstore_get_peers(local, on_peers, &peers);
-  if (!wait_done(&peers.done) || peers.err_code != 0) {
-    fprintf(stderr, "get_peers: %s\n", peers.err[0] ? peers.err : "unknown");
+  if (!get_peers(local, &peers))
+    goto cleanup;
+  EntryWaiter entry;
+  memset(&entry, 0, sizeof(entry));
+  libp2p_ctx_peerstore_get_peer_info(local, nimffi_str(oi.peerId), on_entry,
+                                     &entry);
+  if (!wait_done(&entry.done) || entry.err_code != 0) {
+    fprintf(stderr, "get_peer_info: %s\n",
+            entry.err[0] ? entry.err : "unknown");
     goto cleanup;
   }
-  bool listed = false;
-  printf("Peerstore holds %zu peer(s):\n", peers.n);
-  for (size_t i = 0; i < peers.n; i++) {
-    printf("  %s\n", peers.peerIds[i]);
-    if (strcmp(peers.peerIds[i], other_info.peerId) == 0)
-      listed = true;
-  }
-  if (!listed) {
-    fprintf(stderr, "Error: stored peer not found in get_peers\n");
-    goto cleanup;
-  }
-
-  // ── get_peer_info: read back the stored addresses and protocols ───────────
-  PeerEntryWaiter entry;
-  if (!get_entry(local, other_info.peerId, &entry))
-    goto cleanup;
-  printf("Stored entry: %zu address(es), %zu protocol(s)\n", entry.naddrs,
-         entry.nprotocols);
-  if (entry.naddrs == 0 || !has_protocol(&entry, CustomProto)) {
-    fprintf(stderr, "Error: stored entry is missing its address or protocol\n");
+  printf("Stored: %zu peer(s), entry has %zu address(es) and %zu protocol(s)\n",
+         peers.n, entry.naddrs, entry.nprotocols);
+  if (!holds(&peers, oi.peerId) || entry.naddrs == 0 || entry.nprotocols == 0) {
+    fprintf(stderr, "Error: peer was not stored correctly\n");
     goto cleanup;
   }
 
-  // ── set_peer_protocols: replace the protocol set, then verify the change ──
-  const char *NewProto = "/cbind/peerstore/2.0.0";
-  NimFfiStr newProtoSlot = nimffi_str(NewProto);
-  SetProtocolsRequest setReq = {nimffi_str(other_info.peerId),
-                                {&newProtoSlot, 1}};
-  if (!AWAIT_BOOL(
-          bw,
-          libp2p_ctx_peerstore_set_peer_protocols(local, &setReq, on_bool, &bw),
-          "set_peer_protocols"))
-    goto cleanup;
-  if (!get_entry(local, other_info.peerId, &entry))
-    goto cleanup;
-  if (has_protocol(&entry, CustomProto) || !has_protocol(&entry, NewProto)) {
-    fprintf(stderr,
-            "Error: set_peer_protocols did not replace the protocols\n");
-    goto cleanup;
-  }
-  printf("Protocols replaced with %s\n", NewProto);
-
-  // ── delete_peer: the store should be empty of it afterwards ───────────────
+  // delete_peer: the store no longer holds it.
   if (!AWAIT_BOOL(bw,
-                  libp2p_ctx_peerstore_delete_peer(
-                      local, nimffi_str(other_info.peerId), on_bool, &bw),
+                  libp2p_ctx_peerstore_delete_peer(local, nimffi_str(oi.peerId),
+                                                   on_bool, &bw),
                   "delete_peer"))
     goto cleanup;
-  memset(&peers, 0, sizeof(peers));
-  libp2p_ctx_peerstore_get_peers(local, on_peers, &peers);
-  if (!wait_done(&peers.done) || peers.err_code != 0) {
-    fprintf(stderr, "get_peers: %s\n", peers.err[0] ? peers.err : "unknown");
+  if (!get_peers(local, &peers))
+    goto cleanup;
+  if (holds(&peers, oi.peerId)) {
+    fprintf(stderr, "Error: peer still present after delete_peer\n");
     goto cleanup;
   }
-  for (size_t i = 0; i < peers.n; i++) {
-    if (strcmp(peers.peerIds[i], other_info.peerId) == 0) {
-      fprintf(stderr, "Error: peer still present after delete_peer\n");
-      goto cleanup;
-    }
-  }
-  printf("Deleted %s from the peerstore\n", other_info.peerId);
+  printf("Deleted %s\n", oi.peerId);
   status = 0;
 
 cleanup:

--- a/cbind/examples/relay.c
+++ b/cbind/examples/relay.c
@@ -1,0 +1,268 @@
+// Circuit relay: three TCP nodes — a relay, a destination and a source. The
+// destination reserves a slot on the relay; the source then reaches it over a
+// `/p2p-circuit` address and runs the same echo exchange as echo.c, but relayed
+// rather than direct. Used when the source can't dial the destination directly
+// (NAT, firewall, incompatible transport) but both can reach the relay.
+//
+// The generated bindings are asynchronous, so every call is wrapped with the
+// blocking helpers in common.h. As in echo.c, the destination serves its
+// incoming stream from `main` (the incoming-stream handler only hands over the
+// stream id) because calling back into the library from its dispatch thread
+// would deadlock.
+#include "common.h"
+
+// TransportType / MuxerType ordinals, mirrored from libp2p_ffi/config.nim.
+static const int64_t TransportTcp = 1;
+static const int64_t MuxerMplex = 0;
+
+static const char *EchoProto = "/cbind/relay-echo/1.0.0";
+static const int64_t EchoMaxSize = 4096;
+
+// Single-slot hand-off from the destination's incoming-stream event to main.
+static atomic_int g_have_stream = 0;
+static uint64_t g_stream_id = 0;
+
+static void onIncomingStream(const IncomingStreamEvent *evt, void *ud) {
+  (void)ud;
+  g_stream_id = evt->streamId;
+  atomic_store(&g_have_stream, 1);
+}
+
+typedef struct {
+  atomic_int done;
+  int err_code;
+  char err[256];
+  uint8_t data[4096];
+  size_t len;
+} ReadWaiter;
+
+static void on_read(int ec, const ReadResponse *reply, const char *em,
+                    void *ud) {
+  ReadWaiter *w = (ReadWaiter *)ud;
+  w->err_code = ec;
+  if (reply && reply->data.data) {
+    w->len =
+        reply->data.len < sizeof(w->data) ? reply->data.len : sizeof(w->data);
+    memcpy(w->data, reply->data.data, w->len);
+  }
+  if (em)
+    snprintf(w->err, sizeof(w->err), "%s", em);
+  atomic_store(&w->done, 1);
+}
+
+// dial_circuit_relay replies with a DialResponse carrying the new stream id.
+typedef struct {
+  atomic_int done;
+  int err_code;
+  char err[256];
+  uint64_t streamId;
+} DialWaiter;
+
+static void on_dial(int ec, const DialResponse *reply, const char *em,
+                    void *ud) {
+  DialWaiter *w = (DialWaiter *)ud;
+  w->err_code = ec;
+  if (reply)
+    w->streamId = reply->streamId;
+  if (em)
+    snprintf(w->err, sizeof(w->err), "%s", em);
+  atomic_store(&w->done, 1);
+}
+
+// circuit_relay_reserve replies with the reservation's relay addresses and its
+// expiry (unix seconds). We only need the reservation to succeed here; the
+// circuit address the source dials is built from the relay's PeerInfo below.
+typedef struct {
+  atomic_int done;
+  int err_code;
+  char err[256];
+  uint64_t expireTime;
+} ReserveWaiter;
+
+static void on_reserve(int ec, const ReservationResponse *reply, const char *em,
+                       void *ud) {
+  ReserveWaiter *w = (ReserveWaiter *)ud;
+  w->err_code = ec;
+  if (reply)
+    w->expireTime = reply->expireTime;
+  if (em)
+    snprintf(w->err, sizeof(w->err), "%s", em);
+  atomic_store(&w->done, 1);
+}
+
+// Reads the request off the accepted stream, echoes it back and releases it.
+// The destination side runs on `main`, just like the server in echo.c.
+static bool serveEcho(LibP2PCtx *dst) {
+  if (!wait_done(&g_have_stream)) {
+    fprintf(stderr, "dst: no incoming stream\n");
+    return false;
+  }
+  uint64_t streamId = g_stream_id;
+
+  ReadWaiter rw;
+  memset(&rw, 0, sizeof(rw));
+  StreamReadLpRequest readReq = {streamId, EchoMaxSize};
+  libp2p_ctx_stream_read_lp(dst, &readReq, on_read, &rw);
+  if (!wait_done(&rw.done) || rw.err_code != 0) {
+    fprintf(stderr, "dst read: %s\n", rw.err[0] ? rw.err : "unknown");
+    return false;
+  }
+
+  BoolWaiter bw;
+  NimFfiBytes payload = {rw.data, rw.len};
+  StreamWriteRequest writeReq = {streamId, payload};
+  bool ok =
+      AWAIT_BOOL(bw, libp2p_ctx_stream_write_lp(dst, &writeReq, on_bool, &bw),
+                 "dst write");
+  AWAIT_BOOL(bw, libp2p_ctx_stream_release(dst, streamId, on_bool, &bw),
+             "dst release");
+  return ok;
+}
+
+// The relay is a circuit-relay server (circuitRelay); source and destination
+// are relay clients (circuitRelayClient) so they can reserve slots and dial
+// `/p2p-circuit` addresses.
+static LibP2PCtx *relayNode(const char *listenAddr, const char *label,
+                            bool asClient) {
+  NimFfiStr addrSlot = nimffi_str(listenAddr);
+  Libp2pConfig cfg;
+  memset(&cfg, 0, sizeof(cfg));
+  cfg.addrs.data = &addrSlot;
+  cfg.addrs.len = 1;
+  cfg.muxer = MuxerMplex;
+  cfg.transport = TransportTcp;
+  cfg.circuitRelay = !asClient;
+  cfg.circuitRelayClient = asClient;
+  return await_create(&cfg, label);
+}
+
+static bool connectTo(LibP2PCtx *from, const PeerInfoWaiter *to,
+                      const char *label) {
+  NimFfiStr connAddrs[MAX_ADDRS];
+  for (size_t i = 0; i < to->naddrs; i++)
+    connAddrs[i] = nimffi_str(to->addrs[i]);
+  ConnectRequest req = {nimffi_str(to->peerId), {connAddrs, to->naddrs}, 0};
+  BoolWaiter bw;
+  return AWAIT_BOOL(bw, libp2p_ctx_connect(from, &req, on_bool, &bw), label);
+}
+
+int main(void) {
+  int status = 1;
+  BoolWaiter bw;
+
+  LibP2PCtx *relay = relayNode("/ip4/127.0.0.1/tcp/5061", "relay", false);
+  LibP2PCtx *dst = relayNode("/ip4/127.0.0.1/tcp/5062", "dst", true);
+  LibP2PCtx *src = relayNode("/ip4/127.0.0.1/tcp/5063", "src", true);
+  if (!relay || !dst || !src) {
+    libp2p_ctx_destroy(relay);
+    libp2p_ctx_destroy(dst);
+    libp2p_ctx_destroy(src);
+    return 1;
+  }
+
+  libp2p_ctx_add_on_incoming_stream_listener(dst, onIncomingStream, NULL);
+
+  // Mount the echo protocol on dst before starting so it is advertised, then
+  // start all three nodes.
+  if (!AWAIT_BOOL(
+          bw,
+          libp2p_ctx_mount_protocol(dst, nimffi_str(EchoProto), on_bool, &bw),
+          "mount_protocol") ||
+      !AWAIT_BOOL(bw, libp2p_ctx_start(relay, on_bool, &bw), "start relay") ||
+      !AWAIT_BOOL(bw, libp2p_ctx_start(dst, on_bool, &bw), "start dst") ||
+      !AWAIT_BOOL(bw, libp2p_ctx_start(src, on_bool, &bw), "start src"))
+    goto cleanup;
+
+  PeerInfoWaiter relayInfo, dstInfo;
+  if (!await_peerinfo(relay, &relayInfo, "relay peerinfo") ||
+      !await_peerinfo(dst, &dstInfo, "dst peerinfo"))
+    goto cleanup;
+  if (relayInfo.naddrs == 0) {
+    fprintf(stderr, "Error: relay has no listen address\n");
+    goto cleanup;
+  }
+  printf("Relay: %s\n", relayInfo.peerId);
+  printf("Dst:   %s\n", dstInfo.peerId);
+
+  // Dst connects to the relay and reserves a slot so the relay will forward
+  // circuit traffic addressed to it.
+  if (!connectTo(dst, &relayInfo, "dst -> relay"))
+    goto cleanup;
+
+  NimFfiStr relayAddrs[MAX_ADDRS];
+  for (size_t i = 0; i < relayInfo.naddrs; i++)
+    relayAddrs[i] = nimffi_str(relayInfo.addrs[i]);
+  CircuitRelayReserveRequest resReq = {nimffi_str(relayInfo.peerId),
+                                       {relayAddrs, relayInfo.naddrs}};
+  ReserveWaiter resw;
+  memset(&resw, 0, sizeof(resw));
+  libp2p_ctx_circuit_relay_reserve(dst, &resReq, on_reserve, &resw);
+  if (!wait_done(&resw.done) || resw.err_code != 0) {
+    fprintf(stderr, "reserve: %s\n", resw.err[0] ? resw.err : "unknown");
+    goto cleanup;
+  }
+  printf("Dst reserved a relay slot (expires at unix %llu)\n",
+         (unsigned long long)resw.expireTime);
+
+  // The circuit address the source dials: the relay's transport address, its
+  // peer id, then /p2p-circuit. The source connects to the relay implicitly
+  // while dialing it.
+  char circuit[512];
+  snprintf(circuit, sizeof(circuit), "%s/p2p/%s/p2p-circuit",
+           relayInfo.addrs[0], relayInfo.peerId);
+  printf("Src dialing dst via: %s\n", circuit);
+
+  DialWaiter dw;
+  memset(&dw, 0, sizeof(dw));
+  DialCircuitRelayRequest dialReq = {nimffi_str(dstInfo.peerId),
+                                     nimffi_str(circuit), nimffi_str(EchoProto),
+                                     0};
+  libp2p_ctx_dial_circuit_relay(src, &dialReq, on_dial, &dw);
+  if (!wait_done(&dw.done) || dw.err_code != 0) {
+    fprintf(stderr, "dial_circuit_relay: %s\n", dw.err[0] ? dw.err : "unknown");
+    goto cleanup;
+  }
+  uint64_t streamId = dw.streamId;
+
+  const char *sent = "hello over the relay";
+  printf("Src sending: %s\n", sent);
+  NimFfiBytes sentBytes = {(uint8_t *)sent, strlen(sent)};
+  StreamWriteRequest writeReq = {streamId, sentBytes};
+  if (!AWAIT_BOOL(bw, libp2p_ctx_stream_write_lp(src, &writeReq, on_bool, &bw),
+                  "stream_write_lp"))
+    goto cleanup;
+
+  // The destination serves the relayed stream on this thread, then the source
+  // reads the echo back.
+  if (!serveEcho(dst))
+    goto cleanup;
+
+  ReadWaiter rw;
+  memset(&rw, 0, sizeof(rw));
+  StreamReadLpRequest readReq = {streamId, EchoMaxSize};
+  libp2p_ctx_stream_read_lp(src, &readReq, on_read, &rw);
+  if (!wait_done(&rw.done) || rw.err_code != 0) {
+    fprintf(stderr, "stream_read_lp: %s\n", rw.err[0] ? rw.err : "unknown");
+    goto cleanup;
+  }
+  printf("Src received: %.*s\n", (int)rw.len, (const char *)rw.data);
+
+  if (rw.len == strlen(sent) && memcmp(rw.data, sent, rw.len) == 0)
+    status = 0;
+  else
+    fprintf(stderr, "Error: relayed echo did not match\n");
+
+  AWAIT_BOOL(bw, libp2p_ctx_stream_close_with_eof(src, streamId, on_bool, &bw),
+             "stream_close_with_eof");
+  AWAIT_BOOL(bw, libp2p_ctx_stream_release(src, streamId, on_bool, &bw),
+             "stream_release");
+
+cleanup:
+  AWAIT_BOOL(bw, libp2p_ctx_stop(src, on_bool, &bw), "stop src");
+  AWAIT_BOOL(bw, libp2p_ctx_stop(dst, on_bool, &bw), "stop dst");
+  AWAIT_BOOL(bw, libp2p_ctx_stop(relay, on_bool, &bw), "stop relay");
+  libp2p_ctx_destroy(src);
+  libp2p_ctx_destroy(dst);
+  libp2p_ctx_destroy(relay);
+  return status;
+}

--- a/cbind/examples/relay.c
+++ b/cbind/examples/relay.c
@@ -1,22 +1,15 @@
-// Circuit relay: three TCP nodes — a relay, a destination and a source. The
-// destination reserves a slot on the relay; the source then reaches it over a
-// `/p2p-circuit` address and runs the same echo exchange as echo.c, but relayed
-// rather than direct. Used when the source can't dial the destination directly
-// (NAT, firewall, incompatible transport) but both can reach the relay.
-//
-// The generated bindings are asynchronous, so every call is wrapped with the
-// blocking helpers in common.h. As in echo.c, the destination serves its
-// incoming stream from `main` (the incoming-stream handler only hands over the
-// stream id) because calling back into the library from its dispatch thread
-// would deadlock.
+// Circuit relay: a relay, a destination and a source. The destination reserves
+// a slot on the relay (circuit_relay_reserve); the source then reaches it over
+// a /p2p-circuit address (dial_circuit_relay) and sends one message, which the
+// destination reads off its relayed stream. As in echo.c the destination serves
+// its incoming stream from main. Calls are made blocking via common.h.
 #include "common.h"
 
 // TransportType / MuxerType ordinals, mirrored from libp2p_ffi/config.nim.
 static const int64_t TransportTcp = 1;
 static const int64_t MuxerMplex = 0;
 
-static const char *EchoProto = "/cbind/relay-echo/1.0.0";
-static const int64_t EchoMaxSize = 4096;
+static const char *Proto = "/cbind/relay/1.0.0";
 
 // Single-slot hand-off from the destination's incoming-stream event to main.
 static atomic_int g_have_stream = 0;
@@ -50,7 +43,6 @@ static void on_read(int ec, const ReadResponse *reply, const char *em,
   atomic_store(&w->done, 1);
 }
 
-// dial_circuit_relay replies with a DialResponse carrying the new stream id.
 typedef struct {
   atomic_int done;
   int err_code;
@@ -69,90 +61,40 @@ static void on_dial(int ec, const DialResponse *reply, const char *em,
   atomic_store(&w->done, 1);
 }
 
-// circuit_relay_reserve replies with the reservation's relay addresses and its
-// expiry (unix seconds). We only need the reservation to succeed here; the
-// circuit address the source dials is built from the relay's PeerInfo below.
-typedef struct {
-  atomic_int done;
-  int err_code;
-  char err[256];
-  uint64_t expireTime;
-} ReserveWaiter;
-
+// reserve replies with a ReservationResponse we don't inspect; reuse
+// BoolWaiter.
 static void on_reserve(int ec, const ReservationResponse *reply, const char *em,
                        void *ud) {
-  ReserveWaiter *w = (ReserveWaiter *)ud;
+  (void)reply;
+  BoolWaiter *w = (BoolWaiter *)ud;
   w->err_code = ec;
-  if (reply)
-    w->expireTime = reply->expireTime;
   if (em)
     snprintf(w->err, sizeof(w->err), "%s", em);
   atomic_store(&w->done, 1);
 }
 
-// Reads the request off the accepted stream, echoes it back and releases it.
-// The destination side runs on `main`, just like the server in echo.c.
-static bool serveEcho(LibP2PCtx *dst) {
-  if (!wait_done(&g_have_stream)) {
-    fprintf(stderr, "dst: no incoming stream\n");
-    return false;
-  }
-  uint64_t streamId = g_stream_id;
-
-  ReadWaiter rw;
-  memset(&rw, 0, sizeof(rw));
-  StreamReadLpRequest readReq = {streamId, EchoMaxSize};
-  libp2p_ctx_stream_read_lp(dst, &readReq, on_read, &rw);
-  if (!wait_done(&rw.done) || rw.err_code != 0) {
-    fprintf(stderr, "dst read: %s\n", rw.err[0] ? rw.err : "unknown");
-    return false;
-  }
-
-  BoolWaiter bw;
-  NimFfiBytes payload = {rw.data, rw.len};
-  StreamWriteRequest writeReq = {streamId, payload};
-  bool ok =
-      AWAIT_BOOL(bw, libp2p_ctx_stream_write_lp(dst, &writeReq, on_bool, &bw),
-                 "dst write");
-  AWAIT_BOOL(bw, libp2p_ctx_stream_release(dst, streamId, on_bool, &bw),
-             "dst release");
-  return ok;
-}
-
-// The relay is a circuit-relay server (circuitRelay); source and destination
-// are relay clients (circuitRelayClient) so they can reserve slots and dial
-// `/p2p-circuit` addresses.
-static LibP2PCtx *relayNode(const char *listenAddr, const char *label,
-                            bool asClient) {
-  NimFfiStr addrSlot = nimffi_str(listenAddr);
+// The relay is a circuit-relay server; source and destination are relay clients
+// so they can reserve slots and dial /p2p-circuit addresses.
+static LibP2PCtx *createNode(const char *addr, const char *label, bool client) {
+  NimFfiStr slot = nimffi_str(addr);
   Libp2pConfig cfg;
   memset(&cfg, 0, sizeof(cfg));
-  cfg.addrs.data = &addrSlot;
+  cfg.addrs.data = &slot;
   cfg.addrs.len = 1;
   cfg.muxer = MuxerMplex;
   cfg.transport = TransportTcp;
-  cfg.circuitRelay = !asClient;
-  cfg.circuitRelayClient = asClient;
+  cfg.circuitRelay = !client;
+  cfg.circuitRelayClient = client;
   return await_create(&cfg, label);
-}
-
-static bool connectTo(LibP2PCtx *from, const PeerInfoWaiter *to,
-                      const char *label) {
-  NimFfiStr connAddrs[MAX_ADDRS];
-  for (size_t i = 0; i < to->naddrs; i++)
-    connAddrs[i] = nimffi_str(to->addrs[i]);
-  ConnectRequest req = {nimffi_str(to->peerId), {connAddrs, to->naddrs}, 0};
-  BoolWaiter bw;
-  return AWAIT_BOOL(bw, libp2p_ctx_connect(from, &req, on_bool, &bw), label);
 }
 
 int main(void) {
   int status = 1;
   BoolWaiter bw;
 
-  LibP2PCtx *relay = relayNode("/ip4/127.0.0.1/tcp/5061", "relay", false);
-  LibP2PCtx *dst = relayNode("/ip4/127.0.0.1/tcp/5062", "dst", true);
-  LibP2PCtx *src = relayNode("/ip4/127.0.0.1/tcp/5063", "src", true);
+  LibP2PCtx *relay = createNode("/ip4/127.0.0.1/tcp/5061", "relay", false);
+  LibP2PCtx *dst = createNode("/ip4/127.0.0.1/tcp/5062", "dst", true);
+  LibP2PCtx *src = createNode("/ip4/127.0.0.1/tcp/5063", "src", true);
   if (!relay || !dst || !src) {
     libp2p_ctx_destroy(relay);
     libp2p_ctx_destroy(dst);
@@ -162,12 +104,9 @@ int main(void) {
 
   libp2p_ctx_add_on_incoming_stream_listener(dst, onIncomingStream, NULL);
 
-  // Mount the echo protocol on dst before starting so it is advertised, then
-  // start all three nodes.
   if (!AWAIT_BOOL(
-          bw,
-          libp2p_ctx_mount_protocol(dst, nimffi_str(EchoProto), on_bool, &bw),
-          "mount_protocol") ||
+          bw, libp2p_ctx_mount_protocol(dst, nimffi_str(Proto), on_bool, &bw),
+          "mount") ||
       !AWAIT_BOOL(bw, libp2p_ctx_start(relay, on_bool, &bw), "start relay") ||
       !AWAIT_BOOL(bw, libp2p_ctx_start(dst, on_bool, &bw), "start dst") ||
       !AWAIT_BOOL(bw, libp2p_ctx_start(src, on_bool, &bw), "start src"))
@@ -175,87 +114,70 @@ int main(void) {
 
   PeerInfoWaiter relayInfo, dstInfo;
   if (!await_peerinfo(relay, &relayInfo, "relay peerinfo") ||
-      !await_peerinfo(dst, &dstInfo, "dst peerinfo"))
+      !await_peerinfo(dst, &dstInfo, "dst peerinfo") || relayInfo.naddrs == 0)
     goto cleanup;
-  if (relayInfo.naddrs == 0) {
-    fprintf(stderr, "Error: relay has no listen address\n");
-    goto cleanup;
-  }
-  printf("Relay: %s\n", relayInfo.peerId);
-  printf("Dst:   %s\n", dstInfo.peerId);
+  printf("Relay: %s\nDst:   %s\n", relayInfo.peerId, dstInfo.peerId);
 
-  // Dst connects to the relay and reserves a slot so the relay will forward
-  // circuit traffic addressed to it.
-  if (!connectTo(dst, &relayInfo, "dst -> relay"))
-    goto cleanup;
-
+  // Dst connects to the relay and reserves a slot so the relay forwards circuit
+  // traffic addressed to it.
   NimFfiStr relayAddrs[MAX_ADDRS];
   for (size_t i = 0; i < relayInfo.naddrs; i++)
     relayAddrs[i] = nimffi_str(relayInfo.addrs[i]);
+  ConnectRequest connReq = {
+      nimffi_str(relayInfo.peerId), {relayAddrs, relayInfo.naddrs}, 0};
+  if (!AWAIT_BOOL(bw, libp2p_ctx_connect(dst, &connReq, on_bool, &bw),
+                  "dst -> relay"))
+    goto cleanup;
   CircuitRelayReserveRequest resReq = {nimffi_str(relayInfo.peerId),
                                        {relayAddrs, relayInfo.naddrs}};
-  ReserveWaiter resw;
-  memset(&resw, 0, sizeof(resw));
-  libp2p_ctx_circuit_relay_reserve(dst, &resReq, on_reserve, &resw);
-  if (!wait_done(&resw.done) || resw.err_code != 0) {
-    fprintf(stderr, "reserve: %s\n", resw.err[0] ? resw.err : "unknown");
+  if (!AWAIT_BOOL(
+          bw, libp2p_ctx_circuit_relay_reserve(dst, &resReq, on_reserve, &bw),
+          "reserve"))
     goto cleanup;
-  }
-  printf("Dst reserved a relay slot (expires at unix %llu)\n",
-         (unsigned long long)resw.expireTime);
 
-  // The circuit address the source dials: the relay's transport address, its
-  // peer id, then /p2p-circuit. The source connects to the relay implicitly
-  // while dialing it.
+  // Circuit address: the relay's transport address, its peer id, /p2p-circuit.
+  // Dialing it connects the source to the relay implicitly.
   char circuit[512];
   snprintf(circuit, sizeof(circuit), "%s/p2p/%s/p2p-circuit",
            relayInfo.addrs[0], relayInfo.peerId);
-  printf("Src dialing dst via: %s\n", circuit);
-
   DialWaiter dw;
   memset(&dw, 0, sizeof(dw));
   DialCircuitRelayRequest dialReq = {nimffi_str(dstInfo.peerId),
-                                     nimffi_str(circuit), nimffi_str(EchoProto),
-                                     0};
+                                     nimffi_str(circuit), nimffi_str(Proto), 0};
   libp2p_ctx_dial_circuit_relay(src, &dialReq, on_dial, &dw);
   if (!wait_done(&dw.done) || dw.err_code != 0) {
     fprintf(stderr, "dial_circuit_relay: %s\n", dw.err[0] ? dw.err : "unknown");
     goto cleanup;
   }
-  uint64_t streamId = dw.streamId;
 
-  const char *sent = "hello over the relay";
-  printf("Src sending: %s\n", sent);
-  NimFfiBytes sentBytes = {(uint8_t *)sent, strlen(sent)};
-  StreamWriteRequest writeReq = {streamId, sentBytes};
-  if (!AWAIT_BOOL(bw, libp2p_ctx_stream_write_lp(src, &writeReq, on_bool, &bw),
-                  "stream_write_lp"))
+  const char *msg = "hello over the relay";
+  printf("Src sending via %s: %s\n", circuit, msg);
+  NimFfiBytes bytes = {(uint8_t *)msg, strlen(msg)};
+  StreamWriteRequest wr = {dw.streamId, bytes};
+  if (!AWAIT_BOOL(bw, libp2p_ctx_stream_write_lp(src, &wr, on_bool, &bw),
+                  "write"))
     goto cleanup;
 
-  // The destination serves the relayed stream on this thread, then the source
-  // reads the echo back.
-  if (!serveEcho(dst))
-    goto cleanup;
-
-  ReadWaiter rw;
-  memset(&rw, 0, sizeof(rw));
-  StreamReadLpRequest readReq = {streamId, EchoMaxSize};
-  libp2p_ctx_stream_read_lp(src, &readReq, on_read, &rw);
-  if (!wait_done(&rw.done) || rw.err_code != 0) {
-    fprintf(stderr, "stream_read_lp: %s\n", rw.err[0] ? rw.err : "unknown");
+  // Dst serves its relayed stream from this thread: read and verify.
+  if (!wait_done(&g_have_stream)) {
+    fprintf(stderr, "dst: no incoming stream\n");
     goto cleanup;
   }
-  printf("Src received: %.*s\n", (int)rw.len, (const char *)rw.data);
-
-  if (rw.len == strlen(sent) && memcmp(rw.data, sent, rw.len) == 0)
+  ReadWaiter rw;
+  memset(&rw, 0, sizeof(rw));
+  StreamReadLpRequest rd = {g_stream_id, 4096};
+  libp2p_ctx_stream_read_lp(dst, &rd, on_read, &rw);
+  if (!wait_done(&rw.done) || rw.err_code != 0) {
+    fprintf(stderr, "dst read: %s\n", rw.err[0] ? rw.err : "unknown");
+    goto cleanup;
+  }
+  printf("Dst received: %.*s\n", (int)rw.len, (const char *)rw.data);
+  if (rw.len == strlen(msg) && memcmp(rw.data, msg, rw.len) == 0)
     status = 0;
   else
-    fprintf(stderr, "Error: relayed echo did not match\n");
-
-  AWAIT_BOOL(bw, libp2p_ctx_stream_close_with_eof(src, streamId, on_bool, &bw),
-             "stream_close_with_eof");
-  AWAIT_BOOL(bw, libp2p_ctx_stream_release(src, streamId, on_bool, &bw),
-             "stream_release");
+    fprintf(stderr, "Error: relayed message did not match\n");
+  AWAIT_BOOL(bw, libp2p_ctx_stream_release(dst, g_stream_id, on_bool, &bw),
+             "dst release");
 
 cleanup:
   AWAIT_BOOL(bw, libp2p_ctx_stop(src, on_bool, &bw), "stop src");

--- a/cbind/libp2p_ffi.nim
+++ b/cbind/libp2p_ffi.nim
@@ -1,16 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-## C FFI bindings for nim-libp2p, built on top of `nim-ffi`.
-##
-## `nim-ffi` provides the FFI runtime and generates the C/CDDL bindings. This
-## file only declares the library state, the request/response shapes and the
-## libp2p-specific bodies; `genBindings()` at the bottom emits the foreign
-## bindings consumed by `logos-co/logos-libp2p-module`.
-##
-## The `{.ffi.}` config types and all of their parsing live in
-## `libp2p_ffi/config.nim`, `include`d below — see that file for the
-## `config.parse()` entry point and for why it is included rather than imported.
+## C FFI bindings for nim-libp2p, on top of `nim-ffi` (the FFI runtime + C/CDDL
+## generator). Declares the request/response shapes and libp2p bodies that
+## `genBindings()` emits at the bottom; config parsing lives in the `include`d `config`.
 
 import ffi
 
@@ -32,11 +25,9 @@ import ../libp2p/protocols/connectivity/relay/client
 import ../libp2p/extended_peer_record
 
 type StreamRegistry = ref object
-  ## Owns the live streams handed out across the FFI boundary and the
-  ## release-waiter futures that keep custom-protocol handlers alive until the
-  ## host is done with the stream. A `ref` so the custom-protocol handler can
-  ## capture it directly instead of the whole `LibP2P`, which would form a
-  ## `lib -> customProtocols -> handler -> lib` cycle that `--mm:refc` leaks.
+  ## Owns the live streams handed across the FFI boundary and the release-waiter
+  ## futures keeping custom-protocol handlers alive until the host is done. A `ref`
+  ## so a handler captures it alone, avoiding a `lib` cycle that leaks under `--mm:refc`.
   streams: Table[uint64, Stream]
   nextStreamId: uint64
   releaseWaiters: Table[uint64, Future[void].Raising([CancelledError])]
@@ -236,8 +227,7 @@ proc mountGossipsub(lib: LibP2P, triggerSelf: bool): Result[void, string] =
   ok()
 
 proc defaultKadConfig(): KadDHTConfig =
-  # Validator/selector are host callbacks that can't cross the FFI boundary, so
-  # fall back to the defaults.
+  # Validator/selector are host callbacks that can't cross the FFI boundary; use the defaults.
   KadDHTConfig.new(
     validator = DefaultEntryValidator(), selector = DefaultEntrySelector()
   )
@@ -387,13 +377,11 @@ proc libp2pStop*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} =
 
 proc libp2pDestroy*(lib: LibP2P): Future[void] {.ffiDtor.} =
   ## Owns the full teardown: the FFI runtime runs this on the worker loop at
-  ## shutdown, so the switch is gracefully stopped before the threads are joined
-  ## and the context is freed. Destroy alone is sufficient; libp2pStop is
-  ## optional and only useful for an explicit, error-reporting shutdown.
+  ## shutdown, so the switch stops gracefully before threads join and the context is
+  ## freed. Sufficient on its own; libp2pStop is optional, for explicit shutdown.
   await shutdownSwitch(lib)
 
-# Hand-maintained C-ABI mirror of `Libp2pConfig`: the `{.ffi.}` config crosses as
-# CBOR, not a C struct, so it's absent from the generated bindings. Keep in sync.
+# Hand-maintained C-ABI mirror of `Libp2pConfig`: the `{.ffi.}` config crosses as CBOR, not a C struct, so it's absent from the generated bindings. Keep in sync.
 type CLibp2pConfig {.exportc: "libp2p_config", bycopy.} = object
   mountGossipsub: cint
   gossipsubTriggerSelf: cint
@@ -428,8 +416,7 @@ proc libp2pPublicKey*(lib: LibP2P): Future[Result[seq[byte], string]] {.ffi.} =
   if peerInfo.isNil():
     return err("switch peerInfo is nil")
 
-  # Scheme-native serialization, so whatever key the switch was built with
-  # round-trips — not just secp256k1. The default builder uses Ed25519.
+  # Scheme-native serialization: whatever key the switch was built with round-trips, not just secp256k1 (the default builder uses Ed25519).
   let rawBytes = peerInfo.publicKey.getRawBytes().valueOr:
     return err("could not serialize public key: " & $error)
   ok(rawBytes)
@@ -446,9 +433,7 @@ func dialTimeout(timeoutMs: int64): Duration =
 proc libp2pConnect*(
     lib: LibP2P, req: ConnectRequest
 ): Future[Result[bool, string]] {.ffi: "timeout = 30000".} =
-  # The FFI runtime caps every handler at a 5s default; a dial+upgrade can take
-  # up to libp2p's 30s UpgradeTimeout, so raise the backstop to match. The
-  # per-call `req.timeoutMs` bounds the dial itself whenever it is shorter.
+  # Raise the FFI handler backstop (5s default) to libp2p's 30s UpgradeTimeout; `req.timeoutMs` bounds the dial itself when shorter.
   let multiaddresses = parseMultiaddrs(req.multiaddrs).valueOr:
     return err(error)
 
@@ -499,10 +484,7 @@ proc libp2pConnectedPeers*(
 proc libp2pDial*(
     lib: LibP2P, req: DialRequest
 ): Future[Result[DialResponse, string]] {.ffi: "timeout = 30000".} =
-  # See libp2pConnect: a dial can run to the 30s UpgradeTimeout, so the handler
-  # needs more than the FFI runtime's 5s default or the caller is unblocked with
-  # a spurious timeout while this handler keeps running and leaks the streamId.
-  # `req.timeoutMs` bounds the dial itself.
+  # Same 30s backstop as libp2pConnect (else a slow dial trips a spurious timeout and leaks the streamId); `req.timeoutMs` bounds the dial itself.
   let peerId = PeerId.init(req.peerId).valueOr:
     return err($error)
   let stream =
@@ -534,10 +516,8 @@ proc libp2pDialCircuitRelay*(
 
 func validateReadLength(n: int64): Result[int, string] =
   ## Guards attacker-controlled read lengths before they size an allocation:
-  ## rejects negatives and anything past the `MaxReadBytes` DoS ceiling. The
-  ## ceiling (64 MiB) sits well below `int.high` even on 32-bit targets, so the
-  ## `int(n)` narrowing below is always safe; `int.high` stays as a backstop in
-  ## case the ceiling is ever raised.
+  ## rejects negatives and anything past the `MaxReadBytes` ceiling (64 MiB), which
+  ## sits well below `int.high` even on 32-bit, so the `int(n)` narrowing is always safe.
   if n < 0:
     return err("invalid read length")
   if n > MaxReadBytes:
@@ -625,8 +605,7 @@ proc libp2pMountProtocol*(
   if lib.customProtocols.hasKey(proto) or proto in peerInfo.protocols:
     return err("protocol already mounted: " & proto)
 
-  # Capture the registry ref, not `lib`: a closure over `lib` stored back into
-  # `lib.customProtocols` would cycle and leak under `--mm:refc`.
+  # Capture the registry ref, not `lib`: a closure over `lib` stored back into `lib.customProtocols` would cycle and leak under `--mm:refc`.
   let streams = lib.streams
   proc handle(
       stream: Stream, selectedProto: string
@@ -1074,7 +1053,7 @@ proc parseMetricHelp(helpLine: string): string =
   ## `helpLine` is the collector's pre-formatted "# HELP <name> <text>\n";
   ## returns <text> (which itself may contain whitespace), or "" when absent.
   const PrefixTokens = 3 # "#", "HELP", "<name>"
-  let tokens = helpLine.splitWhitespace(maxsplit = PrefixTokens)
+  let tokens = helpLine.splitWhitespace(PrefixTokens)
   if tokens.len <= PrefixTokens:
     return ""
   tokens[PrefixTokens].strip()

--- a/cbind/libp2p_ffi.nim
+++ b/cbind/libp2p_ffi.nim
@@ -8,7 +8,7 @@
 import ffi
 
 import std/[tables, sequtils, sets, json, jsonutils, strutils, locks]
-from std/times import getTime, toUnix, Time, toMilliseconds
+from std/times import getTime, toUnix, Time, nanosecond
 import metrics
 
 import ../libp2p
@@ -1058,6 +1058,11 @@ proc parseMetricHelp(helpLine: string): string =
     return ""
   tokens[PrefixTokens].strip()
 
+func toUnixMillis(t: Time): int64 =
+  ## Milliseconds since the Unix epoch. `std/times` has no `toMilliseconds` on
+  ## Nim 2.2.4, so build it from the second and nanosecond components.
+  t.toUnix() * 1000 + t.nanosecond div 1_000_000
+
 proc addMetricEntry(
     entries: ptr seq[MetricEntry],
     metricType: string,
@@ -1080,7 +1085,7 @@ proc addMetricEntry(
     help: help,
     labels: labelPairs,
     value: value,
-    timestamp: timestamp.toMilliseconds(),
+    timestamp: timestamp.toUnixMillis(),
   )
 
 proc collectRegistryMetrics(registry: Registry): seq[MetricEntry] {.gcsafe.} =

--- a/cbind/libp2p_ffi.nim
+++ b/cbind/libp2p_ffi.nim
@@ -14,8 +14,9 @@
 
 import ffi
 
-import std/[tables, sequtils]
-from std/times import getTime, toUnix
+import std/[tables, sequtils, sets, json, jsonutils, strutils, locks]
+from std/times import getTime, toUnix, Time, toMilliseconds
+import metrics
 
 import ../libp2p
 import ../libp2p/[multiaddress, peerid]
@@ -157,6 +158,35 @@ type DecodeXprRequest {.ffi.} = object
 type LookupRequest {.ffi.} = object
   serviceId: string
   serviceData: seq[byte]
+
+type ReservationResponse {.ffi.} = object
+  addrs: seq[string]
+  expireTime: uint64
+
+type CircuitRelayReserveRequest {.ffi.} = object
+  relayPeerId: string
+  relayAddrs: seq[string]
+
+type AddPeerRequest {.ffi.} = object
+  peerId: string
+  addrs: seq[string]
+  protocols: seq[string]
+
+type SetAddressesRequest {.ffi.} = object
+  peerId: string
+  addrs: seq[string]
+
+type SetProtocolsRequest {.ffi.} = object
+  peerId: string
+  protocols: seq[string]
+
+type PeerStoreEntryResponse {.ffi.} = object
+  peerId: string
+  addrs: seq[string]
+  protocols: seq[string]
+  publicKey: seq[byte]
+  agentVersion: string
+  protoVersion: string
 
 type IncomingStreamEvent {.ffi.} = object
   proto: string
@@ -882,6 +912,103 @@ proc libp2pDecodeXpr*(
 
   ok(toExtendedRecordEntry(sxpr.data))
 
+proc libp2pCircuitRelayReserve*(
+    lib: LibP2P, req: CircuitRelayReserveRequest
+): Future[Result[ReservationResponse, string]] {.ffi.} =
+  let cl = lib.relayClient.valueOr:
+    return err("relay client is not mounted (set circuitRelayClient=true in config)")
+
+  let peerId = PeerId.init(req.relayPeerId).valueOr:
+    return err($error)
+
+  let multiaddresses = parseMultiaddrs(req.relayAddrs).valueOr:
+    return err(error)
+
+  let rsvp =
+    try:
+      await cl.reserve(peerId, multiaddresses)
+    except ReservationError as e:
+      return err("reservation failed: " & e.msg)
+    except DialFailedError as e:
+      return err("dial failed: " & e.msg)
+
+  ok(ReservationResponse(addrs: rsvp.addrs.mapIt($it), expireTime: rsvp.expire))
+
+proc libp2pPeerstoreGetPeers*(
+    lib: LibP2P
+): Future[Result[PeersResponse, string]] {.ffi.} =
+  var peerIds: seq[string]
+  try:
+    for peerId in keys(lib.switch.peerStore[AddressBook].book):
+      peerIds.add($peerId)
+  except LPError as e:
+    return err(e.msg)
+  ok(PeersResponse(peerIds: peerIds))
+
+proc libp2pPeerstoreGetPeerInfo*(
+    lib: LibP2P, peerId: string
+): Future[Result[PeerStoreEntryResponse, string]] {.ffi.} =
+  let pid = PeerId.init(peerId).valueOr:
+    return err($error)
+  let peerStore = lib.switch.peerStore
+  try:
+    var entry = PeerStoreEntryResponse(peerId: $pid)
+    entry.addrs = peerStore[AddressBook][pid].mapIt($it)
+    entry.protocols = peerStore[ProtoBook][pid]
+    if peerStore[KeyBook].contains(pid):
+      entry.publicKey = peerStore[KeyBook][pid].getBytes().valueOr:
+        seq[byte].default
+    entry.agentVersion = peerStore[AgentBook][pid]
+    entry.protoVersion = peerStore[ProtoVersionBook][pid]
+    ok(entry)
+  except LPError as e:
+    err(e.msg)
+
+proc libp2pPeerstoreAddPeer*(
+    lib: LibP2P, req: AddPeerRequest
+): Future[Result[bool, string]] {.ffi.} =
+  let pid = PeerId.init(req.peerId).valueOr:
+    return err($error)
+  if req.addrs.len == 0:
+    return err("at least one address is required")
+
+  let addrs = parseMultiaddrs(req.addrs).valueOr:
+    return err(error)
+
+  let peerStore = lib.switch.peerStore
+  peerStore[AddressBook].extend(pid, addrs)
+  if req.protocols.len > 0:
+    peerStore[ProtoBook].extend(pid, req.protocols)
+  ok(true)
+
+proc libp2pPeerstoreSetPeerAddresses*(
+    lib: LibP2P, req: SetAddressesRequest
+): Future[Result[bool, string]] {.ffi.} =
+  let pid = PeerId.init(req.peerId).valueOr:
+    return err($error)
+
+  let addrs = parseMultiaddrs(req.addrs).valueOr:
+    return err(error)
+
+  lib.switch.peerStore[AddressBook][pid] = addrs
+  ok(true)
+
+proc libp2pPeerstoreSetPeerProtocols*(
+    lib: LibP2P, req: SetProtocolsRequest
+): Future[Result[bool, string]] {.ffi.} =
+  let pid = PeerId.init(req.peerId).valueOr:
+    return err($error)
+  lib.switch.peerStore[ProtoBook][pid] = req.protocols
+  ok(true)
+
+proc libp2pPeerstoreDeletePeer*(
+    lib: LibP2P, peerId: string
+): Future[Result[bool, string]] {.ffi.} =
+  let pid = PeerId.init(peerId).valueOr:
+    return err($error)
+  lib.switch.peerStore.del(pid)
+  ok(true)
+
 proc libp2pCreateCid*(
     lib: LibP2P, req: CreateCidRequest
 ): Future[Result[string, string]] {.ffi.} =
@@ -920,5 +1047,91 @@ proc libp2pNewPrivateKey*(
     return err("could not get bytes for private key")
 
   ok(keyData)
+
+type LabelPair = object
+  name: string
+  value: string
+
+type MetricEntry = object
+  name: string
+  `type`: string
+  help: string
+  labels: seq[LabelPair]
+  value: float64
+  timestamp: int64
+
+const UntypedMetricKind = "untyped"
+
+proc parseMetricType(typeLine: string): string =
+  ## `typeLine` is the collector's pre-formatted "# TYPE <name> <kind>\n";
+  ## returns <kind>, or "untyped" when the line is empty or malformed.
+  let tokens = typeLine.splitWhitespace()
+  if tokens.len < 4:
+    return UntypedMetricKind
+  tokens[^1]
+
+proc parseMetricHelp(helpLine: string): string =
+  ## `helpLine` is the collector's pre-formatted "# HELP <name> <text>\n";
+  ## returns <text> (which itself may contain whitespace), or "" when absent.
+  const PrefixTokens = 3 # "#", "HELP", "<name>"
+  let tokens = helpLine.splitWhitespace(maxsplit = PrefixTokens)
+  if tokens.len <= PrefixTokens:
+    return ""
+  tokens[PrefixTokens].strip()
+
+proc addMetricEntry(
+    entries: ptr seq[MetricEntry],
+    metricType: string,
+    help: string,
+    name: string,
+    value: float64,
+    labels, labelValues: openArray[string],
+    timestamp: Time,
+) {.gcsafe, raises: [].} =
+  # Skip _created entries: OpenMetrics timestamp metadata, not measurements.
+  if name.endsWith("_created"):
+    return
+  doAssert labels.len == labelValues.len, "metric label count mismatch"
+  var labelPairs = newSeq[LabelPair](labels.len)
+  for i in 0 ..< labels.len:
+    labelPairs[i] = LabelPair(name: labels[i], value: labelValues[i])
+  entries[].add MetricEntry(
+    name: name,
+    `type`: metricType,
+    help: help,
+    labels: labelPairs,
+    value: value,
+    timestamp: timestamp.toMilliseconds(),
+  )
+
+proc collectRegistryMetrics(registry: Registry): seq[MetricEntry] {.gcsafe.} =
+  var entries: seq[MetricEntry]
+  {.cast(gcsafe).}:
+    withLock registry.lock:
+      for collector in registry.collectors:
+        let metricType = parseMetricType(collector.typ)
+        let help = parseMetricHelp(collector.help)
+        let entriesPtr = addr entries
+        collector.collect(
+          proc(
+              name: string,
+              value: float64,
+              labels, labelValues: openArray[string],
+              timestamp: Time,
+          ) {.gcsafe, raises: [].} =
+            addMetricEntry(
+              entriesPtr, metricType, help, name, value, labels, labelValues, timestamp
+            )
+        )
+  entries
+
+proc libp2pCollectMetrics*(lib: LibP2P): Future[Result[string, string]] {.ffi.} =
+  var jsonText: string
+  try:
+    {.cast(gcsafe).}:
+      jsonText = $collectRegistryMetrics(defaultRegistry).toJson()
+  except CatchableError as e:
+    return err("failed to serialize metrics: " & e.msg)
+  ok(jsonText)
 
 genBindings()


### PR DESCRIPTION
**nim-ffi cbind migration — PR train**

1. #2772 — deps + pinning
2. #2773 — scaffold + CI
3. #2774 — connectivity
4. #2775 — streams (+ echo)
5. #2776 — pubsub (+ gossipsub)
6. #2777 — kad + CID + crypto
7. #2778 — service discovery
8. #2779 — relay / peerstore / metrics ← this PR
9. #2780 — flip + delete legacy

---
Part 8 of a 9-PR train that replaces the hand-rolled `cbind/` C bindings with the generated **nim-ffi** codegen, landing it domain by domain so each PR stays reviewable and CI-green (build the FFI lib + generate bindings + build/run examples).

Targets `chore/cbind/ffi/07-service-disco` (stacked).

**This PR adds**
- `libp2pCircuitRelayReserve`.
- Peerstore: `addPeer`, `deletePeer`, `getPeerInfo`, `getPeers`, `setPeerAddresses`, `setPeerProtocols`.
- `libp2pCollectMetrics` (OpenMetrics -> JSON).
- After this PR the new library is at full parity with the legacy cbind API surface.

**Review artifact:** Header diff shows the relay/peerstore/metrics entry points — the last additions before the flip.
