### PR TITLE
fix(ci): ignore missing sources in coverage genhtml

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -85,7 +85,10 @@ jobs:
           find nimcache -name *.c -delete
           lcov --capture --directory nimcache --output-file coverage/coverage.info
           lcov --extract coverage/coverage.info "${PWD}/libp2p/*" --output-file coverage/coverage.f.info
-          genhtml coverage/coverage.f.info --output-directory coverage/output
+          # Ignore source files that no longer exist on disk: a restored nimcache
+          # can carry .gcno graphs for files deleted since (e.g. upnp_mapper.nim),
+          # and genhtml otherwise hard-errors trying to read the missing source.
+          genhtml coverage/coverage.f.info --ignore-errors source --output-directory coverage/output
 
       - name: Upload coverage to codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -85,9 +85,6 @@ jobs:
           find nimcache -name *.c -delete
           lcov --capture --directory nimcache --output-file coverage/coverage.info
           lcov --extract coverage/coverage.info "${PWD}/libp2p/*" --output-file coverage/coverage.f.info
-          # Ignore source files that no longer exist on disk: a restored nimcache
-          # can carry .gcno graphs for files deleted since (e.g. upnp_mapper.nim),
-          # and genhtml otherwise hard-errors trying to read the missing source.
           genhtml coverage/coverage.f.info --ignore-errors source --output-directory coverage/output
 
       - name: Upload coverage to codecov


### PR DESCRIPTION
## Summary

The `codecov` coverage job intermittently fails at the `genhtml` step. It restores `nimcache` from a cache keyed on branch (falling back to `master`), so a restored cache can carry `.gcno` coverage graphs for source files that have since been deleted from the tree (e.g. `upnp_mapper.nim`, removed with the nim-libplum NAT migration). `genhtml` then hard-errors trying to read the missing source, failing the whole job even though nothing is wrong with the actual coverage.

Passing `--ignore-errors source` makes `genhtml` skip source files it can't find on disk instead of aborting.

## Affected Areas

- [x] Build / Tooling
  <!-- CI only: .github/workflows/coverage.yml -->

## Compatibility & Downstream Validation

N/A — CI-only change, no library code touched.

## Impact on Library Users

No impact — internal CI change. No API, behavior, or performance implications.

## Risk Assessment

Minimal. The flag only relaxes `genhtml`'s handling of source files it cannot locate; the `coverage.f.info` report uploaded to codecov is produced by `lcov` upstream of this step and is unchanged. Coverage numbers for existing files are unaffected.

## References

- Deletion that first surfaced this: `upnp_mapper.nim` removed in #2821 (chore(nat): replace nim-nat-traversal with nim-libplum)