### PR TITLE
ci: fix dependnecies cache keys

### DIFF
--- a/.github/workflows/cbindings.yml
+++ b/.github/workflows/cbindings.yml
@@ -47,7 +47,7 @@ jobs:
           path: nimbledeps
           # Keep this in sync with ci.yml's cache key so entries are
           # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
-          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned') }}
+          key: nimbledeps-root-linux-amd64-gcc-${{ hashFiles('.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
@@ -107,7 +107,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: nimbledeps
-          key: nimbledeps-macos-15-arm64-clang-${{ hashFiles('.pinned', 'cbind/.pinned') }}
+          key: nimbledeps-cbind-macos-15-arm64-clang-${{ hashFiles('.pinned', 'cbind/.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
             tests/nimbledeps
           # Keep this in sync with ci.yml's cache key so entries are
           # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
-          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned', 'tests/.pinned') }}
+          key: nimbledeps-with-tests-linux-amd64-gcc-${{ hashFiles('.pinned', 'tests/.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/daily_runnable_examples.yml
+++ b/.github/workflows/daily_runnable_examples.yml
@@ -45,7 +45,7 @@ jobs:
           path: nimbledeps
           # Keep this in sync with ci.yml's cache key so entries are
           # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
-          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned') }}
+          key: nimbledeps-root-linux-amd64-gcc-${{ hashFiles('.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/daily_test_all_no_flags.yml
+++ b/.github/workflows/daily_test_all_no_flags.yml
@@ -47,7 +47,7 @@ jobs:
             tests/nimbledeps
           # Keep this in sync with ci.yml's cache key so entries are
           # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
-          key: nimbledeps-macos-15-arm64-clang-${{ hashFiles('.pinned', 'tests/.pinned') }}
+          key: nimbledeps-with-tests-macos-15-arm64-clang-${{ hashFiles('.pinned', 'tests/.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -47,7 +47,7 @@ jobs:
           path: nimbledeps
           # Keep this in sync with ci.yml's cache key so entries are
           # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
-          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned') }}
+          key: nimbledeps-root-linux-amd64-gcc-${{ hashFiles('.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -115,7 +115,7 @@ jobs:
           # artifacts across mismatched toolchains (linux<->windows,
           # gcc<->clang). Keep this key in sync with the other workflows that
           # cache nimbledeps so cache entries are reusable across them.
-          key: nimbledeps-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ hashFiles('.pinned', 'tests/.pinned') }}
+          key: nimbledeps-with-tests-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ hashFiles('.pinned', 'tests/.pinned') }}
 
       - name: Restore llvm-mingw (Windows) from cache
         if: runner.os == 'Windows' && matrix.platform.cc == 'clang'

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   test:
     env:
-      NIMBLE_COMMIT: a399f502dec7ffcd905c1cf54b13274ad990bada # v0.24.1
+      NIMBLE_COMMIT: 42ef70c2102a942c46f13eb76872326edd525cec # v0.22.3
     timeout-minutes: 55
     strategy:
       fail-fast: false
@@ -42,7 +42,7 @@ jobs:
         nim:
           - ref: v2.2.4
             memory_management: refc
-            nimble_commit: 9207e8b2bbdf66b5a4d1020214cff44d2d30df92 # v0.20.1
+            nimble_commit: 9207e8b2bbdf66b5a4d1020214cff44d2d30df92 # v0.22.3
           - ref: v2.2.10
             memory_management: refc
           - ref: v2.2.10

--- a/.github/workflows/test_multiformat_exts.yml
+++ b/.github/workflows/test_multiformat_exts.yml
@@ -81,7 +81,7 @@ jobs:
           path: |
             nimbledeps
             tests/nimbledeps
-          key: nimbledeps-${{ needs.pick-platform.outputs.os }}-${{ needs.pick-platform.outputs.cpu }}-${{ needs.pick-platform.outputs.cc }}-${{ hashFiles('.pinned', 'tests/.pinned') }}
+          key: nimbledeps-with-tests-${{ needs.pick-platform.outputs.os }}-${{ needs.pick-platform.outputs.cpu }}-${{ needs.pick-platform.outputs.cc }}-${{ hashFiles('.pinned', 'tests/.pinned') }}
 
       - name: Restore llvm-mingw (Windows) from cache
         if: runner.os == 'Windows' && needs.pick-platform.outputs.cc == 'clang'

--- a/.github/workflows/test_multiformat_exts.yml
+++ b/.github/workflows/test_multiformat_exts.yml
@@ -48,7 +48,7 @@ jobs:
   test:
     needs: pick-platform
     env:
-      NIMBLE_COMMIT: a399f502dec7ffcd905c1cf54b13274ad990bada # v0.24.1
+      NIMBLE_COMMIT: 42ef70c2102a942c46f13eb76872326edd525cec # v0.22.3
     timeout-minutes: 55
     runs-on: ${{ needs.pick-platform.outputs.builder }}
     name: "test_multiformat_exts"


### PR DESCRIPTION
since `nim-libp2p` is monorepo of different subprojects, there needs to be different deps cache, storing everything under same key is not correct. 