### PR TITLE
fix(yamux): align default window with spec and reject invalid versions

### DIFF
--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -16,8 +16,8 @@ logScope:
 const
   YamuxCodec* = "/yamux/1.0.0"
   YamuxVersion = 0.uint8
-  YamuxDefaultWindowSize* = 256000
-  MaxSendQueueSize = 256000
+  YamuxDefaultWindowSize* = 256 * 1024
+  MaxSendQueueSize = YamuxDefaultWindowSize
   MaxChannelCount* = 256
   MaxSendWindow = int64(high(uint32))
 
@@ -25,10 +25,10 @@ when defined(libp2p_yamux_metrics):
   declareGauge libp2p_yamux_channels, "yamux channels", labels = ["initiator", "peer"]
   declareHistogram libp2p_yamux_send_queue,
     "message send queue length (in byte)",
-    buckets = [0.0, 100.0, 250.0, 1000.0, 2000.0, 3200.0, 6400.0, 25600.0, 256000.0]
+    buckets = [0.0, 100.0, 250.0, 1000.0, 2000.0, 3200.0, 6400.0, 25600.0, 262144.0]
   declareHistogram libp2p_yamux_recv_queue,
     "message recv queue length (in byte)",
-    buckets = [0.0, 100.0, 250.0, 1000.0, 2000.0, 3200.0, 6400.0, 25600.0, 256000.0]
+    buckets = [0.0, 100.0, 250.0, 1000.0, 2000.0, 3200.0, 6400.0, 25600.0, 262144.0]
 
 type
   YamuxError* = object of MuxerError
@@ -66,7 +66,8 @@ proc readHeader(
   var hdr: YamuxHeader
   hdr.version = buffer[0]
   let flags = fromBytesBE(uint16, buffer[2 .. 3])
-  if not hdr.msgType.checkedEnumAssign(buffer[1]) or flags notin 0'u16 .. 15'u16:
+  if hdr.version != YamuxVersion or not hdr.msgType.checkedEnumAssign(buffer[1]) or
+      flags notin 0'u16 .. 15'u16:
     raise newException(YamuxError, "Wrong header")
   hdr.flags = cast[set[MsgFlags]](flags)
   hdr.streamId = fromBytesBE(uint32, buffer[4 .. 7])

--- a/tests/libp2p/muxers/test_yamux.nim
+++ b/tests/libp2p/muxers/test_yamux.nim
@@ -121,7 +121,8 @@ suite "Yamux":
       let streamA = await yamuxa.newStream()
       check streamA == yamuxa.getStreams()[0]
 
-      await wait(streamA.write(newSeq[byte](256000)), 1.seconds) # shouldn't block
+      await wait(streamA.write(newSeq[byte](YamuxDefaultWindowSize)), 1.seconds)
+        # shouldn't block
 
       let secondWriter = streamA.write(newSeq[byte](20))
       await sleepAsync(10.milliseconds)
@@ -149,7 +150,8 @@ suite "Yamux":
       let streamA = await yamuxa.newStream()
       check streamA == yamuxa.getStreams()[0]
 
-      await wait(streamA.write(newSeq[byte](256000)), 1.seconds) # shouldn't block
+      await wait(streamA.write(newSeq[byte](YamuxDefaultWindowSize)), 1.seconds)
+        # shouldn't block
 
       let secondWriter = streamA.write(newSeq[byte](20))
       await sleepAsync(10.milliseconds)
@@ -185,8 +187,8 @@ suite "Yamux":
       yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
         YamuxChannel(stream).setMaxRecvWindow(newWindow)
         try:
-          var buffer: array[256000, byte]
-          while (await stream.readOnce(addr buffer[0], 256000)) > 0:
+          var buffer: array[YamuxDefaultWindowSize, byte]
+          while (await stream.readOnce(addr buffer[0], YamuxDefaultWindowSize)) > 0:
             numberOfRead.inc()
           writerBlocker.complete()
         except CancelledError, LPStreamError:
@@ -198,7 +200,8 @@ suite "Yamux":
       check streamA == yamuxa.getStreams()[0]
 
       # Need to exhaust initial window first
-      await wait(streamA.write(newSeq[byte](256000)), 1.seconds) # shouldn't block
+      await wait(streamA.write(newSeq[byte](YamuxDefaultWindowSize)), 1.seconds)
+        # shouldn't block
       const extraBytes = 160
       await streamA.write(newSeq[byte](extraBytes))
       await streamA.close()
@@ -225,7 +228,7 @@ suite "Yamux":
       let streamA = await yamuxa.newStream()
       check streamA == yamuxa.getStreams()[0]
 
-      await streamA.write(newSeq[byte](256000))
+      await streamA.write(newSeq[byte](YamuxDefaultWindowSize))
       let wrFut = collect(newSeq):
         for _ in 0 .. 3:
           streamA.write(newSeq[byte](100000))
@@ -270,9 +273,9 @@ suite "Yamux":
       yamuxb.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
         try:
           await readerBlocker1
-          var buffer: array[256000, byte]
-          # For the first roundtrip, the send window size is assumed to be 256k
-          discard await stream.readOnce(addr buffer[0], 256000)
+          var buffer: array[YamuxDefaultWindowSize, byte]
+          # For the first roundtrip, the default send window size is assumed.
+          discard await stream.readOnce(addr buffer[0], YamuxDefaultWindowSize)
           await readerBlocker2
           discard await stream.readOnce(addr buffer[0], 40000)
         except CancelledError, LPStreamError:
@@ -283,7 +286,8 @@ suite "Yamux":
       let streamA = await yamuxa.newStream()
       check streamA == yamuxa.getStreams()[0]
 
-      await wait(streamA.write(newSeq[byte](256000)), 1.seconds) # shouldn't block
+      await wait(streamA.write(newSeq[byte](YamuxDefaultWindowSize)), 1.seconds)
+        # shouldn't block
 
       let secondWriter = streamA.write(newSeq[byte](64000))
       await sleepAsync(10.milliseconds)

--- a/tests/libp2p/muxers/test_yamux_header.nim
+++ b/tests/libp2p/muxers/test_yamux_header.nim
@@ -200,14 +200,13 @@ suite "Yamux Header Tests":
     expect LPStreamIncompleteError:
       discard await headerFut
 
-  asyncTest "Non-zero version byte is preserved":
+  asyncTest "Non-zero version byte should raise YamuxError":
     let valid = YamuxHeader.data(streamId = 1, length = 100, {Syn}).encode()
     var mutated = valid
     mutated[0] = 1'u8
 
-    let decoded = await readBytes(mutated)
-    check:
-      decoded.version == 1
+    expect YamuxError:
+      discard await readBytes(mutated)
 
   asyncTest "Invalid msgType should raise YamuxError":
     let valid = YamuxHeader.data(streamId = 1, length = 0, {}).encode()


### PR DESCRIPTION
## Summary
Align yamux’s default stream window with the spec/reference 256 KiB value (`256 * 1024`) instead of decimal `256000`, and reject headers whose version byte is not `0`.

This matches the default initial credit and version handling used by go-yamux and rust-yamux. Existing yamux tests were updated to use `YamuxDefaultWindowSize` for window exhaustion cases and to expect `YamuxError` for non-zero-version headers.

## Affected Areas
- [x] Protocol Logic  
  Yamux stream-window defaults and header validation.

- [x] Other  
  Yamux muxer/header tests and metrics bucket boundaries.

## Impact on Library Users
No API changes.

Behavior changes:
- fresh yamux streams now start with a 262144-byte default window;
- malformed/non-zero-version yamux headers now fail as protocol errors instead of being accepted.

## Risk Assessment
Low. This brings Nim yamux behavior in line with upstream Go and Rust implementations. The main compatibility impact is that peers sending non-zero yamux versions are now rejected, which is expected for `/yamux/1.0.0`.

## References
- Yamux specification: https://github.com/hashicorp/yamux/blob/master/spec.md
- go-yamux: https://github.com/libp2p/go-yamux
- rust-yamux: https://github.com/libp2p/rust-yamux