### PR TITLE
fix(multiaddress): decode empty optional observedAddr 

### DIFF
--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -1362,7 +1362,7 @@ proc readFieldInto*(
 
   if readFieldInto(stream, data, header, pbytes):
     value = MultiAddress.init(data).valueOr:
-      raise newException(ProtobufValueError, "Invalid protobuf MultiAddress")
+      return false
     true
   else:
     false

--- a/tests/libp2p/multiformat/test_multiaddress.nim
+++ b/tests/libp2p/multiformat/test_multiaddress.nim
@@ -4,7 +4,7 @@
 {.used.}
 
 import std/[sequtils, net], stew/byteutils
-import protobuf_serialization
+import protobuf_serialization, protobuf_serialization/pkg/results
 import ../../../libp2p/[multicodec, multiaddress, peerid, protobuf/minprotobuf]
 import ../../tools/[unittest, multiaddress]
 
@@ -19,6 +19,7 @@ type
   Serializable {.proto2.} = object
     ma {.fieldNumber: 1, required, ext.}: MultiAddress
     addrs {.fieldNumber: 2, ext.}: seq[MultiAddress]
+    observedAddr {.fieldNumber: 4, ext.}: Opt[MultiAddress]
 
 const
   SuccessVectors = [
@@ -254,7 +255,7 @@ suite "Protobuf serialization of types containing MultiAddress":
       serializable = Serializable(ma: MultiAddress(), addrs: @[])
       encoded = Protobuf.encode(serializable)
 
-    expect ProtobufValueError:
+    expect ProtobufReadError:
       discard Protobuf.decode(encoded, Serializable)
 
   test "decode should skip invalid multiaddresses":
@@ -268,6 +269,18 @@ suite "Protobuf serialization of types containing MultiAddress":
 
     check decoded.ma == serializable.ma
     check decoded.addrs[0] == serializable.addrs[1]
+
+  test "decode should treat an empty optional multiaddress as none":
+    let
+      base =
+        Serializable(ma: MultiAddress.init("/ip4/1.2.3.4/tcp/80").get(), addrs: @[])
+      # Append field 4 (observedAddr) as an empty length-delimited value.
+      emptyObservedAddr = @[byte 0x22, 0x00]
+      encoded = Protobuf.encode(base) & emptyObservedAddr
+      decoded = Protobuf.decode(encoded, Serializable)
+
+    check decoded.observedAddr.isNone
+    check decoded.ma == base.ma
 
 suite "MultiAddress test suite":
   test "go-multiaddr success test vectors":

--- a/tests/libp2p/multiformat/test_multiaddress.nim
+++ b/tests/libp2p/multiformat/test_multiaddress.nim
@@ -272,11 +272,12 @@ suite "Protobuf serialization of types containing MultiAddress":
 
   test "decode should treat an empty optional multiaddress as none":
     let
-      base =
-        Serializable(ma: MultiAddress.init("/ip4/1.2.3.4/tcp/80").get(), addrs: @[])
-      # Append field 4 (observedAddr) as an empty length-delimited value.
-      emptyObservedAddr = @[byte 0x22, 0x00]
-      encoded = Protobuf.encode(base) & emptyObservedAddr
+      # An empty multiaddress encodes as a present but zero-length field 4.
+      base = Serializable(
+        ma: MultiAddress.init("/ip4/1.2.3.4/tcp/80").get(),
+        observedAddr: Opt.some(MultiAddress()),
+      )
+      encoded = Protobuf.encode(base)
       decoded = Protobuf.decode(encoded, Serializable)
 
     check decoded.observedAddr.isNone


### PR DESCRIPTION
 ## Summary

Fixes #2781. Empty `observedAddr` in an Identify message no longer aborts the whole decode and drops the connection.

The `MultiAddress` protobuf decoder raised on any `MultiAddress.init` failure, including empty input. This makes it return false instead, matching the `seq[MultiAddress]` decoder right below it. An `Opt[MultiAddress]` field then decodes to `none`, while a `required` field still fails through the serialization layer's missing-required check.

## Affected Areas

- [x] MultiAddress

## Compatibility & Downstream Validation

nim to py-libp2p over WebSocket passes in the unified-testing transport suite after this change. No downstream API changes for Nimbus, Waku, or Codex.

## Impact on Library Users

Behavior change, no API change. An `Opt[MultiAddress]` protobuf field with an empty or undecodable value now decodes to `none` instead of raising. `required` MultiAddress fields still fail as before, so nothing that decoded before loses data now.

## Risk Assessment

Low. Relaxes one optional-field decode path to match existing seq behavior and the identify spec.