### PR TITLE
fix(identify): handle missing optional pub key

### DIFF
--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -174,15 +174,15 @@ proc identify*(
 
   debug "identify: info received", stream, identifyMsg
 
-  let
-    pubkey = identifyMsg.publicKey.valueOr:
-      raise newException(IdentityInvalidMsgError, "No pubkey in identify")
+  var peer: PeerId
+  identifyMsg.publicKey.withValue(pubkey):
     peer = PeerId.init(pubkey).valueOr:
       raise newException(IdentityInvalidMsgError, $error)
-
-  if peer != remotePeerId:
-    trace "Peer ids don't match", remote = peer, local = remotePeerId
-    raise newException(IdentityNoMatchError, "Peer ids don't match")
+    if peer != remotePeerId:
+      trace "Peer ids don't match", remote = peer, local = remotePeerId
+      raise newException(IdentityNoMatchError, "Peer ids don't match")
+  else:
+    peer = remotePeerId
 
   identifyMsg.observedAddr.withValue(observed):
     # Currently, we use the ObservedAddrManager only to find our dialable external NAT address. Therefore, addresses

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -3,8 +3,7 @@
 
 {.used.}
 
-import std/sets
-import chronos, chronicles
+import chronos, chronicles, protobuf_serialization, sets
 import
   ../../../libp2p/[
     protocols/identify,
@@ -21,7 +20,6 @@ import
     crypto/crypto,
     upgrademngrs/upgrade,
   ]
-import protobuf_serialization
 import ../../tools/[unittest, crypto, multiaddress, switch_builder]
 
 type IdentifyMsgNoPubKey {.proto2.} = object

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -21,7 +21,11 @@ import
     crypto/crypto,
     upgrademngrs/upgrade,
   ]
+import protobuf_serialization
 import ../../tools/[unittest, crypto, multiaddress, switch_builder]
+
+type IdentifyMsgNoPubKey {.proto2.} = object
+  protocols {.fieldNumber: 3.}: seq[string]
 
 suite "Identify":
   teardown:
@@ -110,6 +114,38 @@ suite "Identify":
       check id.agentVersion.get() == customAgentVersion
       check id.protos == @["/test/proto1/1.0.0", "/test/proto2/1.0.0"]
       check id.signedPeerRecord.isNone()
+
+    asyncTest "identify without publicKey falls back to remotePeerId":
+      # A minimal peer (e.g. eth-p2p-z over QUIC) may omit the optional publicKey field.
+      # The security handshake already authenticated the remote, so identify
+      # must accept the message and fall back to remotePeerId instead of rejecting.
+      const testProtos = @["/test/proto1/1.0.0"]
+      proc noPubKeyHandler(
+          stream: Stream, proto: string
+      ) {.async: (raises: [CancelledError]).} =
+        try:
+          await stream.writeLp(
+            Protobuf.encode(IdentifyMsgNoPubKey(protocols: testProtos))
+          )
+        except LPError as e:
+          trace "failed to write pubkey-less identify", description = e.msg
+        finally:
+          await stream.closeWithEOF()
+
+      msListen.addHandler(LPProtocol.new(@[IdentifyCodec], noPubKeyHandler))
+      proc acceptHandler(): Future[void] {.async.} =
+        let c = await transport1.accept()
+        await msListen.handle(c)
+
+      acceptFut = acceptHandler()
+      conn = await transport2.dial(transport1.addrs[0])
+
+      discard await msDial.select(conn, IdentifyCodec)
+      let id = await identifyProto2.identify(conn, remotePeerInfo.peerId)
+
+      check id.pubkey.isNone()
+      check id.peerId == remotePeerInfo.peerId
+      check id.protos == testProtos
 
     asyncTest "handle failed identify":
       msListen.addHandler(identifyProto1)

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -128,7 +128,7 @@ suite "Identify":
             Protobuf.encode(IdentifyMsgNoPubKey(protocols: testProtos))
           )
         except LPError as e:
-          trace "failed to write pubkey-less identify", description = e.msg
+          raiseAssert "failed to write pubkey-less identify: " & e.msg
         finally:
           await stream.closeWithEOF()
 

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -3,6 +3,7 @@
 
 {.used.}
 
+import std/sets
 import chronos, chronicles
 import
   ../../../libp2p/[
@@ -194,9 +195,11 @@ suite "Identify":
         countAddressesWithPattern(switch2.peerInfo.addrs, TCP_IP6) > 1
 
         # ensure all addresses are advertized.
-        # that is, peer store will have all address of other peer
-        switch1.peerStore[AddressBook][switch2.peerInfo.peerId] == switch2.peerInfo.addrs
-        switch2.peerStore[AddressBook][switch1.peerInfo.peerId] == switch1.peerInfo.addrs
+        # that is, peer store will have all address of other peer.
+        toHashSet(switch1.peerStore[AddressBook][switch2.peerInfo.peerId]) ==
+          toHashSet(switch2.peerInfo.addrs)
+        toHashSet(switch2.peerStore[AddressBook][switch1.peerInfo.peerId]) ==
+          toHashSet(switch1.peerInfo.addrs)
 
         switch1.peerStore[KeyBook][switch2.peerInfo.peerId] == switch2.peerInfo.publicKey
         switch2.peerStore[KeyBook][switch1.peerInfo.peerId] == switch1.peerInfo.publicKey
@@ -232,7 +235,8 @@ suite "Identify":
       switch2.peerInfo.addrs.add(MultiAddress.init("/ip4/127.0.0.1/tcp/5555").tryGet())
 
       check:
-        switch1.peerStore[AddressBook][switch2.peerInfo.peerId] != switch2.peerInfo.addrs
+        toHashSet(switch1.peerStore[AddressBook][switch2.peerInfo.peerId]) !=
+          toHashSet(switch2.peerInfo.addrs)
         switch1.peerStore[ProtoBook][switch2.peerInfo.peerId] !=
           switch2.peerInfo.protocols
 
@@ -242,7 +246,8 @@ suite "Identify":
         switch1.peerStore[ProtoBook][switch2.peerInfo.peerId] ==
           switch2.peerInfo.protocols
       checkUntilTimeout:
-        switch1.peerStore[AddressBook][switch2.peerInfo.peerId] == switch2.peerInfo.addrs
+        toHashSet(switch1.peerStore[AddressBook][switch2.peerInfo.peerId]) ==
+          toHashSet(switch2.peerInfo.addrs)
 
       await closeAll()
 
@@ -251,7 +256,8 @@ suite "Identify":
       switch2.peerInfo.addrs.add(MultiAddress.init("/ip4/127.0.0.1/tcp/5555").tryGet())
 
       check:
-        switch1.peerStore[AddressBook][switch2.peerInfo.peerId] != switch2.peerInfo.addrs
+        toHashSet(switch1.peerStore[AddressBook][switch2.peerInfo.peerId]) !=
+          toHashSet(switch2.peerInfo.addrs)
         switch1.peerStore[ProtoBook][switch2.peerInfo.peerId] !=
           switch2.peerInfo.protocols
 


### PR DESCRIPTION
## Summary

Addresses https://github.com/vacp2p/nim-libp2p/issues/2786

1. **identify: accept a missing `publicKey`.** identify treated the optional `publicKey` field as mandatory and dropped the connection when it was absent, breaking interop with minimal QUIC-only peers. It now falls back to the peer id from the security handshake (`remotePeerId`) when the field is missing, and still enforces the match when it is present.

2. **test-only: compare advertised addresses as sets.** The identify-push tests asserted exact equality between the peer store's address list and `peerInfo.addrs`. The `AddressBook` keeps a unique address per peer, but wildcard listen addrs (`/ip6/::`) expand to every interface address, which can include duplicates when one link-local is shared across interfaces (macOS `awdl0`/`llw0`). The tests now compare address sets, matching the assertion's intent. 
This only fixes local failures on macOS. CI was not affected.

## Affected Areas

- [x] Peer Management / Discovery
    identify `publicKey` handling and its tests.

## Compatibility & Downstream Validation

Backward compatible. Only relaxes a receiver-side check, no wire format or API signature change, so no downstream build or integration work is required.

## Impact on Library Users

A peer that sends identify without `publicKey` is now accepted instead of dropped. On authenticated transports (Noise, TLS, QUIC) the remote identity is unchanged because it comes from the handshake. For such peers `IdentifyInfo.pubkey` is `none`, so `KeyBook` is not populated for them. Existing consumers already treat that field as optional.

## Risk Assessment

Low. The change removes a rejection path rather than adding one. A present-but-mismatched `publicKey` still raises `IdentityNoMatchError`.