### PR TITLE
fix: avoid unused allFinished copies

### DIFF
--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -775,7 +775,7 @@ proc triggerTrim(c: ConnManager) {.gcsafe, raises: [].} =
 proc drainOnCloseTasks(c: ConnManager) {.async: (raises: []).} =
   ## Drains the per-muxer onClose tasks once muxers are closed, so they finish
   ## cleanup instead of being cancelled mid-flight.
-  discard await noCancel allFinished(c.onCloseFuts)
+  await noCancel allFutures(c.onCloseFuts)
   c.onCloseFuts = @[]
 
 proc close*(c: ConnManager) {.async: (raises: [CancelledError]).} =

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -60,7 +60,7 @@ proc drainChannelTasks(channs: seq[LPChannel]) {.async: (raises: []).} =
       futs.add(chann.handlerFut)
     if not chann.resetMessageFut.isNil():
       futs.add(chann.resetMessageFut)
-  discard await noCancel allFinished(futs)
+  await noCancel allFutures(futs)
 
 proc cleanupChann(m: Mplex, chann: LPChannel) {.async: (raises: []).} =
   ## remove the local channel from the internal tables

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -568,7 +568,7 @@ proc drainChannelTasks(channels: seq[YamuxChannel]) {.async: (raises: []).} =
       futs.add(channel.handlerFut)
     if not channel.sendLoopFut.isNil():
       futs.add(channel.sendLoopFut)
-  discard await noCancel allFinished(futs)
+  await noCancel allFutures(futs)
 
 method close*(m: Yamux) {.async: (raises: []).} =
   if m.isClosed == true:

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -440,7 +440,7 @@ method stop*(transport: QuicTransport) {.async: (raises: []).} =
   let futs = transport.connections.mapIt(it.close())
   await noCancel allFutures(futs)
 
-  discard await noCancel allFinished(transport.closeFuts)
+  await noCancel allFutures(transport.closeFuts)
   transport.closeFuts = @[]
 
   var endpointStops: seq[Future[void]]

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -178,7 +178,7 @@ method stop*(self: TcpTransport): Future[void] {.async: (raises: []).} =
         await acceptFut.value().closeWait()
     self.acceptFuts = @[]
 
-    discard await noCancel allFinished(self.closeFuts)
+    await noCancel allFutures(self.closeFuts)
     self.closeFuts = @[]
 
     if self.clients[Direction.In].len != 0 or self.clients[Direction.Out].len != 0:
@@ -198,7 +198,7 @@ method stop*(self: TcpTransport): Future[void] {.async: (raises: []).} =
       "No incoming connections possible without start"
     await noCancel allFutures(self.clients[Direction.Out].mapIt(it.closeWait()))
 
-    discard await noCancel allFinished(self.closeFuts)
+    await noCancel allFutures(self.closeFuts)
     self.closeFuts = @[]
 
 method accept*(


### PR DESCRIPTION
## Summary
Use `allFutures` for teardown drains where the result from `allFinished` was discarded. This keeps the same wait-for-completion behavior while avoiding the unused sequence copy

## Affected Areas
- [x] Transports: TCP and QUIC close-future drains
- [x] Peer Management / Discovery: ConnManager on-close drain
- [x] Protocol Logic: mplex and yamux channel task drains

## References
- Review comment: https://github.com/vacp2p/nim-libp2p/pull/2605#discussion_r3576772515