### PR TITLE
chore(makefile): simplify code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,4 @@
-# test_all is compiled in `TEST_ALL_SLICES` translation units. Each slice
-# imports a deterministic 1/N subset of the test files (see tests/imports.nim).
-# On 32-bit targets the Nim compiler is itself a 32-bit process capped at ~3 GB
-# of address space; the unsharded TU overran that on orc. Two slices halve the
-# memory footprint enough to fit, and the overhead is small on 64-bit targets.
-# Number of test binaries to compile and run concurrently; 1 keeps `make test`
-# serial. CI raises it, using fewer lanes on 32-bit to stay under the ~3 GB cap.
-TEST_JOBS ?= 1
-
-TEST_ALL_SLICES ?= 2
-TEST_ALL_SLICE_IDS := $(shell seq 0 $$(( $(TEST_ALL_SLICES) - 1 )))
-TEST_ALL_SLICE_TARGETS := $(addprefix _test_all_slice_,$(TEST_ALL_SLICE_IDS))
-
-.PHONY: all build deps cbind clean test _run_all_tests $(TEST_ALL_SLICE_TARGETS) \
+.PHONY: all build deps cbind clean test \
         test_multiformat_exts test_integration \
         install_pinned pin unpin gen_multicodec format clean-nim nat_libs nat_pkg_dir_check
 
@@ -143,7 +130,11 @@ $(NAT_LIBS_STAMP): | nat_pkg_dir_check
 
 test: nimble.paths nat_libs
 ifeq ($(TEST_PATH),)
-	$(MAKE) -j$(TEST_JOBS) _run_all_tests
+	$(NIMC) c $(NIM_FLAGS) \
+	  $(if $(CICOV),--nimcache:nimcache/test_all,) \
+	  tests/test_all.nim
+	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
+	$(MAKE) test_multiformat_exts
 else
 	$(NIMC) c $(NIM_FLAGS) \
 	  $(if $(CICOV),--nimcache:nimcache/test_all,) \
@@ -151,18 +142,6 @@ else
 	  tests/test_all.nim
 	./tests/test_all $(RUNNER_FLAGS) --xml:tests/results_test_all.xml
 endif
-
-_run_all_tests: $(TEST_ALL_SLICE_TARGETS) test_multiformat_exts
-
-# Per-target nimcache, always: concurrent compiles must not share one.
-$(TEST_ALL_SLICE_TARGETS): _test_all_slice_%: nimble.paths nat_libs
-	$(NIMC) c $(NIM_FLAGS) \
-	  --nimcache:nimcache/test_all_$* \
-	  -d:sliceTotal=$(TEST_ALL_SLICES) \
-	  -d:sliceIdx=$* \
-	  -o:tests/test_all_$* \
-	  tests/test_all.nim
-	./tests/test_all_$* $(RUNNER_FLAGS) --xml:tests/results_test_all_$*.xml
 
 test_multiformat_exts: nimble.paths nat_libs
 	$(NIMC) c $(NIM_FLAGS) \


### PR DESCRIPTION
concurrent compiles should not be done, not in local and not in CI. 
compiler can already effectively utilize CPU. 
hack for splitting test binary should only be done for platform for which it is needed - using raw nim commands for this case is better, hack should not really propagate everywhere 