### PR TITLE
ci: save build cache when in merge queue

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,6 +48,9 @@ jobs:
         run: |
           nimble install_pinned
 
+      - name: Build prerequisites
+        run: make nimble.paths nat_libs
+
       - name: Restore build cache
         uses: actions/cache@v5
         with:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -54,6 +54,9 @@ jobs:
         run: |
           nimble install_pinned
 
+      - name: Build prerequisites
+        run: make nimble.paths nat_libs
+        
       - name: Build and run examples
         run: |
           nim --version

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -191,13 +191,13 @@ jobs:
 
       - name: Save build cache
         uses: actions/cache/save@v5
-        if: github.ref_name == 'master'
+        if: github.event_name == 'merge_group'
         with:
           path: nimcache
           key: ${{ steps.nimcache-restore.outputs.cache-primary-key }}
 
       - name: Prune old nimcache entries
-        if: github.ref_name == 'master'
+        if: github.event_name == 'merge_group'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
code in merge queue is head of build state. master is building exactly the same merge queue, while next commit in merge queue will have current build state. 

closes: #2771