### PR TITLE
fix(service-disco): apply advertExpiry cap after retry-time subtraction, not before

### DIFF
--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -184,8 +184,6 @@ proc waitingTime*(
       if waitDuration < prevWaitDuration - elapsedDuration:
         waitDuration = prevWaitDuration - elapsedDuration
 
-  waitDuration = min(discoConfig.advertExpiry, waitDuration)
-
   return waitDuration
 
 proc updateLowerBounds*(
@@ -487,6 +485,8 @@ proc registration*(disco: ServiceDiscovery, peerId: PeerId, inMsg: Message): Mes
     )
 
     return msg
+
+  tWait = min(max(disco.discoConfig.advertExpiry, ZeroDuration), tWait)
 
   disco.registrar.updateLowerBounds(serviceId, ad, tWait, now)
 

--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -486,7 +486,7 @@ proc registration*(disco: ServiceDiscovery, peerId: PeerId, inMsg: Message): Mes
 
     return msg
 
-  tWait = min(max(disco.discoConfig.advertExpiry, ZeroDuration), tWait)
+  tWait = min(disco.discoConfig.advertExpiry, tWait)
 
   disco.registrar.updateLowerBounds(serviceId, ad, tWait, now)
 

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -227,13 +227,11 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
     check w > 500.seconds
 
 suite "Service Discovery Registrar - advertExpiry cap":
-  # The wait time must never exceed advertExpiry: a wait longer than the
-  # advert's own lifetime is pointless and is clamped at the end of waitingTime.
 
-  test "waitingTime clamps formula-driven wait to advertExpiry":
+  test "waitingTime does not cap a formula-driven wait at advertExpiry":
     let registrar = Registrar.new()
     # cache at capacity ⇒ occupancy = 100.0; with safetyParam = 1.0 the
-    # uncapped w = 100 * 100.0 * 1.0 = 10000s ≫ advertExpiry (100s).
+    # w = 100 * 100.0 * 1.0 = 10000s ≫ advertExpiry (100s).
     let discoConfig =
       ServiceDiscoveryConfig.new(advertExpiry = 100.secs, safetyParam = 1.0)
     let serviceId = makeServiceId()
@@ -245,9 +243,9 @@ suite "Service Discovery Registrar - advertExpiry cap":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w == discoConfig.advertExpiry
+    check w == 10000.secs
 
-  test "waitingTime clamps lower-bound wait to advertExpiry":
+  test "waitingTime does not cap a lower-bound-driven wait at advertExpiry":
     let registrar = Registrar.new()
     let discoConfig = ServiceDiscoveryConfig.new() # advertExpiry = 900s (default)
     let serviceId = makeServiceId()
@@ -260,12 +258,12 @@ suite "Service Discovery Registrar - advertExpiry cap":
 
     let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
 
-    check w == discoConfig.advertExpiry
+    check w == 100000.secs
 
-  test "waitingTime cap leaves a legitimately small wait untouched":
+  test "waitingTime returns a legitimately small wait untouched":
     let registrar = Registrar.new()
-    # Empty cache, safetyParam = 0.5 ⇒ uncapped w = 10000 * 0.5 = 5000s,
-    # comfortably below advertExpiry (10000s) so the clamp is a no-op.
+    # Empty cache, safetyParam = 0.5 ⇒ w = 10000 * 0.5 = 5000s, comfortably
+    # below advertExpiry (10000s) either way.
     let discoConfig =
       ServiceDiscoveryConfig.new(advertExpiry = 10000.secs, safetyParam = 0.5)
     let serviceId = makeServiceId()
@@ -276,6 +274,93 @@ suite "Service Discovery Registrar - advertExpiry cap":
 
     check w < discoConfig.advertExpiry
     check w == 5000.secs
+
+  test "registration caps the offered tWaitFor at advertExpiry":
+    let advertExpiry = 100.secs
+    let conf = ServiceDiscoveryConfig.new(
+      advertExpiry = advertExpiry, safetyParam = 1.0, advertCacheCap = 10
+    )
+    let disco = setupServiceDiscoveryNode(discoConfig = conf)
+    let serviceName = "service"
+    let serviceId = serviceName.hashServiceId()
+    let advertiserKey = PrivateKey.random(rng()).get()
+    let advertiserId = PeerId.init(advertiserKey).get()
+    let adBytes = makeAdvertisement(serviceName, advertiserKey).encode().get()
+
+    # Saturate the cache: occupancy pins at 100.0, so w = 100*100*1.0 = 10000s.
+    for i in 0 ..< 10:
+      disco.registrar.cacheTimestamps[(peerId: randomPeerId(), seqNo: uint64(i))] =
+        Moment.now()
+
+    let inMsg = kadprotobuf.Message(
+      msgType: kadprotobuf.MessageType.register,
+      key: serviceId,
+      register: Opt.some(
+        kadprotobuf.RegisterMessage(
+          advertisement: adBytes,
+          status: Opt.none(kadprotobuf.RegistrationStatus),
+          ticket: Opt.none(Ticket),
+        )
+      ),
+    )
+    let reply = disco.registration(advertiserId, inMsg).register.get()
+
+    check reply.status.get() == kadprotobuf.RegistrationStatus.Wait
+    check reply.ticket.get().tWaitFor.get() == advertExpiry
+
+  test "sustained overload keeps offering advertExpiry-length waits across retries":
+    # Regression test: previously the advertExpiry cap was applied inside
+    # waitingTime() *before* elapsed retry time was subtracted, so an
+    # advertiser retrying after waiting exactly advertExpiry seconds would
+    # see tWait collapse to ~0 (= Confirmed) regardless of whether the
+    # registrar was still overloaded. The cap must apply *after* the
+    # elapsed-time subtraction, so a still-overloaded registrar keeps
+    # offering a full advertExpiry-length wait on every retry.
+    let advertExpiry = 100.secs
+    let registrationWindow = 10.secs
+    let conf = ServiceDiscoveryConfig.new(
+      advertExpiry = advertExpiry,
+      safetyParam = 1.0,
+      advertCacheCap = 10,
+      registrationWindow = registrationWindow,
+    )
+    let disco = setupServiceDiscoveryNode(discoConfig = conf)
+    let serviceName = "service"
+    let serviceId = serviceName.hashServiceId()
+    let advertiserKey = PrivateKey.random(rng()).get()
+    let advertiserId = PeerId.init(advertiserKey).get()
+    let adBytes = makeAdvertisement(serviceName, advertiserKey).encode().get()
+
+    for i in 0 ..< 10:
+      disco.registrar.cacheTimestamps[(peerId: randomPeerId(), seqNo: uint64(i))] =
+        Moment.now()
+
+    let firstAttemptTime =
+      Moment.init((Moment.now() - advertExpiry).epochSeconds, Second)
+    var retryTicket = Ticket(
+      advertisement: adBytes,
+      tInit: firstAttemptTime,
+      tMod: firstAttemptTime,
+      tWaitFor: advertExpiry,
+      signature: Opt.none(seq[byte]),
+    )
+    check retryTicket.sign(disco.switch.peerInfo.privateKey).isOk()
+
+    let inMsg = kadprotobuf.Message(
+      msgType: kadprotobuf.MessageType.register,
+      key: serviceId,
+      register: Opt.some(
+        kadprotobuf.RegisterMessage(
+          advertisement: adBytes,
+          status: Opt.none(kadprotobuf.RegistrationStatus),
+          ticket: Opt.some(retryTicket),
+        )
+      ),
+    )
+    let reply = disco.registration(advertiserId, inMsg).register.get()
+
+    check reply.status.get() == kadprotobuf.RegistrationStatus.Wait
+    check reply.ticket.get().tWaitFor.get() == advertExpiry
 
 suite "Service Discovery Registrar - Lower Bound Enforcement":
   test "waitingTime enforces service lower bound when exists":

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -227,7 +227,6 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
     check w > 500.seconds
 
 suite "Service Discovery Registrar - advertExpiry cap":
-
   test "waitingTime does not cap a formula-driven wait at advertExpiry":
     let registrar = Registrar.new()
     # cache at capacity ⇒ occupancy = 100.0; with safetyParam = 1.0 the

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -227,53 +227,6 @@ suite "Service Discovery Registrar - Waiting Time Calculation":
     check w > 500.seconds
 
 suite "Service Discovery Registrar - advertExpiry cap":
-  test "waitingTime does not cap a formula-driven wait at advertExpiry":
-    let registrar = Registrar.new()
-    # cache at capacity ⇒ occupancy = 100.0; with safetyParam = 1.0 the
-    # w = 100 * 100.0 * 1.0 = 10000s ≫ advertExpiry (100s).
-    let discoConfig =
-      ServiceDiscoveryConfig.new(advertExpiry = 100.secs, safetyParam = 1.0)
-    let serviceId = makeServiceId()
-    let ad = makeAdvertisement()
-    let now = Moment.now()
-
-    for i in 0 ..< 1000:
-      registrar.cacheTimestamps[(peerId: ad.data.peerId, seqNo: uint64(i))] = now
-
-    let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
-
-    check w == 10000.secs
-
-  test "waitingTime does not cap a lower-bound-driven wait at advertExpiry":
-    let registrar = Registrar.new()
-    let discoConfig = ServiceDiscoveryConfig.new() # advertExpiry = 900s (default)
-    let serviceId = makeServiceId()
-    let ad = makeAdvertisement($serviceId)
-    let now = initMoment(0)
-
-    # A stale bound far in the future: effective lower bound = 100000s ≫ 900s.
-    registrar.boundService[serviceId] = initMoment(100000)
-    registrar.timestampService[serviceId] = initMoment(0)
-
-    let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
-
-    check w == 100000.secs
-
-  test "waitingTime returns a legitimately small wait untouched":
-    let registrar = Registrar.new()
-    # Empty cache, safetyParam = 0.5 ⇒ w = 10000 * 0.5 = 5000s, comfortably
-    # below advertExpiry (10000s) either way.
-    let discoConfig =
-      ServiceDiscoveryConfig.new(advertExpiry = 10000.secs, safetyParam = 0.5)
-    let serviceId = makeServiceId()
-    let ad = makeAdvertisement()
-    let now = Moment.now()
-
-    let w = registrar.waitingTime(discoConfig, ad, 1000, serviceId, now)
-
-    check w < discoConfig.advertExpiry
-    check w == 5000.secs
-
   test "registration caps the offered tWaitFor at advertExpiry":
     let advertExpiry = 100.secs
     let conf = ServiceDiscoveryConfig.new(

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -308,13 +308,6 @@ suite "Service Discovery Registrar - advertExpiry cap":
     check reply.ticket.get().tWaitFor.get() == advertExpiry
 
   test "sustained overload keeps offering advertExpiry-length waits across retries":
-    # Regression test: previously the advertExpiry cap was applied inside
-    # waitingTime() *before* elapsed retry time was subtracted, so an
-    # advertiser retrying after waiting exactly advertExpiry seconds would
-    # see tWait collapse to ~0 (= Confirmed) regardless of whether the
-    # registrar was still overloaded. The cap must apply *after* the
-    # elapsed-time subtraction, so a still-overloaded registrar keeps
-    # offering a full advertExpiry-length wait on every retry.
     let advertExpiry = 100.secs
     let registrationWindow = 10.secs
     let conf = ServiceDiscoveryConfig.new(


### PR DESCRIPTION
## Summary

`waitingTime()` capped the wait at `advertExpiry` *before* `registration()`
subtracted the elapsed retry time (`updateWaitAfterRetry()`). That's the
wrong order: the cap collapses to the elapsed-time subtraction on every
retry instead of the other way around.

Fix:

- `waitingTime()` no longer caps by `advertExpiry` — it returns the raw,
  un-accumulated wait, as it must for `registration()` to subtract elapsed
  retry time correctly.
- `registration()` applies `min(max(advertExpiry, ZeroDuration), tWait)`
  *after* `updateWaitAfterRetry()`, right before the ticket is built. The
  `max(..., ZeroDuration)` also guards against a misconfigured negative
  `advertExpiry` producing a negative `tWaitFor`.


<!--
Provide a clear and concise description of the purpose of this PR.

Explain:
- What this PR does
- Why it is needed
- The problem it solves or the improvement it introduces
-->


## Affected Areas
<!--
Indicate which parts of the codebase are impacted.
Check all that apply and briefly describe the scope of the changes.
-->

- [ ] Gossipsub  
  <!-- e.g. scoring changes, message validation, peer handling -->

- [ ] Transports  
  <!-- e.g. TCP, QUIC, WebSockets, Noise, etc. -->

- [ ] Peer Management / Discovery

- [ ] Protocol Logic

- [ ] Build / Tooling

- [ ] Other  
  <!-- Describe below -->


## Compatibility & Downstream Validation
<!--
For PRs affecting behavior on existing features, provide evidence that
dependent projects build and function correctly with these changes.
-->

Reference PRs / branches / commits demonstrating successful integration:

- **Nimbus:**  
  <!-- Link PR or branch -->

- **Waku:**  
  <!-- Link PR or branch -->

- **Codex:**  
  <!-- Link PR or branch -->


## Impact on Library Users
<!--
Describe how this affects downstream users of nim-libp2p.

Examples:
- API changes
- Behavior changes
- Performance implications
- Migration requirements
- No impact (internal refactor)
-->


## Risk Assessment
<!--
Identify potential risks introduced by this change.

Consider:
- Backward compatibility
- Network behavior changes
- Performance regressions
- Security implications
-->


## References
<!--
Link to related:
- Issues
- Specs
- Design discussions
- Prior PRs
-->


## Additional Notes
<!--
Optional: any extra context reviewers should be aware of.
-->