### PR TITLE
fix(dialer): reset streams after failed protocol negotiation

### DIFF
--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -315,7 +315,7 @@ proc negotiateStream*(
   trace "Negotiating stream", stream, protos
   let selected = await MultistreamSelect.select(stream, protos)
   if not protos.contains(selected):
-    await stream.closeWithEOF()
+    await stream.reset()
     raise newException(
       DialFailedError,
       "Unable to select sub-protocol. Selected: " & $selected & ". Available: " & $protos,
@@ -323,7 +323,7 @@ proc negotiateStream*(
 
   self.ms.lookupProtocol(selected).withValue(protocol):
     if not protocol.reserveOutgoing(stream.peerId):
-      await stream.closeWithEOF()
+      await stream.reset()
       raise newException(
         DialFailedError, "Outbound stream budget exceeded for protocol: " & selected
       )

--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -546,7 +546,7 @@ proc identify*(
   if stream == nil:
     return
 
-  var cancelled = false
+  var identifyCompleted = false
   try:
     if (await MultistreamSelect.select(stream, peerStore.identify.codec())):
       let info = await peerStore.identify.identify(stream, stream.peerId)
@@ -561,14 +561,14 @@ proc identify*(
         muxer.setShortAgent(knownAgent)
 
       peerStore.updatePeerInfo(info, stream.observedAddr, Opt.some(dir))
+      identifyCompleted = true
   except CancelledError as exc:
-    cancelled = true
     raise exc
   finally:
-    if cancelled:
-      await noCancel stream.reset()
-    else:
+    if identifyCompleted:
       await noCancel stream.closeWithEOF()
+    else:
+      await noCancel stream.reset()
 
 proc getMostObservedProtosAndPorts*(self: PeerStore): seq[MultiAddress] =
   return self.identify.observedAddrManager.getMostObservedProtosAndPorts()

--- a/libp2p/services/identify_pusher.nim
+++ b/libp2p/services/identify_pusher.nim
@@ -73,6 +73,7 @@ proc sendOne(p: IdentifyPusher, peerId: PeerId) {.async: (raises: [CancelledErro
   if muxer.isNil:
     return
   var stream: Stream
+  var pushCompleted = false
   try:
     stream = await muxer.newStream()
     if stream.isNil:
@@ -81,6 +82,7 @@ proc sendOne(p: IdentifyPusher, peerId: PeerId) {.async: (raises: [CancelledErro
 
     if await MultistreamSelect.select(stream, IdentifyPushCodec):
       await p.identifyPush.push(p.peerInfo, stream)
+      pushCompleted = true
   except CancelledError as e:
     raise e
   except MuxerError as e:
@@ -92,10 +94,10 @@ proc sendOne(p: IdentifyPusher, peerId: PeerId) {.async: (raises: [CancelledErro
     trace "stream error during identify push", peerId, description = e.msg
   finally:
     if not stream.isNil:
-      # Close the stream unconditionally to prevent resource leaks,
-      # mainly issue in tests and `checkTrackers`.
-      # In production cancelling is fine.
-      await noCancel stream.closeWithEOF()
+      if pushCompleted:
+        await noCancel stream.closeWithEOF()
+      else:
+        await noCancel stream.reset()
 
 proc broadcast(p: IdentifyPusher) =
   ## Send an IdentifyPush message with our current `peerInfo` to every

--- a/tests/libp2p/protocols/test_autonat_v2_service.nim
+++ b/tests/libp2p/protocols/test_autonat_v2_service.nim
@@ -536,7 +536,7 @@ suite "AutonatV2 Service":
 
   asyncTest "Handler must receive the dial-back address on Reachable":
     let
-      (service, _) = newService(NetworkReachability.Reachable)
+      (service, client) = newService(NetworkReachability.Reachable)
       switch = createSwitch(Opt.some(service))
     var switches = createSwitches(3)
 
@@ -554,10 +554,11 @@ suite "AutonatV2 Service":
     service.setStatusAndConfidenceHandler(statusAndConfidenceHandler)
     await switch.startAndConnect(switches)
     let capturedAddr = await awaiter
+    await client.finished
 
     check service.networkReachability == NetworkReachability.Reachable
     check capturedAddr.isSome()
-    check capturedAddr.get() == switch.peerInfo.addrs[0]
+    check capturedAddr.get() == client.allTestAddrs[^1][0]
 
     await switch.stop()
     await switches.stopAll()
@@ -586,7 +587,7 @@ suite "AutonatV2 Service":
 
     check service.networkReachability == NetworkReachability.NotReachable
     check capturedAddr.isSome()
-    check capturedAddr.get() == switch.peerInfo.addrs[0]
+    check capturedAddr.get() == client.allTestAddrs[^1][0]
 
     await switch.stop()
     await switches.stopAll()

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -438,9 +438,7 @@ suite "Identify":
     ms.addHandler(limitedPing)
 
     let
-      dialer = Dialer.new(
-        localInfo.peerId, ConnManager.new(), peerStore, @[], ms, nil
-      )
+      dialer = Dialer.new(localInfo.peerId, ConnManager.new(), peerStore, @[], ms, nil)
       stream = await muxDialer.newStream()
       negotiateFut = dialer.negotiateStream(stream, @[IdentifyCodec])
 

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -8,12 +8,15 @@ import
   ../../../libp2p/[
     protocols/identify,
     protocols/ping,
+    protocols/protocol,
     multiaddress,
     peerinfo,
     peerid,
     stream/connection,
     multistream,
     transports/transport,
+    connmanager,
+    dialer,
     switch,
     builders,
     transports/tcptransport,
@@ -342,8 +345,7 @@ suite "Identify":
     let storedAddrs = client.peerStore[AddressBook][server.peerInfo.peerId]
     check countAddressesWithPattern(storedAddrs, QUIC_V1) == 1
 
-  asyncTest "outgoing identify hangs when the peer answers `na`":
-    # TODO: #2800 identify: outgoing identify hangs against peers that don't serve identify
+  asyncTest "outgoing identify resets when the peer answers `na`":
     let (connDialer, connListener) = bridgedConnections(
       closeTogether = false, dirA = Direction.Out, dirB = Direction.In
     )
@@ -381,12 +383,77 @@ suite "Identify":
       peerStore = PeerStore.new(Identify.new(remoteInfo))
     let identifyFut = peerStore.identify(muxDialer, Direction.Out)
 
-    # Short sleep so a real hang is distinguished from identify still mid-negotiation.
-    await sleepAsync(200.milliseconds)
-    let isHanging = not identifyFut.finished()
-
-    # Let the listener close so the test finishes cleanly.
-    blocker.complete()
+    check await identifyFut.withTimeout(1.seconds)
     await identifyFut
 
-    check isHanging
+    # Let the listener handler finish so the test cleans up deterministically.
+    blocker.complete()
+
+  asyncTest "failed protocol negotiations reset the stream":
+    let (connDialer, connListener) = bridgedConnections(
+      closeTogether = false, dirA = Direction.Out, dirB = Direction.In
+    )
+    let
+      muxDialer = Mplex.new(connDialer)
+      muxListener = Mplex.new(connListener)
+      handleDialer = muxDialer.handle()
+      handleListener = muxListener.handle()
+    defer:
+      await allFutures(
+        connDialer.close(),
+        connListener.close(),
+        muxDialer.close(),
+        muxListener.close(),
+        handleDialer,
+        handleListener,
+      )
+
+    # Leave the stream open after rejecting the requested protocol. A
+    # multistream responder may continue waiting for another protocol token.
+    let blocker = newFuture[void]()
+    muxListener.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
+      try:
+        discard await MultistreamSelect.handle(stream, @[PingCodec])
+      except CancelledError, LPStreamError, MultiStreamError:
+        discard
+      try:
+        await blocker
+      except CatchableError:
+        discard
+      await noCancel stream.close()
+
+    let
+      localInfo = PeerInfo.new(PrivateKey.random(PKScheme.Ed25519, rng()).get())
+      peerStore = PeerStore.new(Identify.new(localInfo))
+      ms = MultistreamSelect.new()
+
+    proc unusedHandler(
+        stream: Stream, proto: string
+    ): Future[void] {.async: (raises: [CancelledError]).} =
+      discard
+
+    let limitedPing = LPProtocol.new(
+      @[PingCodec], unusedHandler, maxOutgoingStreamsTotal = 0
+    )
+    ms.addHandler(limitedPing)
+
+    let
+      dialer = Dialer.new(
+        localInfo.peerId, ConnManager.new(), peerStore, @[], ms, nil
+      )
+      stream = await muxDialer.newStream()
+      negotiateFut = dialer.negotiateStream(stream, @[IdentifyCodec])
+
+    check await negotiateFut.withTimeout(1.seconds)
+    expect DialFailedError:
+      discard await negotiateFut
+
+    let
+      budgetStream = await muxDialer.newStream()
+      budgetFut = dialer.negotiateStream(budgetStream, @[PingCodec])
+    check await budgetFut.withTimeout(1.seconds)
+    expect DialFailedError:
+      discard await budgetFut
+
+    # Let the listener handler finish so the test cleans up deterministically.
+    blocker.complete()

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -432,9 +432,8 @@ suite "Identify":
     ): Future[void] {.async: (raises: [CancelledError]).} =
       discard
 
-    let limitedPing = LPProtocol.new(
-      @[PingCodec], unusedHandler, maxOutgoingStreamsTotal = 0
-    )
+    let limitedPing =
+      LPProtocol.new(@[PingCodec], unusedHandler, maxOutgoingStreamsTotal = 0)
     ms.addHandler(limitedPing)
 
     let


### PR DESCRIPTION
## Summary

Fixes hangs after failed multistream protocol negotiation when the remote peer leaves the stream open after responding `na`.

Failed identify probes, identify push attempts, and general dial negotiation failures now reset the stream instead of closing with EOF. Successful identify and identify-push paths still close with EOF after completing the protocol.

Adds regression coverage for outbound identify against a peer that rejects identify, plus general failed protocol negotiation paths.

## Impact on Library Users

Prevents outbound identify and protocol dials from hanging against peers that do not support the requested protocol. No API changes.

## Risk Assessment

Low. The change is limited to failure-path stream cleanup; successful negotiation paths preserve the existing EOF close behavior.

## References

Closes #2800