### PR TITLE
build(android): add libp2p_ffi mobile targets

### DIFF
--- a/.github/workflows/mobile_android.yml
+++ b/.github/workflows/mobile_android.yml
@@ -54,8 +54,6 @@ jobs:
           test -f "$out/lib/liblibp2p.so"
           test -f "$out/lib/liblibp2p.a"
           test -f "$out/lib/libc++_shared.so"
-          test -f "$out/lib/libminiupnpc.a"
-          test -f "$out/lib/libnatpmp.a"
           test -f "$out/include/libp2p.h"
           test -f "$out/include/nim_ffi_cbor.h"
           test -f "$out/include/nim_ffi_prelude.h"

--- a/.github/workflows/mobile_android.yml
+++ b/.github/workflows/mobile_android.yml
@@ -1,0 +1,73 @@
+name: Mobile Android
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cbind-ffi-android:
+    timeout-minutes: 60
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - abi: arm64-v8a
+            attr: cbind-ffi-android-arm64-v8a
+            machine: AArch64
+          - abi: x86_64
+            attr: cbind-ffi-android-x86_64
+            machine: Advanced Micro Devices X86-64
+
+    defaults:
+      run:
+        shell: bash
+
+    name: "Android ${{ matrix.abi }} FFI check build"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Build Android C ABI package
+        run: |
+          nix --extra-experimental-features "nix-command flakes" \
+            build ".#${{ matrix.attr }}" \
+            -o "result-${{ matrix.abi }}"
+
+      - name: Verify Android artifacts
+        run: |
+          out="result-${{ matrix.abi }}"
+
+          test -f "$out/lib/liblibp2p.so"
+          test -f "$out/lib/liblibp2p.a"
+          test -f "$out/lib/libc++_shared.so"
+          test -f "$out/lib/libminiupnpc.a"
+          test -f "$out/lib/libnatpmp.a"
+          test -f "$out/include/libp2p.h"
+          test -f "$out/include/nim_ffi_cbor.h"
+          test -f "$out/include/nim_ffi_prelude.h"
+          test -f "$out/include/tinycbor/cbor.h"
+          test -f "$out/include/cddl_bindings/libp2p.cddl"
+          test -x "$out/bin/libp2p_ffi_android_check"
+
+          readelf -h "$out/lib/liblibp2p.so" | tee liblibp2p.readelf
+          readelf -h "$out/bin/libp2p_ffi_android_check" | tee check.readelf
+
+          grep -q "Machine:[[:space:]]*${{ matrix.machine }}" liblibp2p.readelf
+          grep -q "Machine:[[:space:]]*${{ matrix.machine }}" check.readelf
+
+          file "$out/lib/liblibp2p.so"
+          file "$out/bin/libp2p_ffi_android_check"

--- a/.pinned
+++ b/.pinned
@@ -7,7 +7,7 @@ httputils;https://github.com/status-im/nim-http-utils@#f142cb2e8bd812dd002a6493b
 json_serialization;https://github.com/status-im/nim-json-serialization@#a6dcf03e04e179127a5fcb7e495d19a821d56c17
 metrics;https://github.com/status-im/nim-metrics@#b4b70a88fe1755d281366cbc3f22d7515240d192
 nimcrypto;https://github.com/cheatfate/nimcrypto@#721fb99ee099b632eb86dfad1f0d96ee87583774
-lsquic;https://github.com/vacp2p/nim-lsquic@#186ec5b98747bdeaa98d3460b9e71823cac3b57a
+lsquic;https://github.com/vacp2p/nim-lsquic@#079768948ac03d8f2384e03045a090cb88aeb7d9
 results;https://github.com/arnetheduck/nim-results@#df8113dda4c2d74d460a8fa98252b0b771bf1f27
 secp256k1;https://github.com/status-im/nim-secp256k1@#d8f1288b7c72f00be5fc2c5ea72bf5cae1eafb15
 serialization;https://github.com/status-im/nim-serialization@#f80cfd8657f272a2abd063d070b77f2a74f704cd

--- a/cbind/examples/libp2p_ffi_android_check.c
+++ b/cbind/examples/libp2p_ffi_android_check.c
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (c) Status Research & Development GmbH
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "libp2p.h"
+
+enum {
+    LIBP2P_FFI_MUXER_YAMUX = 1,
+    LIBP2P_FFI_TRANSPORT_TCP = 1,
+    CALLBACK_TIMEOUT_SECONDS = 20,
+};
+
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    int done;
+    int err_code;
+    char err_msg[512];
+    LibP2PCtx* ctx;
+    bool bool_reply;
+} CallbackWait;
+
+static void wait_init(CallbackWait* wait) {
+    memset(wait, 0, sizeof(*wait));
+    wait->err_code = NIMFFI_RET_OK;
+    if (pthread_mutex_init(&wait->mutex, NULL) != 0) {
+        fprintf(stderr, "pthread_mutex_init failed\n");
+        exit(2);
+    }
+    if (pthread_cond_init(&wait->cond, NULL) != 0) {
+        fprintf(stderr, "pthread_cond_init failed\n");
+        exit(2);
+    }
+}
+
+static void wait_destroy(CallbackWait* wait) {
+    pthread_cond_destroy(&wait->cond);
+    pthread_mutex_destroy(&wait->mutex);
+}
+
+static void record_error(CallbackWait* wait, int err_code, const char* err_msg) {
+    wait->err_code = err_code;
+    if (err_msg != NULL && err_msg[0] != '\0') {
+        snprintf(wait->err_msg, sizeof(wait->err_msg), "%s", err_msg);
+    } else if (err_code != NIMFFI_RET_OK) {
+        snprintf(wait->err_msg, sizeof(wait->err_msg), "FFI returned error code %d", err_code);
+    }
+}
+
+static void signal_done(CallbackWait* wait) {
+    wait->done = 1;
+    pthread_cond_signal(&wait->cond);
+}
+
+static void on_created(int err_code, LibP2PCtx* ctx, const char* err_msg, void* user_data) {
+    CallbackWait* wait = (CallbackWait*)user_data;
+    pthread_mutex_lock(&wait->mutex);
+    record_error(wait, err_code, err_msg);
+    if (err_code == NIMFFI_RET_OK && ctx == NULL) {
+        record_error(wait, -1, "create callback returned a null context");
+    } else {
+        wait->ctx = ctx;
+    }
+    signal_done(wait);
+    pthread_mutex_unlock(&wait->mutex);
+}
+
+static void on_bool_reply(int err_code, const bool* reply, const char* err_msg, void* user_data) {
+    CallbackWait* wait = (CallbackWait*)user_data;
+    pthread_mutex_lock(&wait->mutex);
+    record_error(wait, err_code, err_msg);
+    if (err_code == NIMFFI_RET_OK && reply == NULL) {
+        record_error(wait, -1, "bool callback returned a null reply");
+    } else if (reply != NULL) {
+        wait->bool_reply = *reply;
+    }
+    signal_done(wait);
+    pthread_mutex_unlock(&wait->mutex);
+}
+
+static int wait_for_callback(CallbackWait* wait, const char* op) {
+    struct timespec deadline;
+    if (clock_gettime(CLOCK_REALTIME, &deadline) != 0) {
+        fprintf(stderr, "%s: clock_gettime failed: %s\n", op, strerror(errno));
+        return 1;
+    }
+    deadline.tv_sec += CALLBACK_TIMEOUT_SECONDS;
+
+    pthread_mutex_lock(&wait->mutex);
+    int rc = 0;
+    while (!wait->done && rc == 0) {
+        rc = pthread_cond_timedwait(&wait->cond, &wait->mutex, &deadline);
+    }
+
+    int err_code = wait->err_code;
+    char err_msg[sizeof(wait->err_msg)];
+    snprintf(err_msg, sizeof(err_msg), "%s", wait->err_msg);
+    pthread_mutex_unlock(&wait->mutex);
+
+    if (rc == ETIMEDOUT) {
+        fprintf(stderr, "%s: timed out after %d seconds\n", op, CALLBACK_TIMEOUT_SECONDS);
+        return 1;
+    }
+    if (rc != 0) {
+        fprintf(stderr, "%s: pthread_cond_timedwait failed: %s\n", op, strerror(rc));
+        return 1;
+    }
+    if (err_code != NIMFFI_RET_OK) {
+        fprintf(stderr, "%s: %s\n", op, err_msg[0] ? err_msg : "FFI callback failed");
+        return 1;
+    }
+    return 0;
+}
+
+static int create_node(LibP2PCtx** out_ctx) {
+    Libp2pConfig config;
+    memset(&config, 0, sizeof(config));
+
+    NimFfiStr listen_addrs[] = { nimffi_str("/ip4/127.0.0.1/tcp/0") };
+    config.addrs.data = listen_addrs;
+    config.addrs.len = 1;
+    config.dnsResolver = nimffi_str("");
+    config.transport = LIBP2P_FFI_TRANSPORT_TCP;
+    config.muxer = LIBP2P_FFI_MUXER_YAMUX;
+    config.maxConnections = 8;
+    config.maxIn = 4;
+    config.maxOut = 4;
+    config.maxConnsPerPeer = 2;
+
+    CallbackWait create_wait;
+    wait_init(&create_wait);
+    int submit = libp2p_ctx_create(&config, on_created, &create_wait);
+    if (submit != 0) {
+        fprintf(stderr, "create: submit failed\n");
+        wait_destroy(&create_wait);
+        return 1;
+    }
+    if (wait_for_callback(&create_wait, "create") != 0) {
+        wait_destroy(&create_wait);
+        return 1;
+    }
+
+    *out_ctx = create_wait.ctx;
+    wait_destroy(&create_wait);
+    return 0;
+}
+
+static int call_bool_method(const char* op, LibP2PCtx* ctx,
+        int (*fn)(const LibP2PCtx*, void (*)(int, const bool*, const char*, void*), void*)) {
+    CallbackWait wait;
+    wait_init(&wait);
+    int submit = fn(ctx, on_bool_reply, &wait);
+    if (submit != 0) {
+        fprintf(stderr, "%s: submit failed\n", op);
+        wait_destroy(&wait);
+        return 1;
+    }
+    if (wait_for_callback(&wait, op) != 0) {
+        wait_destroy(&wait);
+        return 1;
+    }
+    if (!wait.bool_reply) {
+        fprintf(stderr, "%s: expected true reply\n", op);
+        wait_destroy(&wait);
+        return 1;
+    }
+    wait_destroy(&wait);
+    return 0;
+}
+
+int main(void) {
+    setvbuf(stdout, NULL, _IONBF, 0);
+    setvbuf(stderr, NULL, _IONBF, 0);
+
+    LibP2PCtx* ctx = NULL;
+    if (create_node(&ctx) != 0) {
+        return 1;
+    }
+
+    int rc = 0;
+    if (call_bool_method("start", ctx, libp2p_ctx_start) != 0) {
+        rc = 1;
+        goto cleanup;
+    }
+    if (call_bool_method("stop", ctx, libp2p_ctx_stop) != 0) {
+        rc = 1;
+        goto cleanup;
+    }
+
+cleanup:
+    libp2p_ctx_destroy(ctx);
+    return rc;
+}

--- a/cbind/examples/libp2p_ffi_android_check.c
+++ b/cbind/examples/libp2p_ffi_android_check.c
@@ -12,189 +12,198 @@
 #include "libp2p.h"
 
 enum {
-    LIBP2P_FFI_MUXER_YAMUX = 1,
-    LIBP2P_FFI_TRANSPORT_TCP = 1,
-    CALLBACK_TIMEOUT_SECONDS = 20,
+  LIBP2P_FFI_MUXER_YAMUX = 1,
+  LIBP2P_FFI_TRANSPORT_TCP = 1,
+  CALLBACK_TIMEOUT_SECONDS = 20,
 };
 
 typedef struct {
-    pthread_mutex_t mutex;
-    pthread_cond_t cond;
-    int done;
-    int err_code;
-    char err_msg[512];
-    LibP2PCtx* ctx;
-    bool bool_reply;
+  pthread_mutex_t mutex;
+  pthread_cond_t cond;
+  int done;
+  int err_code;
+  char err_msg[512];
+  LibP2PCtx *ctx;
+  bool bool_reply;
 } CallbackWait;
 
-static void wait_init(CallbackWait* wait) {
-    memset(wait, 0, sizeof(*wait));
-    wait->err_code = NIMFFI_RET_OK;
-    if (pthread_mutex_init(&wait->mutex, NULL) != 0) {
-        fprintf(stderr, "pthread_mutex_init failed\n");
-        exit(2);
-    }
-    if (pthread_cond_init(&wait->cond, NULL) != 0) {
-        fprintf(stderr, "pthread_cond_init failed\n");
-        exit(2);
-    }
+static void wait_init(CallbackWait *wait) {
+  memset(wait, 0, sizeof(*wait));
+  wait->err_code = NIMFFI_RET_OK;
+  if (pthread_mutex_init(&wait->mutex, NULL) != 0) {
+    fprintf(stderr, "pthread_mutex_init failed\n");
+    exit(2);
+  }
+  if (pthread_cond_init(&wait->cond, NULL) != 0) {
+    fprintf(stderr, "pthread_cond_init failed\n");
+    exit(2);
+  }
 }
 
-static void wait_destroy(CallbackWait* wait) {
-    pthread_cond_destroy(&wait->cond);
-    pthread_mutex_destroy(&wait->mutex);
+static void wait_destroy(CallbackWait *wait) {
+  pthread_cond_destroy(&wait->cond);
+  pthread_mutex_destroy(&wait->mutex);
 }
 
-static void record_error(CallbackWait* wait, int err_code, const char* err_msg) {
-    wait->err_code = err_code;
-    if (err_msg != NULL && err_msg[0] != '\0') {
-        snprintf(wait->err_msg, sizeof(wait->err_msg), "%s", err_msg);
-    } else if (err_code != NIMFFI_RET_OK) {
-        snprintf(wait->err_msg, sizeof(wait->err_msg), "FFI returned error code %d", err_code);
-    }
+static void record_error(CallbackWait *wait, int err_code,
+                         const char *err_msg) {
+  wait->err_code = err_code;
+  if (err_msg != NULL && err_msg[0] != '\0') {
+    snprintf(wait->err_msg, sizeof(wait->err_msg), "%s", err_msg);
+  } else if (err_code != NIMFFI_RET_OK) {
+    snprintf(wait->err_msg, sizeof(wait->err_msg), "FFI returned error code %d",
+             err_code);
+  }
 }
 
-static void signal_done(CallbackWait* wait) {
-    wait->done = 1;
-    pthread_cond_signal(&wait->cond);
+static void signal_done(CallbackWait *wait) {
+  wait->done = 1;
+  pthread_cond_signal(&wait->cond);
 }
 
-static void on_created(int err_code, LibP2PCtx* ctx, const char* err_msg, void* user_data) {
-    CallbackWait* wait = (CallbackWait*)user_data;
-    pthread_mutex_lock(&wait->mutex);
-    record_error(wait, err_code, err_msg);
-    if (err_code == NIMFFI_RET_OK && ctx == NULL) {
-        record_error(wait, -1, "create callback returned a null context");
-    } else {
-        wait->ctx = ctx;
-    }
-    signal_done(wait);
-    pthread_mutex_unlock(&wait->mutex);
+static void on_created(int err_code, LibP2PCtx *ctx, const char *err_msg,
+                       void *user_data) {
+  CallbackWait *wait = (CallbackWait *)user_data;
+  pthread_mutex_lock(&wait->mutex);
+  record_error(wait, err_code, err_msg);
+  if (err_code == NIMFFI_RET_OK && ctx == NULL) {
+    record_error(wait, -1, "create callback returned a null context");
+  } else {
+    wait->ctx = ctx;
+  }
+  signal_done(wait);
+  pthread_mutex_unlock(&wait->mutex);
 }
 
-static void on_bool_reply(int err_code, const bool* reply, const char* err_msg, void* user_data) {
-    CallbackWait* wait = (CallbackWait*)user_data;
-    pthread_mutex_lock(&wait->mutex);
-    record_error(wait, err_code, err_msg);
-    if (err_code == NIMFFI_RET_OK && reply == NULL) {
-        record_error(wait, -1, "bool callback returned a null reply");
-    } else if (reply != NULL) {
-        wait->bool_reply = *reply;
-    }
-    signal_done(wait);
-    pthread_mutex_unlock(&wait->mutex);
+static void on_bool_reply(int err_code, const bool *reply, const char *err_msg,
+                          void *user_data) {
+  CallbackWait *wait = (CallbackWait *)user_data;
+  pthread_mutex_lock(&wait->mutex);
+  record_error(wait, err_code, err_msg);
+  if (err_code == NIMFFI_RET_OK && reply == NULL) {
+    record_error(wait, -1, "bool callback returned a null reply");
+  } else if (reply != NULL) {
+    wait->bool_reply = *reply;
+  }
+  signal_done(wait);
+  pthread_mutex_unlock(&wait->mutex);
 }
 
-static int wait_for_callback(CallbackWait* wait, const char* op) {
-    struct timespec deadline;
-    if (clock_gettime(CLOCK_REALTIME, &deadline) != 0) {
-        fprintf(stderr, "%s: clock_gettime failed: %s\n", op, strerror(errno));
-        return 1;
-    }
-    deadline.tv_sec += CALLBACK_TIMEOUT_SECONDS;
+static int wait_for_callback(CallbackWait *wait, const char *op) {
+  struct timespec deadline;
+  if (clock_gettime(CLOCK_REALTIME, &deadline) != 0) {
+    fprintf(stderr, "%s: clock_gettime failed: %s\n", op, strerror(errno));
+    return 1;
+  }
+  deadline.tv_sec += CALLBACK_TIMEOUT_SECONDS;
 
-    pthread_mutex_lock(&wait->mutex);
-    int rc = 0;
-    while (!wait->done && rc == 0) {
-        rc = pthread_cond_timedwait(&wait->cond, &wait->mutex, &deadline);
-    }
+  pthread_mutex_lock(&wait->mutex);
+  int rc = 0;
+  while (!wait->done && rc == 0) {
+    rc = pthread_cond_timedwait(&wait->cond, &wait->mutex, &deadline);
+  }
 
-    int err_code = wait->err_code;
-    char err_msg[sizeof(wait->err_msg)];
-    snprintf(err_msg, sizeof(err_msg), "%s", wait->err_msg);
-    pthread_mutex_unlock(&wait->mutex);
+  int err_code = wait->err_code;
+  char err_msg[sizeof(wait->err_msg)];
+  snprintf(err_msg, sizeof(err_msg), "%s", wait->err_msg);
+  pthread_mutex_unlock(&wait->mutex);
 
-    if (rc == ETIMEDOUT) {
-        fprintf(stderr, "%s: timed out after %d seconds\n", op, CALLBACK_TIMEOUT_SECONDS);
-        return 1;
-    }
-    if (rc != 0) {
-        fprintf(stderr, "%s: pthread_cond_timedwait failed: %s\n", op, strerror(rc));
-        return 1;
-    }
-    if (err_code != NIMFFI_RET_OK) {
-        fprintf(stderr, "%s: %s\n", op, err_msg[0] ? err_msg : "FFI callback failed");
-        return 1;
-    }
-    return 0;
+  if (rc == ETIMEDOUT) {
+    fprintf(stderr, "%s: timed out after %d seconds\n", op,
+            CALLBACK_TIMEOUT_SECONDS);
+    return 1;
+  }
+  if (rc != 0) {
+    fprintf(stderr, "%s: pthread_cond_timedwait failed: %s\n", op,
+            strerror(rc));
+    return 1;
+  }
+  if (err_code != NIMFFI_RET_OK) {
+    fprintf(stderr, "%s: %s\n", op,
+            err_msg[0] ? err_msg : "FFI callback failed");
+    return 1;
+  }
+  return 0;
 }
 
-static int create_node(LibP2PCtx** out_ctx) {
-    Libp2pConfig config;
-    memset(&config, 0, sizeof(config));
+static int create_node(LibP2PCtx **out_ctx) {
+  Libp2pConfig config;
+  memset(&config, 0, sizeof(config));
 
-    NimFfiStr listen_addrs[] = { nimffi_str("/ip4/127.0.0.1/tcp/0") };
-    config.addrs.data = listen_addrs;
-    config.addrs.len = 1;
-    config.dnsResolver = nimffi_str("");
-    config.transport = LIBP2P_FFI_TRANSPORT_TCP;
-    config.muxer = LIBP2P_FFI_MUXER_YAMUX;
-    config.maxConnections = 8;
-    config.maxIn = 4;
-    config.maxOut = 4;
-    config.maxConnsPerPeer = 2;
+  NimFfiStr listen_addrs[] = {nimffi_str("/ip4/127.0.0.1/tcp/0")};
+  config.addrs.data = listen_addrs;
+  config.addrs.len = 1;
+  config.dnsResolver = nimffi_str("");
+  config.transport = LIBP2P_FFI_TRANSPORT_TCP;
+  config.muxer = LIBP2P_FFI_MUXER_YAMUX;
+  config.maxConnections = 8;
+  config.maxIn = 4;
+  config.maxOut = 4;
+  config.maxConnsPerPeer = 2;
 
-    CallbackWait create_wait;
-    wait_init(&create_wait);
-    int submit = libp2p_ctx_create(&config, on_created, &create_wait);
-    if (submit != 0) {
-        fprintf(stderr, "create: submit failed\n");
-        wait_destroy(&create_wait);
-        return 1;
-    }
-    if (wait_for_callback(&create_wait, "create") != 0) {
-        wait_destroy(&create_wait);
-        return 1;
-    }
-
-    *out_ctx = create_wait.ctx;
+  CallbackWait create_wait;
+  wait_init(&create_wait);
+  int submit = libp2p_ctx_create(&config, on_created, &create_wait);
+  if (submit != 0) {
+    fprintf(stderr, "create: submit failed\n");
     wait_destroy(&create_wait);
-    return 0;
+    return 1;
+  }
+  if (wait_for_callback(&create_wait, "create") != 0) {
+    wait_destroy(&create_wait);
+    return 1;
+  }
+
+  *out_ctx = create_wait.ctx;
+  wait_destroy(&create_wait);
+  return 0;
 }
 
-static int call_bool_method(const char* op, LibP2PCtx* ctx,
-        int (*fn)(const LibP2PCtx*, void (*)(int, const bool*, const char*, void*), void*)) {
-    CallbackWait wait;
-    wait_init(&wait);
-    int submit = fn(ctx, on_bool_reply, &wait);
-    if (submit != 0) {
-        fprintf(stderr, "%s: submit failed\n", op);
-        wait_destroy(&wait);
-        return 1;
-    }
-    if (wait_for_callback(&wait, op) != 0) {
-        wait_destroy(&wait);
-        return 1;
-    }
-    if (!wait.bool_reply) {
-        fprintf(stderr, "%s: expected true reply\n", op);
-        wait_destroy(&wait);
-        return 1;
-    }
+static int call_bool_method(
+    const char *op, LibP2PCtx *ctx,
+    int (*fn)(const LibP2PCtx *,
+              void (*)(int, const bool *, const char *, void *), void *)) {
+  CallbackWait wait;
+  wait_init(&wait);
+  int submit = fn(ctx, on_bool_reply, &wait);
+  if (submit != 0) {
+    fprintf(stderr, "%s: submit failed\n", op);
     wait_destroy(&wait);
-    return 0;
+    return 1;
+  }
+  if (wait_for_callback(&wait, op) != 0) {
+    wait_destroy(&wait);
+    return 1;
+  }
+  if (!wait.bool_reply) {
+    fprintf(stderr, "%s: expected true reply\n", op);
+    wait_destroy(&wait);
+    return 1;
+  }
+  wait_destroy(&wait);
+  return 0;
 }
 
 int main(void) {
-    setvbuf(stdout, NULL, _IONBF, 0);
-    setvbuf(stderr, NULL, _IONBF, 0);
+  setvbuf(stdout, NULL, _IONBF, 0);
+  setvbuf(stderr, NULL, _IONBF, 0);
 
-    LibP2PCtx* ctx = NULL;
-    if (create_node(&ctx) != 0) {
-        return 1;
-    }
+  LibP2PCtx *ctx = NULL;
+  if (create_node(&ctx) != 0) {
+    return 1;
+  }
 
-    int rc = 0;
-    if (call_bool_method("start", ctx, libp2p_ctx_start) != 0) {
-        rc = 1;
-        goto cleanup;
-    }
-    if (call_bool_method("stop", ctx, libp2p_ctx_stop) != 0) {
-        rc = 1;
-        goto cleanup;
-    }
+  int rc = 0;
+  if (call_bool_method("start", ctx, libp2p_ctx_start) != 0) {
+    rc = 1;
+    goto cleanup;
+  }
+  if (call_bool_method("stop", ctx, libp2p_ctx_stop) != 0) {
+    rc = 1;
+    goto cleanup;
+  }
 
 cleanup:
-    libp2p_ctx_destroy(ctx);
-    return rc;
+  libp2p_ctx_destroy(ctx);
+  return rc;
 }

--- a/cbind/libp2p_ffi.nim
+++ b/cbind/libp2p_ffi.nim
@@ -49,7 +49,7 @@ type LibP2P* = ref object
   topicHandlers: Table[string, TopicHandler]
   customProtocols: Table[string, LPProtocol]
   streams: StreamRegistry
-  stopped: bool
+  running: bool
 
 declareLibrary("libp2p", LibP2P)
 
@@ -265,11 +265,7 @@ proc createLibp2pNode(config: Libp2pConfig): Result[LibP2P, string] =
       return err("could not create libp2p node: " & e.msg)
 
   let lib = LibP2P(
-    switch: switch,
-    rng: rng,
-    relayClient: relayClientOpt,
-    streams: StreamRegistry(),
-    stopped: true,
+    switch: switch, rng: rng, relayClient: relayClientOpt, streams: StreamRegistry()
   )
 
   ?mountProtocols(lib, cfg)
@@ -285,19 +281,19 @@ proc libp2pNew*(config: Libp2pConfig): Future[Result[LibP2P, string]] {.ffiCtor.
 proc shutdownSwitch(lib: LibP2P) {.async.} =
   ## Single source of truth for graceful shutdown. Idempotent: safe to call from
   ## both an explicit `libp2pStop` and `libp2pDestroy`'s teardown.
-  if lib.stopped:
+  if not lib.running:
     return
-  lib.stopped = true
   await lib.switch.stop()
+  lib.running = false
 
 proc libp2pStart*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} =
-  if not lib.stopped:
+  if lib.running:
     return ok(true)
   try:
     await lib.switch.start()
   except LPError as e:
     return err(e.msg)
-  lib.stopped = false
+  lib.running = true
   ok(true)
 
 proc libp2pStop*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} =

--- a/docs/mobile_android.md
+++ b/docs/mobile_android.md
@@ -14,8 +14,8 @@ toolchain from Nix:
 | `x86_64` | `amd64` | `x86_64-linux-android23-clang` |
 
 The Nix derivation currently pins Android NDK `27.2.12479018` through
-`androidenv.composeAndroidPackages` and rebuilds the vendored `nat_traversal` C
-libraries with the same Android clang used for Nim-generated C code.
+`androidenv.composeAndroidPackages` and uses the same Android clang for
+Nim-generated C code and the C check harness.
 
 ## Build Commands
 
@@ -53,8 +53,6 @@ result/
   lib/liblibp2p.so
   lib/liblibp2p.a
   lib/libc++_shared.so
-  lib/libminiupnpc.a
-  lib/libnatpmp.a
   nix-support/android-target
 ```
 
@@ -86,14 +84,7 @@ library.
 For shared-library linking, package the matching ABI's `lib/liblibp2p.so` and
 `lib/libc++_shared.so` with the Android application and load them through the
 normal Android native library path. For static linking, link `lib/liblibp2p.a`
-together with `lib/libminiupnpc.a`, `lib/libnatpmp.a`, and the Android C++
-runtime selected by your application.
-
-## Dependency Notes
-
-The Android derivation uses a writable copy of `nat_traversal` so its vendored
-`miniupnpc` and `libnatpmp` archives can be rebuilt with the selected Android
-clang.
+together with the Android C++ runtime selected by your application.
 
 ## Android Check Harness
 

--- a/docs/mobile_android.md
+++ b/docs/mobile_android.md
@@ -1,0 +1,134 @@
+# Android Mobile Builds For libp2p_ffi
+
+`cbind/libp2p_ffi.nim` is the supported C ABI target for mobile builds. The
+legacy `cbind/libp2p.nim` target is not extended for Android.
+
+## Supported Targets
+
+The Android build uses Android API 23 by default and builds with the NDK clang
+toolchain from Nix:
+
+| Android ABI | Nim CPU | C compiler |
+| --- | --- | --- |
+| `arm64-v8a` | `arm64` | `aarch64-linux-android23-clang` |
+| `x86_64` | `amd64` | `x86_64-linux-android23-clang` |
+
+The Nix derivation currently pins Android NDK `27.2.12479018` through
+`androidenv.composeAndroidPackages` and rebuilds the vendored `nat_traversal` C
+libraries with the same Android clang used for Nim-generated C code.
+
+## Build Commands
+
+Build a single ABI:
+
+```sh
+nix build .#cbind-ffi-android-arm64-v8a
+nix build .#cbind-ffi-android-x86_64
+```
+
+Build both ABI layouts in one output:
+
+```sh
+nix build .#cbind-ffi-android
+```
+
+The host C ABI package remains available as:
+
+```sh
+nix build .#cbind-ffi
+```
+
+## Artifact Layout
+
+Single-ABI outputs are flat:
+
+```text
+result/
+  bin/libp2p_ffi_android_check
+  include/libp2p.h
+  include/nim_ffi_cbor.h
+  include/nim_ffi_prelude.h
+  include/tinycbor/...
+  include/cddl_bindings/libp2p.cddl
+  lib/liblibp2p.so
+  lib/liblibp2p.a
+  lib/libc++_shared.so
+  lib/libminiupnpc.a
+  lib/libnatpmp.a
+  nix-support/android-target
+```
+
+The aggregate output nests the same layout by ABI:
+
+```text
+result/android/arm64-v8a/...
+result/android/x86_64/...
+```
+
+`liblibp2p.so` and `liblibp2p.a` intentionally keep the same naming as the host
+`cbind-ffi` package.
+
+## Downstream Linking Notes
+
+Use the generated high-level C helpers in `include/libp2p.h`:
+
+- `libp2p_ctx_create`
+- `libp2p_ctx_start`
+- `libp2p_ctx_stop`
+- `libp2p_ctx_destroy`
+
+The generated header uses TinyCBOR for request and response encoding. The Nix
+output installs the required TinyCBOR headers and C sources under
+`include/tinycbor`. Downstream C or C++ code that calls the generated helper
+functions should compile those TinyCBOR `.c` files into the app or a support
+library.
+
+For shared-library linking, package the matching ABI's `lib/liblibp2p.so` and
+`lib/libc++_shared.so` with the Android application and load them through the
+normal Android native library path. For static linking, link `lib/liblibp2p.a`
+together with `lib/libminiupnpc.a`, `lib/libnatpmp.a`, and the Android C++
+runtime selected by your application.
+
+## Dependency Notes
+
+The Android derivation uses a writable copy of `nat_traversal` so its vendored
+`miniupnpc` and `libnatpmp` archives can be rebuilt with the selected Android
+clang.
+
+## Android Check Harness
+
+The Nix Android derivation compiles `cbind/examples/libp2p_ffi_android_check.c`
+for each ABI. The harness includes the generated nim-ffi C header, creates a
+default TCP/Yamux node, starts it, stops it, destroys the context, and fails on
+callback errors or timeouts.
+
+The derivation only compiles and links the harness. To run it on a device or
+emulator, build the ABI matching the device and push the shared library and
+check binary:
+
+```sh
+nix build .#cbind-ffi-android-arm64-v8a
+
+adb shell 'mkdir -p /data/local/tmp/nim-libp2p'
+adb push result/lib/liblibp2p.so /data/local/tmp/nim-libp2p/
+adb push result/bin/libp2p_ffi_android_check /data/local/tmp/nim-libp2p/
+adb shell 'cd /data/local/tmp/nim-libp2p && chmod 755 libp2p_ffi_android_check && LD_LIBRARY_PATH=. ./libp2p_ffi_android_check'
+```
+
+For an x86_64 emulator, replace the build command with:
+
+```sh
+nix build .#cbind-ffi-android-x86_64
+```
+
+## CI Coverage
+
+`.github/workflows/mobile_android.yml` builds both Android ABI packages and
+checks that each output contains:
+
+- shared and static `liblibp2p` libraries
+- Android `libc++_shared.so` runtime for the shared object
+- generated C headers and CDDL
+- TinyCBOR headers used by the generated C helper layer
+- the linked Android check executable
+- Android ELF machine headers matching the selected ABI

--- a/flake.nix
+++ b/flake.nix
@@ -20,10 +20,42 @@
         "x86_64-windows"
       ];
       forAllSystems = nixpkgs.lib.genAttrs systems;
+      pkgsFor = system: import nixpkgs {
+        inherit system;
+        config = {
+          android_sdk.accept_license = true;
+          allowUnfreePredicate = pkg:
+            let name = nixpkgs.lib.getName pkg;
+            in nixpkgs.lib.any (prefix: nixpkgs.lib.hasPrefix prefix name) [
+              "android"
+              "build-tools"
+              "cmdline-tools"
+              "ndk"
+              "platform-tools"
+              "platforms"
+              "tools"
+            ];
+        };
+      };
     in {
       packages = forAllSystems (system:
         let
-          pkgs = import nixpkgs { inherit system; };
+          pkgs = pkgsFor system;
+          androidSupported = pkgs.stdenv.hostPlatform.isLinux || pkgs.stdenv.hostPlatform.isDarwin;
+          androidArm64 = import ./nix/cbind-ffi-android.nix {
+            inherit pkgs;
+            src = ./.;
+            abi = "arm64-v8a";
+            androidTriple = "aarch64-linux-android";
+            nimCpu = "arm64";
+          };
+          androidX86 = import ./nix/cbind-ffi-android.nix {
+            inherit pkgs;
+            src = ./.;
+            abi = "x86_64";
+            androidTriple = "x86_64-linux-android";
+            nimCpu = "amd64";
+          };
         in {
           default = import ./nix/default.nix {
             inherit pkgs;
@@ -42,12 +74,22 @@
             inherit pkgs;
             src = ./.;
           };
+        } // pkgs.lib.optionalAttrs androidSupported {
+          cbind-ffi-android-arm64-v8a = androidArm64;
+
+          cbind-ffi-android-x86_64 = androidX86;
+
+          cbind-ffi-android = pkgs.runCommand "nim-libp2p-cbind-ffi-android" { } ''
+            mkdir -p $out/android/arm64-v8a $out/android/x86_64
+            cp -R ${androidArm64}/. $out/android/arm64-v8a/
+            cp -R ${androidX86}/.   $out/android/x86_64/
+          '';
         }
       );
 
       devShells = forAllSystems (system:
         let
-          pkgs = import nixpkgs { inherit system; };
+          pkgs = pkgsFor system;
         in {
           default = pkgs.mkShell {
             nativeBuildInputs = [

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -11,7 +11,7 @@ requires "nim >= 2.2.4",
   "nimcrypto >= 0.6.0", "bearssl >= 0.2.7",
   "https://github.com/vacp2p/nim-boringssl >= 0.0.8", "chronicles >= 0.11.0",
   "chronos >= 4.2.2", "metrics >= 0.2.2", "secp256k1", "stew >= 0.4.2", "results",
-  "serialization", "lsquic >= 0.5.4", "protobuf_serialization >= 0.5.3",
+  "serialization", "lsquic >= 0.5.5", "protobuf_serialization >= 0.5.3",
   "https://github.com/status-im/nim-websock >= 0.4.0",
   "https://github.com/logos-storage/nim-libplum#acefbe424cf9d1f05f2d93533790c9ac4e034df8"
 

--- a/nix/cbind-ffi-android.nix
+++ b/nix/cbind-ffi-android.nix
@@ -10,13 +10,9 @@ let
   deps = import ./deps.nix { inherit pkgs; };
   cbindDeps = import ./cbind-deps.nix { inherit pkgs; };
 
-  # nat_traversal is copied into the build directory because its vendored C
-  # archives need to be rebuilt with the Android toolchain.
-  depsWithoutWritable = builtins.removeAttrs deps [ "nat_traversal" ];
-
   pathArgs =
     builtins.concatStringsSep " "
-      (map (p: "--path:${p}") (builtins.attrValues depsWithoutWritable));
+      (map (p: "--path:${p}") (builtins.attrValues deps));
 
   cbindPathArgs =
     builtins.concatStringsSep " "
@@ -98,31 +94,16 @@ pkgs.stdenv.mkDerivation {
     fi
 
     mkdir -p build $NIMCACHE
-
-    echo "== Preparing writable dependency copies for Android ${abi} =="
-    NAT_PKG=$TMPDIR/nat_traversal
-    cp -r ${deps.nat_traversal} $NAT_PKG
-    chmod -R +w $NAT_PKG
-
-    echo "== Building nat_traversal vendored C libs for Android ${abi} =="
-    make -C "$NAT_PKG/vendor/miniupnp/miniupnpc" \
-      CC="$ANDROID_CC" AR="$ANDROID_AR" RANLIB="$ANDROID_RANLIB" \
-      CFLAGS="-Os -fPIC -DANDROID" \
-      build/libminiupnpc.a
-
-    make -C "$NAT_PKG/vendor/libnatpmp-upstream" \
-      CC="$ANDROID_CC" AR="$ANDROID_AR" RANLIB="$ANDROID_RANLIB" \
-      CFLAGS="-Wall -Os -fPIC -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4" \
-      libnatpmp.a
+    echo 'INPUT(-lc)' > build/libpthread.so
 
     # ffiThreadExitTimeoutMs: bound the FFI thread's graceful-shutdown wait; the
     # 1500ms default is too tight for libp2pDestroy's switch.stop() over many conns.
-    commonArgs="--noNimblePath ${cbindPathArgs} ${pathArgs} --path:$NAT_PKG \
+    commonArgs="--noNimblePath ${cbindPathArgs} ${pathArgs} \
       --os:android --cpu:${nimCpu} --cc:clang \
       --clang.path:$ANDROID_TOOLCHAIN/bin \
       --clang.exe:${androidCcName} --clang.linkerexe:${androidCxxName} \
       --passC:-DANDROID --passC:-fPIC \
-      --passL:-lc++_shared --passL:-llog --passL:-ldl --passL:-lm \
+      --passL:-L$PWD/build --passL:-lc++_shared --passL:-llog --passL:-ldl --passL:-lm \
       --threads:on --opt:size --noMain --mm:refc --d:metrics \
       -d:ffiThreadExitTimeoutMs=5000 \
       --nimMainPrefix:liblibp2p --nimcache:$NIMCACHE"
@@ -156,7 +137,7 @@ pkgs.stdenv.mkDerivation {
       obj=build/check-objects/$(basename "$src" .c).o
       "$ANDROID_CC" -std=c11 -fPIE -I cbind/c_bindings/tinycbor -c "$src" -o "$obj"
     done
-    "$ANDROID_CXX" -fPIE -pie -pthread \
+    "$ANDROID_CXX" -L build -fPIE -pie -pthread \
       build/check-objects/*.o build/liblibp2p.so \
       -lc++_shared -ldl -lm -llog \
       -o build/libp2p_ffi_android_check
@@ -172,9 +153,6 @@ pkgs.stdenv.mkDerivation {
     cp build/liblibp2p.so $out/lib/
     cp build/liblibp2p.a  $out/lib/
     cp "$ANDROID_CXX_STDLIB" $out/lib/
-    cp $NAT_PKG/vendor/miniupnp/miniupnpc/build/libminiupnpc.a $out/lib/
-    cp $NAT_PKG/vendor/libnatpmp-upstream/libnatpmp.a          $out/lib/
-
     cp cbind/c_bindings/*.h $out/include/
     cp -r cbind/c_bindings/tinycbor $out/include/
     cp -r cbind/cddl_bindings $out/include/

--- a/nix/cbind-ffi-android.nix
+++ b/nix/cbind-ffi-android.nix
@@ -27,7 +27,8 @@ let
   androidCxxName = "${androidTriple}${androidApiString}-clang++";
 
   androidHostTag =
-    if pkgs.stdenv.hostPlatform.isDarwin then "darwin-x86_64"
+    if pkgs.stdenv.hostPlatform.system == "aarch64-darwin" then "darwin-arm64"
+    else if pkgs.stdenv.hostPlatform.isDarwin then "darwin-x86_64"
     else if pkgs.stdenv.hostPlatform.system == "aarch64-linux" then "linux-aarch64"
     else "linux-x86_64";
 

--- a/nix/cbind-ffi-android.nix
+++ b/nix/cbind-ffi-android.nix
@@ -1,0 +1,197 @@
+{ pkgs
+, src
+, abi
+, androidTriple
+, nimCpu
+, androidApi ? 23
+}:
+
+let
+  deps = import ./deps.nix { inherit pkgs; };
+  cbindDeps = import ./cbind-deps.nix { inherit pkgs; };
+
+  # nat_traversal is copied into the build directory because its vendored C
+  # archives need to be rebuilt with the Android toolchain.
+  depsWithoutWritable = builtins.removeAttrs deps [ "nat_traversal" ];
+
+  pathArgs =
+    builtins.concatStringsSep " "
+      (map (p: "--path:${p}") (builtins.attrValues depsWithoutWritable));
+
+  cbindPathArgs =
+    builtins.concatStringsSep " "
+      (map (p: "--path:${p}") (builtins.attrValues cbindDeps));
+
+  androidApiString = toString androidApi;
+  androidCcName = "${androidTriple}${androidApiString}-clang";
+  androidCxxName = "${androidTriple}${androidApiString}-clang++";
+
+  androidHostTag =
+    if pkgs.stdenv.hostPlatform.isDarwin then "darwin-x86_64"
+    else if pkgs.stdenv.hostPlatform.system == "aarch64-linux" then "linux-aarch64"
+    else "linux-x86_64";
+
+  androidComposition = pkgs.androidenv.composeAndroidPackages {
+    cmdLineToolsVersion = "9.0";
+    toolsVersion = "26.1.1";
+    platformToolsVersion = "34.0.5";
+    buildToolsVersions = [ "34.0.0" ];
+    platformVersions = [ androidApiString ];
+    includeCmake = false;
+    ndkVersion = "27.2.12479018";
+    includeNDK = true;
+  };
+
+  androidSdk = androidComposition.androidsdk;
+  tinycborVendor = "${cbindDeps.ffi}/ffi/codegen/templates/cpp/vendor/tinycbor";
+in
+pkgs.stdenv.mkDerivation {
+  pname = "nim-libp2p-cbind-ffi-android-${abi}";
+  version = "dev";
+
+  inherit src;
+
+  nativeBuildInputs = [
+    pkgs.nim-2_2
+    pkgs.git
+    pkgs.nimble
+    pkgs.gnumake
+    pkgs.which
+    pkgs.file
+    pkgs.binutils
+  ];
+
+  # Android ELF files are not host ELF files; host fixup/patchelf would be wrong.
+  dontFixup = true;
+
+  buildPhase = ''
+    export HOME=$TMPDIR
+    export XDG_CACHE_HOME=$TMPDIR/.cache
+    export NIMBLE_DIR=$TMPDIR/.nimble
+    export NIMCACHE=$TMPDIR/nimcache
+
+    export ANDROID_SDK_ROOT=${androidSdk}/libexec/android-sdk
+    export ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk-bundle
+
+    ANDROID_TOOLCHAIN=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/${androidHostTag}
+    export PATH=$ANDROID_TOOLCHAIN/bin:$PATH
+
+    export ANDROID_CC=$ANDROID_TOOLCHAIN/bin/${androidCcName}
+    export ANDROID_CXX=$ANDROID_TOOLCHAIN/bin/${androidCxxName}
+    export ANDROID_AR=$ANDROID_TOOLCHAIN/bin/llvm-ar
+    export ANDROID_RANLIB=$ANDROID_TOOLCHAIN/bin/llvm-ranlib
+    export ANDROID_READELF=$ANDROID_TOOLCHAIN/bin/llvm-readelf
+    export ANDROID_CXX_STDLIB=$ANDROID_TOOLCHAIN/sysroot/usr/lib/${androidTriple}/libc++_shared.so
+
+    if [ ! -x "$ANDROID_CC" ]; then
+      echo "missing Android clang: $ANDROID_CC" >&2
+      exit 1
+    fi
+    if [ ! -x "$ANDROID_CXX" ]; then
+      echo "missing Android clang++: $ANDROID_CXX" >&2
+      exit 1
+    fi
+    if [ ! -f "$ANDROID_CXX_STDLIB" ]; then
+      echo "missing Android libc++_shared.so: $ANDROID_CXX_STDLIB" >&2
+      exit 1
+    fi
+
+    mkdir -p build $NIMCACHE
+
+    echo "== Preparing writable dependency copies for Android ${abi} =="
+    NAT_PKG=$TMPDIR/nat_traversal
+    cp -r ${deps.nat_traversal} $NAT_PKG
+    chmod -R +w $NAT_PKG
+
+    echo "== Building nat_traversal vendored C libs for Android ${abi} =="
+    make -C "$NAT_PKG/vendor/miniupnp/miniupnpc" \
+      CC="$ANDROID_CC" AR="$ANDROID_AR" RANLIB="$ANDROID_RANLIB" \
+      CFLAGS="-Os -fPIC -DANDROID" \
+      build/libminiupnpc.a
+
+    make -C "$NAT_PKG/vendor/libnatpmp-upstream" \
+      CC="$ANDROID_CC" AR="$ANDROID_AR" RANLIB="$ANDROID_RANLIB" \
+      CFLAGS="-Wall -Os -fPIC -DENABLE_STRNATPMPERR -DNATPMP_MAX_RETRIES=4" \
+      libnatpmp.a
+
+    # ffiThreadExitTimeoutMs: bound the FFI thread's graceful-shutdown wait; the
+    # 1500ms default is too tight for libp2pDestroy's switch.stop() over many conns.
+    commonArgs="--noNimblePath ${cbindPathArgs} ${pathArgs} --path:$NAT_PKG \
+      --os:android --cpu:${nimCpu} --cc:clang \
+      --clang.path:$ANDROID_TOOLCHAIN/bin \
+      --clang.exe:${androidCcName} --clang.linkerexe:${androidCxxName} \
+      --passC:-DANDROID --passC:-fPIC \
+      --passL:-lc++_shared --passL:-llog --passL:-ldl --passL:-lm \
+      --threads:on --opt:size --noMain --mm:refc --d:metrics \
+      -d:ffiThreadExitTimeoutMs=5000 \
+      --nimMainPrefix:liblibp2p --nimcache:$NIMCACHE"
+
+    echo "== Building Android FFI library (shared) for ${abi} =="
+    nim c $commonArgs --app:lib --out:build/liblibp2p.so cbind/libp2p_ffi.nim
+
+    echo "== Building Android FFI library (static) for ${abi} =="
+    nim c $commonArgs --app:staticlib --out:build/liblibp2p.a cbind/libp2p_ffi.nim
+
+    echo "== Generating C bindings =="
+    nim c $commonArgs --app:lib -d:ffiGenBindings -d:targetLang=c \
+      -d:ffiOutputDir=cbind/c_bindings -d:ffiSrcPath=libp2p_ffi.nim \
+      -o:/dev/null cbind/libp2p_ffi.nim
+
+    echo "== Generating CDDL schema =="
+    nim c $commonArgs --app:lib -d:ffiGenBindings -d:targetLang=cddl \
+      -d:ffiOutputDir=cbind/cddl_bindings -d:ffiSrcPath=libp2p_ffi.nim \
+      -o:/dev/null cbind/libp2p_ffi.nim
+
+    mkdir -p cbind/c_bindings/tinycbor
+    cp ${tinycborVendor}/* cbind/c_bindings/tinycbor/
+
+    echo "== Compiling Android C check harness for ${abi} =="
+    mkdir -p build/check-objects
+    "$ANDROID_CC" -std=c11 -fPIE -pthread \
+      -I cbind/c_bindings -I cbind/c_bindings/tinycbor \
+      -c cbind/examples/libp2p_ffi_android_check.c \
+      -o build/check-objects/libp2p_ffi_android_check.o
+    for src in cbind/c_bindings/tinycbor/*.c; do
+      obj=build/check-objects/$(basename "$src" .c).o
+      "$ANDROID_CC" -std=c11 -fPIE -I cbind/c_bindings/tinycbor -c "$src" -o "$obj"
+    done
+    "$ANDROID_CXX" -fPIE -pie -pthread \
+      build/check-objects/*.o build/liblibp2p.so \
+      -lc++_shared -ldl -lm -llog \
+      -o build/libp2p_ffi_android_check
+
+    "$ANDROID_READELF" -h build/liblibp2p.so > build/liblibp2p.so.readelf
+    "$ANDROID_READELF" -h build/libp2p_ffi_android_check > build/libp2p_ffi_android_check.readelf
+    "$ANDROID_AR" t build/liblibp2p.a > /dev/null
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib $out/include $out/bin $out/nix-support
+
+    cp build/liblibp2p.so $out/lib/
+    cp build/liblibp2p.a  $out/lib/
+    cp "$ANDROID_CXX_STDLIB" $out/lib/
+    cp $NAT_PKG/vendor/miniupnp/miniupnpc/build/libminiupnpc.a $out/lib/
+    cp $NAT_PKG/vendor/libnatpmp-upstream/libnatpmp.a          $out/lib/
+
+    cp cbind/c_bindings/*.h $out/include/
+    cp -r cbind/c_bindings/tinycbor $out/include/
+    cp -r cbind/cddl_bindings $out/include/
+
+    cp build/libp2p_ffi_android_check $out/bin/
+    cp build/*.readelf $out/nix-support/
+
+    printf '%s\n' \
+      "abi=${abi}" \
+      "android_api=${androidApiString}" \
+      "android_triple=${androidTriple}" \
+      "nim_cpu=${nimCpu}" \
+      "cc=${androidCcName}" \
+      > $out/nix-support/android-target
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Android ${abi} C ABI build of nim-libp2p libp2p_ffi";
+    platforms = platforms.linux ++ platforms.darwin;
+  };
+}

--- a/nix/cbind-ffi.nix
+++ b/nix/cbind-ffi.nix
@@ -16,6 +16,8 @@ let
     builtins.concatStringsSep " "
       (map (p: "--path:${p}") (builtins.attrValues cbindDeps));
 
+  tinycborVendor = "${cbindDeps.ffi}/ffi/codegen/templates/cpp/vendor/tinycbor";
+
   libExt =
     if pkgs.stdenv.hostPlatform.isWindows then "dll"
     else if pkgs.stdenv.hostPlatform.isDarwin then "dylib"
@@ -75,6 +77,8 @@ pkgs.stdenv.mkDerivation {
     # Install nim-ffi's headers (libp2p.h + companions) flat: consumers stage
     # them via `cp $out/include/*.h`, so a nested dir would be missed.
     cp cbind/c_bindings/*.h   $out/include/
+    # libp2p.h includes <tinycbor/cbor.h>; install the vendored C runtime too.
+    cp -r ${tinycborVendor} $out/include/tinycbor
     cp -r cbind/cddl_bindings $out/include/
   '';
 }

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -138,8 +138,8 @@
 
   lsquic = pkgs.fetchgit {
     url = "https://github.com/vacp2p/nim-lsquic";
-    rev = "3813b849d70edbef24dac3926b32949029721fdc";
-    sha256 = "016r3i7xj5mriaf199xr91j1f8312s89zgp66fiy9bj1j1i22yp7";
+    rev = "079768948ac03d8f2384e03045a090cb88aeb7d9";
+    sha256 = "0vpmwmin1vydm7lrs98vqkwm4ja3y8h4gzv8mz9spnvi450jwam1";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
## Summary

Adds Android build support for the `cbind/libp2p_ffi.nim` C ABI target.

This PR adds Nix packages for:

- `cbind-ffi-android-arm64-v8a`
- `cbind-ffi-android-x86_64`
- `cbind-ffi-android`

Each Android package builds shared/static `liblibp2p` artifacts, generated C headers/CDDL, required runtime/vendor libraries, and a small Android check harness that creates, starts, stops, and destroys a libp2p node through the generated C API.

It also adds Android CI coverage, Android build documentation, updates `nim-lsquic` to `0.5.5`, and fixes the `libp2p_ffi` start/stop path needed by the generated FFI bindings.

## Affected Areas

- [x] Build / Tooling  
  Adds Android Nix build targets, Android CI, Android artifact checks, and Android build documentation.

- [x] Other  
  Extends the nim-ffi C ABI packaging path used by downstream native consumers.

## Impact on Library Users

Downstream Android applications can build and package `liblibp2p.so` or `liblibp2p.a` for `arm64-v8a` and `x86_64`.

The Android outputs include the generated headers, CDDL schema, TinyCBOR headers, `libc++_shared.so`, and the vendored NAT traversal static libraries needed for downstream linking.

## Risk Assessment

Most risk is isolated to Android/Nix packaging and CI build time.

The `libp2p_ffi` start/stop changes are required for the generated FFI API to compile and for a newly created node to start correctly. Existing legacy cbind support is not extended or replaced by this PR.

## References

Depends on / should wait for:

- https://github.com/vacp2p/nim-libp2p/pull/2780

That PR flips the nim-ffi migration to make `libp2p_ffi` the active C binding path. This Android work should merge after that lands.