### PR TITLE
fix(kademlia): align DHT message and provider limits for interop

### DIFF
--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -25,12 +25,12 @@ const
   DefaultProvidedKeyCapacity* = 500 # maximum number of provided keys to store at once
   DefaultRepublishInterval* = 10.minutes # same as bootstrap
   DefaultCleanupProvidersInterval* = 10.minutes # same as bootstrap
-  DefaultProviderExpirationInterval* = 30.minutes # recommended by the spec
+  DefaultProviderExpirationInterval* = 48.hours
   DefaultRecordExpirationInterval* = 24.hours
     # KV entries older than this are considered stale and will be evicted
   DefaultCleanupDataEntriesInterval* = 1.hours # how often to scan for stale KV entries
 
-  MaxMsgSize* = 4096
+  MaxMsgSize* = 1 shl 22 # 4 MiB
 
   DefaultMaxProvidersPerKey* = 20 ## upper bound on providers stored per key
   DefaultMaxShortlistSize* = DefaultReplication * 2
@@ -38,9 +38,8 @@ const
   DefaultMaxReceivedSize* = DefaultReplication
     ## upper bound on per-query ``ReceivedTable``
   DefaultMaxValueSize* = 3072
-    ## upper bound (bytes) on a stored record value. Held below ``MaxMsgSize``
-    ## (4096) to leave headroom for the protobuf overhead from other message
-    ## fields, so an accepted value still fits in a single LP frame.
+    ## upper bound (bytes) on a stored record value. Kept much lower than the
+    ## RPC frame cap so PUT_VALUE/GET_VALUE records stay independently bounded.
   DefaultMaxLocalRecords* = 500 ## upper bound on locally stored value records
   DefaultMaxConcurrentRpcs* = 100
     ## upper bound on in-flight outbound RPCs across find/get/put/provider

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -99,7 +99,7 @@ proc new*(
     while not stream.atEof:
       let buf =
         try:
-          await stream.readLp(MaxMsgSize)
+          await stream.readLp(ServiceDiscoveryMaxMsgSize)
         except LPStreamEOFError:
           return
         except LPStreamError as exc:

--- a/libp2p/protocols/service_discovery/connection.nim
+++ b/libp2p/protocols/service_discovery/connection.nim
@@ -35,7 +35,7 @@ proc send*(
     writeRes = catch:
       await stream.writeLp(encodedMsg)
     readRes = catch:
-      await stream.readLp(MaxMsgSize)
+      await stream.readLp(ServiceDiscoveryMaxMsgSize)
 
   if writeRes.isErr:
     return err("connection writing failed: " & writeRes.error.msg)

--- a/libp2p/protocols/service_discovery/types.nim
+++ b/libp2p/protocols/service_discovery/types.nim
@@ -19,6 +19,7 @@ const
   DefaultSelfSPRRereshTime* = 10.minutes
 
   ExtendedServiceDiscoveryCodec* = "/logos/service-discovery/1.0.0"
+  ServiceDiscoveryMaxMsgSize* = 4096
 
   Default_K_register* = 3
   Default_K_lookup* = 5

--- a/tests/libp2p/service_discovery/component/test_error.nim
+++ b/tests/libp2p/service_discovery/component/test_error.nim
@@ -10,7 +10,6 @@ import
     stream/connection,
     switch,
   ]
-from ../../../../libp2p/protocols/kademlia/types import MaxMsgSize
 import ../../../../libp2p/protocols/kademlia/protobuf as kad_protobuf
 import ../../../tools/[lifecycle, unittest]
 import ../utils
@@ -27,7 +26,7 @@ proc sendRawMessage(
 
   await conn.writeLp(msgBytes)
 
-  return await conn.readLp(MaxMsgSize)
+  return await conn.readLp(ServiceDiscoveryMaxMsgSize)
 
 proc sendMessage(
     clientNode, registrarNode: ServiceDiscovery, msg: kad_protobuf.Message
@@ -155,7 +154,7 @@ suite "Service Discovery Component - Error Handling":
     defer:
       await clientSwitch.stop()
 
-    let oversizedMsg = newSeq[byte](MaxMsgSize + 1)
+    let oversizedMsg = newSeq[byte](ServiceDiscoveryMaxMsgSize + 1)
 
     expect LPStreamError:
       discard

--- a/tests/libp2p/service_discovery/component/test_lookup_get_ads.nim
+++ b/tests/libp2p/service_discovery/component/test_lookup_get_ads.nim
@@ -97,7 +97,7 @@ suite "Service Discovery Component - Lookup Get Ads":
     check found.get().len == 0
 
   asyncTest "lookup stops querying once F_lookup ads are found":
-    # fLookup small so one GET_ADS response fits under MaxMsgSize=4096.
+    # fLookup small so one GET_ADS response fits under ServiceDiscoveryMaxMsgSize.
     const fLookup = 8
     let conf = ServiceDiscoveryConfig.new(
       safetyParam = 0.0, fLookup = fLookup, fReturn = fLookup


### PR DESCRIPTION
## Summary

Raises the Kademlia RPC frame limit from 4 KiB to 4 MiB so larger `/ipfs/kad/1.0.0` responses, such as peer lists with multiple multiaddrs, are not rejected before decoding.

Also updates the default provider record expiration interval to 48 hours and keeps stored value records independently bounded by `DefaultMaxValueSize`.

Service discovery now uses its own `ServiceDiscoveryMaxMsgSize` constant, preserving the existing 4 KiB limit for those extension messages instead of inheriting the larger Kademlia RPC cap.

## Affected Areas

- [x] Peer Management / Discovery
  - Kademlia provider record expiration defaults
  - Kademlia RPC message size limit

- [x] Protocol Logic
  - Service discovery frame-size handling remains explicitly capped at 4 KiB

## Impact on Library Users

Kademlia nodes can accept larger DHT replies from go-libp2p DHT peers. Provider records are retained for 48 hours by default instead of 30 minutes.

No API migration is required for existing users.

## Risk Assessment

The larger Kademlia read cap increases the maximum accepted RPC frame size. Stored value records remain separately limited by `DefaultMaxValueSize`, and service discovery keeps its previous 4 KiB cap.

## References

- go-libp2p-kad-dht Amino defaults: https://github.com/libp2p/go-libp2p-kad-dht/blob/master/amino/defaults.go