### PR TITLE
test(kad-dht): repro tests for #2826

### DIFF
--- a/tests/libp2p/kademlia/test_find.nim
+++ b/tests/libp2p/kademlia/test_find.nim
@@ -308,3 +308,34 @@ suite "KadDHT Find":
     check:
       responsiveKad.switch.peerInfo.peerId in peerIds
       mockKad.handleFindNodeCalls == retries + 1 # (initial call + retries)
+
+  asyncTest "closerPeers advertises a peer's observed inbound address":
+    # TODO: nim-libp2p#2826
+    let kads = setupKadSwitches(3)
+    let (a, b, c) = (kads[0], kads[1], kads[2])
+    startAndDeferStop(kads)
+
+    let
+      bId = b.switch.peerInfo.peerId
+      bKey = bId.toKey()
+      bListenAddr = b.switch.peerInfo.addrs
+
+    # B dials A and sends a FIND_NODE, so A learns B from the inbound stream.
+    await b.switch.connect(a.switch.peerInfo.peerId, a.switch.peerInfo.addrs)
+    discard (await b.dispatchFindNode(a.switch.peerInfo.peerId, bKey)).expect(
+      "FIND_NODE reply"
+    )
+
+    # A records B under its observed inbound source address, an ephemeral dial
+    # port that is not one of B's listen addresses.
+    checkUntilTimeout:
+      a.switch.peerStore[AddressBook][bId].anyIt(it notin bListenAddr)
+
+    # C asks A for peers near B, and A advertises that observed address in closerPeers.
+    await c.switch.connect(a.switch.peerInfo.peerId, a.switch.peerInfo.addrs)
+    let reply = (await c.dispatchFindNode(a.switch.peerInfo.peerId, bKey)).value()
+    let bCloser =
+      reply.closerPeers.filterIt(it.id.isSome and it.id.get() == bId.getBytes())
+    check:
+      bCloser.len == 1
+      bCloser[0].addrs.anyIt(it notin bListenAddr)

--- a/tests/libp2p/kademlia/test_get_providers.nim
+++ b/tests/libp2p/kademlia/test_get_providers.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import chronos, results, sets, tables
+import chronos, results, sequtils, sets, tables
 import
   ../../../libp2p/[protocols/kademlia, switch, builders, multicodec, multihash, cid]
 import ../../tools/[lifecycle, topology, unittest]
@@ -278,3 +278,48 @@ suite "KadDHT - Get Providers":
       providers.containsPeer(kads[2])
       providers.containsPeer(kads[3])
       providers.containsPeer(kads[4])
+
+  asyncTest "providerPeers carries a provider's listen address, closerPeers its observed address":
+    # TODO: nim-libp2p#2826
+    let
+      a = setupKad(config = testKadConfig(providerRejection = true))
+      b = setupKad()
+      c = setupKad()
+    startAndDeferStop(@[a, b, c])
+
+    let
+      bId = b.switch.peerInfo.peerId
+      bListenAddr = b.switch.peerInfo.addrs
+      providerKey = @[1.byte, 2, 3, 4, 5]
+
+    # B dials A and sends a FIND_NODE, so A learns B from the inbound stream.
+    await b.switch.connect(a.switch.peerInfo.peerId, a.switch.peerInfo.addrs)
+    discard (await b.dispatchFindNode(a.switch.peerInfo.peerId, bId.toKey())).expect(
+      "FIND_NODE reply"
+    )
+
+    # A records B under its observed inbound source address, an ephemeral dial
+    # port that is not one of B's listen addresses.
+    checkUntilTimeout:
+      a.switch.peerStore[AddressBook][bId].anyIt(it notin bListenAddr)
+
+    # B announces itself as a provider, carrying its listen addresses to A.
+    discard (await sendAddProviderAndGetStatus(b, a, providerKey)).expect(
+      "add provider accepted"
+    )
+
+    # C asks A for providers of the key. For the same peer B, A returns a diallable
+    # listen address in providerPeers but its observed inbound source address in
+    # closerPeers.
+    await c.switch.connect(a.switch.peerInfo.peerId, a.switch.peerInfo.addrs)
+    let reply =
+      (await c.dispatchGetProviders(a.switch.peerInfo.peerId, providerKey)).value()
+    let bProvider =
+      reply.providerPeers.filterIt(it.id.isSome and it.id.get() == bId.getBytes())
+    let bCloser =
+      reply.closerPeers.filterIt(it.id.isSome and it.id.get() == bId.getBytes())
+    check:
+      bProvider.len == 1
+      bCloser.len == 1
+      bProvider[0].addrs.anyIt(it in bListenAddr)
+      bCloser[0].addrs.anyIt(it notin bListenAddr)


### PR DESCRIPTION
## Summary

Adds two tests reproducing #2826.
- `test_find.nim` "closerPeers advertises a peer's observed inbound address": a FIND_NODE responder returns the observed inbound source address in `closerPeers`.
- `test_get_providers.nim` "providerPeers carries a provider's listen address, closerPeers its observed address": one GET_PROVIDERS reply carries the listen address in `providerPeers` and the observed address in `closerPeers` for the same peer.