### PR TITLE
ci: save deps cache only in merge queue

### DIFF
--- a/.github/workflows/cbindings.yml
+++ b/.github/workflows/cbindings.yml
@@ -47,7 +47,7 @@ jobs:
           path: nimbledeps
           # Keep this in sync with ci.yml's cache key so entries are
           # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
-          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned') }}
+          key: nimbledeps-root-linux-amd64-gcc-${{ hashFiles('.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
@@ -107,7 +107,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: nimbledeps
-          key: nimbledeps-macos-15-arm64-clang-${{ hashFiles('.pinned', 'cbind/.pinned') }}
+          key: nimbledeps-cbind-macos-15-arm64-clang-${{ hashFiles('.pinned', 'cbind/.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/cbindings.yml
+++ b/.github/workflows/cbindings.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Restore deps from cache
         id: deps-cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: nimbledeps
           # Keep this in sync with ci.yml's cache key so entries are
@@ -53,6 +53,13 @@ jobs:
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
         run: |
           nimble install_pinned
+
+      - name: Save dependencies cache
+        uses: actions/cache/save@v5
+        if: github.event_name == 'merge_group' && steps.deps-cache.outputs.cache-hit != 'true'
+        with:
+          path: nimbledeps
+          key: ${{ steps.deps-cache.outputs.cache-primary-key }}
 
       - name: Build FFI library and generate C/CDDL bindings
         run: |
@@ -104,7 +111,7 @@ jobs:
 
       - name: Restore deps from cache
         id: deps-cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: nimbledeps
           key: nimbledeps-cbind-macos-15-arm64-clang-${{ hashFiles('.pinned', 'cbind/.pinned') }}
@@ -113,6 +120,13 @@ jobs:
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
         run: |
           nimble install_pinned
+
+      - name: Save dependencies cache
+        uses: actions/cache/save@v5
+        if: github.event_name == 'merge_group' && steps.deps-cache.outputs.cache-hit != 'true'
+        with:
+          path: nimbledeps
+          key: ${{ steps.deps-cache.outputs.cache-primary-key }}
 
       - name: Build FFI library and generate C/CDDL bindings
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Restore deps from cache
         id: deps-cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: |
             nimbledeps
@@ -50,6 +50,15 @@ jobs:
         run: |
           nimble install_pinned
           cd tests && nimble install_pinned
+
+      - name: Save dependencies cache
+        uses: actions/cache/save@v5
+        if: github.event_name == 'merge_group' && steps.deps-cache.outputs.cache-hit != 'true'
+        with:
+          path: |
+            nimbledeps
+            tests/nimbledeps
+          key: ${{ steps.deps-cache.outputs.cache-primary-key }}
 
       - name: Build prerequisites
         run: make nimble.paths tests/nimble.paths

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
             tests/nimbledeps
           # Keep this in sync with ci.yml's cache key so entries are
           # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
-          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned', 'tests/.pinned') }}
+          key: nimbledeps-with-tests-linux-amd64-gcc-${{ hashFiles('.pinned', 'tests/.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/daily_runnable_examples.yml
+++ b/.github/workflows/daily_runnable_examples.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Restore deps from cache
         id: deps-cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: nimbledeps
           # Keep this in sync with ci.yml's cache key so entries are

--- a/.github/workflows/daily_runnable_examples.yml
+++ b/.github/workflows/daily_runnable_examples.yml
@@ -45,7 +45,7 @@ jobs:
           path: nimbledeps
           # Keep this in sync with ci.yml's cache key so entries are
           # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
-          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned') }}
+          key: nimbledeps-root-linux-amd64-gcc-${{ hashFiles('.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/daily_test_all_no_flags.yml
+++ b/.github/workflows/daily_test_all_no_flags.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Restore deps from cache
         id: deps-cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: |
             nimbledeps

--- a/.github/workflows/daily_test_all_no_flags.yml
+++ b/.github/workflows/daily_test_all_no_flags.yml
@@ -47,7 +47,7 @@ jobs:
             tests/nimbledeps
           # Keep this in sync with ci.yml's cache key so entries are
           # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
-          key: nimbledeps-macos-15-arm64-clang-${{ hashFiles('.pinned', 'tests/.pinned') }}
+          key: nimbledeps-with-tests-macos-15-arm64-clang-${{ hashFiles('.pinned', 'tests/.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -47,7 +47,7 @@ jobs:
           path: nimbledeps
           # Keep this in sync with ci.yml's cache key so entries are
           # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
-          key: nimbledeps-linux-amd64-gcc-${{ hashFiles('.pinned') }}
+          key: nimbledeps-root-linux-amd64-gcc-${{ hashFiles('.pinned') }}
 
       - name: Install deps
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Restore deps from cache
         id: deps-cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: nimbledeps
           # Keep this in sync with ci.yml's cache key so entries are
@@ -53,6 +53,13 @@ jobs:
         if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
         run: |
           nimble install_pinned
+
+      - name: Save dependencies cache
+        uses: actions/cache/save@v5
+        if: github.event_name == 'merge_group' && steps.deps-cache.outputs.cache-hit != 'true'
+        with:
+          path: nimbledeps
+          key: ${{ steps.deps-cache.outputs.cache-primary-key }}
 
       - name: Build prerequisites
         run: make nimble.paths

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -115,7 +115,7 @@ jobs:
           # artifacts across mismatched toolchains (linux<->windows,
           # gcc<->clang). Keep this key in sync with the other workflows that
           # cache nimbledeps so cache entries are reusable across them.
-          key: nimbledeps-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ hashFiles('.pinned', 'tests/.pinned') }}
+          key: nimbledeps-with-tests-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ hashFiles('.pinned', 'tests/.pinned') }}
 
       - name: Restore llvm-mingw (Windows) from cache
         if: runner.os == 'Windows' && matrix.platform.cc == 'clang'

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -106,7 +106,7 @@ jobs:
 
       - name: Restore dependencies from cache
         id: deps-cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: |
             nimbledeps
@@ -164,6 +164,15 @@ jobs:
         run: |
           nimble install_pinned
           cd tests && nimble install_pinned
+
+      - name: Save dependencies cache
+        uses: actions/cache/save@v5
+        if: github.event_name == 'merge_group' && steps.deps-cache.outputs.cache-hit != 'true'
+        with:
+          path: |
+            nimbledeps
+            tests/nimbledeps
+          key: ${{ steps.deps-cache.outputs.cache-primary-key }}
 
       - name: Build prerequisites
         run: make nimble.paths tests/nimble.paths

--- a/.github/workflows/test_multiformat_exts.yml
+++ b/.github/workflows/test_multiformat_exts.yml
@@ -81,7 +81,7 @@ jobs:
           path: |
             nimbledeps
             tests/nimbledeps
-          key: nimbledeps-${{ needs.pick-platform.outputs.os }}-${{ needs.pick-platform.outputs.cpu }}-${{ needs.pick-platform.outputs.cc }}-${{ hashFiles('.pinned', 'tests/.pinned') }}
+          key: nimbledeps-with-tests-${{ needs.pick-platform.outputs.os }}-${{ needs.pick-platform.outputs.cpu }}-${{ needs.pick-platform.outputs.cc }}-${{ hashFiles('.pinned', 'tests/.pinned') }}
 
       - name: Restore llvm-mingw (Windows) from cache
         if: runner.os == 'Windows' && needs.pick-platform.outputs.cc == 'clang'

--- a/.github/workflows/test_multiformat_exts.yml
+++ b/.github/workflows/test_multiformat_exts.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Restore dependencies from cache
         id: deps-cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: |
             nimbledeps
@@ -130,6 +130,15 @@ jobs:
         run: |
           nimble install_pinned
           cd tests && nimble install_pinned
+
+      - name: Save dependencies cache
+        uses: actions/cache/save@v5
+        if: github.event_name == 'merge_group' && steps.deps-cache.outputs.cache-hit != 'true'
+        with:
+          path: |
+            nimbledeps
+            tests/nimbledeps
+          key: ${{ steps.deps-cache.outputs.cache-primary-key }}
 
       - name: Build prerequisites
         run: make nimble.paths tests/nimble.paths


### PR DESCRIPTION
pr may be needed if cache size doesn't decrease over time - after pr with fixed dependencies keys is merged.

- could add lable "cache-deps" so that experimental prs with changed deps can store deps. but usually it should be better to pay cost on those prs, in order to have ci for all other prs fly - if cache is full then we get almost 0 benefits from it.

- optionally drop old entries?

