### PR TITLE
chore(kad-dht): loosen validation on AddProvider for interop tests

### DIFF
--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -247,9 +247,9 @@ method handleAddProvider*(
     error "Key not set: handleAddProvider", msg = msg, stream = stream
     return
 
-  if not MultiHash.validate(msgKey):
-    error "Received key is an invalid Multihash",
-      msg = msg, stream = stream, key = msgKey
+  if msgKey.len == 0 or msgKey.len > MaxProviderKeyLen:
+    error "ADD_PROVIDER key length out of bounds",
+      msg = msg, stream = stream, keyLen = msgKey.len, maxLen = MaxProviderKeyLen
     if kad.config.providerRejection:
       await stream.sendAddProviderResponse(kad, AddProviderStatus.rejected)
     return

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -48,8 +48,7 @@ const
   DefaultMaxPeersPerSubnet* = 10
     ## upper bound on Kademlia routing-table peers sharing one IP subnet
 
-  MaxProviderKeyLen* = 80
-    ## Upper bound (bytes) on an ADD_PROVIDER key, matching go-libp2p-kad-dht.
+  MaxProviderKeyLen* = 80 ## Upper bound (bytes) on an ADD_PROVIDER key
 
 type Key* = seq[byte]
 

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -48,6 +48,9 @@ const
   DefaultMaxPeersPerSubnet* = 10
     ## upper bound on Kademlia routing-table peers sharing one IP subnet
 
+  MaxProviderKeyLen* = 80
+    ## Upper bound (bytes) on an ADD_PROVIDER key, matching go-libp2p-kad-dht.
+
 type Key* = seq[byte]
 
 proc toCid*(k: Key): Cid =

--- a/tests/libp2p/kademlia/test_add_provider.nim
+++ b/tests/libp2p/kademlia/test_add_provider.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import chronos, results, sets, sequtils, tables
+import chronos, results, sets, sequtils, tables, stew/byteutils
 import
   ../../../libp2p/[protocols/kademlia, switch, builders, multicodec, multihash, cid]
 import ../../tools/[lifecycle, topology, unittest]
@@ -221,12 +221,10 @@ suite "KadDHT - Add Provider":
       receiverKad.providerManager.providerRecords[0].provider.id.get() ==
         senderKad.switch.peerInfo.peerId.getBytes()
 
-  asyncTest "Add provider rejects invalid multihash key":
+  asyncTest "Add provider accepts a non-multihash key within length bound":
+    # Interop parity: go/js/py/dotnet advertise raw, non-multihash provider keys
     let kads = setupKadSwitches(1)
-
     let senderKad = kads[0]
-
-    # Setup receiver with mock that injects invalid multihash key
     var receiverKad = setupMockKad()
 
     startAndDeferStop(kads & receiverKad)
@@ -235,17 +233,63 @@ suite "KadDHT - Add Provider":
 
     check receiverKad.providerManager.providerRecords.len == 0
 
-    # Inject message with invalid multihash key
+    let rawKey = "interop-test-key-0123".toBytes()
+    check not MultiHash.validate(rawKey) # sanity: not a valid multihash
+
     receiverKad.handleAddProviderMessage = Opt.some(
       Message(
         msgType: MessageType.addProvider,
-        key: @[1.byte, 1, 1],
+        key: rawKey,
         providerPeers: @[senderKad.switch.peerInfo.toPeer()],
       )
     )
     await senderKad.addProvider(senderKad.rtable.selfId.toCid())
 
-    # Provider should NOT be stored due to invalid multihash validation
+    checkUntilTimeout:
+      receiverKad.providerManager.providerRecords.len == 1
+      receiverKad.providerManager.knownKeys.hasKey(rawKey)
+
+  asyncTest "Add provider rejects an empty key":
+    let kads = setupKadSwitches(1)
+    let senderKad = kads[0]
+    var receiverKad = setupMockKad()
+
+    startAndDeferStop(kads & receiverKad)
+
+    await connect(senderKad, receiverKad)
+
+    receiverKad.handleAddProviderMessage = Opt.some(
+      Message(
+        msgType: MessageType.addProvider,
+        key: newSeq[byte](0),
+        providerPeers: @[senderKad.switch.peerInfo.toPeer()],
+      )
+    )
+    await senderKad.addProvider(senderKad.rtable.selfId.toCid())
+
+    # Empty key is out of bounds, record must not be stored
+    await sleepAsync(200.milliseconds)
+    check receiverKad.providerManager.providerRecords.len == 0
+
+  asyncTest "Add provider rejects a key exceeding the length bound":
+    let kads = setupKadSwitches(1)
+    let senderKad = kads[0]
+    var receiverKad = setupMockKad()
+
+    startAndDeferStop(kads & receiverKad)
+
+    await connect(senderKad, receiverKad)
+
+    receiverKad.handleAddProviderMessage = Opt.some(
+      Message(
+        msgType: MessageType.addProvider,
+        key: newSeq[byte](MaxProviderKeyLen + 1),
+        providerPeers: @[senderKad.switch.peerInfo.toPeer()],
+      )
+    )
+    await senderKad.addProvider(senderKad.rtable.selfId.toCid())
+
+    # Over-length key is out of bounds → record must not be stored
     await sleepAsync(200.milliseconds)
     check receiverKad.providerManager.providerRecords.len == 0
 
@@ -626,3 +670,26 @@ suite "KadDHT - ADD_PROVIDER Rejection":
     # Receiver rejects (limit already full); record count stays at 1
     await sleepAsync(200.milliseconds)
     check receiverKad.providerManager.providerRecords.len == 1
+
+  asyncTest "Out-of-bounds key is rejected when providerRejection enabled":
+    let senderKad = setupKad(testKadConfig(providerRejection = true))
+    # Mock receiver injects an over-length key regardless of what is sent.
+    let receiverKad = setupMockKad(
+      testKadConfig(providerRejection = true),
+      handleAddProviderMessage = Opt.some(
+        Message(
+          msgType: MessageType.addProvider, key: newSeq[byte](MaxProviderKeyLen + 1)
+        )
+      ),
+    )
+
+    startAndDeferStop(@[senderKad] & receiverKad)
+    await connect(senderKad, receiverKad)
+
+    let status = await senderKad.sendAddProviderAndGetStatus(
+      receiverKad, senderKad.rtable.selfId.toCid().toKey()
+    )
+    check:
+      status.isOk()
+      status.value() == AddProviderStatus.rejected
+      receiverKad.providerManager.providerRecords.len == 0

--- a/tests/libp2p/kademlia/test_add_provider.nim
+++ b/tests/libp2p/kademlia/test_add_provider.nim
@@ -268,7 +268,7 @@ suite "KadDHT - Add Provider":
     await senderKad.addProvider(senderKad.rtable.selfId.toCid())
 
     # Empty key is out of bounds, record must not be stored
-    await sleepAsync(200.milliseconds)
+    await sleepAsync(200.milliseconds) # sleep needed for negative assertion
     check receiverKad.providerManager.providerRecords.len == 0
 
   asyncTest "Add provider rejects a key exceeding the length bound":
@@ -289,8 +289,8 @@ suite "KadDHT - Add Provider":
     )
     await senderKad.addProvider(senderKad.rtable.selfId.toCid())
 
-    # Over-length key is out of bounds → record must not be stored
-    await sleepAsync(200.milliseconds)
+    # Over-size key is out of bounds, record must not be stored
+    await sleepAsync(200.milliseconds) # sleep needed for negative assertion
     check receiverKad.providerManager.providerRecords.len == 0
 
   asyncTest "Add provider with CID key extracts multihash":


### PR DESCRIPTION
## Summary

Resolves #2820, which asks whether nim should require ADD_PROVIDER keys to be valid multihashes. The agreed resolution there is to match go-libp2p-kad-dht rather than change the other implementations.

`handleAddProvider` no longer requires the key to be a valid multihash. It now accepts any key with `0 < len <= 80` bytes, matching `go-libp2p`.

## Affected Areas

- [x] Peer Management / Discovery

## Impact on Library Users

Behavior change, no API change.

When a nim node receives ADD_PROVIDER, it now stores the record for any key up to 80 bytes instead of dropping keys that are not valid multihashes. Existing nim usage is unaffected: `startProviding` and `addProvider` derive the key from a Cid, which is a valid multihash and stays within the bound. A nim node that stores provider records for other peers now accepts the same length-bounded keys as go, py, and dotnet.

## Risk Assessment

Low. The multihash check gave no functional protection, since routing distance is computed over the sha256 of the key regardless of its structure. The per-key cap (`maxProvidersPerKey`) and provider record expiry still apply, so accepting shorter keys does not let a peer store unbounded records. The change is on the receiver side only, so nim peers keep interoperating with each other.