### PR TITLE
fix(kad): target the requested bucket when refreshing

### DIFF
--- a/.github/workflows/test_multiformat_exts.yml
+++ b/.github/workflows/test_multiformat_exts.yml
@@ -57,6 +57,8 @@ jobs:
         shell: ${{ needs.pick-platform.outputs.shell }}
     steps:
       - name: selected platform
+        # msys2 is only installed by Setup Nim below, so it cannot be the shell here.
+        shell: bash
         run: echo "(${{ needs.pick-platform.outputs.os }}-${{ needs.pick-platform.outputs.cpu }} / ${{ needs.pick-platform.outputs.cc }} / Nim ${{ needs.pick-platform.outputs.nim_ref }} / ${{ needs.pick-platform.outputs.nim_mm }})"
 
       - name: Checkout

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -36,11 +36,10 @@ proc refreshTable*(
     if not (forceRefresh or bucket.isStale()):
       continue
 
-    # Buckets too near to target are covered by the findNode on selfId above.
-    let randomKey = randomKeyInBucket(rtable, i, kad.rng).valueOr:
+    let target = rtable.refreshTarget(i, kad.rng).valueOr:
       trace "No refresh target for bucket", bucket = i
       continue
-    discard await kad.findNode(randomKey, rtable)
+    discard await kad.findNode(target, rtable)
 
 proc bootstrap*(
     kad: KadDHT, forceRefresh = false

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -36,8 +36,10 @@ proc refreshTable*(
     if not (forceRefresh or bucket.isStale()):
       continue
 
-    let randomKey =
-      randomKeyInBucket(rtable.selfId, i, kad.rng, rtable.config.maxBuckets)
+    # Buckets too near to target are covered by the findNode on selfId above.
+    let randomKey = randomKeyInBucket(rtable, i, kad.rng).valueOr:
+      trace "No refresh target for bucket", bucket = i
+      continue
     discard await kad.findNode(randomKey, rtable)
 
 proc bootstrap*(

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -237,3 +237,15 @@ proc randomKey*(bucket: Bucket, rng: Rng): Opt[Key] =
     proc(e: NodeEntry): Key =
       e.nodeId
   )
+
+proc refreshTarget*(rtable: RoutingTable, bucketIndex: int, rng: Rng): Opt[Key] =
+  ## Key to run a findNode against in order to refresh `bucketIndex`.
+  let random = randomKeyInBucket(rtable, bucketIndex, rng)
+  if random.isSome():
+    return random
+
+  # Buckets near self need a shared prefix too long to draw at random. A peer
+  # the bucket already holds has that prefix by construction.
+  if bucketIndex notin 0 ..< rtable.buckets.len:
+    return Opt.none(Key)
+  rtable.buckets[bucketIndex].randomKey(rng)

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -210,11 +210,6 @@ proc isStale*(bucket: Bucket): bool =
   return false
 
 proc randomKeyInBucket*(rtable: RoutingTable, bucketIndex: int, rng: Rng): Opt[Key] =
-  ## Returns a random key that `rtable` places in `bucketIndex`, for use as a
-  ## bucket-refresh lookup target. A key's bucket is decided by its hash, which
-  ## cannot be inverted, so candidates are drawn until one hashes into the
-  ## bucket, costing ~2^lz draws. Buckets nearer than `MaxRefreshLeadingZeros`,
-  ## and searches that exhaust their budget, return `none`.
   let lz = clamp(bucketIndex, 0, bucketCount(rtable.config.maxBuckets) - 1)
   if lz > MaxRefreshLeadingZeros:
     return Opt.none(Key)
@@ -222,11 +217,10 @@ proc randomKeyInBucket*(rtable: RoutingTable, bucketIndex: int, rng: Rng): Opt[K
   # A draw hits the bucket with probability ~2^-(lz+1); overshooting is free.
   let maxAttempts = 32 shl lz
   let selfHash = rtable.selfHash()
-  var candidate: array[IdLength, byte]
+  var key = newSeqUninit[byte](IdLength)
 
   for _ in 0 ..< maxAttempts:
-    rng.generate(candidate)
-    let key = @candidate
+    rng.generate(key)
     if rtable.bucketIndexFor(selfHash, key) == lz:
       return Opt.some(key)
 

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import algorithm, sequtils, math, bitops
+import algorithm, sequtils
 import chronos, chronicles, results
 import ./types
 import ./kademlia_metrics
@@ -45,17 +45,19 @@ proc new*(
 func bucketCount(maxBuckets: int): int =
   clamp(maxBuckets, 1, MaxBucketsLimit)
 
-proc bucketIndex*(rtable: RoutingTable, key: Key): int =
-  let
-    selfHash =
-      if rtable.config.selfIdPreHashed:
-        rtable.selfId
-      else:
-        rtable.selfId.hashFor(rtable.config.hasher)
-    keyHash = key.hashFor(rtable.config.hasher)
-    lz = xorDistance(selfHash, keyHash).leadingZeros
+func selfHash(rtable: RoutingTable): Key =
+  if rtable.config.selfIdPreHashed:
+    rtable.selfId
+  else:
+    rtable.selfId.hashFor(rtable.config.hasher)
+
+func bucketIndexFor(rtable: RoutingTable, selfHash: Key, key: Key): int =
+  let lz = xorDistance(selfHash, key.hashFor(rtable.config.hasher)).leadingZeros()
 
   min(lz, bucketCount(rtable.config.maxBuckets) - 1)
+
+func bucketIndex*(rtable: RoutingTable, key: Key): int =
+  rtable.bucketIndexFor(rtable.selfHash(), key)
 
 proc peerIndexInBucket(bucket: Bucket, nodeId: Key): Opt[int] =
   for i, p in bucket.peers:
@@ -207,32 +209,28 @@ proc isStale*(bucket: Bucket): bool =
       return true
   return false
 
-proc randomKeyInBucket*(
-    selfId: Key, bucketIndex: int, rng: Rng, maxBuckets: int = DefaultMaxBuckets
-): Key =
-  let
-    leadingZeros = clamp(bucketIndex, 0, bucketCount(maxBuckets) - 1)
-    (byteIdx, rem) = divmod(leadingZeros, 8)
-    boundBitIdx = 7 - rem
+proc randomKeyInBucket*(rtable: RoutingTable, bucketIndex: int, rng: Rng): Opt[Key] =
+  ## Returns a random key that `rtable` places in `bucketIndex`, for use as a
+  ## bucket-refresh lookup target. A key's bucket is decided by its hash, which
+  ## cannot be inverted, so candidates are drawn until one hashes into the
+  ## bucket, costing ~2^lz draws. Buckets nearer than `MaxRefreshLeadingZeros`,
+  ## and searches that exhaust their budget, return `none`.
+  let lz = clamp(bucketIndex, 0, bucketCount(rtable.config.maxBuckets) - 1)
+  if lz > MaxRefreshLeadingZeros:
+    return Opt.none(Key)
 
-  var key = selfId
+  # A draw hits the bucket with probability ~2^-(lz+1); overshooting is free.
+  let maxAttempts = 32 shl lz
+  let selfHash = rtable.selfHash()
+  var candidate: array[IdLength, byte]
 
-  # For the boundary byte, from 0 to boundBitIdx the bits should be random.
-  for i in byteIdx ..< IdLength:
-    rng.generate(key[i])
+  for _ in 0 ..< maxAttempts:
+    rng.generate(candidate)
+    let key = @candidate
+    if rtable.bucketIndexFor(selfHash, key) == lz:
+      return Opt.some(key)
 
-  # For the boundary byte, from boundBitIdx to 7 the bits should be the same as seflId.
-  for i in boundBitIdx .. 7:
-    if selfId[byteIdx].testBit(i):
-      key[byteIdx].setBit(i)
-    else:
-      key[byteIdx].clearBit(i)
-
-  # The bit at the boundary should be the opposite of selfId. So that the XOR is not 0.
-  if selfId[byteIdx].testBit(boundBitIdx) == key[byteIdx].testBit(boundBitIdx):
-    key[byteIdx].flipBit(boundBitIdx)
-
-  key
+  Opt.none(Key)
 
 proc allKeys*(bucket: Bucket): seq[Key] =
   return bucket.peers.mapIt(it.nodeId)

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -14,6 +14,10 @@ const
   MaxBucketsLimit* = IdLength * 8
     ## a bucket per shared prefix bit; deeper prefixes than the key is long cannot exist
   DefaultMaxBuckets* = MaxBucketsLimit
+  MaxRefreshLeadingZeros* = 12
+    ## Cap on the prefix bits a refresh target may share with the local id:
+    ## targets cost ~2^bits hashes to find, so buckets nearer than this are
+    ## left to the self-lookup that starts every refresh.
   DefaultTimeout* = 5.seconds
   DefaultBucketRefreshTime* = 10.minutes
   DefaultBucketStaleTime* = 30.minutes

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -15,9 +15,6 @@ const
     ## a bucket per shared prefix bit; deeper prefixes than the key is long cannot exist
   DefaultMaxBuckets* = MaxBucketsLimit
   MaxRefreshLeadingZeros* = 12
-    ## Cap on the prefix bits a refresh target may share with the local id:
-    ## targets cost ~2^bits hashes to find, so buckets nearer than this are
-    ## left to the self-lookup that starts every refresh.
   DefaultTimeout* = 5.seconds
   DefaultBucketRefreshTime* = 10.minutes
   DefaultBucketStaleTime* = 30.minutes

--- a/tests/libp2p/kademlia/test_routing_table.nim
+++ b/tests/libp2p/kademlia/test_routing_table.nim
@@ -15,6 +15,15 @@ proc testKey*(x: byte): Key =
 suite "KadDHT Routing Table":
   const TargetBucket = 6
 
+  proc keyInBucket(rt: RoutingTable, bucket: int): Key =
+    randomKeyInBucket(rt, bucket, rng()).expect("bucket is reachable")
+
+  proc keyWithPrefix(leadingZeros: int): Key =
+    ## Key whose distance from `testKey(0)` has exactly `leadingZeros` leading zeros.
+    var buf: array[IdLength, byte]
+    buf[leadingZeros div 8] = 0b1000_0000'u8 shr (leadingZeros mod 8)
+    return @buf
+
   test "inserts single key in correct bucket":
     let selfId = testKey(0)
     var rt = RoutingTable.new(selfId)
@@ -38,7 +47,7 @@ suite "KadDHT Routing Table":
     let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     var rt = RoutingTable.new(selfId, config)
     for _ in 0 ..< config.replication + 5:
-      let kid = randomKeyInBucket(selfId, TargetBucket, rng())
+      let kid = rt.keyInBucket(TargetBucket)
       discard rt.insert(kid)
 
     check TargetBucket < rt.buckets.len
@@ -50,7 +59,7 @@ suite "KadDHT Routing Table":
     let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     var rt = RoutingTable.new(selfId, config)
     for _ in 0 ..< config.replication + 10:
-      let kid = randomKeyInBucket(selfId, TargetBucket, rng())
+      let kid = rt.keyInBucket(TargetBucket)
       discard rt.insert(kid)
 
     check rt.buckets[TargetBucket].peers.len == config.replication
@@ -58,7 +67,7 @@ suite "KadDHT Routing Table":
     # new entry should evict oldest entry
     let (oldest, _) = rt.buckets[TargetBucket].oldestPeer()
 
-    check rt.insert(randomKeyInBucket(selfId, TargetBucket, rng()))
+    check rt.insert(rt.keyInBucket(TargetBucket))
 
     let (oldestAfterInsert, _) = rt.buckets[TargetBucket].oldestPeer()
 
@@ -70,9 +79,9 @@ suite "KadDHT Routing Table":
     let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     var rt = RoutingTable.new(selfId, config)
 
-    let key1 = randomKeyInBucket(selfId, TargetBucket, rng())
-    let key2 = randomKeyInBucket(selfId, TargetBucket, rng())
-    let key3 = randomKeyInBucket(selfId, TargetBucket, rng())
+    let key1 = rt.keyInBucket(TargetBucket)
+    let key2 = rt.keyInBucket(TargetBucket)
+    let key3 = rt.keyInBucket(TargetBucket)
 
     discard rt.insert(key1)
     discard rt.insert(key2)
@@ -163,7 +172,7 @@ suite "KadDHT Routing Table":
     let selfId = testKey(0)
     var rt =
       RoutingTable.new(selfId, RoutingTableConfig.new(hasher = Opt.some(noOpHasher)))
-    var rid = randomKeyInBucket(selfId, TargetBucket, rng())
+    let rid = randomKeyInBucket(rt, TargetBucket, rng()).expect("bucket is reachable")
     let idx = rt.bucketIndex(rid)
     check:
       idx == TargetBucket
@@ -175,8 +184,7 @@ suite "KadDHT Routing Table":
       RoutingTable.new(selfId, RoutingTableConfig.new(hasher = Opt.some(noOpHasher)))
 
     for lz in 0 .. 8:
-      let key = randomKeyInBucket(selfId, lz, rng())
-      check rt.bucketIndex(key) == lz
+      check rt.bucketIndex(keyWithPrefix(lz)) == lz
 
   test "small maxBuckets keeps prefix resolution and saturates the last bucket":
     let selfId = testKey(0)
@@ -188,13 +196,41 @@ suite "KadDHT Routing Table":
 
     # Prefix lengths below the cap each get their own bucket.
     for lz in 0 ..< MaxBuckets - 1:
-      let key = randomKeyInBucket(selfId, lz, rng(), MaxBuckets)
-      check rt.bucketIndex(key) == lz
+      check rt.bucketIndex(keyWithPrefix(lz)) == lz
 
     # Deeper prefixes all fall into the last bucket.
     for lz in MaxBuckets - 1 .. MaxBuckets + 8:
-      let key = randomKeyInBucket(selfId, lz, rng(), DefaultMaxBuckets)
-      check rt.bucketIndex(key) == MaxBuckets - 1
+      check rt.bucketIndex(keyWithPrefix(lz)) == MaxBuckets - 1
+
+  test "randomKeyInBucket targets the bucket under the default (hashing) hasher":
+    # The bucket of a key is decided by its *hash*, so a target built by
+    # manipulating selfId's bits lands in an unrelated bucket once hashed.
+    let selfId = testKey(0)
+    var rt = RoutingTable.new(selfId, RoutingTableConfig.new())
+
+    for bucket in [0, 1, TargetBucket, MaxRefreshLeadingZeros]:
+      for _ in 0 ..< 5:
+        let rid = randomKeyInBucket(rt, bucket, rng()).expect("bucket is reachable")
+        check rt.bucketIndex(rid) == bucket
+
+  test "randomKeyInBucket returns none for buckets too near to search for":
+    let selfId = testKey(0)
+    var rt = RoutingTable.new(selfId, RoutingTableConfig.new())
+
+    check randomKeyInBucket(rt, MaxRefreshLeadingZeros + 1, rng()).isNone()
+
+  test "randomKeyInBucket respects a narrow bucket split":
+    # Service-discovery tables split the id space into few buckets.
+    const MaxBuckets = 16
+    let selfId = testKey(0)
+    var rt = RoutingTable.new(selfId, RoutingTableConfig.new(maxBuckets = MaxBuckets))
+
+    for bucket in 0 .. MaxRefreshLeadingZeros:
+      let rid = randomKeyInBucket(rt, bucket, rng()).expect("bucket is reachable")
+      check rt.bucketIndex(rid) == bucket
+
+    # The last bucket needs 15 shared prefix bits — beyond the cap.
+    check randomKeyInBucket(rt, MaxBuckets - 1, rng()).isNone()
 
   test "randomKey returns none for empty bucket":
     var bucket: Bucket
@@ -204,7 +240,7 @@ suite "KadDHT Routing Table":
     let selfId = testKey(0)
     let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     var rt = RoutingTable.new(selfId, config)
-    let key = randomKeyInBucket(selfId, TargetBucket, rng())
+    let key = rt.keyInBucket(TargetBucket)
     discard rt.insert(key)
 
     let picked = randomKey(rt.buckets[TargetBucket], rng())
@@ -218,7 +254,7 @@ suite "KadDHT Routing Table":
     var rt = RoutingTable.new(selfId, config)
     var keys: seq[Key]
     for _ in 0 ..< config.replication:
-      let k = randomKeyInBucket(selfId, TargetBucket, rng())
+      let k = rt.keyInBucket(TargetBucket)
       keys.add(k)
       discard rt.insert(k)
 

--- a/tests/libp2p/kademlia/test_routing_table.nim
+++ b/tests/libp2p/kademlia/test_routing_table.nim
@@ -12,17 +12,24 @@ proc testKey*(x: byte): Key =
   buf[31] = x
   return @buf
 
+proc randomTestKey(): Key =
+  var buf = newSeqUninit[byte](IdLength)
+  rng().generate(buf)
+  buf
+
+proc keyWithLeadingZeros(n: int): Key =
+  ## Key whose XOR distance to an all-zero selfId under `noOpHasher` has
+  ## exactly `n` leading zero bits.
+  doAssert n < IdLength * 8, "an all-zero key has no first set bit"
+  var buf: array[IdLength, byte]
+  buf[n div 8] = 0x80'u8 shr (n mod 8)
+  return @buf
+
 suite "KadDHT Routing Table":
   const TargetBucket = 6
 
   proc keyInBucket(rt: RoutingTable, bucket: int): Key =
     randomKeyInBucket(rt, bucket, rng()).expect("bucket is reachable")
-
-  proc keyWithPrefix(leadingZeros: int): Key =
-    ## Key whose distance from `testKey(0)` has exactly `leadingZeros` leading zeros.
-    var buf: array[IdLength, byte]
-    buf[leadingZeros div 8] = 0b1000_0000'u8 shr (leadingZeros mod 8)
-    return @buf
 
   test "inserts single key in correct bucket":
     let selfId = testKey(0)
@@ -184,7 +191,7 @@ suite "KadDHT Routing Table":
       RoutingTable.new(selfId, RoutingTableConfig.new(hasher = Opt.some(noOpHasher)))
 
     for lz in 0 .. 8:
-      check rt.bucketIndex(keyWithPrefix(lz)) == lz
+      check rt.bucketIndex(keyWithLeadingZeros(lz)) == lz
 
   test "small maxBuckets keeps prefix resolution and saturates the last bucket":
     let selfId = testKey(0)
@@ -196,11 +203,11 @@ suite "KadDHT Routing Table":
 
     # Prefix lengths below the cap each get their own bucket.
     for lz in 0 ..< MaxBuckets - 1:
-      check rt.bucketIndex(keyWithPrefix(lz)) == lz
+      check rt.bucketIndex(keyWithLeadingZeros(lz)) == lz
 
     # Deeper prefixes all fall into the last bucket.
     for lz in MaxBuckets - 1 .. MaxBuckets + 8:
-      check rt.bucketIndex(keyWithPrefix(lz)) == MaxBuckets - 1
+      check rt.bucketIndex(keyWithLeadingZeros(lz)) == MaxBuckets - 1
 
   test "randomKeyInBucket targets the bucket under the default (hashing) hasher":
     # The bucket of a key is decided by its *hash*, so a target built by
@@ -231,6 +238,44 @@ suite "KadDHT Routing Table":
 
     # The last bucket needs 15 shared prefix bits — beyond the cap.
     check randomKeyInBucket(rt, MaxBuckets - 1, rng()).isNone()
+
+  test "refreshTarget falls back to a peer of a bucket too near to search for":
+    # Buckets past the cap share too long a prefix with selfId to draw at random.
+    const NearBucket = MaxRefreshLeadingZeros + 1
+    let selfId = testKey(0)
+    var rt = RoutingTable.new(selfId, RoutingTableConfig.new())
+
+    var inserted: seq[Key]
+    while inserted.len < 3:
+      let key = randomTestKey()
+      if rt.bucketIndex(key) != NearBucket:
+        continue
+      discard rt.insert(key)
+      inserted.add(key)
+
+    check randomKeyInBucket(rt, NearBucket, rng()).isNone()
+
+    let target = rt.refreshTarget(NearBucket, rng()).expect("bucket holds peers")
+    check:
+      target in inserted
+      rt.bucketIndex(target) == NearBucket
+
+  test "refreshTarget returns none for an unreachable empty bucket":
+    let selfId = testKey(0)
+    var rt = RoutingTable.new(selfId, RoutingTableConfig.new())
+
+    check rt.refreshTarget(MaxRefreshLeadingZeros + 1, rng()).isNone()
+
+  test "refreshTarget prefers a random key when the bucket is reachable":
+    let selfId = testKey(0)
+    var rt = RoutingTable.new(selfId, RoutingTableConfig.new())
+    let peer = rt.keyInBucket(TargetBucket)
+    discard rt.insert(peer)
+
+    let target = rt.refreshTarget(TargetBucket, rng()).expect("bucket is reachable")
+    check:
+      target != peer
+      rt.bucketIndex(target) == TargetBucket
 
   test "randomKey returns none for empty bucket":
     var bucket: Bucket


### PR DESCRIPTION
## Summary

Per-bucket refresh never queried the bucket it was asked to refresh. It degenerated into an unbiased random lookup, landing in bucket 0 roughly half the time regardless of the target — so the maintenance Kademlia relies on to keep sparse buckets alive was effectively not happening.

`randomKeyInBucket` built a key by manipulating the raw bits of `selfId` so that the *unhashed* XOR against `selfId` had exactly `i` leading zeros. But `bucketIndex` hashes the key before measuring distance (`key.hashFor(rtable.config.hasher)`), and both routing tables are constructed without a hasher (`kademlia.nim`, `routing_table_manager.nim`), so `hashFor` falls through to `defaultHasher` = sha256. Hashing destroys the prefix relationship the generator so carefully built, making the generated key's actual bucket uniformly random.

Measured on the production config (default sha256 hasher), asking for a bucket over 2000 draws:

| bucket requested | times actually hit | landed in bucket 0 |
|---|---|---|
| 1 | 477 / 2000 | 990 |
| 3 | 125 / 2000 | 1010 |
| 6 | 20 / 2000 | 1001 |
| 10 | 0 / 2000 | 982 |

Every existing test passed `hasher = Opt.some(noOpHasher)`, the identity hasher — the one configuration where the old code was correct, and why this stayed green.

The target is sent over the wire as a raw key that each remote peer hashes itself (`dispatchFindNode` -> `handleFindNode` -> `findClosestPeers`), so a target cannot be generated in hash space, and sha256 cannot be inverted. The target therefore has to be found by preimage search. This is the same conclusion go-libp2p reached; it pays the cost at build time via a precomputed prefix table (`GenRandPeerID` / `keyPrefixMap`) rather than at runtime.

`randomKeyInBucket` now takes the `RoutingTable` — it needs the hasher and `selfIdPreHashed`, which the old free-function signature could not see — and draws candidate keys until one *hashes* into the wanted bucket, returning `Opt[Key]`. `bucketIndex` is split so the search loop can hoist the self-hash out instead of re-hashing `selfId` on every attempt.

Because the search costs ~2^lz hashes, buckets nearer than `MaxRefreshLeadingZeros` (12) return `none` and are skipped by `refreshTable`. That cap is not a coverage gap: those near buckets are exactly the ones the `findNode(selfId)` at the top of `refreshTable` already refreshes, and a bucket past 12 only populates in a network of ~8k+ peers. 12 was chosen by measurement — a search at the cap costs ~14ms, where go-libp2p's equivalent of 15 would block the event loop ~110ms.

After the fix, targeting accuracy is 200/200 for every reachable bucket (0, 1, 3, 6, 10, 12), near buckets are declined rather than silently mistargeted, and the service-discovery table shape (`maxBuckets=16`, prehashed self) resolves correctly.

## Affected Areas

- [x] Peer Management / Discovery
- [x] Protocol Logic

Scope of changes:

- `libp2p/protocols/kademlia/routing_table.nim` — `randomKeyInBucket` rewritten to search in hash space; `bucketIndex` split into `bucketIndexFor` (accepts a precomputed self-hash) plus a private `selfHash` helper; new private `minLeadingZeros`.
- `libp2p/protocols/kademlia.nim` — `refreshTable` handles `Opt[Key]` and skips buckets with no reachable target.
- `libp2p/protocols/kademlia/types.nim` — new `MaxRefreshLeadingZeros` constant.
- `tests/libp2p/kademlia/test_routing_table.nim` — call sites updated; new coverage on the default hasher.

Both the main DHT routing table and the service-discovery per-service tables (which refresh through the same `refreshTable` via `refreshAllTables`) were affected by the bug.

## Compatibility & Downstream Validation

No wire-format or protocol change — the FIND_NODE key on the wire is still an ordinary raw key, and peers handle it exactly as before. The change is confined to which target the local node picks for its own refresh lookups, so no downstream integration branches are needed to validate it.

- **Nimbus:** N/A
- **Waku:** N/A
- **Codex:** N/A

## Impact on Library Users

**Breaking API change** to an exported proc, though one with no known external callers:

```nim
# before
proc randomKeyInBucket*(selfId: Key, bucketIndex: int, rng: Rng, maxBuckets: int = DefaultMaxBuckets): Key

# after
proc randomKeyInBucket*(rtable: RoutingTable, bucketIndex: int, rng: Rng): Opt[Key]
```

It takes the routing table instead of a bare `selfId` + `maxBuckets` (it needs the table's hasher to be correct at all) and returns `Opt[Key]`, since a target is not always obtainable. Callers pass the `RoutingTable` they already hold and handle `none` by skipping.

`bucketIndex` is now a `func` rather than a `proc`. This is a strengthening — existing call sites are unaffected.

Behavior change: bucket refresh now actually explores the bucket it targets, which is the intended Kademlia maintenance. Expect refresh lookups to reach sparse/distant buckets that previously went unrefreshed.

Performance: each refresh target now costs a bounded preimage search — negligible for low buckets (~0.01ms at bucket 0-1, ~0.2ms at bucket 6) and ~14ms at the bucket-12 cap. This is paid at most once per stale bucket per `bucketRefreshTime` (default 10 minutes), and only for buckets that are both non-empty and stale.

## Risk Assessment

- **Backward compatibility:** no wire or on-disk format change. Source-breaking only for direct callers of `randomKeyInBucket` (signature above).
- **Network behavior:** refresh traffic now spreads across buckets as designed instead of concentrating on bucket 0. Volume is unchanged — the same number of `findNode` calls, aimed at the right places. Buckets past the cap are covered by the existing self-lookup.
- **Performance:** the search is synchronous and blocks the event loop for its duration. Bucket occupancy is influenceable by a sybil that farms peer IDs to fill buckets 0-12, but the total is self-limiting: each bucket costs half the next, so the whole ladder sums to ~2^13 draws (~15ms) per 10-minute refresh cycle. Worst case for a single bucket is ~14ms at the cap.
- **Security:** targets are drawn from the same `Rng` as before and remain uniformly distributed within the target bucket, so refresh targets stay unpredictable. The wire key is now uniform random rather than carrying `selfId`'s prefix bits.

## References

- Kademlia bucket refresh: <https://docs.libp2p.io/concepts/discovery-routing/kaddht/>
- Prior art for the cap and the preimage-search approach: go-libp2p-kbucket `GenRandPeerID` / `maxCplForRefresh`, which precomputes a 16-bit prefix preimage table.

## Additional Notes

Verification was done against a standalone harness driving the real `RoutingTable` under the default sha256 hasher, which produced the before/after numbers above.

The three new tests exercise the **default sha256 hasher** — the configuration the bug actually lived in — rather than only `noOpHasher`: exact bucket targeting across several buckets, `none` past the cap, and the narrow 16-bucket service-discovery split. `Run Kademlia DHT interoperability tests` passes on this branch.

One note on the attempt budget: it is deliberately generous rather than tight. A budget of ~4x the expected draws would fail ~1.8% of the time per call, which across the 25-call loops in the existing tests would have made them flaky roughly a third of the time. Overshooting is free, since the loop exits on the first success.