### PR TITLE
fix(service-disco): ads pruning

### DIFF
--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -54,6 +54,20 @@ proc removeAd*(ipTree: IpTree, ad: Advertisement) {.raises: [].} =
 proc isExpired(now, ts: Moment, expiry: Duration): bool =
   now - ts > expiry
 
+proc removeAdvertisementEverywhere(registrar: Registrar, ad: Advertisement) =
+  let key = ad.toAdvertisementKey()
+
+  registrar.cacheTimestamps.del(key)
+
+  for _, sads in registrar.cache.mpairs:
+    var j = 0
+    while j < sads.len:
+      if sads[j].toAdvertisementKey() == key:
+        registrar.ipTree.removeAd(sads[j])
+        sads.delete(j)
+      else:
+        inc(j)
+
 proc pruneAdsForService(
     registrar: Registrar,
     serviceId: ServiceId,
@@ -72,11 +86,7 @@ proc pruneAdsForService(
       remove = isExpired(now, ts[], advertExpiry)
 
     if remove:
-      # Free global state only while this key still owns a timestamp.
-      if key in registrar.cacheTimestamps:
-        registrar.ipTree.removeAd(ad)
-        registrar.cacheTimestamps.del(key)
-      ads.delete(i)
+      registrar.removeAdvertisementEverywhere(ad)
       inc(expiredCount)
     else:
       inc(i)
@@ -324,18 +334,18 @@ proc evictOldestAd*(
     return
 
   var emptiedSids: seq[ServiceId] = @[]
-  var removedFromIpTree = false
+  disco.registrar.cacheTimestamps.del(oldestKey)
 
   for sid, sads in disco.registrar.cache.mpairs:
     var i = 0
     var removedFromThisService = false
     while i < sads.len:
       if sads[i].toAdvertisementKey() == oldestKey:
-        # Free IP tree / timestamp once; further service lists are orphans.
-        if not removedFromIpTree:
-          disco.registrar.ipTree.removeAd(sads[i])
-          disco.registrar.cacheTimestamps.del(oldestKey)
-          removedFromIpTree = true
+        # Each service holding this key was a separate ad_cache admission
+        # (an advertisement is associated to its service_id) that added
+        # the IP once - remove it once per matching entry, not once total,
+        # or the tree stays inflated for every service beyond the first.
+        disco.registrar.ipTree.removeAd(sads[i])
         sads.delete(i)
         removedFromThisService = true
       else:
@@ -368,11 +378,17 @@ proc updateExistingAd*(
     registrar.cacheTimestamps[existing.toAdvertisementKey()] = now
     return false
   elif ad.data.seqNo > existing.data.seqNo:
-    registrar.ipTree.removeAd(existing)
-    registrar.cacheTimestamps.del(existing.toAdvertisementKey())
+    let oldKey = existing.toAdvertisementKey()
+    for _, sads in registrar.cache.mpairs:
+      for j in 0 ..< sads.len:
+        if sads[j].toAdvertisementKey() == oldKey:
+          registrar.ipTree.removeAd(sads[j])
+          registrar.ipTree.insertAd(ad)
+          sads[j] = ad
+
+    registrar.cacheTimestamps.del(oldKey)
     ads[idx] = ad
     registrar.cacheTimestamps[ad.toAdvertisementKey()] = now
-    registrar.ipTree.insertAd(ad)
     return true
   else:
     return false
@@ -387,10 +403,16 @@ proc insertNewAd*(
   ## Insert a brand-new advertisement into the cache.
   ## Evicts the globally oldest entry first if the cache is at capacity.
   ## Returns true (a new insertion always warrants a metrics update).
-  if disco.registrar.cacheTimestamps.len.uint64 >= disco.discoConfig.advertCacheCap:
+  ## The IP tree is incremented unconditionally, once per (service, ad)
+  ## admission - the same physical ad accepted for 3 services is 3 separate
+  ## ad_cache admissions, and each one adds the IP once.
+  let key = ad.toAdvertisementKey()
+  let isNewKey = key notin disco.registrar.cacheTimestamps
+  if isNewKey and
+      disco.registrar.cacheTimestamps.len.uint64 >= disco.discoConfig.advertCacheCap:
     evictOldestAd(disco, serviceId, ads)
   ads.add(ad)
-  disco.registrar.cacheTimestamps[ad.toAdvertisementKey()] = now
+  disco.registrar.cacheTimestamps[key] = now
   disco.registrar.ipTree.insertAd(ad)
   return true
 

--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -66,14 +66,20 @@ proc pruneAdsForService(
   while i < ads.len:
     let ad = ads[i]
     let key = ad.toAdvertisementKey()
+    # Default true: missing timestamp → orphan, must leave this service list
+    var remove = true
     registrar.cacheTimestamps.withValue(key, ts):
-      if isExpired(now, ts[], advertExpiry):
+      remove = isExpired(now, ts[], advertExpiry)
+
+    if remove:
+      # Free global state only while this key still owns a timestamp.
+      if key in registrar.cacheTimestamps:
         registrar.ipTree.removeAd(ad)
         registrar.cacheTimestamps.del(key)
-        ads.delete(i)
-        inc(expiredCount)
-      else:
-        inc(i)
+      ads.delete(i)
+      inc(expiredCount)
+    else:
+      inc(i)
 
 proc pruneEmptyServices(registrar: Registrar) =
   var toRemove: seq[ServiceId] = @[]
@@ -317,27 +323,33 @@ proc evictOldestAd*(
   let oldestKey = disco.findOldestKey().valueOr:
     return
 
-  var emptiedSid: ServiceId
-  var sidBecameEmpty = false
+  var emptiedSids: seq[ServiceId] = @[]
+  var removedFromIpTree = false
 
-  block search:
-    for sid, sads in disco.registrar.cache.mpairs:
-      for i in 0 ..< sads.len:
-        if sads[i].toAdvertisementKey() == oldestKey:
+  for sid, sads in disco.registrar.cache.mpairs:
+    var i = 0
+    var removedFromThisService = false
+    while i < sads.len:
+      if sads[i].toAdvertisementKey() == oldestKey:
+        # Free IP tree / timestamp once; further service lists are orphans.
+        if not removedFromIpTree:
           disco.registrar.ipTree.removeAd(sads[i])
           disco.registrar.cacheTimestamps.del(oldestKey)
-          sads.delete(i)
+          removedFromIpTree = true
+        sads.delete(i)
+        removedFromThisService = true
+      else:
+        inc(i)
 
-          if sid == serviceId:
-            ads = sads
-          elif sads.len == 0:
-            emptiedSid = sid
-            sidBecameEmpty = true
+    if sads.len == 0:
+      emptiedSids.add(sid)
 
-          break search
+    # Sync the caller's working list only when we mutated this service's entry.
+    if removedFromThisService and sid == serviceId:
+      ads = sads
 
-  if sidBecameEmpty:
-    disco.registrar.cache.del(emptiedSid)
+  for sid in emptiedSids:
+    disco.registrar.cache.del(sid)
 
 proc updateExistingAd*(
     registrar: Registrar,

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -492,6 +492,85 @@ suite "Service Discovery Registrar - Cache Pruning":
 
     check ad notin registrar.cache.getOrDefault(serviceId)
 
+  test "pruneExpiredAds removes same expired ad from all services":
+    let registrar = Registrar.new()
+    let serviceId1 = makeServiceId(1)
+    let serviceId2 = makeServiceId(2)
+    let ad = makeAdvertisement(addrs = @[makeMultiAddress("10.0.0.1")])
+    let now = Moment.now()
+
+    registrar.cache[serviceId1] = @[ad]
+    registrar.cache[serviceId2] = @[ad]
+    registrar.cacheTimestamps[ad.toAdvertisementKey()] = now - 1000.secs
+    registrar.ipTree.insertAd(ad)
+
+    pruneExpiredAds(registrar, 900.secs)
+
+    check:
+      registrar.cache.len == 0
+      ad.toAdvertisementKey() notin registrar.cacheTimestamps
+      registrar.ipTree.root.counter == 0
+
+    # Second prune must be a no-op
+    pruneExpiredAds(registrar, 900.secs)
+    check registrar.cache.len == 0
+
+  test "pruneExpiredAds removes orphan ad with no timestamp":
+    let registrar = Registrar.new()
+    let serviceId = makeServiceId()
+    let ad = makeAdvertisement($serviceId)
+
+    registrar.cache[serviceId] = @[ad]
+    # Deliberately no cacheTimestamps entry
+
+    pruneExpiredAds(registrar, 900.secs)
+
+    check:
+      ad notin registrar.cache.getOrDefault(serviceId)
+      registrar.cache.len == 0
+
+  test "pruneExpiredAds progresses past mixed fresh, orphan, and expired ads":
+    let registrar = Registrar.new()
+    let serviceId = makeServiceId()
+    let fresh = makeAdvertisement($serviceId)
+    let orphan = makeAdvertisement($serviceId)
+    let expired = makeAdvertisement($serviceId)
+    let now = Moment.now()
+
+    registrar.cache[serviceId] = @[fresh, orphan, expired]
+    registrar.cacheTimestamps[fresh.toAdvertisementKey()] = now
+    # orphan has no timestamp
+    registrar.cacheTimestamps[expired.toAdvertisementKey()] = now - 1000.secs
+
+    pruneExpiredAds(registrar, 900.secs)
+
+    check:
+      registrar.cache[serviceId].len == 1
+      fresh in registrar.cache[serviceId]
+      orphan notin registrar.cache[serviceId]
+      expired notin registrar.cache[serviceId]
+      fresh.toAdvertisementKey() in registrar.cacheTimestamps
+      expired.toAdvertisementKey() notin registrar.cacheTimestamps
+
+  test "pruneExpiredAds removes multi-service ad from IP tree only once":
+    let registrar = Registrar.new()
+    let serviceId1 = makeServiceId(1)
+    let serviceId2 = makeServiceId(2)
+    let ad = makeAdvertisement(addrs = @[makeMultiAddress("192.168.1.1")])
+    let now = Moment.now()
+
+    registrar.cache[serviceId1] = @[ad]
+    registrar.cache[serviceId2] = @[ad]
+    registrar.cacheTimestamps[ad.toAdvertisementKey()] = now - 1000.secs
+    registrar.ipTree.insertAd(ad)
+    check registrar.ipTree.root.counter == 1
+
+    pruneExpiredAds(registrar, 900.secs)
+
+    check:
+      registrar.cache.len == 0
+      registrar.ipTree.root.counter == 0
+
 suite "Service Discovery Registrar - State Management":
   test "cache can store multiple ads for same service ID":
     let registrar = Registrar.new()
@@ -1218,7 +1297,8 @@ suite "Service Discovery Registrar - insertNewAd":
       kRegister = 3, bucketsCount = 16, advertCacheCap = cap.uint64
     )
     let disco = setupServiceDiscoveryNode(discoConfig = config)
-    let serviceId = makeServiceId()
+    # Use a service id outside the filled range so the working list starts empty
+    let serviceId = makeServiceId(100)
     let now = initMoment(5000)
 
     # Fill cache exactly to capacity; the first entry gets the oldest timestamp
@@ -1245,6 +1325,45 @@ suite "Service Discovery Registrar - insertNewAd":
     check oldestAd.toAdvertisementKey() notin disco.registrar.cacheTimestamps
     check newAd.toAdvertisementKey() in disco.registrar.cacheTimestamps
     check ads.len == 1
+
+  test "evictOldestAd removes shared ad from all services":
+    # Oldest key is registered under two services; eviction must clear both
+    # lists (not leave an orphan without a timestamp).
+    let cap = 2
+    let config = ServiceDiscoveryConfig.new(
+      kRegister = 3, bucketsCount = 16, advertCacheCap = cap.uint64
+    )
+    let disco = setupServiceDiscoveryNode(discoConfig = config)
+    let serviceId1 = makeServiceId(1)
+    let serviceId2 = makeServiceId(2)
+    let serviceId3 = makeServiceId(3)
+    let now = initMoment(5000)
+
+    let oldestAd = makeAdvertisement(addrs = @[makeMultiAddress("10.0.0.1")])
+    let otherAd = makeAdvertisement(addrs = @[makeMultiAddress("10.0.0.2")])
+
+    disco.registrar.cache[serviceId1] = @[oldestAd]
+    disco.registrar.cache[serviceId2] = @[oldestAd]
+    disco.registrar.cache[serviceId3] = @[otherAd]
+    disco.registrar.cacheTimestamps[oldestAd.toAdvertisementKey()] = initMoment(100)
+    disco.registrar.cacheTimestamps[otherAd.toAdvertisementKey()] = now
+    disco.registrar.ipTree.insertAd(oldestAd)
+    disco.registrar.ipTree.insertAd(otherAd)
+
+    # At capacity (2 unique keys); insert into a fresh service so the working
+    # list only receives the new ad after oldestAd is evicted everywhere.
+    let newServiceId = makeServiceId(4)
+    let newAd = makeAdvertisement(addrs = @[makeMultiAddress("10.0.0.3")])
+    var ads: seq[Advertisement] = @[]
+    discard disco.insertNewAd(newServiceId, ads, newAd, now)
+
+    check:
+      oldestAd.toAdvertisementKey() notin disco.registrar.cacheTimestamps
+      serviceId1 notin disco.registrar.cache
+      serviceId2 notin disco.registrar.cache
+      otherAd in disco.registrar.cache.getOrDefault(serviceId3)
+      newAd in ads
+      ads.len == 1
 
 suite "Service Discovery Registrar - registration response":
   test "wait response records the wait time and does not cache the ad":

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -583,6 +583,8 @@ suite "Service Discovery Registrar - Cache Pruning":
     registrar.cache[serviceId1] = @[ad]
     registrar.cache[serviceId2] = @[ad]
     registrar.cacheTimestamps[ad.toAdvertisementKey()] = now - 1000.secs
+    # Each service's copy is a separate ad_cache admission
+    registrar.ipTree.insertAd(ad)
     registrar.ipTree.insertAd(ad)
 
     pruneExpiredAds(registrar, 900.secs)
@@ -633,7 +635,7 @@ suite "Service Discovery Registrar - Cache Pruning":
       fresh.toAdvertisementKey() in registrar.cacheTimestamps
       expired.toAdvertisementKey() notin registrar.cacheTimestamps
 
-  test "pruneExpiredAds removes multi-service ad from IP tree only once":
+  test "pruneExpiredAds removes multi-service ad from IP tree once per service":
     let registrar = Registrar.new()
     let serviceId1 = makeServiceId(1)
     let serviceId2 = makeServiceId(2)
@@ -643,8 +645,10 @@ suite "Service Discovery Registrar - Cache Pruning":
     registrar.cache[serviceId1] = @[ad]
     registrar.cache[serviceId2] = @[ad]
     registrar.cacheTimestamps[ad.toAdvertisementKey()] = now - 1000.secs
+    # Each service's copy is a separate ad_cache admission
     registrar.ipTree.insertAd(ad)
-    check registrar.ipTree.root.counter == 1
+    registrar.ipTree.insertAd(ad)
+    check registrar.ipTree.root.counter == 2
 
     pruneExpiredAds(registrar, 900.secs)
 
@@ -1336,6 +1340,40 @@ suite "Service Discovery Registrar - updateExistingAd":
     check currentAd.toAdvertisementKey() in registrar.cacheTimestamps
     check staleAd.toAdvertisementKey() notin registrar.cacheTimestamps
 
+  test "higher seqNo replaces stale copies in every other service that cached it":
+    let registrar = Registrar.new()
+    let serviceId1 = makeServiceId(1)
+    let serviceId2 = makeServiceId(2)
+    let privateKey = PrivateKey.random(rng()).get()
+    let oldAd = makeAdvertisement(
+      privateKey = privateKey, seqNo = 1, addrs = @[makeMultiAddress("10.0.0.1")]
+    )
+    let newAd = makeAdvertisement(
+      privateKey = privateKey, seqNo = 2, addrs = @[makeMultiAddress("192.168.1.1")]
+    )
+
+    registrar.cache[serviceId1] = @[oldAd]
+    registrar.cache[serviceId2] = @[oldAd]
+    registrar.cacheTimestamps[oldAd.toAdvertisementKey()] = initMoment(1000)
+    # Each service's copy is a separate ad_cache admission
+    registrar.ipTree.insertAd(oldAd)
+    registrar.ipTree.insertAd(oldAd)
+    check registrar.ipTree.root.counter == 2
+
+    var ads1 = registrar.cache[serviceId1]
+    let changed = registrar.updateExistingAd(ads1, 0, newAd, initMoment(2000))
+    registrar.cache[serviceId1] = ads1
+
+    check changed
+    check registrar.cache[serviceId1].len == 1
+    check registrar.cache[serviceId1][0].data.seqNo == 2
+    # serviceId2 was never passed into updateExistingAd directly.
+    check registrar.cache[serviceId2].len == 1
+    check registrar.cache[serviceId2][0].data.seqNo == 2
+    check oldAd.toAdvertisementKey() notin registrar.cacheTimestamps
+    check newAd.toAdvertisementKey() in registrar.cacheTimestamps
+    check registrar.ipTree.root.counter == 2
+
 suite "Service Discovery Registrar - insertNewAd":
   test "inserts ad into cache, IP tree, and timestamps, returns true":
     let disco =
@@ -1353,6 +1391,30 @@ suite "Service Discovery Registrar - insertNewAd":
     check ad.toAdvertisementKey() in disco.registrar.cacheTimestamps
     check disco.registrar.cacheTimestamps[ad.toAdvertisementKey()] == now
     check disco.registrar.ipTree.root.counter > 0
+
+  test "same ad accepted for three services counts the IP tree once per service":
+    # ad_cache associates each advertisement to its service_id : the
+    # same physical ad admitted for 3 services is 3 separate admissions,
+    # each of which adds the IP once - not one shared contribution.
+    let disco =
+      setupServiceDiscoveryNode(discoConfig = ServiceDiscoveryConfig.new(fReturn = 3))
+    let serviceId1 = makeServiceId(1)
+    let serviceId2 = makeServiceId(2)
+    let serviceId3 = makeServiceId(3)
+    let ad = makeAdvertisement(addrs = @[makeMultiAddress("10.0.0.1")])
+    let now = initMoment(1000)
+
+    var ads1: seq[Advertisement] = @[]
+    var ads2: seq[Advertisement] = @[]
+    var ads3: seq[Advertisement] = @[]
+    discard disco.insertNewAd(serviceId1, ads1, ad, now)
+    discard disco.insertNewAd(serviceId2, ads2, ad, now)
+    discard disco.insertNewAd(serviceId3, ads3, ad, now)
+    disco.registrar.cache[serviceId1] = ads1
+    disco.registrar.cache[serviceId2] = ads2
+    disco.registrar.cache[serviceId3] = ads3
+
+    check disco.registrar.ipTree.root.counter == 3
 
   test "inserts ad without eviction when cache is under capacity":
     let disco = setupServiceDiscoveryNode(


### PR DESCRIPTION
Ads are stored per service (`cache[ServiceId]`), but timestamps are global by `(peerId, seqNo)`. When the same ad appeared under multiple services, the first prune deleted the shared timestamp; the next service hit `withValue` with no match and never advanced `i`, so `pruneAdsForService` looped forever and left orphans uncleared.