### PR TITLE
chore(builders): disable IdentifyPusher by default

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -113,7 +113,7 @@ proc new*(T: type[SwitchBuilder]): T =
     circuitRelay: Opt.none(Relay),
     rdvConfig: Opt.none(RendezVousConfig),
     kad: Opt.none(KadInfo),
-    identifyPusherEnabled: true,
+    identifyPusherEnabled: false,
     enableWildcardResolver: true,
     addressPolicy: defaultAddressPolicy,
     addressTtls: AddressConfidenceTtls(),

--- a/tests/libp2p/test_peer_store_component.nim
+++ b/tests/libp2p/test_peer_store_component.nim
@@ -70,8 +70,8 @@ suite "PeerStore Address TTL - Component":
 
   asyncTest "later identify update does not downgrade a verified High address":
     let
-      listener = makeStandardSwitch()
-      dialer = makeStandardSwitch()
+      listener = makeStandardSwitchBuilder().withIdentifyPusher().build()
+      dialer = makeStandardSwitchBuilder().withIdentifyPusher().build()
     startAndDeferStop(@[listener, dialer])
 
     # Wait for the listener to finish identifying the dialer,


### PR DESCRIPTION
closes: #2818 