### PR TITLE
ci: dropping i386 orc from tests

### DIFF
--- a/.github/workflows/daily_common.yml
+++ b/.github/workflows/daily_common.yml
@@ -158,26 +158,11 @@ jobs:
           if [[ '${{ matrix.config.cc }}' == 'clang' ]]; then
             NIMFLAGS="$NIMFLAGS --cc:clang"
           fi
-          if [[ '${{ matrix.config.cpu }}' == 'i386' && '${{ matrix.nim.memory_management }}' == 'orc' ]]; then
-            # On i386 (32-bit), the Nim compiler is limited to ~3 GB of address
-            # space and cannot compile the full test_all in one go. Split the
-            # test corpus into `sliceTotal` translation units; each slice
-            # compiles a deterministic subset of the test files.
-            NIMFLAGS="$NIMFLAGS -d:sliceTotal=2"
-            nim c $NIMFLAGS -d:sliceIdx=0 -o:tests/test_all_0 ./tests/test_all
-            nim c $NIMFLAGS -d:sliceIdx=1 -o:tests/test_all_1 ./tests/test_all
-          else
-            nim c $NIMFLAGS ./tests/test_all
-          fi
+          nim c $NIMFLAGS ./tests/test_all
 
       - name: Run tests
         run: |
-          if [[ -f ./tests/test_all_0 && -f ./tests/test_all_1 ]]; then
-            ./tests/test_all_0 --output-level=VERBOSE --console --xml:tests/results_test_all_0.xml
-            ./tests/test_all_1 --output-level=VERBOSE --console --xml:tests/results_test_all_1.xml
-          else
-            ./tests/test_all --output-level=VERBOSE --console --xml:tests/results_test_all.xml
-          fi
+          ./tests/test_all --output-level=VERBOSE --console --xml:tests/results_test_all.xml
 
       - name: Run integration tests
         if: ${{ matrix.config.os == 'linux' && matrix.config.cpu == 'amd64' }}

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -47,6 +47,14 @@ jobs:
             memory_management: refc
           - ref: v2.2.10
             memory_management: orc
+        exclude:
+          - platform:
+              os: linux
+              cpu: i386
+              cc: gcc
+            nim:
+              ref: v2.2.10
+              memory_management: orc
         include:
           - platform:
               os: linux
@@ -177,17 +185,7 @@ jobs:
           if [[ '${{ matrix.platform.cc }}' == 'clang' ]]; then
             NIMFLAGS="$NIMFLAGS --cc:clang"
           fi
-          if [[ '${{ matrix.platform.cpu }}' == 'i386' && '${{ matrix.nim.memory_management }}' == 'orc' ]]; then
-            # On i386 (32-bit), the Nim compiler is limited to ~3 GB of address
-            # space and cannot compile the full test_all in one go. Split the
-            # test corpus into `sliceTotal` translation units; each slice
-            # compiles a deterministic subset of the test files.
-            NIMFLAGS="$NIMFLAGS -d:sliceTotal=2"
-            nim c $NIMFLAGS -d:sliceIdx=0 -o:tests/test_all_0 ./tests/test_all
-            nim c $NIMFLAGS -d:sliceIdx=1 -o:tests/test_all_1 ./tests/test_all
-          else
-            nim c $NIMFLAGS ./tests/test_all
-          fi
+          nim c $NIMFLAGS ./tests/test_all
 
       - name: Save build cache
         uses: actions/cache/save@v5
@@ -210,12 +208,7 @@ jobs:
       - name: Run tests
         id: run-tests
         run: |
-          if [[ -f ./tests/test_all_0 && -f ./tests/test_all_1 ]]; then
-            ./tests/test_all_0 --output-level=VERBOSE --console --xml:tests/results_test_all_0.xml
-            ./tests/test_all_1 --output-level=VERBOSE --console --xml:tests/results_test_all_1.xml
-          else
-            ./tests/test_all --output-level=VERBOSE --console --xml:tests/results_test_all.xml
-          fi
+          ./tests/test_all --output-level=VERBOSE --console --xml:tests/results_test_all.xml
 
       - name: Fix xml newlines
         if: ${{ !cancelled() && steps.run-tests.outcome == 'failure' }}

--- a/tests/imports.nim
+++ b/tests/imports.nim
@@ -7,24 +7,11 @@ import std/os
 import std/strutils
 import std/sequtils
 
-# Split the test corpus across `sliceTotal` translation units; each invocation
-# of test_all.nim compiles only the files whose sorted index is `sliceIdx` mod
-# `sliceTotal`. On 32-bit targets the Nim compiler is itself a 32-bit process
-# and is capped at ~3 GB of address space, which the unsharded TU overran on
-# orc. Slicing keeps each compile under that ceiling and is a no-op when
-# sliceTotal == 1.
-const sliceTotal* {.intdefine.}: int = 1
-const sliceIdx* {.intdefine.}: int = 0
-static:
-  doAssert sliceTotal >= 1, "sliceTotal must be >= 1"
-  doAssert sliceIdx >= 0 and sliceIdx < sliceTotal,
-    "sliceIdx must be in [0, sliceTotal)"
-
 proc printImportSummary(importedFiles: seq[string], baseDir: string) =
   ## Prints a summary of imported test files at compile time
   echo "\n"
   echo "=================================="
-  echo "Dynamic test import (slice ", sliceIdx, "/", sliceTotal, ")"
+  echo "Dynamic test import"
   echo "Imported ", importedFiles.len, " files."
   echo ""
   for file in importedFiles:
@@ -65,8 +52,7 @@ macro importTests*(
     if isTestFile and not isIgnored and isMatched:
       matchingFiles.add(file)
 
-  # Deterministic order so a given (sliceIdx, sliceTotal) always selects the
-  # same set across runs and platforms.
+  # Deterministic order keeps the generated imports stable across runs and platforms.
   sort(
     matchingFiles,
     proc(a, b: string): int =
@@ -74,10 +60,9 @@ macro importTests*(
   )
 
   var importedFiles: seq[string] = @[]
-  for i, file in matchingFiles:
-    if i mod sliceTotal == sliceIdx:
-      imports.add(newNimNode(nnkImportStmt).add(newLit(file)))
-      importedFiles.add(file)
+  for file in matchingFiles:
+    imports.add(newNimNode(nnkImportStmt).add(newLit(file)))
+    importedFiles.add(file)
 
   printImportSummary(importedFiles, dir)
 


### PR DESCRIPTION
dropping i386 orc from tests as it was causing OOM issue. also removing hacks related to supporting running tests for this platform. 