### PR TITLE
feat(cbind): list connected peers regardless of direction

### DIFF
--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -481,6 +481,11 @@ proc libp2pConnectedPeers*(
   let peers = lib.switch.connectedPeers(dir)
   ok(PeersResponse(peerIds: peers.mapIt($it)))
 
+proc libp2pConnectedPeersAnyDirection*(
+    lib: LibP2P
+): Future[Result[PeersResponse, string]] {.ffi.} =
+  ok(PeersResponse(peerIds: lib.switch.connectedPeers().mapIt($it)))
+
 proc libp2pDial*(
     lib: LibP2P, req: DialRequest
 ): Future[Result[DialResponse, string]] {.ffi: "timeout = 30000".} =

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -282,6 +282,9 @@ proc maxConnections*(c: ConnManager, dir: Direction): int =
 proc connectedPeers*(c: ConnManager, dir: Direction): seq[PeerId] =
   c.muxerStore.getPeers(dir)
 
+proc connectedPeers*(c: ConnManager): seq[PeerId] =
+  c.muxerStore.getPeers()
+
 proc getConnections*(c: ConnManager): Table[PeerId, seq[Muxer]] =
   return c.muxerStore.getAll()
 

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -119,6 +119,10 @@ method addTransport*(s: Switch, t: Transport) =
 proc connectedPeers*(s: Switch, dir: Direction): seq[PeerId] =
   s.connManager.connectedPeers(dir)
 
+proc connectedPeers*(s: Switch): seq[PeerId] =
+  ## Peers with at least one connection, in either direction.
+  s.connManager.connectedPeers()
+
 proc isConnected*(s: Switch, peerId: PeerId): bool =
   ## returns true if the peer has one or more
   ## associated connections

--- a/tests/libp2p/test_muxer_store.nim
+++ b/tests/libp2p/test_muxer_store.nim
@@ -184,6 +184,33 @@ suite "MuxerStore":
     check store.getPeers(Direction.In).len == 0
     check store.getPeers(Direction.Out).len == 0
 
+  asyncTest "getPeers without direction returns peers of both directions":
+    let store = MuxerStore.new()
+    makeMuxer(muxA, pidA, Direction.In)
+    makeMuxer(muxB, pidB, Direction.Out)
+
+    discard store.add(muxA)
+    discard store.add(muxB)
+
+    let peers = store.getPeers()
+    check peers.len == 2
+    check pidA in peers
+    check pidB in peers
+
+  asyncTest "getPeers without direction lists a both-directions peer once":
+    let store = MuxerStore.new()
+    makeMuxer(muxIn, pid, Direction.In)
+    makeMuxer(muxOut, pid, Direction.Out)
+
+    discard store.add(muxIn)
+    discard store.add(muxOut)
+
+    check store.getPeers() == @[pid]
+
+  test "getPeers without direction returns empty seq when store is empty":
+    let store = MuxerStore.new()
+    check store.getPeers().len == 0
+
   asyncTest "selectMuxer returns correct muxer by direction":
     let store = MuxerStore.new()
     makeMuxer(muxIn, pid, Direction.In)


### PR DESCRIPTION
## Summary

The C bindings could only list connected peers *per direction*: `libp2p_ctx_connected_peers(ctx, direction, …)` requires an `In`/`Out` value and errors on anything else. A host that just wants "who am I connected to" had to make two calls and merge the lists itself, dropping the duplicates for peers connected both ways.

This adds `libp2pConnectedPeersAnyDirection` (C: `libp2p_ctx_connected_peers_any_direction`), returning every peer with at least one connection, deduplicated, in the same `PeersResponse` shape as the direction-filtered call.

The union comes from the connection manager rather than being assembled in the binding: `MuxerStore.getPeers()` (no direction) already existed but wasn't reachable from `Switch`, so this threads it through with `ConnManager.connectedPeers()` and `Switch.connectedPeers()` overloads.

## Affected Areas

- [x] Peer Management / Discovery — read-only accessor overloads on `Switch` and `ConnManager`; connection tracking itself is unchanged.
- [x] Other — C bindings (`cbind/libp2p.nim`): one new FFI proc.

## Compatibility & Downstream Validation

Purely additive: no existing signature, behavior, or wire format changes, so no downstream integration branches were needed.

- **Nimbus:** N/A
- **Waku:** N/A
- **Codex:** N/A

## Impact on Library Users

- New `Switch.connectedPeers()` / `ConnManager.connectedPeers()` overloads (no `dir` argument).
- New C entry point `libp2p_ctx_connected_peers_any_direction`, replying with the existing `PeersResponse`.
- `connectedPeers(dir)` and `libp2p_ctx_connected_peers` are untouched; no migration required.

## Risk Assessment

Low. Additive API, no behavior change on existing paths, and the new overloads are thin delegations to `MuxerStore.getPeers()`, already used internally by `ConnManager`.

## Additional Notes

`MuxerStore.getPeers()` (the no-direction overload) had no coverage despite its direction-filtered sibling having four cases, so `tests/libp2p/test_muxer_store.nim` gains three: both directions listed, a both-directions peer listed once, and the empty-store case. `test_muxer_store` passes (27/27).

The generated header was regenerated locally to confirm the emitted symbol is `libp2p_ctx_connected_peers_any_direction`. The C examples were not run.