### PR TITLE
test(interop): build unified-testing dockerfiles workflow

### DIFF
--- a/.github/workflows/daily_ci_report.yml
+++ b/.github/workflows/daily_ci_report.yml
@@ -42,6 +42,7 @@ jobs:
               ("Daily test all (latests dependnecies)", "daily_test_all_latest_deps.yml"),
               ("Daily test all (without feature flags)", "daily_test_all_no_flags.yml"),
               ("Daily runnable examples", "daily_runnable_examples.yml"),
+              ("Daily interop", "daily_interop.yml"),
           ]
 
           LABEL_NAME = "daily-ci-failure"

--- a/.github/workflows/daily_interop.yml
+++ b/.github/workflows/daily_interop.yml
@@ -1,0 +1,38 @@
+name: Daily interop
+
+on:
+  schedule:
+    - cron: "30 7 * * *"
+  workflow_dispatch:
+  pull_request:
+    types: [labeled, synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-unified-testing-interop-images:
+    name: Build unified-testing interop image (${{ matrix.name }})
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-daily-ci')
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: hole-punching-v2
+            dockerfile: interop/hole-punching-v2/Dockerfile
+          - name: kad-dht-v2
+            dockerfile: interop/kad-dht-v2/Dockerfile
+          - name: transport-v2
+            dockerfile: interop/transport-v2/Dockerfile
+          - name: perf
+            dockerfile: interop/perf/Dockerfile
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - name: Build image
+        run: docker build -f ${{ matrix.dockerfile }} .

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -129,8 +129,8 @@ jobs:
           go build -C ./go-peer -o peer ./peer.go
           ./go-peer/peer & ./nim-peer/src/peer
 
-  # The -v2 interop peers are driven by the external unified-testing suite, so
-  # they are never built anywhere else in CI. Build their Dockerfiles here
+  # These interop peers are driven by the external unified-testing suite,
+  # so they are never built anywhere else in CI. Build their Dockerfiles here
   # to guarantee the peers keep compiling against the current nim-libp2p tree.
   build-unified-testing-interop-images:
     name: Build unified-testing interop image (${{ matrix.name }})
@@ -145,6 +145,8 @@ jobs:
             dockerfile: interop/kad-dht-v2/Dockerfile
           - name: transport-v2
             dockerfile: interop/transport-v2/Dockerfile
+          - name: perf
+            dockerfile: interop/perf/Dockerfile
     steps:
       - uses: actions/checkout@v6
       - uses: docker/setup-buildx-action@v4

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -129,9 +129,6 @@ jobs:
           go build -C ./go-peer -o peer ./peer.go
           ./go-peer/peer & ./nim-peer/src/peer
 
-  # These interop peers are driven by the external unified-testing suite,
-  # so they are never built anywhere else in CI. Build their Dockerfiles here
-  # to guarantee the peers keep compiling against the current nim-libp2p tree.
   build-unified-testing-interop-images:
     name: Build unified-testing interop image (${{ matrix.name }})
     runs-on: ubuntu-22.04

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -128,24 +128,3 @@ jobs:
           nim c ./nim-peer/src/peer.nim
           go build -C ./go-peer -o peer ./peer.go
           ./go-peer/peer & ./nim-peer/src/peer
-
-  build-unified-testing-interop-images:
-    name: Build unified-testing interop image (${{ matrix.name }})
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: hole-punching-v2
-            dockerfile: interop/hole-punching-v2/Dockerfile
-          - name: kad-dht-v2
-            dockerfile: interop/kad-dht-v2/Dockerfile
-          - name: transport-v2
-            dockerfile: interop/transport-v2/Dockerfile
-          - name: perf
-            dockerfile: interop/perf/Dockerfile
-    steps:
-      - uses: actions/checkout@v6
-      - uses: docker/setup-buildx-action@v4
-      - name: Build image
-        run: docker build -f ${{ matrix.dockerfile }} .

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -128,3 +128,25 @@ jobs:
           nim c ./nim-peer/src/peer.nim
           go build -C ./go-peer -o peer ./peer.go
           ./go-peer/peer & ./nim-peer/src/peer
+
+  # The -v2 interop peers are driven by the external unified-testing suite, so
+  # they are never built anywhere else in CI. Build their Dockerfiles here
+  # to guarantee the peers keep compiling against the current nim-libp2p tree.
+  build-unified-testing-interop-images:
+    name: Build unified-testing interop image (${{ matrix.name }})
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: hole-punching-v2
+            dockerfile: interop/hole-punching-v2/Dockerfile
+          - name: kad-dht-v2
+            dockerfile: interop/kad-dht-v2/Dockerfile
+          - name: transport-v2
+            dockerfile: interop/transport-v2/Dockerfile
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - name: Build image
+        run: docker build -f ${{ matrix.dockerfile }} .

--- a/interop/unified_testing.nim
+++ b/interop/unified_testing.nim
@@ -79,7 +79,7 @@ proc readBaseConfig*(): BaseConfig =
     testKey: testKey,
     transport: getEnv("TRANSPORT", "tcp"),
     secureChannel: getEnv("SECURE_CHANNEL", "noise"),
-    muxer: getEnv("MUXER", "mplex"),
+    muxer: getEnv("MUXER", "yamux"),
     testTimeout: parseDurationEnv("TEST_TIMEOUT_SECS", 1.seconds, DefaultTestTimeout),
   )
   config


### PR DESCRIPTION
## Summary

Two interop-testing changes that go together.

First, a new CI job builds the Dockerfiles for the unified-testing interop peers (`hole-punching-v2`, `kad-dht-v2`, `transport-v2`, `perf`). Because these peers are only ever compiled by the external suite, nothing in the CI catches it when they stop building against the current tree. This job just runs `docker build` on each so a broken peer fails here instead of silently rotting.

Second, the unified-testing interop peer now defaults to `yamux` instead of `mplex`. These peers are driven by the external unified-testing suite, and the relayed-circuit hole-punch path failed against rust-libp2p because rust has dropped mplex and is yamux-only. When the nim peer defaulted to mplex, the DCUtR channel over the relayed circuit had no common muxer and negotiation failed with `no muxer available`. Defaulting to yamux fixes the mismatch. `MUXER` env var still overrides it.
  
  