### PR TITLE
fix(quic): propagate accept errors instead of nil

### DIFF
--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -532,13 +532,13 @@ method accept*(
     let conn = await finished
     return self.wrapConnection(conn, Direction.In)
   except QuicError as exc:
-    warn "QUIC accept failed", description = exc.msg
+    debug "Quic Error", description = exc.msg
     raise (ref QuicTransportError)(msg: "QUIC accept failed: " & exc.msg, parent: exc)
   except common.TransportError as exc:
-    warn "QUIC transport accept failed", description = exc.msg
+    debug "Transport Error", description = exc.msg
     raise newTransportClosedError(exc)
   except TransportOsError as exc:
-    warn "QUIC OS accept failed", description = exc.msg
+    debug "OS Error", description = exc.msg
     raise (ref QuicTransportError)(msg: "QUIC OS accept failed: " & exc.msg, parent: exc)
 
 proc listenerEndpointFor(

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -539,7 +539,8 @@ method accept*(
     raise newTransportClosedError(exc)
   except TransportOsError as exc:
     debug "OS Error", description = exc.msg
-    raise (ref QuicTransportError)(msg: "QUIC OS accept failed: " & exc.msg, parent: exc)
+    raise
+      (ref QuicTransportError)(msg: "QUIC OS accept failed: " & exc.msg, parent: exc)
 
 proc listenerEndpointFor(
     self: QuicTransport, address: TransportAddress

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -211,6 +211,9 @@ type QuicMuxer* = ref object of Muxer
 proc new*(
     _: type QuicMuxer, conn: P2PConnection, peerId: Opt[PeerId] = Opt.none(PeerId)
 ): QuicMuxer {.raises: [CertificateParsingError, LPError].} =
+  if conn.isNil:
+    raise (ref QuicTransportError)(msg: "cannot create QUIC muxer from nil connection")
+
   let session = QuicSession(conn)
   session.peerId = peerId.valueOr:
     let certificates = session.connection.certificates()
@@ -437,6 +440,9 @@ method start*(
   await procCall Transport(self).start(listenMAs)
 
 method stop*(transport: QuicTransport) {.async: (raises: []).} =
+  if transport.running:
+    await noCancel procCall Transport(transport).stop()
+
   let futs = transport.connections.mapIt(it.close())
   await noCancel allFutures(futs)
 
@@ -456,8 +462,6 @@ method stop*(transport: QuicTransport) {.async: (raises: []).} =
   await noCancel allFutures(transport.listeners.mapIt(it.stop()))
   transport.listeners = @[]
   transport.acceptFuts = @[]
-
-  await procCall Transport(transport).stop()
 
 proc wrapConnection(
     transport: QuicTransport, connection: QuicConnection, transportDir: Direction
@@ -519,9 +523,8 @@ method accept*(
   if not self.running or self.listeners.len == 0: # Stopped while waiting
     raise newTransportClosedError()
 
-  # becasue some listener has accepted we need to run 
-  # accept manually in the place for this listner again 
-  # so that it keeps accepting for future method calls
+  # Replace the completed accept before awaiting its result so that every
+  # listener remains ready for future connections.
   let index = self.acceptFuts.find(finished)
   self.acceptFuts[index] = self.listeners[index].accept()
 
@@ -529,11 +532,14 @@ method accept*(
     let conn = await finished
     return self.wrapConnection(conn, Direction.In)
   except QuicError as exc:
-    debug "Quic Error", description = exc.msg
+    warn "QUIC accept failed", description = exc.msg
+    raise (ref QuicTransportError)(msg: "QUIC accept failed: " & exc.msg, parent: exc)
   except common.TransportError as exc:
-    debug "Transport Error", description = exc.msg
+    warn "QUIC transport accept failed", description = exc.msg
+    raise newTransportClosedError(exc)
   except TransportOsError as exc:
-    debug "OS Error", description = exc.msg
+    warn "QUIC OS accept failed", description = exc.msg
+    raise (ref QuicTransportError)(msg: "QUIC OS accept failed: " & exc.msg, parent: exc)
 
 proc listenerEndpointFor(
     self: QuicTransport, address: TransportAddress

--- a/tests/libp2p/transports/basic_tests.nim
+++ b/tests/libp2p/transports/basic_tests.nim
@@ -84,12 +84,8 @@ template basicTransportTest*(
       let acceptFut = server.accept()
       await server.stop()
 
-      # quic resolves the parked accept to nil, the rest raise a stopped error
-      if isQuicTransport(ma[0]):
-        check (await acceptFut).isNil
-      else:
-        expect TransportClosedError:
-          discard await acceptFut
+      expect TransportClosedError:
+        discard await acceptFut
 
     asyncTest "transport start/stop events":
       let ma = @[MultiAddress.init(address).tryGet()]

--- a/tests/libp2p/transports/test_quic.nim
+++ b/tests/libp2p/transports/test_quic.nim
@@ -44,6 +44,10 @@ suite "Quic transport":
   teardown:
     checkTrackers()
 
+  test "muxer rejects a nil connection":
+    expect QuicTransportError:
+      discard QuicMuxer.new(RawConn(nil))
+
   basicTransportTest(
     quicTransProvider, addressIP4, validWireAddresses, validNonWireAddresses,
     invalidAddresses,
@@ -57,8 +61,9 @@ suite "Quic transport":
 
   asyncTest "transport e2e - invalid cert - server":
     let server = await createQuicTransport(isServer = true, withInvalidCert = true)
-    asyncSpawn createServerAcceptConn(server)()
+    let serverTask = createServerAcceptConn(server)()
     defer:
+      await serverTask.cancelAndWait()
       await server.stop()
 
     proc runClient() {.async.} =
@@ -71,8 +76,9 @@ suite "Quic transport":
 
   asyncTest "transport e2e - invalid cert - client":
     let server = await createQuicTransport(isServer = true)
-    asyncSpawn createServerAcceptConn(server)()
+    let serverTask = createServerAcceptConn(server)()
     defer:
+      await serverTask.cancelAndWait()
       await server.stop()
 
     proc runClient() {.async.} =

--- a/tests/libp2p/transports/utils.nim
+++ b/tests/libp2p/transports/utils.nim
@@ -48,9 +48,6 @@ proc createServerAcceptConn*(
         (raises: [transport.TransportError, LPError, LPStreamError, CancelledError])
   .} =
     let conn = await server.accept()
-    if conn == nil:
-      return
-
     let muxer = QuicMuxer.new(conn)
     let stream = await muxer.newStream()
     defer:


### PR DESCRIPTION
## Summary

Prevent QUIC accept failures from producing nil connections that can later cause a segmentation fault.

QUIC now:

- marks the transport stopped before closing endpoints, matching TCP shutdown ordering
- raises typed transport errors instead of swallowing accept failures
- rejects nil connections when constructing a QUIC muxer
- reports `TransportClosedError` when shutdown interrupts a pending accept

## Affected Areas

- [x] Transports  
  QUIC accept and shutdown behavior.

## Impact on Library Users

Pending QUIC accepts now raise `TransportClosedError` during shutdown instead of resolving to nil. Other QUIC accept failures are also propagated to callers with their original error as the parent.

## Risk Assessment

Callers that explicitly relied on a nil result from a QUIC accept interrupted by shutdown must handle `TransportClosedError` instead. This aligns QUIC with the existing TCP behavior.

## References

- [Failing daily CI run](https://github.com/vacp2p/nim-libp2p/actions/runs/29333063999)