### PR TITLE
ci: composite actions for dependencies

### DIFF
--- a/.github/actions/install_cbind_deps/action.yml
+++ b/.github/actions/install_cbind_deps/action.yml
@@ -1,0 +1,44 @@
+name: Install C bindings dependencies
+description: Restore, install, and save root and cbind Nimble dependencies.
+
+inputs:
+  os:
+    description: Platform cache OS segment.
+    required: true
+  cpu:
+    description: Platform cache CPU segment.
+    required: true
+  cc:
+    description: Platform cache compiler segment.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install root deps
+      uses: ./.github/actions/install_root_deps
+      with:
+        os: ${{ inputs.os }}
+        cpu: ${{ inputs.cpu }}
+        cc: ${{ inputs.cc }}
+
+    - name: Restore cbind deps from cache
+      id: cbind-deps-cache
+      uses: actions/cache/restore@v5
+      with:
+        path: cbind/nimbledeps
+        key: nimbledeps-cbind-${{ inputs.os }}-${{ inputs.cpu }}-${{ inputs.cc }}-${{ hashFiles('cbind/.pinned') }}
+
+    - name: Install cbind deps
+      if: ${{ steps.cbind-deps-cache.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: |
+        cd cbind
+        nimble install_pinned
+
+    - name: Save cbind dependencies cache
+      uses: actions/cache/save@v5
+      if: github.event_name == 'merge_group' && steps.cbind-deps-cache.outputs.cache-hit != 'true'
+      with:
+        path: cbind/nimbledeps
+        key: ${{ steps.cbind-deps-cache.outputs.cache-primary-key }}

--- a/.github/actions/install_cbind_deps/action.yml
+++ b/.github/actions/install_cbind_deps/action.yml
@@ -11,6 +11,9 @@ inputs:
   cc:
     description: Platform cache compiler segment.
     required: true
+  shell:
+    description: Shell used to run Nimble commands.
+    default: bash
 
 runs:
   using: composite
@@ -21,6 +24,7 @@ runs:
         os: ${{ inputs.os }}
         cpu: ${{ inputs.cpu }}
         cc: ${{ inputs.cc }}
+        shell: ${{ inputs.shell }}
 
     - name: Restore cbind deps from cache
       id: cbind-deps-cache
@@ -31,7 +35,7 @@ runs:
 
     - name: Install cbind deps
       if: ${{ steps.cbind-deps-cache.outputs.cache-hit != 'true' }}
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: |
         cd cbind
         nimble install_pinned

--- a/.github/actions/install_root_deps/action.yml
+++ b/.github/actions/install_root_deps/action.yml
@@ -11,6 +11,9 @@ inputs:
   cc:
     description: Platform cache compiler segment.
     required: true
+  shell:
+    description: Shell used to run Nimble commands.
+    default: bash
 
 runs:
   using: composite
@@ -24,7 +27,7 @@ runs:
 
     - name: Install deps
       if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: nimble install_pinned
 
     - name: Save dependencies cache

--- a/.github/actions/install_root_deps/action.yml
+++ b/.github/actions/install_root_deps/action.yml
@@ -1,0 +1,35 @@
+name: Install root dependencies
+description: Restore, install, and save root Nimble dependencies.
+
+inputs:
+  os:
+    description: Platform cache OS segment.
+    required: true
+  cpu:
+    description: Platform cache CPU segment.
+    required: true
+  cc:
+    description: Platform cache compiler segment.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Restore deps from cache
+      id: deps-cache
+      uses: actions/cache/restore@v5
+      with:
+        path: nimbledeps
+        key: nimbledeps-root-${{ inputs.os }}-${{ inputs.cpu }}-${{ inputs.cc }}-${{ hashFiles('.pinned') }}
+
+    - name: Install deps
+      if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: nimble install_pinned
+
+    - name: Save dependencies cache
+      uses: actions/cache/save@v5
+      if: github.event_name == 'merge_group' && steps.deps-cache.outputs.cache-hit != 'true'
+      with:
+        path: nimbledeps
+        key: ${{ steps.deps-cache.outputs.cache-primary-key }}

--- a/.github/actions/install_test_deps/action.yml
+++ b/.github/actions/install_test_deps/action.yml
@@ -15,27 +15,29 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Restore deps from cache
-      id: deps-cache
+    - name: Install root deps
+      uses: ./.github/actions/install_root_deps
+      with:
+        os: ${{ inputs.os }}
+        cpu: ${{ inputs.cpu }}
+        cc: ${{ inputs.cc }}
+
+    - name: Restore test deps from cache
+      id: test-deps-cache
       uses: actions/cache/restore@v5
       with:
-        path: |
-          nimbledeps
-          tests/nimbledeps
-        key: nimbledeps-with-tests-${{ inputs.os }}-${{ inputs.cpu }}-${{ inputs.cc }}-${{ hashFiles('.pinned', 'tests/.pinned') }}
+        path: tests/nimbledeps
+        key: nimbledeps-tests-${{ inputs.os }}-${{ inputs.cpu }}-${{ inputs.cc }}-${{ hashFiles('tests/.pinned') }}
 
-    - name: Install deps
-      if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
+    - name: Install test deps
+      if: ${{ steps.test-deps-cache.outputs.cache-hit != 'true' }}
       shell: bash
       run: |
-        nimble install_pinned
         cd tests && nimble install_pinned
 
-    - name: Save dependencies cache
+    - name: Save test dependencies cache
       uses: actions/cache/save@v5
-      if: github.event_name == 'merge_group' && steps.deps-cache.outputs.cache-hit != 'true'
+      if: github.event_name == 'merge_group' && steps.test-deps-cache.outputs.cache-hit != 'true'
       with:
-        path: |
-          nimbledeps
-          tests/nimbledeps
-        key: ${{ steps.deps-cache.outputs.cache-primary-key }}
+        path: tests/nimbledeps
+        key: ${{ steps.test-deps-cache.outputs.cache-primary-key }}

--- a/.github/actions/install_test_deps/action.yml
+++ b/.github/actions/install_test_deps/action.yml
@@ -11,6 +11,9 @@ inputs:
   cc:
     description: Platform cache compiler segment.
     required: true
+  shell:
+    description: Shell used to run Nimble commands.
+    default: bash
 
 runs:
   using: composite
@@ -21,6 +24,7 @@ runs:
         os: ${{ inputs.os }}
         cpu: ${{ inputs.cpu }}
         cc: ${{ inputs.cc }}
+        shell: ${{ inputs.shell }}
 
     - name: Restore test deps from cache
       id: test-deps-cache
@@ -31,7 +35,7 @@ runs:
 
     - name: Install test deps
       if: ${{ steps.test-deps-cache.outputs.cache-hit != 'true' }}
-      shell: bash
+      shell: ${{ inputs.shell }}
       run: |
         cd tests && nimble install_pinned
 

--- a/.github/actions/install_test_deps/action.yml
+++ b/.github/actions/install_test_deps/action.yml
@@ -1,0 +1,41 @@
+name: Install root and test dependencies
+description: Restore, install, and save root and test Nimble dependencies.
+
+inputs:
+  os:
+    description: Platform cache OS segment.
+    required: true
+  cpu:
+    description: Platform cache CPU segment.
+    required: true
+  cc:
+    description: Platform cache compiler segment.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Restore deps from cache
+      id: deps-cache
+      uses: actions/cache/restore@v5
+      with:
+        path: |
+          nimbledeps
+          tests/nimbledeps
+        key: nimbledeps-with-tests-${{ inputs.os }}-${{ inputs.cpu }}-${{ inputs.cc }}-${{ hashFiles('.pinned', 'tests/.pinned') }}
+
+    - name: Install deps
+      if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: |
+        nimble install_pinned
+        cd tests && nimble install_pinned
+
+    - name: Save dependencies cache
+      uses: actions/cache/save@v5
+      if: github.event_name == 'merge_group' && steps.deps-cache.outputs.cache-hit != 'true'
+      with:
+        path: |
+          nimbledeps
+          tests/nimbledeps
+        key: ${{ steps.deps-cache.outputs.cache-primary-key }}

--- a/.github/workflows/cbindings.yml
+++ b/.github/workflows/cbindings.yml
@@ -40,19 +40,12 @@ jobs:
           cpu: amd64
           nim_ref: v2.2.10
 
-      - name: Restore deps from cache
-        id: deps-cache
-        uses: actions/cache@v5
+      - name: Install dependencies
+        uses: "./.github/actions/install_cbind_deps"
         with:
-          path: nimbledeps
-          # Keep this in sync with ci.yml's cache key so entries are
-          # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
-          key: nimbledeps-root-linux-amd64-gcc-${{ hashFiles('.pinned') }}
-
-      - name: Install deps
-        if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
-        run: |
-          nimble install_pinned
+          os: linux
+          cpu: amd64
+          cc: gcc
 
       - name: Build FFI library and generate C/CDDL bindings
         run: |
@@ -62,7 +55,6 @@ jobs:
 
           nimble setup
           cd cbind
-          nimble install_pinned
           nimble setup
           nimble buildffi
           nimble genbindings_c
@@ -102,17 +94,12 @@ jobs:
           cpu: arm64
           nim_ref: v2.2.10
 
-      - name: Restore deps from cache
-        id: deps-cache
-        uses: actions/cache@v5
+      - name: Install dependencies
+        uses: "./.github/actions/install_cbind_deps"
         with:
-          path: nimbledeps
-          key: nimbledeps-cbind-macos-15-arm64-clang-${{ hashFiles('.pinned', 'cbind/.pinned') }}
-
-      - name: Install deps
-        if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
-        run: |
-          nimble install_pinned
+          os: macos-15
+          cpu: arm64
+          cc: clang
 
       - name: Build FFI library and generate C/CDDL bindings
         run: |
@@ -122,7 +109,6 @@ jobs:
 
           nimble setup
           cd cbind
-          nimble install_pinned
           nimble setup
           nimble buildffi
           nimble genbindings_c

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,22 +34,12 @@ jobs:
           shell: bash
           nim_ref: v2.2.10
 
-      - name: Restore deps from cache
-        id: deps-cache
-        uses: actions/cache@v5
+      - name: Install dependencies
+        uses: "./.github/actions/install_test_deps"
         with:
-          path: |
-            nimbledeps
-            tests/nimbledeps
-          # Keep this in sync with ci.yml's cache key so entries are
-          # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
-          key: nimbledeps-with-tests-linux-amd64-gcc-${{ hashFiles('.pinned', 'tests/.pinned') }}
-
-      - name: Install deps
-        if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
-        run: |
-          nimble install_pinned
-          cd tests && nimble install_pinned
+          os: linux
+          cpu: amd64
+          cc: gcc
 
       - name: Build prerequisites
         run: make nimble.paths tests/nimble.paths

--- a/.github/workflows/daily_runnable_examples.yml
+++ b/.github/workflows/daily_runnable_examples.yml
@@ -38,19 +38,12 @@ jobs:
           cpu: amd64
           nim_ref: v2.2.10
 
-      - name: Restore deps from cache
-        id: deps-cache
-        uses: actions/cache@v5
+      - name: Install dependencies
+        uses: "./.github/actions/install_root_deps"
         with:
-          path: nimbledeps
-          # Keep this in sync with ci.yml's cache key so entries are
-          # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
-          key: nimbledeps-root-linux-amd64-gcc-${{ hashFiles('.pinned') }}
-
-      - name: Install deps
-        if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
-        run: |
-          nimble install_pinned
+          os: linux
+          cpu: amd64
+          cc: gcc
 
       - name: Run runnableExamples check
         run: |

--- a/.github/workflows/daily_test_all_no_flags.yml
+++ b/.github/workflows/daily_test_all_no_flags.yml
@@ -38,22 +38,12 @@ jobs:
           cpu: arm64
           nim_ref: v2.2.10
 
-      - name: Restore deps from cache
-        id: deps-cache
-        uses: actions/cache@v5
+      - name: Install dependencies
+        uses: "./.github/actions/install_test_deps"
         with:
-          path: |
-            nimbledeps
-            tests/nimbledeps
-          # Keep this in sync with ci.yml's cache key so entries are
-          # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
-          key: nimbledeps-with-tests-macos-15-arm64-clang-${{ hashFiles('.pinned', 'tests/.pinned') }}
-
-      - name: Install deps
-        if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
-        run: |
-          nimble install_pinned
-          cd tests && nimble install_pinned
+          os: macos-15
+          cpu: arm64
+          cc: clang
 
       - name: Build prerequisites
         run: make nimble.paths tests/nimble.paths

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -40,19 +40,12 @@ jobs:
           cpu: amd64
           nim_ref: v2.2.10
 
-      - name: Restore deps from cache
-        id: deps-cache
-        uses: actions/cache@v5
+      - name: Install dependencies
+        uses: "./.github/actions/install_root_deps"
         with:
-          path: nimbledeps
-          # Keep this in sync with ci.yml's cache key so entries are
-          # reusable. See ci.yml for the rationale on os/cpu/cc scoping.
-          key: nimbledeps-root-linux-amd64-gcc-${{ hashFiles('.pinned') }}
-
-      - name: Install deps
-        if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
-        run: |
-          nimble install_pinned
+          os: linux
+          cpu: amd64
+          cc: gcc
 
       - name: Build prerequisites
         run: make nimble.paths

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -104,18 +104,12 @@ jobs:
           shell: ${{ matrix.shell }}
           nim_ref: ${{ matrix.nim.ref }}
 
-      - name: Restore dependencies from cache
-        id: deps-cache
-        uses: actions/cache@v5
+      - name: Install dependencies
+        uses: "./.github/actions/install_test_deps"
         with:
-          path: |
-            nimbledeps
-            tests/nimbledeps
-          # Scope by os/cpu/cc so cache entries can't leak vendored/compiled
-          # artifacts across mismatched toolchains (linux<->windows,
-          # gcc<->clang). Keep this key in sync with the other workflows that
-          # cache nimbledeps so cache entries are reusable across them.
-          key: nimbledeps-with-tests-${{ matrix.platform.os }}-${{ matrix.platform.cpu }}-${{ matrix.platform.cc }}-${{ hashFiles('.pinned', 'tests/.pinned') }}
+          os: ${{ matrix.platform.os }}
+          cpu: ${{ matrix.platform.cpu }}
+          cc: ${{ matrix.platform.cc }}
 
       - name: Restore llvm-mingw (Windows) from cache
         if: runner.os == 'Windows' && matrix.platform.cc == 'clang'
@@ -158,12 +152,6 @@ jobs:
         run: |
           choco install nasm --no-progress -y
           "C:\Program Files\NASM" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
-
-      - name: Install deps
-        if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
-        run: |
-          nimble install_pinned
-          cd tests && nimble install_pinned
 
       - name: Build prerequisites
         run: make nimble.paths tests/nimble.paths

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -104,13 +104,6 @@ jobs:
           shell: ${{ matrix.shell }}
           nim_ref: ${{ matrix.nim.ref }}
 
-      - name: Install dependencies
-        uses: "./.github/actions/install_test_deps"
-        with:
-          os: ${{ matrix.platform.os }}
-          cpu: ${{ matrix.platform.cpu }}
-          cc: ${{ matrix.platform.cc }}
-
       - name: Restore llvm-mingw (Windows) from cache
         if: runner.os == 'Windows' && matrix.platform.cc == 'clang'
         id: windows-mingw-cache
@@ -152,6 +145,14 @@ jobs:
         run: |
           choco install nasm --no-progress -y
           "C:\Program Files\NASM" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Install dependencies
+        uses: "./.github/actions/install_test_deps"
+        with:
+          os: ${{ matrix.platform.os }}
+          cpu: ${{ matrix.platform.cpu }}
+          cc: ${{ matrix.platform.cc }}
+          shell: ${{ matrix.shell }}
 
       - name: Build prerequisites
         run: make nimble.paths tests/nimble.paths

--- a/.github/workflows/test_multiformat_exts.yml
+++ b/.github/workflows/test_multiformat_exts.yml
@@ -74,13 +74,6 @@ jobs:
           shell: ${{ needs.pick-platform.outputs.shell }}
           nim_ref: ${{ needs.pick-platform.outputs.nim_ref }}
 
-      - name: Install dependencies
-        uses: "./.github/actions/install_test_deps"
-        with:
-          os: ${{ needs.pick-platform.outputs.os }}
-          cpu: ${{ needs.pick-platform.outputs.cpu }}
-          cc: ${{ needs.pick-platform.outputs.cc }}
-
       - name: Restore llvm-mingw (Windows) from cache
         if: runner.os == 'Windows' && needs.pick-platform.outputs.cc == 'clang'
         id: windows-mingw-cache
@@ -122,6 +115,14 @@ jobs:
         run: |
           choco install nasm --no-progress -y
           "C:\Program Files\NASM" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Install dependencies
+        uses: "./.github/actions/install_test_deps"
+        with:
+          os: ${{ needs.pick-platform.outputs.os }}
+          cpu: ${{ needs.pick-platform.outputs.cpu }}
+          cc: ${{ needs.pick-platform.outputs.cc }}
+          shell: ${{ needs.pick-platform.outputs.shell }}
 
       - name: Build prerequisites
         run: make nimble.paths tests/nimble.paths

--- a/.github/workflows/test_multiformat_exts.yml
+++ b/.github/workflows/test_multiformat_exts.yml
@@ -74,14 +74,12 @@ jobs:
           shell: ${{ needs.pick-platform.outputs.shell }}
           nim_ref: ${{ needs.pick-platform.outputs.nim_ref }}
 
-      - name: Restore dependencies from cache
-        id: deps-cache
-        uses: actions/cache@v5
+      - name: Install dependencies
+        uses: "./.github/actions/install_test_deps"
         with:
-          path: |
-            nimbledeps
-            tests/nimbledeps
-          key: nimbledeps-with-tests-${{ needs.pick-platform.outputs.os }}-${{ needs.pick-platform.outputs.cpu }}-${{ needs.pick-platform.outputs.cc }}-${{ hashFiles('.pinned', 'tests/.pinned') }}
+          os: ${{ needs.pick-platform.outputs.os }}
+          cpu: ${{ needs.pick-platform.outputs.cpu }}
+          cc: ${{ needs.pick-platform.outputs.cc }}
 
       - name: Restore llvm-mingw (Windows) from cache
         if: runner.os == 'Windows' && needs.pick-platform.outputs.cc == 'clang'
@@ -124,12 +122,6 @@ jobs:
         run: |
           choco install nasm --no-progress -y
           "C:\Program Files\NASM" | Out-File -FilePath $Env:GITHUB_PATH -Encoding utf8 -Append
-
-      - name: Install deps
-        if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
-        run: |
-          nimble install_pinned
-          cd tests && nimble install_pinned
 
       - name: Build prerequisites
         run: make nimble.paths tests/nimble.paths


### PR DESCRIPTION
adding composite actions for getting dependencies:
- `install_root_deps/action.yml` gets from cache or installs dependencies for root project (nim-libp2p library)
- `install_tests_deps/action.yml` gets from cache or installs dependencies for tests
  -  two step deps `root` + `tests`
- `install_cbind_deps/action.yml` gets from cache or installs dependencies for cbind
  -  two step deps `root` + `cbind`
  
this reduces the strain on workflows were these actions are used. simplifies and localizes the code. 
also makes it easier for us to see and compare logic.
better reuse; as root dependence are reused everywhere, other sub-projects and only their deps.

also fixes issues in comment here: https://github.com/vacp2p/nim-libp2p/pull/2874#discussion_r3630264467