### PR TITLE
fix(kad): retry peers that respond with an error, not just silent ones

### DIFF
--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -100,8 +100,7 @@ proc sortedShortlist(
     if pid == selfPid:
       # do not return self
       continue
-    if excludeResponded and state.responded.contains(pid):
-      # already responded, do not query again
+    if excludeResponded and state.responded.getOrDefault(pid) == Success:
       continue
     if state.attempts.getOrDefault(pid, 0) > state.kad.config.retries:
       # depleted retries, do not query again

--- a/tests/libp2p/kademlia/mock_kademlia.nim
+++ b/tests/libp2p/kademlia/mock_kademlia.nim
@@ -13,6 +13,7 @@ type MockKadDHT* = ref object of KadDHT
   handleAddProviderMessage*: Opt[Message]
   handleFindNodeDelay*: Duration
   handleFindNodeCalls*: int
+  handleFindNodeMalformedResponse*: bool
 
 method findNode*(
     kad: MockKadDHT, target: Key, rtable: RoutingTable
@@ -51,4 +52,10 @@ method handleFindNode*(
   kad.handleFindNodeCalls.inc()
   if kad.handleFindNodeDelay > ZeroDuration:
     await sleepAsync(kad.handleFindNodeDelay)
+  if kad.handleFindNodeMalformedResponse:
+    try:
+      await stream.writeLp(@[0xFF'u8, 0xFF, 0xFF])
+    except LPStreamError as exc:
+      debug "Failed to send malformed find-node response", stream = stream, err = exc.msg
+    return
   await procCall handleFindNode(KadDHT(kad), stream, msg)

--- a/tests/libp2p/kademlia/mock_kademlia.nim
+++ b/tests/libp2p/kademlia/mock_kademlia.nim
@@ -56,6 +56,7 @@ method handleFindNode*(
     try:
       await stream.writeLp(@[0xFF'u8, 0xFF, 0xFF])
     except LPStreamError as exc:
-      debug "Failed to send malformed find-node response", stream = stream, err = exc.msg
+      debug "Failed to send malformed find-node response",
+        stream = stream, err = exc.msg
     return
   await procCall handleFindNode(KadDHT(kad), stream, msg)

--- a/tests/libp2p/kademlia/test_find.nim
+++ b/tests/libp2p/kademlia/test_find.nim
@@ -85,8 +85,8 @@ suite "KadDHT Find":
       kads[3].hasKey(kads[0].rtable.selfId)
 
   asyncTest "Find node merges results from parallel queries":
-    #         node[1] - node[3] 
-    #        /                 \ 
+    #         node[1] - node[3]
+    #        /                 \
     # node[0]                   node[5]
     #        \                 /
     #         node[2] - node[4]
@@ -346,7 +346,9 @@ suite "KadDHT Find":
     await connect(kads[2], kads[3])
 
     # Stop kads[1] - dial will fail immediately with DialFailedError
-    # This is marked as RespondedStatus.Failed and NOT retried
+    # This is marked as RespondedStatus.Failed; kads[1] stays eligible for
+    # retry (gated by attempts/retries) but every retry fails the same way
+    # since the switch is stopped, so the lookup still proceeds via kads[2].
     await kads[1].switch.stop()
 
     check not kads[0].hasKey(kads[3].rtable.selfId)
@@ -375,6 +377,24 @@ suite "KadDHT Find":
     let peerIds = await kad.findNode(mockKad.rtable.selfId)
 
     # Lookup terminates gracefully after retry exhaustion
+    check:
+      responsiveKad.switch.peerInfo.peerId in peerIds
+      mockKad.handleFindNodeCalls == retries + 1 # (initial call + retries)
+
+  asyncTest "Find node retries a peer that responded with an error, not just silent peers":
+    const retries = 3
+    let kad = setupKad(config = testKadConfig(retries = retries))
+    let mockKad = setupMockKad(handleFindNodeMalformedResponse = true)
+    let responsiveKad = setupKad()
+    startAndDeferStop(@[kad, mockKad, responsiveKad])
+
+    await connect(kad, mockKad)
+    await connect(kad, responsiveKad)
+
+    check mockKad.handleFindNodeCalls == 0
+
+    let peerIds = await kad.findNode(mockKad.rtable.selfId)
+
     check:
       responsiveKad.switch.peerInfo.peerId in peerIds
       mockKad.handleFindNodeCalls == retries + 1 # (initial call + retries)

--- a/tests/libp2p/kademlia/utils.nim
+++ b/tests/libp2p/kademlia/utils.nim
@@ -91,12 +91,14 @@ proc setupMockKad*(
     getValueResponse: Opt[Message] = Opt.none(Message),
     handleAddProviderMessage: Opt[Message] = Opt.none(Message),
     handleFindNodeDelay: Duration = ZeroDuration,
+    handleFindNodeMalformedResponse: bool = false,
 ): MockKadDHT =
   let switch = makeStandardSwitch(TcpAutoAddress)
   let kad = MockKadDHT.new(switch, bootstrapNodes, config, rng = rng())
   kad.getValueResponse = getValueResponse
   kad.handleAddProviderMessage = handleAddProviderMessage
   kad.handleFindNodeDelay = handleFindNodeDelay
+  kad.handleFindNodeMalformedResponse = handleFindNodeMalformedResponse
   kad.switch.mount(kad)
   kad
 


### PR DESCRIPTION
## Summary

### Problem

In Kademlia lookups, a peer that fully failed to respond (dial error, stream error, decode error) was treated identically to a peer that responded successfully for the purposes of retry eligibility: both got a single entry written into `state.responded`, and `sortedShortlist` excluded any peer with an entry there from being queried again.

Net effect: a peer that answered with an error got zero retries. Meanwhile, a peer that never answered at all (silent, still timing out) never got an entry in responded, so it stayed eligible and was retried up to the full retries budget (5 by default, 6 total attempts).

This is backwards. A peer that responded — even with an error — is proven reachable; the error could be transient. A peer that never answers at all might simply be dead. The peer more worth retrying was getting no chances, and the peer less worth retrying was getting several.

### Fix

A Failed response (dial-level or RPC-level) now falls through to the same attempts > retries check that already gates silent peers — so a peer that responds with an error gets the same retry budget as everyone else, instead of none.

<!--
Provide a clear and concise description of the purpose of this PR.

Explain:
- What this PR does
- Why it is needed
- The problem it solves or the improvement it introduces
-->


## Affected Areas
<!--
Indicate which parts of the codebase are impacted.
Check all that apply and briefly describe the scope of the changes.
-->

- [ ] Gossipsub  
  <!-- e.g. scoring changes, message validation, peer handling -->

- [ ] Transports  
  <!-- e.g. TCP, QUIC, WebSockets, Noise, etc. -->

- [ ] Peer Management / Discovery

- [ ] Protocol Logic

- [ ] Build / Tooling

- [ ] Other  
  <!-- Describe below -->


## Compatibility & Downstream Validation
<!--
For PRs affecting behavior on existing features, provide evidence that
dependent projects build and function correctly with these changes.
-->

Reference PRs / branches / commits demonstrating successful integration:

- **Nimbus:**  
  <!-- Link PR or branch -->

- **Waku:**  
  <!-- Link PR or branch -->

- **Codex:**  
  <!-- Link PR or branch -->


## Impact on Library Users
<!--
Describe how this affects downstream users of nim-libp2p.

Examples:
- API changes
- Behavior changes
- Performance implications
- Migration requirements
- No impact (internal refactor)
-->


## Risk Assessment
<!--
Identify potential risks introduced by this change.

Consider:
- Backward compatibility
- Network behavior changes
- Performance regressions
- Security implications
-->


## References
<!--
Link to related:
- Issues
- Specs
- Design discussions
- Prior PRs
-->


## Additional Notes
<!--
Optional: any extra context reviewers should be aware of.
-->