### PR TITLE
chore(kad): liveness-gated bucket eviction

### DIFF
--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -415,6 +415,8 @@ proc lookOnce*(
   for (peerId, res) in completedRPCBatch:
     let reply = res.valueOr:
       continue
+    # A successful reply proves the peer useful; retain it through eviction.
+    rtable.markUseful(peerId)
     let newPeerInfos = state.updateShortlist(reply)
     kad.switch.updatePeers(
       kad.config.addressPolicy, rtable, newPeerInfos, kad.config.limits.maxPeersPerIp,

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -338,8 +338,10 @@ proc updatePeers*(
       maxPeersPerIpv6Subnet,
     ):
       continue
-    if rtable.insert(p.peerId):
-      addressBook.extend(p.peerId, addrs, AddressConfidence.Low)
+    # Store before insert: a peer rejected for lack of bucket space still reaches
+    # the lookup shortlist, and would be undialable without its addresses.
+    addressBook.extend(p.peerId, addrs, AddressConfidence.Low)
+    discard rtable.insert(p.peerId)
 
 proc updatePeers*(kad: KadDHT, peerInfos: seq[PeerInfo]) {.raises: [].} =
   updatePeers(
@@ -415,7 +417,7 @@ proc lookOnce*(
   for (peerId, res) in completedRPCBatch:
     let reply = res.valueOr:
       continue
-    # A successful reply proves the peer useful; retain it through eviction.
+    # A reply proves the peer useful; retain it through eviction.
     rtable.markUseful(peerId)
     let newPeerInfos = state.updateShortlist(reply)
     kad.switch.updatePeers(

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -77,14 +77,13 @@ proc oldestPeer*(bucket: Bucket): (NodeEntry, int) =
   (oldest, oldestIdx)
 
 func isReplaceable*(entry: NodeEntry, gracePeriod: Duration, now: Moment): bool =
-  ## A peer is replaceable once it has spent longer than `gracePeriod` in the
-  ## table without proving useful. A peer that answered a query within the grace
-  ## period — or that was only just added — is retained.
+  ## Replaceable once past `gracePeriod` in the table without proving useful; a
+  ## peer that answered recently or was just added is retained.
   now - entry.lastUsefulAt.get(entry.addedAt) > gracePeriod
 
 proc replaceableCandidate(bucket: Bucket, gracePeriod: Duration): Opt[int] =
-  ## Least-recently-seen peer that is past the usefulness grace period, i.e. the
-  ## best candidate to evict. `Opt.none` when every peer is still useful/fresh.
+  ## Least-recently-seen peer past the grace period, i.e. the best eviction
+  ## candidate. `Opt.none` when every peer is still useful/fresh.
   let now = Moment.now()
   var candidateIdx = -1
   var oldestSeen: Moment
@@ -145,8 +144,7 @@ proc insert*(rtable: RoutingTable, nodeId: Key): bool =
     bucket.peers.add(NodeEntry(nodeId: nodeId, lastSeen: now, addedAt: now))
     kad_routing_table_insertions.inc()
   else:
-    # A full bucket with no replaceable peer rejects the newcomer rather than
-    # evicting a still-useful one.
+    # Full bucket with no replaceable peer: reject rather than evict a useful one.
     if not bucket.tryReplaceStalePeer(nodeId, rtable.config):
       debug "Cannot insert, no replaceable peer in bucket",
         bucket = idx, nodeId = nodeId
@@ -161,9 +159,8 @@ proc insert*(rtable: RoutingTable, peerId: PeerId): bool =
   insert(rtable, peerId.toKey())
 
 proc markUseful*(rtable: RoutingTable, nodeId: Key) =
-  ## Records that `nodeId` answered a query: refreshes its usefulness and
-  ## last-seen timestamps so it is retained through bucket eviction. No-op when
-  ## the peer is not in the table.
+  ## Records that `nodeId` answered a query, refreshing its usefulness so it
+  ## survives eviction. No-op when the peer is not in the table.
   let idx = rtable.bucketIndex(nodeId)
   if idx >= rtable.buckets.len:
     return

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -19,6 +19,7 @@ proc new*(
     hasher: Opt[XorDHasher] = NoneHasher,
     maxBuckets: int = DefaultMaxBuckets,
     selfIdPreHashed = false,
+    usefulnessGracePeriod: Duration = DefaultUsefulnessGracePeriod,
 ): T =
   doAssert maxBuckets > 0 and maxBuckets <= MaxBucketsLimit,
     "maxBuckets must be in 1 .. " & $MaxBucketsLimit
@@ -27,6 +28,7 @@ proc new*(
     hasher: hasher,
     maxBuckets: maxBuckets,
     selfIdPreHashed: selfIdPreHashed,
+    usefulnessGracePeriod: usefulnessGracePeriod,
   )
 
 proc `$`*(rt: RoutingTable): string =
@@ -74,18 +76,42 @@ proc oldestPeer*(bucket: Bucket): (NodeEntry, int) =
       oldestIdx = i
   (oldest, oldestIdx)
 
-proc replaceOldest(bucket: var Bucket, newNodeId: Key, replication: int): bool =
-  if bucket.peers.len < replication:
+func isReplaceable*(entry: NodeEntry, gracePeriod: Duration, now: Moment): bool =
+  ## A peer is replaceable once it has spent longer than `gracePeriod` in the
+  ## table without proving useful. A peer that answered a query within the grace
+  ## period — or that was only just added — is retained.
+  now - entry.lastUsefulAt.get(entry.addedAt) > gracePeriod
+
+proc replaceableCandidate(bucket: Bucket, gracePeriod: Duration): Opt[int] =
+  ## Least-recently-seen peer that is past the usefulness grace period, i.e. the
+  ## best candidate to evict. `Opt.none` when every peer is still useful/fresh.
+  let now = Moment.now()
+  var candidateIdx = -1
+  var oldestSeen: Moment
+  for i, p in bucket.peers:
+    if not p.isReplaceable(gracePeriod, now):
+      continue
+    if candidateIdx == -1 or p.lastSeen < oldestSeen:
+      candidateIdx = i
+      oldestSeen = p.lastSeen
+  if candidateIdx == -1:
+    return Opt.none(int)
+  Opt.some(candidateIdx)
+
+proc tryReplaceStalePeer(
+    bucket: var Bucket, newNodeId: Key, config: RoutingTableConfig
+): bool =
+  if bucket.peers.len < config.replication:
     trace "Skipping replace: bucket is not full", newNodeId = newNodeId
     return false
 
-  let (oldest, oldestIdx) = bucket.oldestPeer()
-
-  if oldest.nodeId == newNodeId:
-    trace "Failed to replace: same nodeId", newNodeId = newNodeId
+  let idx = bucket.replaceableCandidate(config.usefulnessGracePeriod).valueOr:
+    trace "Skipping replace: no peer past usefulness grace period",
+      newNodeId = newNodeId
     return false
 
-  bucket.peers[oldestIdx] = NodeEntry(nodeId: newNodeId, lastSeen: Moment.now())
+  let now = Moment.now()
+  bucket.peers[idx] = NodeEntry(nodeId: newNodeId, lastSeen: now, addedAt: now)
   true
 
 proc updateRoutingTableMetrics*(rtable: RoutingTable) =
@@ -115,12 +141,14 @@ proc insert*(rtable: RoutingTable, nodeId: Key): bool =
   if keyx.isSome:
     bucket.peers[keyx.unsafeValue].lastSeen = Moment.now()
   elif bucket.peers.len < rtable.config.replication:
-    bucket.peers.add(NodeEntry(nodeId: nodeId, lastSeen: Moment.now()))
+    let now = Moment.now()
+    bucket.peers.add(NodeEntry(nodeId: nodeId, lastSeen: now, addedAt: now))
     kad_routing_table_insertions.inc()
   else:
-    # eviction policy: replace oldest key
-    if not bucket.replaceOldest(nodeId, rtable.config.replication):
-      debug "Cannot insert, failed to replace oldest key in bucket",
+    # A full bucket with no replaceable peer rejects the newcomer rather than
+    # evicting a still-useful one.
+    if not bucket.tryReplaceStalePeer(nodeId, rtable.config):
+      debug "Cannot insert, no replaceable peer in bucket",
         bucket = idx, nodeId = nodeId
       return false
     kad_routing_table_replacements.inc()
@@ -131,6 +159,22 @@ proc insert*(rtable: RoutingTable, nodeId: Key): bool =
 
 proc insert*(rtable: RoutingTable, peerId: PeerId): bool =
   insert(rtable, peerId.toKey())
+
+proc markUseful*(rtable: RoutingTable, nodeId: Key) =
+  ## Records that `nodeId` answered a query: refreshes its usefulness and
+  ## last-seen timestamps so it is retained through bucket eviction. No-op when
+  ## the peer is not in the table.
+  let idx = rtable.bucketIndex(nodeId)
+  if idx >= rtable.buckets.len:
+    return
+  let pos = peerIndexInBucket(rtable.buckets[idx], nodeId).valueOr:
+    return
+  let now = Moment.now()
+  rtable.buckets[idx].peers[pos].lastUsefulAt = Opt.some(now)
+  rtable.buckets[idx].peers[pos].lastSeen = now
+
+proc markUseful*(rtable: RoutingTable, peerId: PeerId) =
+  rtable.markUseful(peerId.toKey())
 
 proc findClosest*(rtable: RoutingTable, targetId: Key, count: int): seq[Key] =
   ## Returns up to `count` nodes in the table with the smallest XOR distance to `targetId`.

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -19,6 +19,10 @@ const
   DefaultBucketRefreshTime* = 10.minutes
   DefaultBucketStaleTime* = 30.minutes
     # peer not seen for this duration marks bucket stale
+  DefaultUsefulnessGracePeriod* = 1.hours
+    ## A newly inserted peer is protected from eviction until it has been in the
+    ## table this long without proving useful (answering a query), mirroring the
+    ## usefulness-grace concept from go-libp2p's k-bucket.
   DefaultRetries* = 5
   DefaultReplication* = 20 ## aka `k` in the spec
   DefaultAlpha* = 10 # concurrency parameter
@@ -195,6 +199,11 @@ type
   NodeEntry* = object
     nodeId*: Key
     lastSeen*: Moment
+    addedAt*: Moment
+    lastUsefulAt*: Opt[Moment]
+      ## Set when the peer answers a query. `Opt.none` means it has not yet
+      ## proven useful; such a peer becomes replaceable once past the grace
+      ## period since it was added.
 
   Bucket* = object
     peers*: seq[NodeEntry]
@@ -204,6 +213,7 @@ type
     hasher*: Opt[XorDHasher]
     maxBuckets*: int
     selfIdPreHashed*: bool
+    usefulnessGracePeriod*: Duration
 
   RoutingTable* = ref object
     selfId*: Key

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -20,9 +20,8 @@ const
   DefaultBucketStaleTime* = 30.minutes
     # peer not seen for this duration marks bucket stale
   DefaultUsefulnessGracePeriod* = 1.hours
-    ## A newly inserted peer is protected from eviction until it has been in the
-    ## table this long without proving useful (answering a query), mirroring the
-    ## usefulness-grace concept from go-libp2p's k-bucket.
+    ## New peers resist eviction until in the table this long without proving
+    ## useful; mirrors go-libp2p's k-bucket usefulness grace.
   DefaultRetries* = 5
   DefaultReplication* = 20 ## aka `k` in the spec
   DefaultAlpha* = 10 # concurrency parameter
@@ -201,9 +200,8 @@ type
     lastSeen*: Moment
     addedAt*: Moment
     lastUsefulAt*: Opt[Moment]
-      ## Set when the peer answers a query. `Opt.none` means it has not yet
-      ## proven useful; such a peer becomes replaceable once past the grace
-      ## period since it was added.
+      ## Set when the peer answers a query; `Opt.none` until then, which makes it
+      ## replaceable once past the grace period since it was added.
 
   Bucket* = object
     peers*: seq[NodeEntry]

--- a/tests/libp2p/kademlia/test_routing_table.nim
+++ b/tests/libp2p/kademlia/test_routing_table.nim
@@ -61,7 +61,14 @@ suite "KadDHT Routing Table":
     let bucket = rt.buckets[TargetBucket]
     check bucket.peers.len <= config.replication
 
-  test "evicts oldest key at max capacity":
+  proc agePastGrace(rt: RoutingTable, bucketIdx: int) =
+    ## Push every peer past the usefulness grace period so eviction can act.
+    var bucket = rt.buckets[bucketIdx]
+    for i in 0 ..< bucket.peers.len:
+      bucket.peers[i].addedAt = Moment.now() - 2.hours
+    rt.buckets[bucketIdx] = bucket
+
+  test "evicts oldest replaceable key at max capacity":
     let selfId = testKey(0)
     let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     var rt = RoutingTable.new(selfId, config)
@@ -71,15 +78,52 @@ suite "KadDHT Routing Table":
 
     check rt.buckets[TargetBucket].peers.len == config.replication
 
+    # Fresh peers are protected by the grace period; age them so they are
+    # eligible for eviction.
+    rt.agePastGrace(TargetBucket)
+
     # new entry should evict oldest entry
     let (oldest, _) = rt.buckets[TargetBucket].oldestPeer()
 
     check rt.insert(rt.keyInBucket(TargetBucket))
 
-    let (oldestAfterInsert, _) = rt.buckets[TargetBucket].oldestPeer()
+    check:
+      rt.buckets[TargetBucket].peers.len == config.replication
+      not rt.buckets[TargetBucket].allKeys().contains(oldest.nodeId)
 
-    # oldest was evicted
-    check oldest.nodeId != oldestAfterInsert.nodeId
+  test "retains peers still within the usefulness grace period":
+    let selfId = testKey(0)
+    let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
+    var rt = RoutingTable.new(selfId, config)
+    for _ in 0 ..< config.replication:
+      discard rt.insert(randomKeyInBucket(selfId, TargetBucket, rng()))
+
+    let before = rt.buckets[TargetBucket].allKeys()
+    let newcomer = randomKeyInBucket(selfId, TargetBucket, rng())
+
+    # Bucket is full of fresh, unproven peers: the newcomer is rejected rather
+    # than blindly evicting one of them.
+    check:
+      not rt.insert(newcomer)
+      rt.buckets[TargetBucket].allKeys() == before
+      not rt.buckets[TargetBucket].allKeys().contains(newcomer)
+
+  test "markUseful protects a peer from eviction":
+    let selfId = testKey(0)
+    let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
+    var rt = RoutingTable.new(selfId, config)
+    for _ in 0 ..< config.replication:
+      discard rt.insert(randomKeyInBucket(selfId, TargetBucket, rng()))
+
+    rt.agePastGrace(TargetBucket)
+
+    # The oldest-seen peer would be evicted first, but marking it useful keeps
+    # it and forces a different peer out.
+    let (oldest, _) = rt.buckets[TargetBucket].oldestPeer()
+    rt.markUseful(oldest.nodeId)
+
+    check rt.insert(randomKeyInBucket(selfId, TargetBucket, rng()))
+    check rt.buckets[TargetBucket].allKeys().contains(oldest.nodeId)
 
   test "re-insert existing key updates lastSeen":
     let selfId = testKey(0)

--- a/tests/libp2p/kademlia/test_routing_table.nim
+++ b/tests/libp2p/kademlia/test_routing_table.nim
@@ -78,11 +78,9 @@ suite "KadDHT Routing Table":
 
     check rt.buckets[TargetBucket].peers.len == config.replication
 
-    # Fresh peers are protected by the grace period; age them so they are
-    # eligible for eviction.
+    # Age fresh peers past the grace period so they become evictable.
     rt.agePastGrace(TargetBucket)
 
-    # new entry should evict oldest entry
     let (oldest, _) = rt.buckets[TargetBucket].oldestPeer()
 
     check rt.insert(rt.keyInBucket(TargetBucket))
@@ -96,13 +94,12 @@ suite "KadDHT Routing Table":
     let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     var rt = RoutingTable.new(selfId, config)
     for _ in 0 ..< config.replication:
-      discard rt.insert(randomKeyInBucket(selfId, TargetBucket, rng()))
+      discard rt.insert(rt.keyInBucket(TargetBucket))
 
     let before = rt.buckets[TargetBucket].allKeys()
-    let newcomer = randomKeyInBucket(selfId, TargetBucket, rng())
+    let newcomer = rt.keyInBucket(TargetBucket)
 
-    # Bucket is full of fresh, unproven peers: the newcomer is rejected rather
-    # than blindly evicting one of them.
+    # Full of fresh, unproven peers: the newcomer is rejected, none evicted.
     check:
       not rt.insert(newcomer)
       rt.buckets[TargetBucket].allKeys() == before
@@ -113,16 +110,15 @@ suite "KadDHT Routing Table":
     let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     var rt = RoutingTable.new(selfId, config)
     for _ in 0 ..< config.replication:
-      discard rt.insert(randomKeyInBucket(selfId, TargetBucket, rng()))
+      discard rt.insert(rt.keyInBucket(TargetBucket))
 
     rt.agePastGrace(TargetBucket)
 
-    # The oldest-seen peer would be evicted first, but marking it useful keeps
-    # it and forces a different peer out.
+    # Marking the oldest-seen peer useful spares it and evicts a different one.
     let (oldest, _) = rt.buckets[TargetBucket].oldestPeer()
     rt.markUseful(oldest.nodeId)
 
-    check rt.insert(randomKeyInBucket(selfId, TargetBucket, rng()))
+    check rt.insert(rt.keyInBucket(TargetBucket))
     check rt.buckets[TargetBucket].allKeys().contains(oldest.nodeId)
 
   test "re-insert existing key updates lastSeen":


### PR DESCRIPTION
## Summary

When a k-bucket is full, the routing table used to evict the peer with the oldest `lastSeen` unconditionally (`routing_table.nim` `replaceOldest`). There was no liveness or usefulness signal anywhere in the eviction path, so a reliable, recently-useful close peer could be dropped in favour of a fresh, slow, or already-dead one.

This PR replaces blind oldest-eviction with a usefulness/liveness-gated policy, mirroring go-libp2p's `isReplaceable` semantics: peers that recently answered a query are retained, and a full bucket of still-useful peers rejects the newcomer rather than evicting a good peer.

Closes #2852.

## Affected Areas

- [x] Peer Management / Discovery
  <!-- Kademlia DHT routing-table bucket eviction -->

- [x] Protocol Logic
  <!-- find/lookup marks responders useful -->

Specifics:
- `types.nim`: `NodeEntry` gains `addedAt: Moment` and `lastUsefulAt: Opt[Moment]`; new `DefaultUsefulnessGracePeriod` (1h) and a configurable `usefulnessGracePeriod` on `RoutingTableConfig`.
- `routing_table.nim`: new `isReplaceable` predicate (a peer is replaceable only once it has spent longer than the grace period in the table without answering a query); eviction (`replaceOldest` -> `replaceReplaceable`) evicts the least-recently-seen peer among replaceable ones, and rejects the newcomer when every peer is still fresh/useful; new `markUseful` refreshes `lastUsefulAt`/`lastSeen`.
- `find.nim`: every successful query reply in `lookOnce` calls `rtable.markUseful(peerId)`, wiring the usefulness signal into eviction.

## Compatibility & Downstream Validation

N/A — internal Kademlia routing-table behavior change; no public API removed or renamed. New `RoutingTableConfig.usefulnessGracePeriod` defaults to preserve sensible behavior, and new `NodeEntry` fields default to zero/`Opt.none`.

## Impact on Library Users

- No breaking API changes. `RoutingTable.new`/`RoutingTableConfig.new` gain an optional `usefulnessGracePeriod` parameter with a default.
- Behavior change: a full bucket no longer always evicts on insert. A newcomer is rejected when all existing peers are within the usefulness grace period, so routing tables retain proven-useful close peers longer.

## Risk Assessment

- Backward compatibility: additive fields and one optional constructor parameter; existing call sites compile unchanged.
- Network behavior: routing-table churn decreases for healthy tables (fewer evictions of useful peers). During cold start, freshly inserted peers are protected for the grace period, so a full bucket can transiently reject new candidates — acceptable given the grace period is bounded and such peers are unproven. The grace value is a tuning knob; the 1h default is intentionally conservative.
- Performance: eviction is still a single linear scan of the bucket; no extra allocations or network calls on the insert path.
- Security: no new external input handling.

## References

- Parent: #1756
- Prior art: go-libp2p `go-libp2p-kbucket/table.go` (`isReplaceable`, `usefulnessGracePeriod`)

## Additional Notes

Scoped to the primary work in #2852. Deferred to follow-ups, matching the issue's own "optionally"/"stretch" framing:
- Network `ping()` of the eviction candidate before evicting — the sync `insert`/`updatePeers` path (also called from the sync `KadDHT.new`) cannot `await`, so wiring a ping requires an async refactor. The usefulness gate already prevents evicting a peer that was live within the grace period.
- RTT/latency-EWMA insertion gate (stretch goal).