### PR TITLE
fix(gossipsub): concurrent peers table access during topic unsubscribe

### DIFF
--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -539,9 +539,6 @@ method onTopicSubscription*(
   # removes the last handler
 
   # Notify others that we are no longer interested in the topic.
-  # Iterate over a snapshot: sending may synchronously re-enter and mutate
-  # `p.peers` (e.g. via send hooks or peer add/remove from the network path),
-  # which would otherwise corrupt a live table iteration.
   for peer in toSeq(p.peers.values):
     # If we don't have a sendStream yet, we will
     # send the full sub list when we get the sendStream,

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -538,8 +538,11 @@ method onTopicSubscription*(
   # Called when subscribe is called the first time for a topic or unsubscribe
   # removes the last handler
 
-  # Notify others that we are no longer interested in the topic
-  for _, peer in p.peers:
+  # Notify others that we are no longer interested in the topic.
+  # Iterate over a snapshot: sending may synchronously re-enter and mutate
+  # `p.peers` (e.g. via send hooks or peer add/remove from the network path),
+  # which would otherwise corrupt a live table iteration.
+  for peer in toSeq(p.peers.values):
     # If we don't have a sendStream yet, we will
     # send the full sub list when we get the sendStream,
     # so no need to send it here

--- a/tests/libp2p/pubsub/test_gossipsub.nim
+++ b/tests/libp2p/pubsub/test_gossipsub.nim
@@ -178,6 +178,35 @@ suite "GossipSub":
     check:
       true
 
+  asyncTest "unsubscribeAll does not crash when peers table is mutated during iteration":
+    let (gossipSub, conns, peers) = setupGossipSubWithPeers(3, topic)
+    defer:
+      await teardownGossipSub(gossipSub, conns)
+
+    # An onSend hook fires synchronously from within the peers-table iteration
+    # in onTopicSubscription (via sendSubs -> send -> sendObservers). We use it
+    # to mutate `gossipSub.peers` mid-iteration, standing in for an incoming
+    # subscription arriving on the network path.
+    let extraPeerId = randomPeerId()
+    let extraPeer = peers[0]
+
+    var injected = false
+    proc onSend(p: PubSubPeer, msg: var RPCMsg) {.gcsafe, raises: [].} =
+      # Only inject during the unsubscribe subscription message (which carries
+      # `subscriptions`), not during unrelated control-message broadcasts.
+      if not injected and msg.subscriptions.len > 0:
+        injected = true
+        gossipSub.peers[extraPeerId] = extraPeer
+
+    let observers = new(seq[PubSubObserver])
+    observers[].add(PubSubObserver(onSend: onSend))
+    for peer in peers:
+      peer.observers = observers
+
+    gossipSub.unsubscribeAll(topic)
+
+    check injected
+
   asyncTest "unsubscribePeer - removes peer from mesh, gossipsub, fanout and subscribedDirectPeers":
     # Given a GossipSub instance with one peer in mesh
     let


### PR DESCRIPTION
## Summary

Fixes a crash observed during a nimbus-eth2 fork transition (FULU→GLOAS), where fork-driven gossip topic cleanup aborts the node with:

```
tables.nim(771, 13) `len(t) == L` the length of the table changed while iterating over it [AssertionDefect]
```

The crash path is `updateGossipStatus` → `removeFuluMessageHandlers` → `unsubscribe`/`unsubscribeAll` → `PubSub.onTopicSubscription`, which iterates `p.peers` directly (`for _, peer in p.peers`) while sending unsubscribe messages. Any modification of `p.peers` that happens synchronously within that iteration — e.g. a send hook, or a re-entrant peer add/remove originating from the network path — changes the table length and trips Nim's `len(t) == L` iterator guard, raising an uncatchable-in-practice `AssertionDefect` that takes the whole node down.

The fix is to iterate over a snapshot of the peers rather than the live table, so a concurrent modification of `p.peers` can no longer corrupt the in-flight iteration.

## Affected Areas

- [x] Gossipsub
  <!-- pubsub topic subscription / peer notification path -->

## Compatibility & Downstream Validation

- **Nimbus:** reproduces the reported fork-transition crash; this change removes the abort.
- **Waku:** N/A — no API or wire-format change.
- **Codex:** N/A — no API or wire-format change.

## Impact on Library Users

No API or behavior change. The set of peers notified on (un)subscribe is unchanged; only the iteration is made robust against concurrent table mutation. Internal robustness fix.

## Risk Assessment

- Backward compatibility: unaffected — no public API or wire change.
- Network behavior: unchanged; the same subscribe/unsubscribe messages are sent to the same peers.
- Performance: negligible — one extra shallow snapshot of the peers collection per (un)subscribe notification.
- Security: none.

## References

- Repro test added in `tests/libp2p/pubsub/test_gossipsub.nim`: "unsubscribeAll does not crash when peers table is mutated during iteration".