### PR TITLE
ci: harden workflow permissions

### DIFF
--- a/.github/workflows/auto_assign_pr.yml
+++ b/.github/workflows/auto_assign_pr.yml
@@ -5,6 +5,9 @@ on:
     types:
       - opened
 
+permissions:
+  pull-requests: write
+
 jobs:
   assign_creator:
     runs-on: ubuntu-latest

--- a/.github/workflows/cbindings.yml
+++ b/.github/workflows/cbindings.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   c-bindings:
     timeout-minutes: 30
@@ -30,6 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Setup Nim
@@ -85,6 +89,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Setup Nim

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   codecov:
     name: Run coverage and upload to codecov
@@ -25,6 +28,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Nim
         uses: "./.github/actions/install_nim"

--- a/.github/workflows/daily_ci_report.yml
+++ b/.github/workflows/daily_ci_report.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   issues: write
 
 jobs:

--- a/.github/workflows/daily_interop.yml
+++ b/.github/workflows/daily_interop.yml
@@ -33,6 +33,8 @@ jobs:
             dockerfile: interop/perf/Dockerfile
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: docker/setup-buildx-action@v4
       - name: Build image
         run: docker build -f ${{ matrix.dockerfile }} .

--- a/.github/workflows/daily_nimbus.yml
+++ b/.github/workflows/daily_nimbus.yml
@@ -11,6 +11,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   compile_nimbus:
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-daily-ci')

--- a/.github/workflows/daily_runnable_examples.yml
+++ b/.github/workflows/daily_runnable_examples.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Setup Nim

--- a/.github/workflows/daily_test_all_latest_deps_matrix.yml
+++ b/.github/workflows/daily_test_all_latest_deps_matrix.yml
@@ -4,7 +4,6 @@ on:
   workflow_call:
 
 permissions:
-  actions: write
   contents: read
 
 jobs:
@@ -79,6 +78,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Setup Nim

--- a/.github/workflows/daily_test_all_no_flags.yml
+++ b/.github/workflows/daily_test_all_no_flags.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   tests-no-flags:
     env:
@@ -30,6 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Setup Nim

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,6 +15,8 @@ on:
         required: false
         default: ""
 
+permissions: {}
+
 jobs:
   bumper:
     # Pushes new refs to interested external repositories, so they can do early testing against libp2p's newer versions

--- a/.github/workflows/dependencies_matrix.yml
+++ b/.github/workflows/dependencies_matrix.yml
@@ -8,6 +8,8 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   bumper:
     runs-on: ubuntu-latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -5,6 +5,9 @@ on:
     - cron: "0 5 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     timeout-minutes: 20
@@ -18,6 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Setup Nim
@@ -77,6 +81,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   examples:
     env:
@@ -30,6 +33,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Setup Nim

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -15,12 +15,17 @@ concurrency:
 env:
   NIMBLE_COMMIT: aa8e6ea09ecac774b6fad42552569ce07bef37ec # v0.24.1
 
+permissions:
+  contents: read
+
 jobs:
   run-transport-interop:
     name: Run transport interoperability tests
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: docker/setup-buildx-action@v4
       - name: Build image
         run: docker build --load -t nim-libp2p-transport-head -f interop/transport/Dockerfile .
@@ -40,6 +45,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: docker/setup-buildx-action@v4
       - name: Build image
         run: docker build --load -t nim-libp2p-hp-head -f interop/hole-punching/Dockerfile .
@@ -58,6 +65,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -87,6 +96,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -116,6 +127,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -8,6 +8,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  checks: write
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   nph:
     name: Linters
@@ -17,6 +23,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 2  # In PR, has extra merge commit: ^1 = PR, ^2 = base
+          persist-credentials: false
 
       - name: Check NPH formatting
         uses: arnetheduck/nph-action@v1

--- a/.github/workflows/mobile_android.yml
+++ b/.github/workflows/mobile_android.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   cbind-ffi-android:
     timeout-minutes: 60
@@ -36,6 +39,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Install Nix

--- a/.github/workflows/mobile_ios.yml
+++ b/.github/workflows/mobile_ios.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   cbind-ffi-ios:
     timeout-minutes: 90
@@ -40,6 +43,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Install Nix

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -12,6 +12,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  actions: write
+  checks: write
+  contents: read
+
 jobs:
   test:
     env:
@@ -88,6 +93,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Setup Nim

--- a/.github/workflows/test_multiformat_exts.yml
+++ b/.github/workflows/test_multiformat_exts.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   pick-platform:
     runs-on: ubuntu-latest
@@ -47,6 +50,9 @@ jobs:
 
   test:
     needs: pick-platform
+    permissions:
+      checks: write
+      contents: read
     env:
       NIMBLE_COMMIT: aa8e6ea09ecac774b6fad42552569ce07bef37ec # v0.24.1
     timeout-minutes: 55
@@ -64,6 +70,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: true
 
       - name: Setup Nim


### PR DESCRIPTION
- declare explicit `GITHUB_TOKEN` permissions across workflows
- set checkout steps to `persist-credentials: false` when later `git push` auth is not needed
- keep write scopes only for workflows that publish docs, report checks, comment on PRs, delete caches, or assign PRs

## Notes

- `documentation.yml` keeps persisted credentials on the `gh-pages` checkouts because those jobs push documentation updates.
- `dependencies_matrix.yml` keeps persisted credentials on its external repository checkout because it uses repository-specific PAT secrets to push dependency bump branches.
- `update_copilot_instructions.yml` keeps checkout credentials because it pushes an automated branch and opens a PR.
