### PR TITLE
fix(kad): avoid advertising ephemeral peer addresses

### DIFF
--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -530,12 +530,8 @@ method handleFindNode*(
       stream = stream, err = exc.msg
     return
 
-  # Prefer address-aware admission so inbound FIND_NODE senders go through the
-  # same diversity checks as peers learned from DHT responses. observedAddr may
-  # be the only address known before Identify has populated the peerstore.
-  var addrs = kad.switch.peerStore[AddressBook][stream.peerId]
-  stream.observedAddr.withValue(observedAddr):
-    if observedAddr notin addrs:
-      addrs.add(observedAddr)
+  # Only admit senders with known dialable addresses; an inbound connection
+  # may use an ephemeral source port.
+  let addrs = kad.switch.peerStore[AddressBook][stream.peerId]
   if addrs.len > 0:
     kad.updatePeers(@[PeerInfo(peerId: stream.peerId, addrs: addrs)])

--- a/libp2p/protocols/kademlia/get.nim
+++ b/libp2p/protocols/kademlia/get.nim
@@ -48,9 +48,6 @@ proc dispatchGetVal*(
   if reply.closerPeers.len > 0:
     kad_responses_with_closer_peers.inc(labelValues = [$MessageType.getValue])
 
-  stream.observedAddr.withValue(observedAddr):
-    kad.updatePeers(@[PeerInfo(peerId: stream.peerId, addrs: @[observedAddr])])
-
   return ok(reply)
 
 proc bestValidRecord(

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -277,6 +277,9 @@ method handleAddProvider*(
 
   if not atCap:
     for peer in validPeers:
+      let providerId = PeerId.init(peer.id.get()).valueOr:
+        continue
+      kad.updatePeers(@[PeerInfo(peerId: providerId, addrs: peer.addrs)])
       kad.providerManager.addProviderRecord(
         ProviderRecord(
           provider: peer,
@@ -334,9 +337,6 @@ proc dispatchGetProviders*(
     kad_responses_with_closer_peers.inc(labelValues = [$MessageType.getProviders])
 
   debug "Received reply for GetProviders", peer = peer, reply = reply
-
-  stream.observedAddr.withValue(observedAddr):
-    kad.updatePeers(@[PeerInfo(peerId: stream.peerId, addrs: @[observedAddr])])
 
   return ok(reply)
 

--- a/tests/libp2p/kademlia/test_find.nim
+++ b/tests/libp2p/kademlia/test_find.nim
@@ -308,3 +308,27 @@ suite "KadDHT Find":
     check:
       responsiveKad.switch.peerInfo.peerId in peerIds
       mockKad.handleFindNodeCalls == retries + 1 # (initial call + retries)
+
+  asyncTest "closerPeers does not advertise an observed inbound address":
+    let kads = setupKadSwitches(3)
+    let (a, b, c) = (kads[0], kads[1], kads[2])
+    startAndDeferStop(kads)
+
+    let
+      bId = b.switch.peerInfo.peerId
+      bKey = bId.toKey()
+      bListenAddrs = b.switch.peerInfo.addrs
+
+    # B's inbound connection to A uses an ephemeral source port.
+    await b.switch.connect(a.switch.peerInfo.peerId, a.switch.peerInfo.addrs)
+    discard (await b.dispatchFindNode(a.switch.peerInfo.peerId, bKey)).expect(
+      "FIND_NODE reply"
+    )
+
+    check a.switch.peerStore[AddressBook][bId].allIt(it in bListenAddrs)
+
+    await c.switch.connect(a.switch.peerInfo.peerId, a.switch.peerInfo.addrs)
+    let reply = (await c.dispatchFindNode(a.switch.peerInfo.peerId, bKey)).value()
+    let bCloser =
+      reply.closerPeers.filterIt(it.id.isSome and it.id.get() == bId.getBytes())
+    check bCloser.mapIt(it.addrs).concat().allIt(it in bListenAddrs)

--- a/tests/libp2p/kademlia/test_get_providers.nim
+++ b/tests/libp2p/kademlia/test_get_providers.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import chronos, results, sets, tables
+import chronos, results, sequtils, sets, tables
 import
   ../../../libp2p/[protocols/kademlia, switch, builders, multicodec, multihash, cid]
 import ../../tools/[lifecycle, topology, unittest]
@@ -278,3 +278,40 @@ suite "KadDHT - Get Providers":
       providers.containsPeer(kads[2])
       providers.containsPeer(kads[3])
       providers.containsPeer(kads[4])
+
+  asyncTest "provider listen addresses are advertised in closerPeers":
+    let
+      a = setupKad(config = testKadConfig(providerRejection = true))
+      b = setupKad()
+      c = setupKad()
+    startAndDeferStop(@[a, b, c])
+
+    let
+      bId = b.switch.peerInfo.peerId
+      bListenAddrs = b.switch.peerInfo.addrs
+      providerKey = @[1.byte, 2, 3, 4, 5]
+
+    await b.switch.connect(a.switch.peerInfo.peerId, a.switch.peerInfo.addrs)
+    discard (await b.dispatchFindNode(a.switch.peerInfo.peerId, bId.toKey())).expect(
+      "FIND_NODE reply"
+    )
+    check a.switch.peerStore[AddressBook][bId].allIt(it in bListenAddrs)
+
+    discard (await sendAddProviderAndGetStatus(b, a, providerKey)).expect(
+      "add provider accepted"
+    )
+    checkUntilTimeout:
+      bListenAddrs.allIt(it in a.switch.peerStore[AddressBook][bId])
+
+    await c.switch.connect(a.switch.peerInfo.peerId, a.switch.peerInfo.addrs)
+    let reply =
+      (await c.dispatchGetProviders(a.switch.peerInfo.peerId, providerKey)).value()
+    let bProvider =
+      reply.providerPeers.filterIt(it.id.isSome and it.id.get() == bId.getBytes())
+    let bCloser =
+      reply.closerPeers.filterIt(it.id.isSome and it.id.get() == bId.getBytes())
+    check:
+      bProvider.len == 1
+      bCloser.len == 1
+      bProvider[0].addrs.anyIt(it in bListenAddrs)
+      bCloser.mapIt(it.addrs).concat().allIt(it in bListenAddrs)


### PR DESCRIPTION
## Summary

Prevents Kademlia from storing a connection's observed remote address as a dialable peer address. For inbound connections, this may contain an ephemeral source port that was later advertised through `closerPeers`.

Accepted `ADD_PROVIDER` messages now populate the address book from the provider's announced listen addresses, avoiding a dependency on Identify timing.

Adds regression coverage for `FIND_NODE` and `GET_PROVIDERS`.

## Affected Areas

- [x] Peer Management / Discovery  
  Corrects the address provenance used for Kademlia routing-table peers.

- [x] Protocol Logic  
  Updates `FIND_NODE`, `GET_VALUE`, `GET_PROVIDERS`, and `ADD_PROVIDER` address handling.

## Impact on Library Users

No API changes.

`closerPeers` no longer advertises observed connection endpoints. Inbound `FIND_NODE` senders are admitted only when a dialable address is already known, while accepted provider announcements supply their listen addresses directly.

## Risk Assessment

Routing-table admission may be delayed until Identify or a DHT message supplies a dialable address. Provider addresses continue through the existing address policy and routing-table admission checks.

## References

- Fixes [[#2826](https://github.com/vacp2p/nim-libp2p/issues/2826)](https://github.com/vacp2p/nim-libp2p/issues/2826)
- Regression scenarios adapted from [[#2831](https://github.com/vacp2p/nim-libp2p/pull/2831)](https://github.com/vacp2p/nim-libp2p/pull/2831)