### PR TITLE
test: Expand stream tests to yamux

### DIFF
--- a/tests/libp2p/transports/stream_tests.nim
+++ b/tests/libp2p/transports/stream_tests.nim
@@ -220,7 +220,11 @@ template streamTransportTest*(
         await serverResetDone
 
         var buffer: array[1, byte]
-        check (await stream.readOnce(addr buffer[0], 1)) == 0
+        # EOF until this side reads the RST frame, reset once it lands
+        try:
+          check (await stream.readOnce(addr buffer[0], 1)) == 0
+        except LPStreamResetError:
+          discard
 
         expect LPStreamResetError:
           await stream.writeLp(fromHex("1234"))
@@ -555,19 +559,24 @@ template streamTransportTest*(
         await allFutures(writeFuts)
         await serverHandlerDone
 
+    await runSingleStreamScenario(
+      @[addressIP4],
+      transportProvider,
+      streamProvider,
+      serverStreamHandler,
+      clientStreamHandler,
+    )
+
   asyncTest "single large write":
     const messageSize = 2 * 1024 * 1024
     const chunkSize = 256 * 1024
-    var serverHandlerDone = newFuture[void]()
+    let serverHandlerDone = newFuture[void]()
 
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
-      noExceptionWithStreamClose(stream):
+      noExceptionWithStreamClose(stream, serverHandlerDone):
         let receivedData =
           await readStreamByChunkTillEOF(stream, chunkSize, messageSize)
-        let matches = receivedData == newData(messageSize)
-        check matches
-
-        serverHandlerDone.complete()
+        check receivedData == newData(messageSize)
 
     proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):

--- a/tests/libp2p/transports/stream_tests.nim
+++ b/tests/libp2p/transports/stream_tests.nim
@@ -520,7 +520,7 @@ template streamTransportTest*(
     )
 
   asyncTest "stream with multiple parallel writes":
-    const messageSize = 2 * 1024 * 1024
+    const messageSize = 20 * 1024
     const chunkSize = 256 * 1024
     const parallelWrites = 10
     let serverHandlerDone = newFuture[void]()
@@ -553,6 +553,25 @@ template streamTransportTest*(
           let fut = stream.write(message)
           writeFuts.add(fut)
         await allFutures(writeFuts)
+        await serverHandlerDone
+
+  asyncTest "single large write":
+    const messageSize = 2 * 1024 * 1024
+    const chunkSize = 256 * 1024
+    var serverHandlerDone = newFuture[void]()
+
+    proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
+      noExceptionWithStreamClose(stream):
+        let receivedData =
+          await readStreamByChunkTillEOF(stream, chunkSize, messageSize)
+        let matches = receivedData == newData(messageSize)
+        check matches
+
+        serverHandlerDone.complete()
+
+    proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
+      noExceptionWithStreamClose(stream):
+        await stream.write(newData(messageSize))
         await serverHandlerDone
 
     await runSingleStreamScenario(

--- a/tests/libp2p/transports/test_tcp.nim
+++ b/tests/libp2p/transports/test_tcp.nim
@@ -11,6 +11,7 @@ import
     upgrademngrs/upgrade,
     muxers/muxer,
     muxers/mplex/mplex,
+    muxers/yamux/yamux,
   ]
 import ../../tools/[unittest]
 import ./basic_tests
@@ -21,8 +22,14 @@ import ./tcp_tests
 proc tcpTransProvider(): Transport =
   TcpTransport.new(upgrade = Upgrade())
 
-proc streamProvider(conn: RawConn, handle: bool = true): Muxer =
+proc mplexStreamProvider(conn: RawConn, handle: bool = true): Muxer =
   let muxer = Mplex.new(conn)
+  if handle:
+    asyncSpawn muxer.handle()
+  muxer
+
+proc yamuxStreamProvider(conn: RawConn, handle: bool = true): Muxer =
+  let muxer = Yamux.new(conn)
   if handle:
     asyncSpawn muxer.handle()
   muxer
@@ -51,14 +58,40 @@ suite "TCP transport":
     tcpTransProvider, addressIP4, validWireAddresses, validNonWireAddresses,
     invalidAddresses,
   )
+  
+  # tcp specific tests
+  tcpTests()
+
+suite "TCP transport: ipv4":
+  teardown:
+    checkTrackers()
+
   connectionTransportTest(tcpTransProvider, addressIP4)
+
+suite "TCP transport: ipv6":
+  teardown:
+    checkTrackers()
+
   connectionTransportTest(tcpTransProvider, addressIP6)
+
+suite "TCP transport: mplex":
+  teardown:
+    checkTrackers()
+
   streamTransportTest(
     tcpTransProvider,
     MultiAddress.init(addressIP4).get(),
     Opt.some(MultiAddress.init(addressIP6).get()),
-    streamProvider,
+    mplexStreamProvider,
   )
 
-  # tcp specific tests
-  tcpTests()
+suite "TCP transport: yamux":
+  teardown:
+    checkTrackers()
+
+  streamTransportTest(
+    tcpTransProvider,
+    MultiAddress.init(addressIP4).get(),
+    Opt.some(MultiAddress.init(addressIP6).get()),
+    yamuxStreamProvider,
+  )

--- a/tests/libp2p/transports/test_tcp.nim
+++ b/tests/libp2p/transports/test_tcp.nim
@@ -58,7 +58,6 @@ suite "TCP transport":
     tcpTransProvider, addressIP4, validWireAddresses, validNonWireAddresses,
     invalidAddresses,
   )
-  
   # tcp specific tests
   tcpTests()
 


### PR DESCRIPTION
## Summary

streamTransportTest is only run on mplex not yamux. Add missing test.

- ipv4 / ipv6 tests separated into their own suite, otherwise they clash with their test names.

- yamux closes the stream if too much data is queued up, so split the tests into two: one for large transfer, and one for burst of small. when the stream is closed early, the test gets stuck as the future never completes.

- needs #2809 to pass

## Affected Areas
<!--
Indicate which parts of the codebase are impacted.
Check all that apply and briefly describe the scope of the changes.
-->

- [ ] Gossipsub  
  <!-- e.g. scoring changes, message validation, peer handling -->

- [X] Transports  
  <!-- e.g. TCP, QUIC, WebSockets, Noise, etc. -->

- [ ] Peer Management / Discovery

- [ ] Protocol Logic

- [ ] Build / Tooling

- [ ] Other  
  <!-- Describe below -->
