### PR TITLE
fix(service-disco): centralize cross-service advertisement cleanup

### DIFF
--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -54,6 +54,21 @@ proc removeAd*(ipTree: IpTree, ad: Advertisement) {.raises: [].} =
 proc isExpired(now, ts: Moment, expiry: Duration): bool =
   now - ts > expiry
 
+proc removeAdvertisementEverywhere(registrar: Registrar, ad: Advertisement) =
+  let key = ad.toAdvertisementKey()
+
+  if key in registrar.cacheTimestamps:
+    registrar.ipTree.removeAd(ad)
+    registrar.cacheTimestamps.del(key)
+
+  for _, sads in registrar.cache.mpairs:
+    var j = 0
+    while j < sads.len:
+      if sads[j].toAdvertisementKey() == key:
+        sads.delete(j)
+      else:
+        inc(j)
+
 proc pruneAdsForService(
     registrar: Registrar,
     serviceId: ServiceId,
@@ -72,11 +87,7 @@ proc pruneAdsForService(
       remove = isExpired(now, ts[], advertExpiry)
 
     if remove:
-      # Free global state only while this key still owns a timestamp.
-      if key in registrar.cacheTimestamps:
-        registrar.ipTree.removeAd(ad)
-        registrar.cacheTimestamps.del(key)
-      ads.delete(i)
+      registrar.removeAdvertisementEverywhere(ad)
       inc(expiredCount)
     else:
       inc(i)

--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -57,14 +57,13 @@ proc isExpired(now, ts: Moment, expiry: Duration): bool =
 proc removeAdvertisementEverywhere(registrar: Registrar, ad: Advertisement) =
   let key = ad.toAdvertisementKey()
 
-  if key in registrar.cacheTimestamps:
-    registrar.ipTree.removeAd(ad)
-    registrar.cacheTimestamps.del(key)
+  registrar.cacheTimestamps.del(key)
 
   for _, sads in registrar.cache.mpairs:
     var j = 0
     while j < sads.len:
       if sads[j].toAdvertisementKey() == key:
+        registrar.ipTree.removeAd(sads[j])
         sads.delete(j)
       else:
         inc(j)
@@ -335,18 +334,18 @@ proc evictOldestAd*(
     return
 
   var emptiedSids: seq[ServiceId] = @[]
-  var removedFromIpTree = false
+  disco.registrar.cacheTimestamps.del(oldestKey)
 
   for sid, sads in disco.registrar.cache.mpairs:
     var i = 0
     var removedFromThisService = false
     while i < sads.len:
       if sads[i].toAdvertisementKey() == oldestKey:
-        # Free IP tree / timestamp once; further service lists are orphans.
-        if not removedFromIpTree:
-          disco.registrar.ipTree.removeAd(sads[i])
-          disco.registrar.cacheTimestamps.del(oldestKey)
-          removedFromIpTree = true
+        # Each service holding this key was a separate ad_cache admission
+        # (an advertisement is associated to its service_id) that added
+        # the IP once - remove it once per matching entry, not once total,
+        # or the tree stays inflated for every service beyond the first.
+        disco.registrar.ipTree.removeAd(sads[i])
         sads.delete(i)
         removedFromThisService = true
       else:
@@ -383,13 +382,13 @@ proc updateExistingAd*(
     for _, sads in registrar.cache.mpairs:
       for j in 0 ..< sads.len:
         if sads[j].toAdvertisementKey() == oldKey:
+          registrar.ipTree.removeAd(sads[j])
+          registrar.ipTree.insertAd(ad)
           sads[j] = ad
 
-    registrar.ipTree.removeAd(existing)
     registrar.cacheTimestamps.del(oldKey)
     ads[idx] = ad
     registrar.cacheTimestamps[ad.toAdvertisementKey()] = now
-    registrar.ipTree.insertAd(ad)
     return true
   else:
     return false
@@ -404,6 +403,9 @@ proc insertNewAd*(
   ## Insert a brand-new advertisement into the cache.
   ## Evicts the globally oldest entry first if the cache is at capacity.
   ## Returns true (a new insertion always warrants a metrics update).
+  ## The IP tree is incremented unconditionally, once per (service, ad)
+  ## admission - the same physical ad accepted for 3 services is 3 separate
+  ## ad_cache admissions, and each one adds the IP once.
   let key = ad.toAdvertisementKey()
   let isNewKey = key notin disco.registrar.cacheTimestamps
   if isNewKey and
@@ -411,8 +413,7 @@ proc insertNewAd*(
     evictOldestAd(disco, serviceId, ads)
   ads.add(ad)
   disco.registrar.cacheTimestamps[key] = now
-  if isNewKey:
-    disco.registrar.ipTree.insertAd(ad)
+  disco.registrar.ipTree.insertAd(ad)
   return true
 
 proc acceptAdvertisement*(

--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -379,8 +379,14 @@ proc updateExistingAd*(
     registrar.cacheTimestamps[existing.toAdvertisementKey()] = now
     return false
   elif ad.data.seqNo > existing.data.seqNo:
+    let oldKey = existing.toAdvertisementKey()
+    for _, sads in registrar.cache.mpairs:
+      for j in 0 ..< sads.len:
+        if sads[j].toAdvertisementKey() == oldKey:
+          sads[j] = ad
+
     registrar.ipTree.removeAd(existing)
-    registrar.cacheTimestamps.del(existing.toAdvertisementKey())
+    registrar.cacheTimestamps.del(oldKey)
     ads[idx] = ad
     registrar.cacheTimestamps[ad.toAdvertisementKey()] = now
     registrar.ipTree.insertAd(ad)
@@ -398,11 +404,15 @@ proc insertNewAd*(
   ## Insert a brand-new advertisement into the cache.
   ## Evicts the globally oldest entry first if the cache is at capacity.
   ## Returns true (a new insertion always warrants a metrics update).
-  if disco.registrar.cacheTimestamps.len.uint64 >= disco.discoConfig.advertCacheCap:
+  let key = ad.toAdvertisementKey()
+  let isNewKey = key notin disco.registrar.cacheTimestamps
+  if isNewKey and
+      disco.registrar.cacheTimestamps.len.uint64 >= disco.discoConfig.advertCacheCap:
     evictOldestAd(disco, serviceId, ads)
   ads.add(ad)
-  disco.registrar.cacheTimestamps[ad.toAdvertisementKey()] = now
-  disco.registrar.ipTree.insertAd(ad)
+  disco.registrar.cacheTimestamps[key] = now
+  if isNewKey:
+    disco.registrar.ipTree.insertAd(ad)
   return true
 
 proc acceptAdvertisement*(

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -1336,6 +1336,32 @@ suite "Service Discovery Registrar - updateExistingAd":
     check currentAd.toAdvertisementKey() in registrar.cacheTimestamps
     check staleAd.toAdvertisementKey() notin registrar.cacheTimestamps
 
+  test "higher seqNo replaces stale copies in every other service that cached it":
+    let registrar = Registrar.new()
+    let serviceId1 = makeServiceId(1)
+    let serviceId2 = makeServiceId(2)
+    let privateKey = PrivateKey.random(rng()).get()
+    let oldAd = makeAdvertisement(privateKey = privateKey, seqNo = 1)
+    let newAd = makeAdvertisement(privateKey = privateKey, seqNo = 2)
+
+    registrar.cache[serviceId1] = @[oldAd]
+    registrar.cache[serviceId2] = @[oldAd]
+    registrar.cacheTimestamps[oldAd.toAdvertisementKey()] = initMoment(1000)
+    registrar.ipTree.insertAd(oldAd)
+
+    var ads1 = registrar.cache[serviceId1]
+    let changed = registrar.updateExistingAd(ads1, 0, newAd, initMoment(2000))
+    registrar.cache[serviceId1] = ads1
+
+    check changed
+    check registrar.cache[serviceId1].len == 1
+    check registrar.cache[serviceId1][0].data.seqNo == 2
+    # serviceId2 was never passed into updateExistingAd directly.
+    check registrar.cache[serviceId2].len == 1
+    check registrar.cache[serviceId2][0].data.seqNo == 2
+    check oldAd.toAdvertisementKey() notin registrar.cacheTimestamps
+    check newAd.toAdvertisementKey() in registrar.cacheTimestamps
+
 suite "Service Discovery Registrar - insertNewAd":
   test "inserts ad into cache, IP tree, and timestamps, returns true":
     let disco =
@@ -1353,6 +1379,27 @@ suite "Service Discovery Registrar - insertNewAd":
     check ad.toAdvertisementKey() in disco.registrar.cacheTimestamps
     check disco.registrar.cacheTimestamps[ad.toAdvertisementKey()] == now
     check disco.registrar.ipTree.root.counter > 0
+
+  test "same ad accepted for three services counts the IP tree only once":
+    let disco =
+      setupServiceDiscoveryNode(discoConfig = ServiceDiscoveryConfig.new(fReturn = 3))
+    let serviceId1 = makeServiceId(1)
+    let serviceId2 = makeServiceId(2)
+    let serviceId3 = makeServiceId(3)
+    let ad = makeAdvertisement(addrs = @[makeMultiAddress("10.0.0.1")])
+    let now = initMoment(1000)
+
+    var ads1: seq[Advertisement] = @[]
+    var ads2: seq[Advertisement] = @[]
+    var ads3: seq[Advertisement] = @[]
+    discard disco.insertNewAd(serviceId1, ads1, ad, now)
+    discard disco.insertNewAd(serviceId2, ads2, ad, now)
+    discard disco.insertNewAd(serviceId3, ads3, ad, now)
+    disco.registrar.cache[serviceId1] = ads1
+    disco.registrar.cache[serviceId2] = ads2
+    disco.registrar.cache[serviceId3] = ads3
+
+    check disco.registrar.ipTree.root.counter == 1
 
   test "inserts ad without eviction when cache is under capacity":
     let disco = setupServiceDiscoveryNode(

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -583,6 +583,8 @@ suite "Service Discovery Registrar - Cache Pruning":
     registrar.cache[serviceId1] = @[ad]
     registrar.cache[serviceId2] = @[ad]
     registrar.cacheTimestamps[ad.toAdvertisementKey()] = now - 1000.secs
+    # Each service's copy is a separate ad_cache admission
+    registrar.ipTree.insertAd(ad)
     registrar.ipTree.insertAd(ad)
 
     pruneExpiredAds(registrar, 900.secs)
@@ -633,7 +635,7 @@ suite "Service Discovery Registrar - Cache Pruning":
       fresh.toAdvertisementKey() in registrar.cacheTimestamps
       expired.toAdvertisementKey() notin registrar.cacheTimestamps
 
-  test "pruneExpiredAds removes multi-service ad from IP tree only once":
+  test "pruneExpiredAds removes multi-service ad from IP tree once per service":
     let registrar = Registrar.new()
     let serviceId1 = makeServiceId(1)
     let serviceId2 = makeServiceId(2)
@@ -643,8 +645,10 @@ suite "Service Discovery Registrar - Cache Pruning":
     registrar.cache[serviceId1] = @[ad]
     registrar.cache[serviceId2] = @[ad]
     registrar.cacheTimestamps[ad.toAdvertisementKey()] = now - 1000.secs
+    # Each service's copy is a separate ad_cache admission
     registrar.ipTree.insertAd(ad)
-    check registrar.ipTree.root.counter == 1
+    registrar.ipTree.insertAd(ad)
+    check registrar.ipTree.root.counter == 2
 
     pruneExpiredAds(registrar, 900.secs)
 
@@ -1341,13 +1345,20 @@ suite "Service Discovery Registrar - updateExistingAd":
     let serviceId1 = makeServiceId(1)
     let serviceId2 = makeServiceId(2)
     let privateKey = PrivateKey.random(rng()).get()
-    let oldAd = makeAdvertisement(privateKey = privateKey, seqNo = 1)
-    let newAd = makeAdvertisement(privateKey = privateKey, seqNo = 2)
+    let oldAd = makeAdvertisement(
+      privateKey = privateKey, seqNo = 1, addrs = @[makeMultiAddress("10.0.0.1")]
+    )
+    let newAd = makeAdvertisement(
+      privateKey = privateKey, seqNo = 2, addrs = @[makeMultiAddress("192.168.1.1")]
+    )
 
     registrar.cache[serviceId1] = @[oldAd]
     registrar.cache[serviceId2] = @[oldAd]
     registrar.cacheTimestamps[oldAd.toAdvertisementKey()] = initMoment(1000)
+    # Each service's copy is a separate ad_cache admission
     registrar.ipTree.insertAd(oldAd)
+    registrar.ipTree.insertAd(oldAd)
+    check registrar.ipTree.root.counter == 2
 
     var ads1 = registrar.cache[serviceId1]
     let changed = registrar.updateExistingAd(ads1, 0, newAd, initMoment(2000))
@@ -1361,6 +1372,7 @@ suite "Service Discovery Registrar - updateExistingAd":
     check registrar.cache[serviceId2][0].data.seqNo == 2
     check oldAd.toAdvertisementKey() notin registrar.cacheTimestamps
     check newAd.toAdvertisementKey() in registrar.cacheTimestamps
+    check registrar.ipTree.root.counter == 2
 
 suite "Service Discovery Registrar - insertNewAd":
   test "inserts ad into cache, IP tree, and timestamps, returns true":
@@ -1380,7 +1392,10 @@ suite "Service Discovery Registrar - insertNewAd":
     check disco.registrar.cacheTimestamps[ad.toAdvertisementKey()] == now
     check disco.registrar.ipTree.root.counter > 0
 
-  test "same ad accepted for three services counts the IP tree only once":
+  test "same ad accepted for three services counts the IP tree once per service":
+    # ad_cache associates each advertisement to its service_id : the
+    # same physical ad admitted for 3 services is 3 separate admissions,
+    # each of which adds the IP once - not one shared contribution.
     let disco =
       setupServiceDiscoveryNode(discoConfig = ServiceDiscoveryConfig.new(fReturn = 3))
     let serviceId1 = makeServiceId(1)
@@ -1399,7 +1414,7 @@ suite "Service Discovery Registrar - insertNewAd":
     disco.registrar.cache[serviceId2] = ads2
     disco.registrar.cache[serviceId3] = ads3
 
-    check disco.registrar.ipTree.root.counter == 1
+    check disco.registrar.ipTree.root.counter == 3
 
   test "inserts ad without eviction when cache is under capacity":
     let disco = setupServiceDiscoveryNode(


### PR DESCRIPTION
## Summary

Centralized the cross-service ad cleanup into one helper (`removeAdvertisementEverywhere`), so a shared advertisement gets removed from every service list in one explicit pass instead of relying on each service's prune loop to lazily stumble onto it.

Follow-up to #2845 

<!--
Provide a clear and concise description of the purpose of this PR.

Explain:
- What this PR does
- Why it is needed
- The problem it solves or the improvement it introduces
-->


## Affected Areas
<!--
Indicate which parts of the codebase are impacted.
Check all that apply and briefly describe the scope of the changes.
-->

- [ ] Gossipsub  
  <!-- e.g. scoring changes, message validation, peer handling -->

- [ ] Transports  
  <!-- e.g. TCP, QUIC, WebSockets, Noise, etc. -->

- [ ] Peer Management / Discovery

- [ ] Protocol Logic

- [ ] Build / Tooling

- [ ] Other  
  <!-- Describe below -->


## Compatibility & Downstream Validation
<!--
For PRs affecting behavior on existing features, provide evidence that
dependent projects build and function correctly with these changes.
-->

Reference PRs / branches / commits demonstrating successful integration:

- **Nimbus:**  
  <!-- Link PR or branch -->

- **Waku:**  
  <!-- Link PR or branch -->

- **Codex:**  
  <!-- Link PR or branch -->


## Impact on Library Users
<!--
Describe how this affects downstream users of nim-libp2p.

Examples:
- API changes
- Behavior changes
- Performance implications
- Migration requirements
- No impact (internal refactor)
-->


## Risk Assessment
<!--
Identify potential risks introduced by this change.

Consider:
- Backward compatibility
- Network behavior changes
- Performance regressions
- Security implications
-->


## References
<!--
Link to related:
- Issues
- Specs
- Design discussions
- Prior PRs
-->


## Additional Notes
<!--
Optional: any extra context reviewers should be aware of.
-->