### PR TITLE
chore(tests): use `await` insted of `waitFor`

### DIFF
--- a/tests/libp2p/discovery/test_rendezvous.nim
+++ b/tests/libp2p/discovery/test_rendezvous.nim
@@ -170,7 +170,7 @@ suite "RendezVous":
     await connect(peerNodes[0], rendezvousNode)
 
     const namespace = "foo"
-    waitFor peerNodes[0].advertise(namespace)
+    await peerNodes[0].advertise(namespace)
     let peerRecords = await rendezvous.request(
       peerNodes[0], Opt.some(namespace), Opt.none(int), Opt.none(seq[PeerId])
     )
@@ -235,7 +235,7 @@ suite "RendezVous":
     await allFutures(peerNodes.mapIt(it.advertise(namespace)))
 
     var data = peerNodes.mapIt(it.switch.peerInfo.signedPeerRecord.data)
-    var peerRecords = waitFor rendezvous.request(
+    var peerRecords = await rendezvous.request(
       peerNodes[0], Opt.some(namespace), Opt.some(5), Opt.none(seq[PeerId])
     )
     check:
@@ -442,13 +442,13 @@ suite "RendezVous":
       rendezvousNode.registered.s.len == 0
 
       (
-        waitFor rendezvous.request(
+        await rendezvous.request(
           peerNodes[0], Opt.some(namespaceFoo), Opt.none(int), Opt.none(seq[PeerId])
         )
       ).len == 0
 
       (
-        waitFor rendezvous.request(
+        await rendezvous.request(
           peerNodes[0], Opt.some(namespaceBar), Opt.none(int), Opt.none(seq[PeerId])
         )
       ).len == 0
@@ -499,7 +499,7 @@ suite "RendezVous":
 
     # Advertise a new peer, next request should return only the new one
     await peerNodes[2].advertise(namespace)
-    let peerRecords = waitFor rendezvous.request(
+    let peerRecords = await rendezvous.request(
       peerNodes[0], Opt.some(namespace), Opt.none(int), Opt.none(seq[PeerId])
     )
     check:
@@ -769,7 +769,7 @@ suite "RendezVous":
 
     const namespace = "foo"
     let custRecord = CustomPeerRecord.init(peerNode.switch.peerInfo.peerId, 1)
-    waitFor peerNode.advertise(namespace, custRecord)
+    await peerNode.advertise(namespace, custRecord)
     let peerRecords = await rendezvous.request[CustomPeerRecord](
       peerNode, Opt.some(namespace), Opt.none(int), Opt.none(seq[PeerId])
     )

--- a/tests/libp2p/test_name_resolve.nim
+++ b/tests/libp2p/test_name_resolve.nim
@@ -59,15 +59,15 @@ suite "Name resolving":
   suite "Generic Resolving":
     var resolver {.threadvar.}: MockResolver
 
-    proc testOne(input: string, output: seq[MultiAddress]) =
-      let resolved = waitFor resolver.resolveMAddress(MultiAddress.init(input).tryGet())
+    proc testOne(input: string, output: seq[MultiAddress]) {.async.} =
+      let resolved = await resolver.resolveMAddress(MultiAddress.init(input).tryGet())
       check resolved == output
 
-    proc testOne(input: string, output: seq[string]) =
-      testOne(input, output.mapIt(MultiAddress.init(it).tryGet()))
+    proc testOne(input: string, output: seq[string]) {.async.} =
+      await testOne(input, output.mapIt(MultiAddress.init(it).tryGet()))
 
-    proc testOne(input, output: string) =
-      testOne(input, @[MultiAddress.init(output).tryGet()])
+    proc testOne(input, output: string) {.async.} =
+      await testOne(input, @[MultiAddress.init(output).tryGet()])
 
     asyncSetup:
       resolver = MockResolver.new()
@@ -76,10 +76,10 @@ suite "Name resolving":
       resolver.ipResponses[("localhost", false)] = @["127.0.0.1"]
       resolver.ipResponses[("localhost", true)] = @["::1"]
 
-      testOne("/dns/localhost/udp/0", @["/ip4/127.0.0.1/udp/0", "/ip6/::1/udp/0"])
-      testOne("/dns4/localhost/tcp/0", "/ip4/127.0.0.1/tcp/0")
-      testOne("/dns6/localhost/tcp/0", "/ip6/::1/tcp/0")
-      testOne(
+      await testOne("/dns/localhost/udp/0", @["/ip4/127.0.0.1/udp/0", "/ip6/::1/udp/0"])
+      await testOne("/dns4/localhost/tcp/0", "/ip4/127.0.0.1/tcp/0")
+      await testOne("/dns6/localhost/tcp/0", "/ip6/::1/tcp/0")
+      await testOne(
         "/dns6/localhost/tcp/4001/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
         "/ip6/::1/tcp/4001/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
       )
@@ -88,7 +88,7 @@ suite "Name resolving":
       resolver.ipResponses[("localhost", false)] = @["127.0.0.1"]
       resolver.ipResponses[("localhost", true)] = @["::1"]
 
-      testOne("/ip6/::1/tcp/0", "/ip6/::1/tcp/0")
+      await testOne("/ip6/::1/tcp/0", "/ip6/::1/tcp/0")
 
     asyncTest "dnsaddr recursive test":
       resolver.txtResponses["_dnsaddr.bootstrap.libp2p.io"] = @[
@@ -106,7 +106,7 @@ suite "Name resolving":
         "dnsaddr=/ip6/2604:1380:2000:7a00::1/tcp/4001/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
       ]
 
-      testOne(
+      await testOne(
         "/dnsaddr/bootstrap.libp2p.io/",
         @[
           "/ip6/2604:1380:1000:6000::1/tcp/4001/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
@@ -134,7 +134,7 @@ suite "Name resolving":
         "dnsaddr=/ip6/2604:1380:1000:6000::1/tcp/4001/p2p/shouldbefiltered",
       ]
 
-      testOne(
+      await testOne(
         "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
         @[
           "/ip4/147.75.69.143/tcp/4001/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
@@ -146,7 +146,7 @@ suite "Name resolving":
       resolver.txtResponses["_dnsaddr.bootstrap.libp2p.io"] =
         @["dnsaddr=/dnsaddr/bootstrap.libp2p.io"]
 
-      testOne("/dnsaddr/bootstrap.libp2p.io/", newSeq[string]())
+      await testOne("/dnsaddr/bootstrap.libp2p.io/", newSeq[string]())
 
     test "getHostname":
       check:


### PR DESCRIPTION
fix for daily test with latest deps:
https://github.com/vacp2p/nim-libp2p/actions/runs/29725083280/job/88296252274
```
/home/runner/work/nim-libp2p/nim-libp2p/tests/libp2p/discovery/test_rendezvous.nim(173, 5) Error: waitFor advertise(peerNodes[0], namespace) do:
  Opt[Duration](oResultPrivate: false) has an illegal effect: NestedPoll
```