### PR TITLE
feat(quic): validate expected peer id during dial

### DIFF
--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -11,7 +11,7 @@ requires "nim >= 2.2.4",
   "nimcrypto >= 0.6.0", "bearssl >= 0.2.7",
   "https://github.com/vacp2p/nim-boringssl >= 0.0.8", "chronicles >= 0.12.3",
   "chronos >= 4.2.2", "metrics >= 0.2.2", "secp256k1", "stew >= 0.4.2", "results",
-  "serialization >= 0.5.0", "json_serialization >= 0.4.4", "lsquic >= 0.5.5",
+  "serialization >= 0.5.0", "json_serialization >= 0.4.4", "lsquic >= 0.6.0",
   "protobuf_serialization >= 0.5.3",
   "https://github.com/status-im/nim-websock >= 0.4.0",
   "https://github.com/logos-storage/nim-libplum#acefbe424cf9d1f05f2d93533790c9ac4e034df8"

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -308,6 +308,9 @@ type QuicTransport* = ref object of Transport
   certGenerator: CertGenerator
   closeFuts: seq[Future[void]]
 
+type PeerIdCertificateVerifier = ref object of CertificateVerifier
+  expectedPeerId: PeerId
+
 proc parseCertificate(certificatesDer: seq[seq[byte]]): Opt[P2pCertificate] =
   if certificatesDer.len != 1:
     trace "CertificateVerifier: expected one certificate in the chain",
@@ -343,6 +346,11 @@ proc verifyCertificatesForPeer(
       expectedPeerId = expectedPeerId
     return false
   true
+
+method verify(
+    self: PeerIdCertificateVerifier, _: string, certificatesDer: seq[seq[byte]]
+): bool =
+  verifyCertificatesForPeer(certificatesDer, self.expectedPeerId)
 
 proc certificateVerifier(_: string, certificatesDer: seq[seq[byte]]): bool {.gcsafe.} =
   verifyCertificates(certificatesDer)
@@ -623,14 +631,13 @@ method dial*(
         await sleepAsync(delay.milliseconds)
 
     let endpoint = self.dialEndpointFor(taAddress)
-    let quicConnection = await endpoint.dial(taAddress)
-    peerId.withValue(expectedPeerId):
-      if not verifyCertificatesForPeer(quicConnection.certificates(), expectedPeerId):
-        quicConnection.abort()
-        raise newException(
-          QuicTransportDialError,
-          "error in quic dial: certificate does not match expected peer id",
+    let quicConnection =
+      if peerId.isSome():
+        await endpoint.dial(
+          taAddress, PeerIdCertificateVerifier(expectedPeerId: peerId.get())
         )
+      else:
+        await endpoint.dial(taAddress)
     return self.wrapConnection(quicConnection, Direction.Out)
   except QuicConfigError as e:
     raise newException(

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -152,8 +152,8 @@
 
   lsquic = pkgs.fetchgit {
     url = "https://github.com/vacp2p/nim-lsquic";
-    rev = "079768948ac03d8f2384e03045a090cb88aeb7d9";
-    sha256 = "0vpmwmin1vydm7lrs98vqkwm4ja3y8h4gzv8mz9spnvi450jwam1";
+    rev = "d6d8f81d854cbc575f6206aa6d72bcdfbe5d07aa";
+    sha256 = "0syyig0jlpph5fghd0ijngq2m99zl4pq5ajckax4y9cpy6ljs532";
     fetchSubmodules = true;
   };
 

--- a/tests/libp2p/transports/test_quic.nim
+++ b/tests/libp2p/transports/test_quic.nim
@@ -140,8 +140,15 @@ suite "Quic transport":
       await client.stop()
       await server.stop()
 
+    let acceptFut = server.accept()
+    defer:
+      await acceptFut.cancelAndWait()
+
     expect QuicTransportDialError:
       discard await client.dial("", server.addrs[0], Opt.some(wrongPeerId))
+
+    # Ensure there was no connection accepted on the server side.
+    check not (await acceptFut.withTimeout(200.milliseconds))
 
   asyncTest "should allow multiple local addresses":
     let server = await createQuicTransport(


### PR DESCRIPTION
## Summary

Updates QUIC transport to use the `nim-lsquic` v0.6.0 per-dial certificate validator when an expected peer ID is provided.

This validates the remote certificate against the expected peer ID during the TLS handshake instead of accepting the QUIC connection first and checking afterward. Dials without an expected peer ID continue using the default certificate verifier.

## Affected Areas

- [x] Transports
  - QUIC dial certificate validation
- [x] Build / Tooling
  - Bumps the `nim-lsquic` dependency requirement and pin to v0.6.0

## Impact on Library Users

The public QUIC transport API is unchanged. QUIC dials with an expected peer ID now fail during handshake when the certificate identity does not match.

## Risk Assessment

Low to medium. The change affects QUIC dial failure timing for peer ID mismatches and depends on the new per-dial validator support in `nim-lsquic` v0.6.0.

## References

- https://github.com/vacp2p/roadmap/blob/master/content/p2p/ift/2026q3-nim-lsquic-per-connection-cert-validators.md
