### PR TITLE
feat(cbind): nat config

### DIFF
--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -7,11 +7,13 @@
 
 import ffi
 
-import std/[tables, sequtils, sets, json, jsonutils, strutils, locks]
+import std/[tables, sequtils, sets, json, jsonutils, strutils, locks, net]
 from std/times import getTime, toUnix, Time, nanosecond
+import chronos
 import metrics
 
 import ../libp2p
+import ../libp2p/services/natservice
 import ../libp2p/[multiaddress, peerid]
 import ../libp2p/crypto/crypto
 import ../libp2p/nameresolving/dnsresolver
@@ -22,6 +24,7 @@ import ../libp2p/protocols/kademlia
 import ../libp2p/protocols/service_discovery
 import ../libp2p/protocols/service_discovery/[random_find, types]
 import ../libp2p/protocols/connectivity/relay/client
+import ../libp2p/protocols/connectivity/autonatv2/service
 import ../libp2p/extended_peer_record
 
 type StreamRegistry = ref object
@@ -346,8 +349,8 @@ proc createLibp2pNode(config: Libp2pConfig): Result[LibP2P, string] =
   if cfg.autonat:
     switchBuilder = switchBuilder.withAutonat()
 
-  if cfg.autonatV2:
-    switchBuilder = switchBuilder.withNAT(autonatConfig(AutonatV2))
+  cfg.nat.withValue(natCfg):
+    switchBuilder = switchBuilder.withNAT(natCfg)
 
   if cfg.autonatV2Server:
     switchBuilder = switchBuilder.withAutonatV2Server()
@@ -431,6 +434,18 @@ type CLibp2pConfig {.exportc: "libp2p_config", bycopy.} = object
   autonat: cint
   autonatV2: cint
   autonatV2Server: cint
+  natPortMappingAuto: cint
+  natPortMappingUpnp: cint
+  natPortMappingNatPmp: cint
+  natExplicitIp: cstring
+  natDiscoveryTimeoutMs: int64
+  natMappingTimeoutMs: int64
+  natReachabilityV1: cint
+  natReachabilityV2: cint
+  natReachabilityScheduleIntervalMs: int64
+  natHolePunching: cint
+  natHolePunchingMaxNumRelays: cint
+  natHolePunchingScheduleIntervalMs: int64
 
 proc libp2pNewDefaultConfig(): CLibp2pConfig {.
     exportc: "libp2p_new_default_config", cdecl, dynlib

--- a/cbind/libp2p/config.nim
+++ b/cbind/libp2p/config.nim
@@ -156,7 +156,101 @@ func optDurationMs(ms: int64): Opt[Duration] =
   else:
     Opt.none(Duration)
 
-proc parseNATConfig(config: Libp2pConfig): Result[Opt[NATConfig], string] =
+proc parsePortMappingConfig(
+    config: Libp2pConfig
+): Result[Opt[PortMappingConfig], string] =
+  if not (
+    config.natPortMappingAuto or config.natPortMappingUpnp or config.natPortMappingNatPmp or
+    config.natExplicitIp.len > 0
+  ):
+    return ok(Opt.none(PortMappingConfig))
+
+  let
+    discoveryTimeout =
+      if config.natDiscoveryTimeoutMs > 0:
+        chronos.milliseconds(config.natDiscoveryTimeoutMs)
+      else:
+        DefaultDiscoveryTimeout
+    mappingTimeout =
+      if config.natMappingTimeoutMs > 0:
+        chronos.milliseconds(config.natMappingTimeoutMs)
+      else:
+        DefaultMappingTimeout
+
+  if config.natExplicitIp.len > 0:
+    try:
+      return ok(
+        Opt.some(
+          PortMappingConfig(
+            mode: ExplicitIp, explicitIp: parseIpAddress(config.natExplicitIp)
+          )
+        )
+      )
+    except ValueError as e:
+      return err("invalid natExplicitIp: " & e.msg)
+  if config.natPortMappingUpnp:
+    return ok(
+      Opt.some(
+        PortMappingConfig(
+          mode: Upnp, discoveryTimeout: discoveryTimeout, mappingTimeout: mappingTimeout
+        )
+      )
+    )
+  if config.natPortMappingNatPmp:
+    return ok(
+      Opt.some(
+        PortMappingConfig(
+          mode: NatPmp,
+          discoveryTimeout: discoveryTimeout,
+          mappingTimeout: mappingTimeout,
+        )
+      )
+    )
+  ok(
+    Opt.some(
+      PortMappingConfig(
+        mode: Auto, discoveryTimeout: discoveryTimeout, mappingTimeout: mappingTimeout
+      )
+    )
+  )
+
+proc parseReachabilityConfig(config: Libp2pConfig): Opt[ReachabilityConfig] =
+  let scheduleInterval = optDurationMs(config.natReachabilityScheduleIntervalMs)
+  if config.natReachabilityV1:
+    return Opt.some(
+      ReachabilityConfig(
+        version: AutonatV1,
+        scheduleInterval: scheduleInterval,
+        v2ServiceConfig: Opt.none(AutonatV2ServiceConfig),
+      )
+    )
+  if config.natReachabilityV2 or config.autonatV2:
+    let v2ServiceConfig =
+      if scheduleInterval.isSome():
+        Opt.some(AutonatV2ServiceConfig.new(scheduleInterval = scheduleInterval))
+      else:
+        Opt.none(AutonatV2ServiceConfig)
+    return Opt.some(
+      ReachabilityConfig(
+        version: AutonatV2,
+        scheduleInterval: scheduleInterval,
+        v2ServiceConfig: v2ServiceConfig,
+      )
+    )
+  Opt.none(ReachabilityConfig)
+
+proc parseHolePunchingConfig(config: Libp2pConfig): Opt[HolePunchingConfig] =
+  if not config.natHolePunching:
+    return Opt.none(HolePunchingConfig)
+  Opt.some(
+    HolePunchingConfig(
+      maxNumRelays: max(1, config.natHolePunchingMaxNumRelays),
+      onReservation: nil,
+      scheduleInterval: optDurationMs(config.natHolePunchingScheduleIntervalMs),
+    )
+  )
+
+proc validateNATConfig(config: Libp2pConfig): Result[void, string] =
   let
     portMappingModes = countEnabled(
       config.natPortMappingAuto,
@@ -187,89 +281,16 @@ proc parseNATConfig(config: Libp2pConfig): Result[Opt[NATConfig], string] =
       return err("natHolePunchingMaxNumRelays requires natHolePunching")
     if config.natHolePunchingScheduleIntervalMs > 0:
       return err("natHolePunchingScheduleIntervalMs requires natHolePunching")
+  ok()
 
-  var nat = NATConfig()
+proc parseNATConfig(config: Libp2pConfig): Result[Opt[NATConfig], string] =
+  ?validateNATConfig(config)
 
-  if portMappingModes == 1:
-    let
-      discoveryTimeout =
-        if config.natDiscoveryTimeoutMs > 0:
-          chronos.milliseconds(config.natDiscoveryTimeoutMs)
-        else:
-          DefaultDiscoveryTimeout
-      mappingTimeout =
-        if config.natMappingTimeoutMs > 0:
-          chronos.milliseconds(config.natMappingTimeoutMs)
-        else:
-          DefaultMappingTimeout
-
-    if config.natExplicitIp.len > 0:
-      try:
-        nat.portMapping = Opt.some(
-          PortMappingConfig(
-            mode: ExplicitIp, explicitIp: parseIpAddress(config.natExplicitIp)
-          )
-        )
-      except ValueError as e:
-        return err("invalid natExplicitIp: " & e.msg)
-    elif config.natPortMappingUpnp:
-      nat.portMapping = Opt.some(
-        PortMappingConfig(
-          mode: Upnp, discoveryTimeout: discoveryTimeout, mappingTimeout: mappingTimeout
-        )
-      )
-    elif config.natPortMappingNatPmp:
-      nat.portMapping = Opt.some(
-        PortMappingConfig(
-          mode: NatPmp,
-          discoveryTimeout: discoveryTimeout,
-          mappingTimeout: mappingTimeout,
-        )
-      )
-    else:
-      nat.portMapping = Opt.some(
-        PortMappingConfig(
-          mode: Auto, discoveryTimeout: discoveryTimeout, mappingTimeout: mappingTimeout
-        )
-      )
-
-  if wantsReachability:
-    let scheduleInterval = optDurationMs(config.natReachabilityScheduleIntervalMs)
-    if wantsReachabilityV1:
-      nat.reachability = Opt.some(
-        ReachabilityConfig(
-          version: AutonatV1,
-          scheduleInterval: scheduleInterval,
-          v2ServiceConfig: Opt.none(AutonatV2ServiceConfig),
-        )
-      )
-    else:
-      let v2ServiceConfig =
-        if scheduleInterval.isSome():
-          Opt.some(AutonatV2ServiceConfig.new(scheduleInterval = scheduleInterval))
-        else:
-          Opt.none(AutonatV2ServiceConfig)
-      nat.reachability = Opt.some(
-        ReachabilityConfig(
-          version: AutonatV2,
-          scheduleInterval: scheduleInterval,
-          v2ServiceConfig: v2ServiceConfig,
-        )
-      )
-
-  if config.natHolePunching:
-    let maxNumRelays =
-      if config.natHolePunchingMaxNumRelays > 0:
-        config.natHolePunchingMaxNumRelays
-      else:
-        1
-    nat.holePunching = Opt.some(
-      HolePunchingConfig(
-        maxNumRelays: maxNumRelays,
-        onReservation: nil,
-        scheduleInterval: optDurationMs(config.natHolePunchingScheduleIntervalMs),
-      )
-    )
+  let nat = NATConfig(
+    portMapping: ?parsePortMappingConfig(config),
+    reachability: parseReachabilityConfig(config),
+    holePunching: parseHolePunchingConfig(config),
+  )
 
   if nat.portMapping.isNone() and nat.reachability.isNone() and nat.holePunching.isNone():
     ok(Opt.none(NATConfig))
@@ -277,20 +298,13 @@ proc parseNATConfig(config: Libp2pConfig): Result[Opt[NATConfig], string] =
     ok(Opt.some(nat))
 
 proc parse(config: Libp2pConfig): Result[ParsedConfig, string] =
-  let transport = parseTransportConfig(config)
-  let dnsServers = ?resolveDnsServers(config.dnsResolver)
-  let addrs = ?parseMultiaddrs(config.addrs)
-  let privKey = ?parsePrivateKey(config.privKey)
-  let bootstrapNodes = ?parseBootstrapNodes(config.bootstrapNodes)
-  let nat = ?parseNATConfig(config)
-
   ok(
     ParsedConfig(
-      dnsServers: dnsServers,
-      addrs: addrs,
-      transport: transport,
-      privKey: privKey,
-      bootstrapNodes: bootstrapNodes,
+      dnsServers: ?resolveDnsServers(config.dnsResolver),
+      addrs: ?parseMultiaddrs(config.addrs),
+      transport: parseTransportConfig(config),
+      privKey: ?parsePrivateKey(config.privKey),
+      bootstrapNodes: ?parseBootstrapNodes(config.bootstrapNodes),
       maxConnections: config.maxConnections,
       maxIn: config.maxIn,
       maxOut: config.maxOut,
@@ -298,7 +312,7 @@ proc parse(config: Libp2pConfig): Result[ParsedConfig, string] =
       circuitRelay: config.circuitRelay,
       circuitRelayClient: config.circuitRelayClient,
       autonat: config.autonat,
-      nat: nat,
+      nat: ?parseNATConfig(config),
       autonatV2Server: config.autonatV2Server,
       mountGossipsub: config.mountGossipsub,
       gossipsubTriggerSelf: config.gossipsubTriggerSelf,

--- a/cbind/libp2p/config.nim
+++ b/cbind/libp2p/config.nim
@@ -30,24 +30,46 @@ type BootstrapNode {.ffi.} = object
 
 type Libp2pConfig {.ffi.} = object
   mountGossipsub: bool
-  gossipsubTriggerSelf: bool
-  mountKad: bool
-  mountServiceDiscovery: bool
-  dnsResolver: string
-  addrs: seq[string]
-  muxer: MuxerType
-  transport: TransportType
+    ## Mount GossipSub for publishing and receiving messages via pubsub.
+  gossipsubTriggerSelf: bool ## Deliver locally published GossipSub messages to self.
+  mountKad: bool ## Mount the Kademlia DHT service.
+  mountServiceDiscovery: bool ## Mount random-find based service discovery.
+  dnsResolver: string ## DNS server address; empty uses the core defaults.
+  addrs: seq[string] ## Listen multiaddresses for the switch.
+  muxer: MuxerType ## Type of muxer used for TCP transports.
+  transport: TransportType ## Type of transport for selecting TCP or QUIC.
   bootstrapNodes: seq[BootstrapNode]
-  privKey: seq[byte]
+    ## Peers to add to the peer store and Kad bootstrap set.
+  privKey: seq[byte] ## Serialized private key; empty generates a fresh key.
   maxConnections: int
-  maxIn: int
-  maxOut: int
-  maxConnsPerPeer: int
-  circuitRelay: bool
-  circuitRelayClient: bool
-  autonat: bool
-  autonatV2: bool
-  autonatV2Server: bool
+    ## Connection manager total limit; non-positive uses the core default.
+  maxIn: int ## Incoming connection limit; non-positive uses the core default.
+  maxOut: int ## Outgoing connection limit; non-positive uses the core default.
+  maxConnsPerPeer: int ## Per-peer connection limit; non-positive uses the core default.
+  circuitRelay: bool ## Mount the relay v2 server.
+  circuitRelayClient: bool ## Enable the relay v2 client transport.
+  autonat: bool ## Enable the legacy direct AutoNAT v1 service.
+  autonatV2: bool ## Compatibility alias for NAT reachability probing with AutoNAT v2.
+  autonatV2Server: bool ## Mount the AutoNAT v2 server.
+  natPortMappingAuto: bool
+    ## Enable gateway port mapping with automatic protocol selection.
+  natPortMappingUpnp: bool ## Enable gateway port mapping restricted to UPnP-IGD.
+  natPortMappingNatPmp: bool ## Enable gateway port mapping restricted to PCP/NAT-PMP.
+  natExplicitIp: string
+    ## Announce this external IP instead of discovering a gateway mapping.
+  natDiscoveryTimeoutMs: int64
+    ## Gateway discovery timeout for port mapping; <= 0 uses the core default.
+  natMappingTimeoutMs: int64
+    ## Gateway mapping request timeout; <= 0 uses the core default.
+  natReachabilityV1: bool ## Enable NAT reachability probing with AutoNAT v1.
+  natReachabilityV2: bool ## Enable NAT reachability probing with AutoNAT v2.
+  natReachabilityScheduleIntervalMs: int64
+    ## Reachability probe interval; <= 0 disables scheduling override.
+  natHolePunching: bool ## Enable AutoNAT v1, AutoRelay, and DCUtR hole punching.
+  natHolePunchingMaxNumRelays: int
+    ## Relay reservation target for hole punching; <= 0 uses the core default.
+  natHolePunchingScheduleIntervalMs: int64
+    ## Hole-punch reachability probe interval; <= 0 disables scheduling override.
 
 type ParsedTransport = object
   ## The transport to build, plus the muxer it needs. A muxer is only used with
@@ -74,7 +96,7 @@ type ParsedConfig = object
   circuitRelay: bool
   circuitRelayClient: bool
   autonat: bool
-  autonatV2: bool
+  nat: Opt[NATConfig]
   autonatV2Server: bool
   mountGossipsub: bool
   gossipsubTriggerSelf: bool
@@ -123,12 +145,144 @@ func parseTransportConfig(config: Libp2pConfig): ParsedTransport =
   of TransportType.Tcp:
     ParsedTransport(kind: TransportType.Tcp, muxer: config.muxer)
 
+func countEnabled(values: varargs[bool]): int =
+  for value in values:
+    if value:
+      result.inc
+
+func optDurationMs(ms: int64): Opt[Duration] =
+  if ms > 0:
+    Opt.some(chronos.milliseconds(ms))
+  else:
+    Opt.none(Duration)
+
+proc parseNATConfig(config: Libp2pConfig): Result[Opt[NATConfig], string] =
+  let
+    portMappingModes = countEnabled(
+      config.natPortMappingAuto,
+      config.natPortMappingUpnp,
+      config.natPortMappingNatPmp,
+      config.natExplicitIp.len > 0,
+    )
+    wantsReachabilityV1 = config.natReachabilityV1
+    wantsReachabilityV2 = config.natReachabilityV2 or config.autonatV2
+    wantsReachability = wantsReachabilityV1 or wantsReachabilityV2
+
+  if portMappingModes > 1:
+    return err("NAT port mapping modes are mutually exclusive")
+  if wantsReachabilityV1 and wantsReachabilityV2:
+    return err("NAT reachability v1 and v2 are mutually exclusive")
+  if wantsReachability and config.natHolePunching:
+    return err(
+      "NAT hole punching and reachability are mutually exclusive; " &
+        "hole punching already runs AutoNAT v1"
+    )
+  if config.natReachabilityScheduleIntervalMs > 0 and not wantsReachability:
+    return err(
+      "natReachabilityScheduleIntervalMs requires natReachabilityV1, " &
+        "natReachabilityV2, or autonatV2"
+    )
+  if not config.natHolePunching:
+    if config.natHolePunchingMaxNumRelays > 0:
+      return err("natHolePunchingMaxNumRelays requires natHolePunching")
+    if config.natHolePunchingScheduleIntervalMs > 0:
+      return err("natHolePunchingScheduleIntervalMs requires natHolePunching")
+
+  var nat = NATConfig()
+
+  if portMappingModes == 1:
+    let
+      discoveryTimeout =
+        if config.natDiscoveryTimeoutMs > 0:
+          chronos.milliseconds(config.natDiscoveryTimeoutMs)
+        else:
+          DefaultDiscoveryTimeout
+      mappingTimeout =
+        if config.natMappingTimeoutMs > 0:
+          chronos.milliseconds(config.natMappingTimeoutMs)
+        else:
+          DefaultMappingTimeout
+
+    if config.natExplicitIp.len > 0:
+      try:
+        nat.portMapping = Opt.some(
+          PortMappingConfig(
+            mode: ExplicitIp, explicitIp: parseIpAddress(config.natExplicitIp)
+          )
+        )
+      except ValueError as e:
+        return err("invalid natExplicitIp: " & e.msg)
+    elif config.natPortMappingUpnp:
+      nat.portMapping = Opt.some(
+        PortMappingConfig(
+          mode: Upnp, discoveryTimeout: discoveryTimeout, mappingTimeout: mappingTimeout
+        )
+      )
+    elif config.natPortMappingNatPmp:
+      nat.portMapping = Opt.some(
+        PortMappingConfig(
+          mode: NatPmp,
+          discoveryTimeout: discoveryTimeout,
+          mappingTimeout: mappingTimeout,
+        )
+      )
+    else:
+      nat.portMapping = Opt.some(
+        PortMappingConfig(
+          mode: Auto, discoveryTimeout: discoveryTimeout, mappingTimeout: mappingTimeout
+        )
+      )
+
+  if wantsReachability:
+    let scheduleInterval = optDurationMs(config.natReachabilityScheduleIntervalMs)
+    if wantsReachabilityV1:
+      nat.reachability = Opt.some(
+        ReachabilityConfig(
+          version: AutonatV1,
+          scheduleInterval: scheduleInterval,
+          v2ServiceConfig: Opt.none(AutonatV2ServiceConfig),
+        )
+      )
+    else:
+      let v2ServiceConfig =
+        if scheduleInterval.isSome():
+          Opt.some(AutonatV2ServiceConfig.new(scheduleInterval = scheduleInterval))
+        else:
+          Opt.none(AutonatV2ServiceConfig)
+      nat.reachability = Opt.some(
+        ReachabilityConfig(
+          version: AutonatV2,
+          scheduleInterval: scheduleInterval,
+          v2ServiceConfig: v2ServiceConfig,
+        )
+      )
+
+  if config.natHolePunching:
+    let maxNumRelays =
+      if config.natHolePunchingMaxNumRelays > 0:
+        config.natHolePunchingMaxNumRelays
+      else:
+        1
+    nat.holePunching = Opt.some(
+      HolePunchingConfig(
+        maxNumRelays: maxNumRelays,
+        onReservation: nil,
+        scheduleInterval: optDurationMs(config.natHolePunchingScheduleIntervalMs),
+      )
+    )
+
+  if nat.portMapping.isNone() and nat.reachability.isNone() and nat.holePunching.isNone():
+    ok(Opt.none(NATConfig))
+  else:
+    ok(Opt.some(nat))
+
 proc parse(config: Libp2pConfig): Result[ParsedConfig, string] =
   let transport = parseTransportConfig(config)
   let dnsServers = ?resolveDnsServers(config.dnsResolver)
   let addrs = ?parseMultiaddrs(config.addrs)
   let privKey = ?parsePrivateKey(config.privKey)
   let bootstrapNodes = ?parseBootstrapNodes(config.bootstrapNodes)
+  let nat = ?parseNATConfig(config)
 
   ok(
     ParsedConfig(
@@ -144,7 +298,7 @@ proc parse(config: Libp2pConfig): Result[ParsedConfig, string] =
       circuitRelay: config.circuitRelay,
       circuitRelayClient: config.circuitRelayClient,
       autonat: config.autonat,
-      autonatV2: config.autonatV2,
+      nat: nat,
       autonatV2Server: config.autonatV2Server,
       mountGossipsub: config.mountGossipsub,
       gossipsubTriggerSelf: config.gossipsubTriggerSelf,


### PR DESCRIPTION
## Summary

Expose NAT runtime configuration through the C bindings so C callers can configure port mapping, reachability probing, and hole punching through `Libp2pConfig`.

The config parser now converts the flat C-facing fields into `NATConfig` during node creation, while preserving zero-initialized config behavior. Existing `autonatV2` remains supported as an AutoNAT v2 reachability alias, and `autonatV2Server` remains separate from `withNAT`.

The C surface intentionally exposes top-level runtime NAT features, not AutoNAT v2 service tuning knobs or Nim-only injection hooks.

## Affected Areas

- [x] Other  
  C bindings config, manual C config mirror, and C binding smoke coverage.
- [x] Protocol Logic  
  NAT config selection for port mapping, reachability, and hole punching.

## Impact on Library Users

C binding users can now configure:

- NAT port mapping via auto, UPnP, NAT-PMP, or explicit IP modes
- AutoNAT v1/v2 reachability probing
- DCUtR hole punching with relay count and scheduling options

Invalid combinations, such as multiple port mapping modes or reachability together with hole punching, now fail during config parsing.

