### PR TITLE
fix(kad): exclude the requester from closerPeers

### DIFF
--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -515,6 +515,20 @@ proc findClosestPeers*(kad: KadDHT, target: Key, requester: PeerId): seq[Peer] =
     closestPeerKeys[0 ..< min(kad.config.replication, closestPeerKeys.len)]
   )
 
+proc findNodeCloserPeers(kad: KadDHT, target: Key, requester: PeerId): seq[Peer] =
+  ## Also returns the target itself, which keeps client-mode peers resolvable.
+  let closest = kad.findClosestPeers(target, requester)
+  if target == requester.toKey():
+    return closest
+
+  let targetPeer = target.toPeer(kad.switch).valueOr:
+    return closest
+
+  if closest.len > 0 and closest[0].id == targetPeer.id:
+    return closest
+
+  return @[targetPeer] & closest
+
 method handleFindNode*(
     kad: KadDHT, stream: Stream, msg: Message
 ) {.base, async: (raises: [CancelledError]).} =
@@ -524,7 +538,7 @@ method handleFindNode*(
 
   let response = Message(
     msgType: Opt.some(MessageType.findNode),
-    closerPeers: kad.findClosestPeers(msgKey, stream.peerId),
+    closerPeers: kad.findNodeCloserPeers(msgKey, stream.peerId),
   )
   let encoded = response.encode(kad.config.hideConnectionStatus)
   kad_message_bytes_sent.inc(encoded.len.int64, labelValues = [$MessageType.findNode])

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -504,12 +504,16 @@ proc findPeer*(
 
   return ok(PeerInfo(peerId: target, addrs: kad.switch.peerStore[AddressBook][target]))
 
-proc findClosestPeers*(kad: KadDHT, target: Key): seq[Peer] =
-  let closestPeerKeys = kad.rtable.findClosest(target, kad.config.replication).filterIt(
-      it != kad.switch.peerInfo.peerId.toKey()
-    )
+proc findClosestPeers*(kad: KadDHT, target: Key, requester: PeerId): seq[Peer] =
+  ## Over-fetches by `excluded.len` so dropping self and `requester` still fills the reply.
+  let excluded = [kad.switch.peerInfo.peerId.toKey(), requester.toKey()]
+  let closestPeerKeys = kad.rtable
+    .findClosest(target, kad.config.replication + excluded.len)
+    .filterIt(it notin excluded)
 
-  return kad.switch.toPeers(closestPeerKeys)
+  return kad.switch.toPeers(
+    closestPeerKeys[0 ..< min(kad.config.replication, closestPeerKeys.len)]
+  )
 
 method handleFindNode*(
     kad: KadDHT, stream: Stream, msg: Message
@@ -519,7 +523,8 @@ method handleFindNode*(
     return
 
   let response = Message(
-    msgType: Opt.some(MessageType.findNode), closerPeers: kad.findClosestPeers(msgKey)
+    msgType: Opt.some(MessageType.findNode),
+    closerPeers: kad.findClosestPeers(msgKey, stream.peerId),
   )
   let encoded = response.encode(kad.config.hideConnectionStatus)
   kad_message_bytes_sent.inc(encoded.len.int64, labelValues = [$MessageType.findNode])

--- a/libp2p/protocols/kademlia/get.nim
+++ b/libp2p/protocols/kademlia/get.nim
@@ -177,7 +177,7 @@ method handleGetValue*(
     let response = Message(
       msgType: Opt.some(MessageType.getValue),
       key: Opt.some(key),
-      closerPeers: kad.findClosestPeers(key),
+      closerPeers: kad.findClosestPeers(key, stream.peerId),
     )
     let encoded = response.encode(kad.config.hideConnectionStatus)
     kad_message_bytes_sent.inc(encoded.len.int64, labelValues = [$MessageType.getValue])
@@ -197,7 +197,7 @@ method handleGetValue*(
         timeReceived: Opt.some(entryRecord.time),
       )
     ),
-    closerPeers: kad.findClosestPeers(key),
+    closerPeers: kad.findClosestPeers(key, stream.peerId),
   )
   let encoded = response.encode(kad.config.hideConnectionStatus)
   kad_message_bytes_sent.inc(encoded.len.int64, labelValues = [$MessageType.getValue])

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -391,7 +391,7 @@ proc handleGetProviders*(
   let response = Message(
     msgType: Opt.some(MessageType.getProviders),
     key: msg.key,
-    closerPeers: kad.findClosestPeers(msgKey),
+    closerPeers: kad.findClosestPeers(msgKey, stream.peerId),
     providerPeers: providers.toSeq(),
   )
   let encoded = response.encode(kad.config.hideConnectionStatus)

--- a/tests/libp2p/kademlia/test_find.nim
+++ b/tests/libp2p/kademlia/test_find.nim
@@ -249,10 +249,60 @@ suite "KadDHT Find":
     let closerPeersIds = response.closerPeers.mapIt(it.id.get())
     check:
       response.msgType == MessageType.findNode
-      # kads[0] knows kads[1] and kads[2], but must not hand kads[1] its own id back
       response.closerPeers.len == 1
       kads[1].rtable.selfId notin closerPeersIds
       kads[2].rtable.selfId in closerPeersIds
+
+  asyncTest "Find node for a known target returns it once":
+    let kads = setupKadSwitches(3)
+    startAndDeferStop(kads)
+
+    await connectHub(kads[0], kads[1 ..^ 1])
+
+    let response = (
+      await kads[1].dispatchFindNode(
+        kads[0].switch.peerInfo.peerId, kads[2].rtable.selfId
+      )
+    ).value()
+
+    check:
+      response.closerPeers.len == 1
+      response.closerPeers[0].id.get() == kads[2].rtable.selfId
+
+  asyncTest "Find node for an unknown target omits it":
+    let kads = setupKadSwitches(3)
+    startAndDeferStop(kads)
+
+    await connectHub(kads[0], kads[1 ..^ 1])
+
+    let unknownTarget = randomPeerId().toKey()
+    let response = (
+      await kads[1].dispatchFindNode(kads[0].switch.peerInfo.peerId, unknownTarget)
+    ).value()
+
+    let closerPeersIds = response.closerPeers.mapIt(it.id.get())
+    check:
+      unknownTarget notin closerPeersIds
+      kads[2].rtable.selfId in closerPeersIds
+
+  asyncTest "Find node returns a target known only from the address book":
+    let kads = setupKadSwitches(3)
+    startAndDeferStop(kads)
+
+    await connectHub(kads[0], kads[1 ..^ 1])
+
+    # A client-mode peer is in nobody's routing table, but its addresses are known.
+    let client = randomPeerId()
+    kads[0].switch.peerStore[AddressBook][client] =
+      @[MultiAddress.init("/ip4/127.0.0.1/tcp/9999").tryGet()]
+
+    let response = (
+      await kads[1].dispatchFindNode(kads[0].switch.peerInfo.peerId, client.toKey())
+    ).value()
+
+    check:
+      not kads[0].hasKey(client.toKey())
+      response.closerPeers[0].id.get() == client.toKey()
 
   asyncTest "Find node excludes the requester for an unrelated target":
     let kads = setupKadSwitches(3)

--- a/tests/libp2p/kademlia/test_find.nim
+++ b/tests/libp2p/kademlia/test_find.nim
@@ -217,10 +217,11 @@ suite "KadDHT Find":
     check kads[0].hasKey(kads[2].rtable.selfId)
 
   asyncTest "Find node with empty key returns closest peers":
-    let kads = setupKadSwitches(2)
+    let kads = setupKadSwitches(3)
     startAndDeferStop(kads)
 
-    await connect(kads[0], kads[1])
+    # Setup: kads[0] <-> kads[1], kads[0] <-> kads[2]
+    await connectHub(kads[0], kads[1 ..^ 1])
 
     # Send FIND_NODE with empty key directly
     let emptyKey: Key = @[]
@@ -231,9 +232,9 @@ suite "KadDHT Find":
     check:
       response.msgType == MessageType.findNode
       response.closerPeers.len == 1
-      response.closerPeers[0].id.get() == kads[1].rtable.selfId
+      response.closerPeers[0].id.get() == kads[2].rtable.selfId
 
-  asyncTest "Find node for own PeerID returns closest peers":
+  asyncTest "Find node for own PeerID excludes the requester":
     let kads = setupKadSwitches(3)
     startAndDeferStop(kads)
 
@@ -248,9 +249,28 @@ suite "KadDHT Find":
     let closerPeersIds = response.closerPeers.mapIt(it.id.get())
     check:
       response.msgType == MessageType.findNode
-      # kads[0] knows kads[1] and kads[2], should return both as closest peers
-      response.closerPeers.len == 2
-      kads[1].rtable.selfId in closerPeersIds
+      # kads[0] knows kads[1] and kads[2], but must not hand kads[1] its own id back
+      response.closerPeers.len == 1
+      kads[1].rtable.selfId notin closerPeersIds
+      kads[2].rtable.selfId in closerPeersIds
+
+  asyncTest "Find node excludes the requester for an unrelated target":
+    let kads = setupKadSwitches(3)
+    startAndDeferStop(kads)
+
+    await connectHub(kads[0], kads[1 ..^ 1])
+
+    # kads[0] knows kads[1] and kads[2], and both fit in a reply, so pre-filter
+    # kads[1] would get itself back even though the target is unrelated to it.
+    let response = (
+      await kads[1].dispatchFindNode(
+        kads[0].switch.peerInfo.peerId, randomPeerId().toKey()
+      )
+    ).value()
+
+    let closerPeersIds = response.closerPeers.mapIt(it.id.get())
+    check:
+      kads[1].rtable.selfId notin closerPeersIds
       kads[2].rtable.selfId in closerPeersIds
 
   asyncTest "Find node with empty routing table returns empty result":


### PR DESCRIPTION
## Summary

`findClosestPeers` built the `closerPeers` list for `FIND_NODE`, `GET_VALUE` and `GET_PROVIDERS` replies while filtering out only self, never the sender. When the sender was in our routing table and landed among the `k` closest to the target key, we handed it back its own peer id.

That is harmless against a client that filters its own id out, but it hung interop against py-libp2p (v0.6.0): on receiving its own id, py-libp2p opened a stream back to itself, sent `FIND_NODE`, and blocked waiting for a reply that a node in client mode never sends, stalling the whole lookup until the test timed out.

This PR excludes the requester as well as self, following go-libp2p's `closestPeersToQuery`. `findClosestPeers` takes the sender as a `requester` argument and the three handlers thread `stream.peerId` into it. It over-fetches from the routing table by the number of excluded keys and truncates back to `replication`, so dropping the sender does not shrink an otherwise full reply.

`FIND_NODE` additionally prepends the target itself when we know its addresses, which closes a real gap: a peer in client mode is in nobody's routing table, so `findPeer` could never resolve one. The target is looked up in the address book rather than the routing table, and is skipped when it is already the closest entry so it is not duplicated.

## Affected Areas

- [x] Peer Management / Discovery — which routing-table peers a node hands back in a reply, and whether a client-mode peer can be resolved at all.

- [x] Protocol Logic — `closerPeers` construction in `handleFindNode` (`find.nim`), `handleGetValue` (`get.nim`) and `handleGetProviders` (`provider.nim`).

## Compatibility & Downstream Validation

The behavior change is confined to kad-dht reply construction and only removes an entry that a correct client already discards, so no downstream integration branches were needed:

- **Nimbus:** N/A
- **Waku:** N/A
- **Codex:** N/A

## Impact on Library Users

`findClosestPeers*` is exported and gains a required `requester: PeerId` parameter — a source-breaking signature change for anyone calling it directly. Every in-tree caller is a DHT handler, and no tests referenced it. There is no wire-format change.

Behaviorally: a node no longer receives itself in `closerPeers`, and `FIND_NODE` for a client-mode peer whose addresses we know now resolves instead of returning nothing.

## Risk Assessment

- Backward compatibility: wire-compatible. Interop improves rather than regresses, since the removed entry is one every correct client already discards.
- Network behavior: replies still carry up to `replication` closest peers because the routing-table lookup over-fetches before filtering. `FIND_NODE` can return one extra entry when the target is prepended.
- Performance: one extra routing-table candidate sorted per reply, and one address-book lookup per `FIND_NODE`. The exclusion set is a stack array. Negligible.
- Security: none identified. The prepended target is only ever a peer we already hold addresses for.

## References

- Closes #2848
- go-libp2p `closestPeersToQuery`: https://github.com/libp2p/go-libp2p-kad-dht/blob/cb9639642a8d54f22a49e7b45b66fd7615f2bbf5/dht.go#L751-L779
- kad-dht spec, `FIND_NODE` / `GET_PROVIDERS` `closerPeers`: https://github.com/libp2p/specs/blob/6b6203ee6f62938ce67efdb33498173f475851c0/kad-dht/README.md?plain=1#L490-L505
- py-libp2p interop hang: https://github.com/libp2p/unified-testing/pull/119

## Additional Notes

The issue asked about `handleFindNode` and `handleGetProviders`. `handleGetValue` builds `closerPeers` the same way and go excludes the sender there too, so it is included for consistency. The target prepend is `FIND_NODE`-only, matching go.

**Deliberate divergence from go:** go prepends the target even when the target *is* the requester, and its comment justifies this as "per spec: FIND_PEER has a special exception where the target peer MUST be included". The spec says no such thing — it contains no `MUST` at all, and `FIND_NODE` states only that `closerPeers` is "the `k` closest `Peer`s". Adopting that half would re-arm the very hang this PR fixes: py-libp2p's `refresh_routing_table` performs a lookup for its own id, and v0.6.0 only filters self out of peerstore-seeded candidates, not out of peers received from a reply. It would dial itself and stall again. So the target is not prepended when it is the requester; a peer wanting its own addresses can use identify. "Find node for own PeerID excludes the requester" guards this.

nim is itself immune to that class of bug from either direction — `sortedShortlist` (`find.nim`) skips self when selecting peers to query, and `RoutingTable.insert` refuses self — but that is no reason to emit it to others.