### PR TITLE
chore(cbind): adopt nim-ffi 0.3.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -463,8 +463,9 @@ CBOR codec and event queue, and *generates* the C/CDDL bindings from the
 annotations in `libp2p.nim`:
 
 - `libp2p.nim` — the top-level FFI module: `declareLibrary` + `{.ffi.}` /
-  `{.ffiCtor.}` / `{.ffiDtor.}` / `{.ffiEvent.}` annotations and the ported
-  libp2p logic; `genBindings()` emits the bindings.
+  `{.ffiCtor.}` / `{.ffiDtor.}` / `{.ffiStatic.}` / `{.ffiEvent.}` /
+  `{.ffiConst.}` annotations and the ported libp2p logic; `genBindings()` emits
+  the bindings.
 - `libp2p/config.nim` — config types and parsing, `include`d into `libp2p.nim`.
 - `c_bindings/` — generated C header (`libp2p.h`), consumed by
   `logos-co/logos-libp2p-module`.
@@ -481,6 +482,12 @@ nimble genbindings_cddl # Generate the CDDL schema
 **cbind conventions**:
 - Requests/responses are CBOR; declare `{.ffi.}` object types for them — never
   raw `ptr`/`pointer` across the boundary.
+- A `##` doc comment on an annotated proc is propagated into the generated
+  bindings, so document the exported API there and nowhere else.
+- Closed value sets are `{.ffi.}` enums (they emit a native C enum and cross the
+  wire as text), not `int` ordinals the host has to hardcode.
+- A proc that needs no node takes no `lib` param and is `{.ffiStatic.}`; its
+  wrapper is `libp2p_static_<name>` and takes no ctx.
 - Stream handles are plain `uint64` ids tracked in `LibP2P` state (nim-ffi has
   no handle type for incoming streams).
 - Convert config-parsing failures to `return err(...)`; never `raiseAssert` on

--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -10,7 +10,8 @@ import os, strutils
 
 requires "taskpools >= 0.1.0",
   "https://github.com/vacp2p/nim-cbor-serialization#1664160e04d153573373afddc552b9cbf6fbe4dc",
-  "https://github.com/logos-messaging/nim-ffi#7ef58f4bf5cf683cfdf2abbdb3d7688727763d65"
+  # nim-ffi v0.3.0-rc.0
+  "https://github.com/logos-messaging/nim-ffi#435eebf9e3896e800c1586058a85df120a7fe870"
 
 proc findInstalledPkgDir(prefix: string): string =
   ## Path of an installed dep dir matching `prefix` (e.g. "ffi-"). Lockfile
@@ -68,10 +69,12 @@ task buildffi, "Build the FFI shared library":
   buildFfiLib()
 
 proc genBindingsFor(lang, outDir: string) =
-  exec "nim c --threads:on --app:lib --noMain --mm:refc -d:metrics" &
+  # `--compileOnly`: the binding files are written during macro expansion, so
+  # codegen is enough — there is nothing to link.
+  exec "nim c --threads:on --noMain --mm:refc -d:metrics --compileOnly" &
     " --nimMainPrefix:liblibp2p -d:ffiGenBindings -d:targetLang=" & lang &
     " -d:ffiOutputDir=" & outDir & " -d:ffiSrcPath=libp2p.nim" & ffiDepPaths() &
-    " --nimcache:nimcache_" & lang & " -o:/dev/null libp2p.nim"
+    " --nimcache:nimcache_" & lang & " libp2p.nim"
 
 task genbindings_c, "Generate C bindings (cbind/c_bindings)":
   genBindingsFor("c", "c_bindings")

--- a/cbind/examples/echo.c
+++ b/cbind/examples/echo.c
@@ -8,10 +8,6 @@
 // serves inline.
 #include "common.h"
 
-// TransportType / MuxerType ordinals, mirrored from libp2p/config.nim.
-static const int64_t TransportTcp = 1;
-static const int64_t MuxerMplex = 0;
-
 static const char *EchoProto = "/cbind/echo/1.0.0";
 static const int64_t EchoMaxSize = 4096;
 
@@ -99,8 +95,8 @@ static LibP2PCtx *createNode(const char *listenAddr, const char *label) {
   memset(&cfg, 0, sizeof(cfg));
   cfg.addrs.data = &addrSlot;
   cfg.addrs.len = 1;
-  cfg.muxer = MuxerMplex;
-  cfg.transport = TransportTcp;
+  cfg.muxer = MUXER_TYPE_MPLEX;
+  cfg.transport = TRANSPORT_TYPE_TCP;
   return await_create(&cfg, label);
 }
 

--- a/cbind/examples/gossipsub.c
+++ b/cbind/examples/gossipsub.c
@@ -4,10 +4,6 @@
 // blocking helpers in common.h.
 #include "common.h"
 
-// TransportType / MuxerType ordinals, mirrored from libp2p/config.nim.
-static const int64_t TransportTcp = 1;
-static const int64_t MuxerMplex = 0;
-
 static const char *Topic = "/cbind/demo";
 
 static atomic_int g_got = 0;
@@ -51,8 +47,8 @@ static LibP2PCtx *gossipsubNode(const char *listenAddr, const char *label) {
   cfg.gossipsubTriggerSelf = true;
   cfg.addrs.data = &addrSlot;
   cfg.addrs.len = 1;
-  cfg.muxer = MuxerMplex;
-  cfg.transport = TransportTcp;
+  cfg.muxer = MUXER_TYPE_MPLEX;
+  cfg.transport = TRANSPORT_TYPE_TCP;
   return await_create(&cfg, label);
 }
 

--- a/cbind/examples/kad.c
+++ b/cbind/examples/kad.c
@@ -10,15 +10,11 @@
 // server, which is why only the client needs to know the server.
 #include "common.h"
 
-// TransportType / MuxerType ordinals, mirrored from libp2p/config.nim.
-static const int64_t TransportTcp = 1;
-static const int64_t MuxerMplex = 0;
-
 // A key is just bytes for the DHT; the value is stored and fetched verbatim.
 static const char *ValueKey = "/cbind/kad/demo-key";
 static const char *ValueData = "hello kademlia";
 
-// libp2p_ctx_create_cid returns the CID string, so it needs its own waiter.
+// libp2p_static_create_cid returns the CID string, so it needs its own waiter.
 typedef struct {
   atomic_int done;
   int err_code;
@@ -96,8 +92,8 @@ static LibP2PCtx *kadNode(const char *listenAddr, const char *label,
   cfg.mountKad = true;
   cfg.addrs.data = &addrSlot;
   cfg.addrs.len = 1;
-  cfg.muxer = MuxerMplex;
-  cfg.transport = TransportTcp;
+  cfg.muxer = MUXER_TYPE_MPLEX;
+  cfg.transport = TRANSPORT_TYPE_TCP;
 
   NimFfiStr bootAddrs[MAX_ADDRS];
   BootstrapNode bootNode;
@@ -178,11 +174,12 @@ int main(void) {
   CidWaiter cw;
   memset(&cw, 0, sizeof(cw));
   const char *cidData = "cbind-kad";
-  CreateCidRequest cidReq = {1,
+  CreateCidRequest cidReq = {CID_VERSION_V1,
                              nimffi_str("raw"),
                              nimffi_str("sha2-256"),
                              {(uint8_t *)cidData, strlen(cidData)}};
-  libp2p_ctx_create_cid(client, &cidReq, on_cid, &cw);
+  // create_cid is context-independent ({.ffiStatic.}), so it takes no ctx.
+  libp2p_static_create_cid(&cidReq, on_cid, &cw);
   if (!wait_done(&cw.done) || cw.err_code != 0) {
     fprintf(stderr, "create_cid: %s\n", cw.err[0] ? cw.err : "unknown");
     goto cleanup_client;

--- a/cbind/examples/libp2p_mobile_check.c
+++ b/cbind/examples/libp2p_mobile_check.c
@@ -11,11 +11,7 @@
 
 #include "libp2p.h"
 
-enum {
-  LIBP2P_FFI_MUXER_YAMUX = 1,
-  LIBP2P_FFI_TRANSPORT_TCP = 1,
-  CALLBACK_TIMEOUT_SECONDS = 20,
-};
+enum { CALLBACK_TIMEOUT_SECONDS = 20 };
 
 typedef struct {
   pthread_mutex_t mutex;
@@ -134,8 +130,8 @@ static int create_node(LibP2PCtx **out_ctx) {
   config.addrs.data = listen_addrs;
   config.addrs.len = 1;
   config.dnsResolver = nimffi_str("");
-  config.transport = LIBP2P_FFI_TRANSPORT_TCP;
-  config.muxer = LIBP2P_FFI_MUXER_YAMUX;
+  config.transport = TRANSPORT_TYPE_TCP;
+  config.muxer = MUXER_TYPE_YAMUX;
   config.maxConnections = 8;
   config.maxIn = 4;
   config.maxOut = 4;
@@ -207,6 +203,10 @@ int main(void) {
   }
 
 cleanup:
-  libp2p_ctx_destroy(ctx);
+  // ctx_destroy reports teardown status; a smoke check should fail on it.
+  if (libp2p_ctx_destroy(ctx) != NIMFFI_RET_OK) {
+    fprintf(stderr, "destroy: context teardown failed\n");
+    rc = 1;
+  }
   return rc;
 }

--- a/cbind/examples/metrics.c
+++ b/cbind/examples/metrics.c
@@ -4,10 +4,6 @@
 // common.h.
 #include "common.h"
 
-// TransportType / MuxerType ordinals, mirrored from libp2p/config.nim.
-static const int64_t TransportTcp = 1;
-static const int64_t MuxerMplex = 0;
-
 // collect_metrics replies with a JSON string (Result[string]).
 typedef struct {
   atomic_int done;
@@ -38,8 +34,8 @@ int main(void) {
   memset(&cfg, 0, sizeof(cfg));
   cfg.addrs.data = &addr;
   cfg.addrs.len = 1;
-  cfg.muxer = MuxerMplex;
-  cfg.transport = TransportTcp;
+  cfg.muxer = MUXER_TYPE_MPLEX;
+  cfg.transport = TRANSPORT_TYPE_TCP;
 
   LibP2PCtx *node = await_create(&cfg, "node");
   if (!node)

--- a/cbind/examples/peerstore.c
+++ b/cbind/examples/peerstore.c
@@ -3,10 +3,6 @@
 // list it, read it back, then delete it. Calls are made blocking via common.h.
 #include "common.h"
 
-// TransportType / MuxerType ordinals, mirrored from libp2p/config.nim.
-static const int64_t TransportTcp = 1;
-static const int64_t MuxerMplex = 0;
-
 static const char *Proto = "/cbind/peerstore/1.0.0";
 
 // get_peers replies with a PeersResponse of peer-id strings.
@@ -79,8 +75,8 @@ static LibP2PCtx *createNode(const char *addr, const char *label) {
   memset(&cfg, 0, sizeof(cfg));
   cfg.addrs.data = &slot;
   cfg.addrs.len = 1;
-  cfg.muxer = MuxerMplex;
-  cfg.transport = TransportTcp;
+  cfg.muxer = MUXER_TYPE_MPLEX;
+  cfg.transport = TRANSPORT_TYPE_TCP;
   return await_create(&cfg, label);
 }
 

--- a/cbind/examples/relay.c
+++ b/cbind/examples/relay.c
@@ -5,10 +5,6 @@
 // its incoming stream from main. Calls are made blocking via common.h.
 #include "common.h"
 
-// TransportType / MuxerType ordinals, mirrored from libp2p/config.nim.
-static const int64_t TransportTcp = 1;
-static const int64_t MuxerMplex = 0;
-
 static const char *Proto = "/cbind/relay/1.0.0";
 
 // Single-slot hand-off from the destination's incoming-stream event to main.
@@ -81,8 +77,8 @@ static LibP2PCtx *createNode(const char *addr, const char *label, bool client) {
   memset(&cfg, 0, sizeof(cfg));
   cfg.addrs.data = &slot;
   cfg.addrs.len = 1;
-  cfg.muxer = MuxerMplex;
-  cfg.transport = TransportTcp;
+  cfg.muxer = MUXER_TYPE_MPLEX;
+  cfg.transport = TRANSPORT_TYPE_TCP;
   cfg.circuitRelay = !client;
   cfg.circuitRelayClient = client;
   return await_create(&cfg, label);

--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -49,6 +49,10 @@ declareLibrary("libp2p", LibP2P)
 
 include "libp2p/config"
 
+type PeerDirection {.ffi.} = enum
+  Inbound = "in"
+  Outbound = "out"
+
 type PeerInfoResponse {.ffi.} = object
   peerId: string
   addrs: seq[string]
@@ -105,6 +109,20 @@ type CreateCidRequest {.ffi.} = object
 
 type NewPrivateKeyRequest {.ffi.} = object
   scheme: int
+
+# Named wire values for the two `int` fields above, so a host doesn't hardcode
+# them. A `{.ffi.}` enum can't do this job here: Nim reads `CidV0` and `CIDv0` as
+# one identifier, so a mirror enum collides with the very type it mirrors.
+const
+  # Not libp2p's `CidVersion` ordinals (`CIDvIncorrect` takes 0 there) — the
+  # wire numbering is cbind's own, mapped in `libp2pCreateCid`.
+  CidVersionV0 {.ffiConst.} = 0
+  CidVersionV1 {.ffiConst.} = 1
+  # These are cast straight to `PKScheme`, so derive them and they can't drift.
+  KeySchemeRsa {.ffiConst.} = ord(PKScheme.RSA)
+  KeySchemeEd25519 {.ffiConst.} = ord(PKScheme.Ed25519)
+  KeySchemeSecp256k1 {.ffiConst.} = ord(PKScheme.Secp256k1)
+  KeySchemeEcdsa {.ffiConst.} = ord(PKScheme.ECDSA)
 
 type KadPutValueRequest {.ffi.} = object
   key: seq[byte]
@@ -187,9 +205,11 @@ type PubsubMessageEvent {.ffi.} = object
   topic: string
   data: seq[byte]
 
-proc onIncomingStream*(event: IncomingStreamEvent) {.ffiEvent: "on_incoming_stream".}
+proc onIncomingStream*(event: IncomingStreamEvent) {.ffiEvent.} =
+  ## Fired by a mounted custom protocol when a peer opens a stream on it.
 
-proc onPubsubMessage*(event: PubsubMessageEvent) {.ffiEvent: "on_pubsub_message".}
+proc onPubsubMessage*(event: PubsubMessageEvent) {.ffiEvent.} =
+  ## Fired for every message received on a subscribed gossipsub topic.
 
 proc register(reg: StreamRegistry, stream: Stream): uint64 =
   reg.nextStreamId.inc()
@@ -212,10 +232,9 @@ proc release(reg: StreamRegistry, id: uint64) =
       releaseWaiter.complete()
   reg.streams.del(id)
 
-const MaxReadBytes = 64 * 1024 * 1024
-  ## Upper bound on a single stream read. Caps the buffer an untrusted peer can
-  ## make us pre-allocate before any byte arrives; well above libp2p's largest
-  ## framed messages, so legitimate reads are unaffected.
+const MaxReadBytes {.ffiConst.} = 64 * 1024 * 1024
+  ## Caps the buffer an untrusted peer can make us pre-allocate before any byte
+  ## arrives; well above libp2p's largest framed messages.
 
 proc mountGossipsub(lib: LibP2P, triggerSelf: bool): Result[void, string] =
   let gs = GossipSub.init(switch = lib.switch, triggerSelf = triggerSelf, rng = lib.rng)
@@ -284,14 +303,14 @@ proc withConfiguredTransport(
     builder: SwitchBuilder, transport: ParsedTransport
 ): SwitchBuilder =
   case transport.kind
-  of TransportType.QUIC:
+  of TransportType.Quic:
     builder.withQuicTransport()
-  of TransportType.TCP:
+  of TransportType.Tcp:
     let tcp = builder.withTcpTransport()
     case transport.muxer
-    of MuxerType.MPLEX:
+    of MuxerType.Mplex:
       tcp.withMplex()
-    of MuxerType.YAMUX:
+    of MuxerType.Yamux:
       tcp.withYamux()
 
 proc createLibp2pNode(config: Libp2pConfig): Result[LibP2P, string] =
@@ -348,6 +367,8 @@ proc createLibp2pNode(config: Libp2pConfig): Result[LibP2P, string] =
   ok(lib)
 
 proc libp2pNew*(config: Libp2pConfig): Future[Result[LibP2P, string]] {.ffiCtor.} =
+  ## Builds the switch from `config` and mounts the requested protocols. The
+  ## node is not listening yet; call `libp2p_ctx_start` for that.
   try:
     createLibp2pNode(config)
   except LPError as e:
@@ -362,6 +383,7 @@ proc shutdownSwitch(lib: LibP2P) {.async.} =
   lib.running = false
 
 proc libp2pStart*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} =
+  ## Starts the switch so it listens and accepts connections. Idempotent.
   if lib.running:
     return ok(true)
   try:
@@ -372,16 +394,20 @@ proc libp2pStart*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} =
   ok(true)
 
 proc libp2pStop*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} =
+  ## Stops the switch and closes every connection. Optional:
+  ## `libp2p_ctx_destroy` does the same at teardown.
   await shutdownSwitch(lib)
   ok(true)
 
 proc libp2pDestroy*(lib: LibP2P): Future[void] {.ffiDtor.} =
-  ## Owns the full teardown: the FFI runtime runs this on the worker loop at
-  ## shutdown, so the switch stops gracefully before threads join and the context is
-  ## freed. Sufficient on its own; libp2pStop is optional, for explicit shutdown.
+  ## Runs on the worker loop, so the switch stops gracefully before the threads
+  ## join. Sufficient on its own; `libp2p_ctx_stop` beforehand is optional.
   await shutdownSwitch(lib)
 
-# Hand-maintained C-ABI mirror of `Libp2pConfig`: the `{.ffi.}` config crosses as CBOR, not a C struct, so it's absent from the generated bindings. Keep in sync.
+# Hand-maintained plain-C mirror of `Libp2pConfig`, for hosts that build the
+# config without the generated header. Not layout-compatible with the generated
+# `Libp2pConfig` (strings and enums differ); `muxer`/`transport` carry the
+# `MuxerType`/`TransportType` ordinals. Keep the field list in sync.
 type CLibp2pConfig {.exportc: "libp2p_config", bycopy.} = object
   mountGossipsub: cint
   gossipsubTriggerSelf: cint
@@ -412,6 +438,7 @@ proc libp2pNewDefaultConfig(): CLibp2pConfig {.
   CLibp2pConfig()
 
 proc libp2pPublicKey*(lib: LibP2P): Future[Result[seq[byte], string]] {.ffi.} =
+  ## The node's public key, serialized in its own key scheme's format.
   let peerInfo = lib.switch.peerInfo
   if peerInfo.isNil():
     return err("switch peerInfo is nil")
@@ -423,8 +450,8 @@ proc libp2pPublicKey*(lib: LibP2P): Future[Result[seq[byte], string]] {.ffi.} =
 
 func dialTimeout(timeoutMs: int64): Duration =
   ## The caller-supplied bound on a single dial. `<= 0` opts out
-  ## (`InfiniteDuration`), deferring to libp2p's own dial timeout — which is
-  ## still capped by the FFI handler backstop (see libp2pConnect).
+  ## (`InfiniteDuration`), deferring to libp2p's own dial timeout. nim-ffi never
+  ## cancels a handler, so nothing else bounds the call.
   if timeoutMs <= 0:
     InfiniteDuration
   else:
@@ -432,8 +459,9 @@ func dialTimeout(timeoutMs: int64): Duration =
 
 proc libp2pConnect*(
     lib: LibP2P, req: ConnectRequest
-): Future[Result[bool, string]] {.ffi: "timeout = 30000".} =
-  # Raise the FFI handler backstop (5s default) to libp2p's 30s UpgradeTimeout; `req.timeoutMs` bounds the dial itself when shorter.
+): Future[Result[bool, string]] {.ffi.} =
+  ## Dials `peerId` at `multiaddrs` and keeps the connection in the switch.
+  ## `timeoutMs <= 0` defers to libp2p's own dial timeout.
   let multiaddresses = parseMultiaddrs(req.multiaddrs).valueOr:
     return err(error)
 
@@ -452,12 +480,14 @@ proc libp2pConnect*(
 proc libp2pDisconnect*(
     lib: LibP2P, peerId: string
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Closes every connection to `peerId`.
   let pid = PeerId.init(peerId).valueOr:
     return err($error)
   await lib.switch.disconnect(pid)
   ok(true)
 
 proc libp2pPeerInfo*(lib: LibP2P): Future[Result[PeerInfoResponse, string]] {.ffi.} =
+  ## The node's own peer id and the addresses it listens on.
   let peerInfo = lib.switch.peerInfo
   if peerInfo.isNil():
     return err("switch peerInfo is nil")
@@ -467,29 +497,26 @@ proc libp2pPeerInfo*(lib: LibP2P): Future[Result[PeerInfoResponse, string]] {.ff
     err(e.msg)
 
 proc libp2pConnectedPeers*(
-    lib: LibP2P, direction: int
+    lib: LibP2P, direction: PeerDirection
 ): Future[Result[PeersResponse, string]] {.ffi.} =
+  ## Peer ids of the currently connected peers, restricted to `direction`.
   let dir =
     case direction
-    of ord(Direction.In):
-      Direction.In
-    of ord(Direction.Out):
-      Direction.Out
-    else:
-      return err("invalid direction: " & $direction)
-
-  let peers = lib.switch.connectedPeers(dir)
-  ok(PeersResponse(peerIds: peers.mapIt($it)))
+    of PeerDirection.Inbound: Direction.In
+    of PeerDirection.Outbound: Direction.Out
+  ok(PeersResponse(peerIds: lib.switch.connectedPeers(dir).mapIt($it)))
 
 proc libp2pConnectedPeersAnyDirection*(
     lib: LibP2P
 ): Future[Result[PeersResponse, string]] {.ffi.} =
+  ## Peer ids of every connected peer, inbound and outbound.
   ok(PeersResponse(peerIds: lib.switch.connectedPeers().mapIt($it)))
 
 proc libp2pDial*(
     lib: LibP2P, req: DialRequest
-): Future[Result[DialResponse, string]] {.ffi: "timeout = 30000".} =
-  # Same 30s backstop as libp2pConnect (else a slow dial trips a spurious timeout and leaks the streamId); `req.timeoutMs` bounds the dial itself.
+): Future[Result[DialResponse, string]] {.ffi.} =
+  ## Opens a stream to `peerId` speaking `proto`, returning its stream id.
+  ## `timeoutMs <= 0` defers to libp2p's own dial timeout.
   let peerId = PeerId.init(req.peerId).valueOr:
     return err($error)
   let stream =
@@ -503,7 +530,9 @@ proc libp2pDial*(
 
 proc libp2pDialCircuitRelay*(
     lib: LibP2P, req: DialCircuitRelayRequest
-): Future[Result[DialResponse, string]] {.ffi: "timeout = 30000".} =
+): Future[Result[DialResponse, string]] {.ffi.} =
+  ## Opens a stream to `peerId` over the circuit-relay address `multiaddr`.
+  ## `timeoutMs <= 0` defers to libp2p's own dial timeout.
   let dstPeerId = PeerId.init(req.peerId).valueOr:
     return err($error)
   let relayCircuitAddr = MultiAddress.init(req.multiaddr).valueOr:
@@ -534,6 +563,7 @@ func validateReadLength(n: int64): Result[int, string] =
 proc libp2pStreamReadExactly*(
     lib: LibP2P, req: StreamReadExactlyRequest
 ): Future[Result[ReadResponse, string]] {.ffi.} =
+  ## Reads exactly `numBytes` from the stream, capped at `MAX_READ_BYTES`.
   let stream = ?lib.streams.get(req.streamId)
   let expected = ?validateReadLength(req.numBytes)
   if expected == 0:
@@ -548,6 +578,7 @@ proc libp2pStreamReadExactly*(
 proc libp2pStreamReadLp*(
     lib: LibP2P, req: StreamReadLpRequest
 ): Future[Result[ReadResponse, string]] {.ffi.} =
+  ## Reads one length-prefixed message, rejecting a prefix above `maxSize`.
   let stream = ?lib.streams.get(req.streamId)
   let maxSize = ?validateReadLength(req.maxSize)
   let data =
@@ -560,6 +591,7 @@ proc libp2pStreamReadLp*(
 proc libp2pStreamWrite*(
     lib: LibP2P, req: StreamWriteRequest
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Writes `data` to the stream as raw bytes.
   let stream = ?lib.streams.get(req.streamId)
   try:
     await stream.write(req.data)
@@ -570,6 +602,7 @@ proc libp2pStreamWrite*(
 proc libp2pStreamWriteLp*(
     lib: LibP2P, req: StreamWriteRequest
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Writes `data` to the stream as one length-prefixed message.
   let stream = ?lib.streams.get(req.streamId)
   try:
     await stream.writeLp(req.data)
@@ -580,6 +613,7 @@ proc libp2pStreamWriteLp*(
 proc libp2pStreamClose*(
     lib: LibP2P, streamId: uint64
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Closes the stream's write side; the handle stays valid until released.
   let stream = ?lib.streams.get(streamId)
   await stream.close()
   ok(true)
@@ -587,6 +621,7 @@ proc libp2pStreamClose*(
 proc libp2pStreamCloseWithEof*(
     lib: LibP2P, streamId: uint64
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Closes the stream and waits for the peer's EOF.
   let stream = ?lib.streams.get(streamId)
   await stream.closeWithEOF()
   ok(true)
@@ -594,6 +629,7 @@ proc libp2pStreamCloseWithEof*(
 proc libp2pStreamRelease*(
     lib: LibP2P, streamId: uint64
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Drops the stream handle, letting a custom-protocol handler finish.
   discard ?lib.streams.get(streamId)
   lib.streams.release(streamId)
   ok(true)
@@ -601,6 +637,8 @@ proc libp2pStreamRelease*(
 proc libp2pMountProtocol*(
     lib: LibP2P, proto: string
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Mounts a custom protocol; each inbound stream on it fires
+  ## `on_incoming_stream` and stays open until the host releases the handle.
   if proto.len == 0:
     return err("proto is empty")
   if lib.switch.isNil():
@@ -639,6 +677,7 @@ proc libp2pMountProtocol*(
 proc libp2pGossipsubPublish*(
     lib: LibP2P, req: PublishRequest
 ): Future[Result[PublishResponse, string]] {.ffi.} =
+  ## Publishes `data` on `topic`, returning how many peers it went to.
   let gossipSub = lib.gossipSub.valueOr:
     return err("gossipsub not initialized")
   let peerCount = await gossipSub.publish(req.topic, req.data)
@@ -647,6 +686,7 @@ proc libp2pGossipsubPublish*(
 proc libp2pGossipsubSubscribe*(
     lib: LibP2P, topic: string
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Subscribes to `topic`; messages arrive as `on_pubsub_message` events.
   let gossipSub = lib.gossipSub.valueOr:
     return err("gossipsub not initialized")
   if not lib.topicHandlers.hasKey(topic):
@@ -659,6 +699,7 @@ proc libp2pGossipsubSubscribe*(
 proc libp2pGossipsubUnsubscribe*(
     lib: LibP2P, topic: string
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Unsubscribes from `topic`. A topic that was never subscribed is a no-op.
   let gossipSub = lib.gossipSub.valueOr:
     return err("gossipsub not initialized")
   let handler = lib.topicHandlers.getOrDefault(topic, nil)
@@ -683,6 +724,7 @@ func toExtendedRecordsResponse(
 proc libp2pKadFindNode*(
     lib: LibP2P, peerId: string
 ): Future[Result[PeersResponse, string]] {.ffi.} =
+  ## Walks the DHT for the peers closest to `peerId`.
   let kad = lib.kad.valueOr:
     return err("kad-dht not initialized")
   let target = PeerId.init(peerId).valueOr:
@@ -697,6 +739,7 @@ proc libp2pKadFindNode*(
 proc libp2pKadPutValue*(
     lib: LibP2P, req: KadPutValueRequest
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Stores `value` under `key` on the DHT nodes closest to it.
   let kad = lib.kad.valueOr:
     return err("kad-dht not initialized")
   let res = await kad.putValue(req.key, req.value)
@@ -707,6 +750,8 @@ proc libp2pKadPutValue*(
 proc libp2pKadGetValue*(
     lib: LibP2P, req: KadGetValueRequest
 ): Future[Result[ReadResponse, string]] {.ffi.} =
+  ## Looks `key` up on the DHT. `quorum` is how many agreeing records to
+  ## require; pass a negative value for the default.
   let kad = lib.kad.valueOr:
     return err("kad-dht not initialized")
   if req.quorum == 0:
@@ -735,6 +780,7 @@ proc kadAndCid(lib: LibP2P, cid: string): Result[(KadDHT, Cid), string] =
 proc libp2pKadAddProvider*(
     lib: LibP2P, cid: string
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Announces this node as a provider of `cid`, once.
   let (kad, c) = kadAndCid(lib, cid).valueOr:
     return err(error)
   await kad.addProvider(c)
@@ -743,6 +789,7 @@ proc libp2pKadAddProvider*(
 proc libp2pKadStartProviding*(
     lib: LibP2P, cid: string
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Announces this node as a provider of `cid` and keeps re-announcing it.
   let (kad, c) = kadAndCid(lib, cid).valueOr:
     return err(error)
   await kad.startProviding(c)
@@ -751,6 +798,7 @@ proc libp2pKadStartProviding*(
 proc libp2pKadStopProviding*(
     lib: LibP2P, cid: string
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Stops re-announcing this node as a provider of `cid`.
   let (kad, c) = kadAndCid(lib, cid).valueOr:
     return err(error)
   kad.stopProviding(c)
@@ -759,6 +807,7 @@ proc libp2pKadStopProviding*(
 proc libp2pKadGetProviders*(
     lib: LibP2P, cid: string
 ): Future[Result[ProvidersResponse, string]] {.ffi.} =
+  ## Finds the peers advertising themselves as providers of `cid`.
   let (kad, c) = kadAndCid(lib, cid).valueOr:
     return err(error)
   let providersSet =
@@ -786,18 +835,21 @@ proc resolveServiceDiscovery(lib: LibP2P): Result[ServiceDiscovery, string] =
 proc libp2pKadRandomRecords*(
     lib: LibP2P
 ): Future[Result[ExtendedRecordsResponse, string]] {.ffi.} =
+  ## Extended peer records collected from a random DHT walk.
   let disco = resolveServiceDiscovery(lib).valueOr:
     return err(error)
   let records = await disco.lookupRandom()
   ok(toExtendedRecordsResponse(records))
 
 proc libp2pServiceDiscoStart*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} =
+  ## Starts the service-discovery background loops.
   let disco = resolveServiceDiscovery(lib).valueOr:
     return err(error)
   await disco.start()
   ok(true)
 
 proc libp2pServiceDiscoStop*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} =
+  ## Stops the service-discovery background loops.
   let disco = resolveServiceDiscovery(lib).valueOr:
     return err(error)
   await disco.stop()
@@ -806,6 +858,7 @@ proc libp2pServiceDiscoStop*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} 
 proc libp2pServiceDiscoStartAdvertising*(
     lib: LibP2P, req: StartAdvertisingRequest
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Advertises `serviceId` (with optional `serviceData`) in this node's record.
   let disco = resolveServiceDiscovery(lib).valueOr:
     return err(error)
   disco.startAdvertising(
@@ -816,6 +869,7 @@ proc libp2pServiceDiscoStartAdvertising*(
 proc libp2pServiceDiscoStopAdvertising*(
     lib: LibP2P, serviceId: string
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Stops advertising `serviceId`.
   let disco = resolveServiceDiscovery(lib).valueOr:
     return err(error)
   await disco.stopAdvertising(serviceId)
@@ -824,6 +878,7 @@ proc libp2pServiceDiscoStopAdvertising*(
 proc libp2pServiceDiscoRegisterInterest*(
     lib: LibP2P, serviceId: string
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Registers interest in `serviceId` so its providers are cached locally.
   let disco = resolveServiceDiscovery(lib).valueOr:
     return err(error)
   discard disco.registerInterest(serviceId)
@@ -832,6 +887,7 @@ proc libp2pServiceDiscoRegisterInterest*(
 proc libp2pServiceDiscoUnregisterInterest*(
     lib: LibP2P, serviceId: string
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Drops the interest previously registered for `serviceId`.
   let disco = resolveServiceDiscovery(lib).valueOr:
     return err(error)
   disco.unregisterInterest(serviceId)
@@ -840,6 +896,7 @@ proc libp2pServiceDiscoUnregisterInterest*(
 proc libp2pServiceDiscoLookup*(
     lib: LibP2P, req: LookupRequest
 ): Future[Result[ExtendedRecordsResponse, string]] {.ffi.} =
+  ## Looks up the extended peer records advertising `serviceId`.
   let disco = resolveServiceDiscovery(lib).valueOr:
     return err(error)
   let service = ServiceInfo(id: req.serviceId, data: Opt.some(req.serviceData))
@@ -851,6 +908,7 @@ proc libp2pServiceDiscoLookup*(
 proc libp2pServiceDiscoRandomLookup*(
     lib: LibP2P
 ): Future[Result[ExtendedRecordsResponse, string]] {.ffi.} =
+  ## Extended peer records from a random walk, whatever they advertise.
   let disco = resolveServiceDiscovery(lib).valueOr:
     return err(error)
   let records = await disco.lookupRandom()
@@ -859,6 +917,8 @@ proc libp2pServiceDiscoRandomLookup*(
 proc libp2pCreateXpr*(
     lib: LibP2P, req: CreateXprRequest
 ): Future[Result[seq[byte], string]] {.ffi.} =
+  ## Signs and encodes an extended peer record for this node. Empty `addrs`
+  ## means the switch's own addresses, `seqNo` 0 means "now".
   let peerInfo = lib.switch.peerInfo
   if peerInfo.isNil():
     return err("switch peerInfo is nil")
@@ -886,8 +946,9 @@ proc libp2pCreateXpr*(
   ok(xpr.encode())
 
 proc libp2pDecodeXpr*(
-    lib: LibP2P, req: DecodeXprRequest
-): Future[Result[ExtendedPeerRecordEntry, string]] {.ffi.} =
+    req: DecodeXprRequest
+): Future[Result[ExtendedPeerRecordEntry, string]] {.ffiStatic.} =
+  ## Decodes a signed extended peer record and verifies its signature.
   let sxpr = SignedExtendedPeerRecord.decode(req.encoded).valueOr:
     return err("failed to decode signed extended peer record: " & $error)
 
@@ -899,6 +960,7 @@ proc libp2pDecodeXpr*(
 proc libp2pCircuitRelayReserve*(
     lib: LibP2P, req: CircuitRelayReserveRequest
 ): Future[Result[ReservationResponse, string]] {.ffi.} =
+  ## Reserves a slot on a circuit relay, returning the relayed addresses.
   let cl = lib.relayClient.valueOr:
     return err("relay client is not mounted (set circuitRelayClient=true in config)")
 
@@ -921,6 +983,7 @@ proc libp2pCircuitRelayReserve*(
 proc libp2pPeerstoreGetPeers*(
     lib: LibP2P
 ): Future[Result[PeersResponse, string]] {.ffi.} =
+  ## Every peer id known to the peer store, connected or not.
   var peerIds: seq[string]
   try:
     for peerId in keys(lib.switch.peerStore[AddressBook].book):
@@ -932,6 +995,7 @@ proc libp2pPeerstoreGetPeers*(
 proc libp2pPeerstoreGetPeerInfo*(
     lib: LibP2P, peerId: string
 ): Future[Result[PeerStoreEntryResponse, string]] {.ffi.} =
+  ## Everything the peer store holds for `peerId`; absent books come back empty.
   let pid = PeerId.init(peerId).valueOr:
     return err($error)
   let peerStore = lib.switch.peerStore
@@ -951,6 +1015,7 @@ proc libp2pPeerstoreGetPeerInfo*(
 proc libp2pPeerstoreAddPeer*(
     lib: LibP2P, req: AddPeerRequest
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Adds `peerId` to the peer store, extending its addresses and protocols.
   let pid = PeerId.init(req.peerId).valueOr:
     return err($error)
   if req.addrs.len == 0:
@@ -968,6 +1033,7 @@ proc libp2pPeerstoreAddPeer*(
 proc libp2pPeerstoreSetPeerAddresses*(
     lib: LibP2P, req: SetAddressesRequest
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Replaces the peer store's addresses for `peerId`.
   let pid = PeerId.init(req.peerId).valueOr:
     return err($error)
 
@@ -980,6 +1046,7 @@ proc libp2pPeerstoreSetPeerAddresses*(
 proc libp2pPeerstoreSetPeerProtocols*(
     lib: LibP2P, req: SetProtocolsRequest
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Replaces the peer store's protocol list for `peerId`.
   let pid = PeerId.init(req.peerId).valueOr:
     return err($error)
   lib.switch.peerStore[ProtoBook][pid] = req.protocols
@@ -988,19 +1055,22 @@ proc libp2pPeerstoreSetPeerProtocols*(
 proc libp2pPeerstoreDeletePeer*(
     lib: LibP2P, peerId: string
 ): Future[Result[bool, string]] {.ffi.} =
+  ## Drops every peer-store entry for `peerId`.
   let pid = PeerId.init(peerId).valueOr:
     return err($error)
   lib.switch.peerStore.del(pid)
   ok(true)
 
 proc libp2pCreateCid*(
-    lib: LibP2P, req: CreateCidRequest
-): Future[Result[string, string]] {.ffi.} =
+    req: CreateCidRequest
+): Future[Result[string, string]] {.ffiStatic.} =
+  ## Builds a CID string from a multicodec, a multihash name and the data.
+  ## `version` is `CID_VERSION_V0` or `CID_VERSION_V1`.
   let cidVer =
     case req.version
-    of 0:
+    of CidVersionV0:
       CIDv0
-    of 1:
+    of CidVersionV1:
       CIDv1
     else:
       return err("cid version must be 0 or 1")
@@ -1020,6 +1090,8 @@ proc libp2pCreateCid*(
 proc libp2pNewPrivateKey*(
     lib: LibP2P, req: NewPrivateKeyRequest
 ): Future[Result[seq[byte], string]] {.ffi.} =
+  ## Generates a private key from the node's RNG. `scheme` is one of the
+  ## `KEY_SCHEME_*` constants.
   if req.scheme < ord(low(PKScheme)) or req.scheme > ord(high(PKScheme)):
     return err("invalid key scheme")
   let scheme = PKScheme(req.scheme)
@@ -1115,6 +1187,7 @@ proc collectRegistryMetrics(registry: Registry): seq[MetricEntry] {.gcsafe.} =
   entries
 
 proc libp2pCollectMetrics*(lib: LibP2P): Future[Result[string, string]] {.ffi.} =
+  ## A JSON snapshot of the Prometheus registry, one object per metric sample.
   var jsonText: string
   try:
     {.cast(gcsafe).}:

--- a/cbind/libp2p/config.nim
+++ b/cbind/libp2p/config.nim
@@ -16,13 +16,13 @@
 ## leak its `*` into the generated field name. `include` (not `import`) keeps the
 ## fields unexported and the emitted bindings clean.
 
-type TransportType {.pure.} = enum
-  QUIC
-  TCP
+type TransportType {.ffi.} = enum
+  Quic = "quic"
+  Tcp = "tcp"
 
-type MuxerType {.pure.} = enum
-  MPLEX
-  YAMUX
+type MuxerType {.ffi.} = enum
+  Mplex = "mplex"
+  Yamux = "yamux"
 
 type BootstrapNode {.ffi.} = object
   peerId: string
@@ -35,10 +35,8 @@ type Libp2pConfig {.ffi.} = object
   mountServiceDiscovery: bool
   dnsResolver: string
   addrs: seq[string]
-  # `MuxerType`/`TransportType` ordinals, passed as `int` because nim-ffi can't
-  # yet carry a Nim enum across the wire (see parseMuxer/parseTransport).
-  muxer: int
-  transport: int
+  muxer: MuxerType
+  transport: TransportType
   bootstrapNodes: seq[BootstrapNode]
   privKey: seq[byte]
   maxConnections: int
@@ -56,9 +54,9 @@ type ParsedTransport = object
   ## TCP, so the variant makes "no muxer for QUIC" unrepresentable rather than
   ## carrying a meaningless default.
   case kind: TransportType
-  of TransportType.TCP:
+  of TransportType.Tcp:
     muxer: MuxerType
-  of TransportType.QUIC:
+  of TransportType.Quic:
     discard
 
 type ParsedConfig = object
@@ -82,24 +80,6 @@ type ParsedConfig = object
   gossipsubTriggerSelf: bool
   mountKad: bool
   mountServiceDiscovery: bool
-
-func parseTransport(v: int): Result[TransportType, string] =
-  case v
-  of ord(TransportType.QUIC):
-    ok(TransportType.QUIC)
-  of ord(TransportType.TCP):
-    ok(TransportType.TCP)
-  else:
-    err("invalid transport ordinal: " & $v)
-
-func parseMuxer(v: int): Result[MuxerType, string] =
-  case v
-  of ord(MuxerType.MPLEX):
-    ok(MuxerType.MPLEX)
-  of ord(MuxerType.YAMUX):
-    ok(MuxerType.YAMUX)
-  else:
-    err("invalid muxer ordinal: " & $v)
 
 proc parseMultiaddrs(raw: openArray[string]): Result[seq[MultiAddress], string] =
   var addrs: seq[MultiAddress]
@@ -135,19 +115,16 @@ proc parsePrivateKey(raw: seq[byte]): Result[Opt[PrivateKey], string] =
     return err("invalid private key: " & $error)
   ok(Opt.some(key))
 
-func parseTransportConfig(config: Libp2pConfig): Result[ParsedTransport, string] =
-  # A muxer is only used with TCP; a QUIC config's `muxer` ordinal is left
-  # unvalidated, matching the transport it applies to.
-  let transport = ?parseTransport(config.transport)
-  case transport
-  of TransportType.QUIC:
-    ok(ParsedTransport(kind: TransportType.QUIC))
-  of TransportType.TCP:
-    let muxer = ?parseMuxer(config.muxer)
-    ok(ParsedTransport(kind: TransportType.TCP, muxer: muxer))
+func parseTransportConfig(config: Libp2pConfig): ParsedTransport =
+  # A muxer is only used with TCP, so a QUIC config's `muxer` is ignored.
+  case config.transport
+  of TransportType.Quic:
+    ParsedTransport(kind: TransportType.Quic)
+  of TransportType.Tcp:
+    ParsedTransport(kind: TransportType.Tcp, muxer: config.muxer)
 
 proc parse(config: Libp2pConfig): Result[ParsedConfig, string] =
-  let transport = ?parseTransportConfig(config)
+  let transport = parseTransportConfig(config)
   let dnsServers = ?resolveDnsServers(config.dnsResolver)
   let addrs = ?parseMultiaddrs(config.addrs)
   let privKey = ?parsePrivateKey(config.privKey)

--- a/cbind/nimble.lock
+++ b/cbind/nimble.lock
@@ -198,8 +198,8 @@
       }
     },
     "ffi": {
-      "version": "0.2.0",
-      "vcsRevision": "7ef58f4bf5cf683cfdf2abbdb3d7688727763d65",
+      "version": "0.3.0",
+      "vcsRevision": "435eebf9e3896e800c1586058a85df120a7fe870",
       "url": "https://github.com/logos-messaging/nim-ffi",
       "downloadMethod": "git",
       "dependencies": [
@@ -210,7 +210,7 @@
         "cbor_serialization"
       ],
       "checksums": {
-        "sha1": "b3c4293dbcc9d3c9a72927005965aa1cf60667b6"
+        "sha1": "2901505700de0f5767ae4469399eb4977b0bd1a0"
       }
     }
   },

--- a/nix/cbind-deps.nix
+++ b/nix/cbind-deps.nix
@@ -19,8 +19,8 @@
 
   ffi = pkgs.fetchgit {
     url = "https://github.com/logos-messaging/nim-ffi";
-    rev = "7ef58f4bf5cf683cfdf2abbdb3d7688727763d65";
-    sha256 = "0jhwmka6339h0zhgcxwplzacpgznwqrj5a79y6qgmmy534p78nbp";
+    rev = "435eebf9e3896e800c1586058a85df120a7fe870";
+    sha256 = "1q2yk63fcckzx5q7wg2gncnv7i9lwa0nw72j54gz6jb2f1ypd7x6";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
## Summary

Moves `cbind/` from the pinned nim-ffi 0.2.0 commit to the 0.3.0-rc.0 release
candidate (`435eebf`) and reworks the annotations to use what 0.3.0 adds.

The bump is not optional-only: 0.3.0 replaced the per-handler timeout with the
non-terminal `RET_STALE_WARN` progress callback, so the `{.ffi: "timeout = 30000".}`
spec on `libp2pConnect` / `libp2pDial` / `libp2pDialCircuitRelay` is now a hard
compile error (`unknown FFI override 'timeout = 30000'`). nim-ffi never cancels a
handler now, so those procs just carry `{.ffi.}` and their own `timeoutMs` bounds
the dial.

On top of that, the new surface removes hand-maintained duplication:

- **Doc comments.** A `##` comment on an annotated proc is propagated into the
  generated bindings, so every exported proc is documented once in
  `cbind/libp2p.nim` and comes out as `/** ... */` on both the raw symbol and the
  `libp2p_ctx_*` wrapper in `c_bindings/libp2p.h` (and as `;` comments in the CDDL
  schema). They are written for the C reader, so they name C symbols
  (`libp2p_ctx_start`, `MAX_READ_BYTES`), not Nim ones.
- **`{.ffi.}` enums.** `Libp2pConfig.muxer`/`.transport` were `int` ordinals with a
  comment saying nim-ffi could not carry an enum, plus `parseMuxer` /
  `parseTransport` validating them by hand — and every C example redeclared
  `static const int64_t TransportTcp = 1;`. They are now `TransportType` /
  `MuxerType` `{.ffi.}` enums emitted as real C enums (`TRANSPORT_TYPE_TCP`,
  `MUXER_TYPE_MPLEX`), crossing the wire as text. The two ordinal parsers and all
  six example copies are gone, and `parseTransportConfig` no longer returns a
  `Result`. `libp2pConnectedPeers` takes a `PeerDirection` enum instead of an
  `int` with an "invalid direction" runtime check.
- **`{.ffiConst.}`.** `MaxReadBytes` is re-emitted as `MAX_READ_BYTES` so a host
  can check a read length against the same cap the library enforces. The two
  remaining `int` fields — `CreateCidRequest.version` and
  `NewPrivateKeyRequest.scheme` — get named `CID_VERSION_V*` / `KEY_SCHEME_*`
  constants for the same reason. They deliberately stay `int` rather than becoming
  `{.ffi.}` enums: Nim reads `CidV0` and libp2p's `CIDv0` as the *same*
  identifier (as `Rsa`/`RSA`, `Ecdsa`/`ECDSA`), so a mirror enum is a style-check
  error against the very type it mirrors. `KEY_SCHEME_*` is derived via
  `ord(PKScheme.X)` since the field is cast straight to `PKScheme`;
  `CID_VERSION_V*` keeps cbind's existing 0/1 numbering, which is deliberately
  *not* libp2p's `CidVersion` ordinals (`CIDvIncorrect` occupies 0 there).
- **`{.ffiStatic.}`.** `libp2pCreateCid` and `libp2pDecodeXpr` never touched `lib`;
  they now take no library param and bind as `libp2p_static_create_cid` /
  `libp2p_static_decode_xpr`, callable without constructing a node.
- **Implicit event names.** `{.ffiEvent.}` derives the wire name from the proc
  name, so the `"on_incoming_stream"` / `"on_pubsub_message"` literals are dropped
  (derivation produces the same names, so the ABI is unchanged).
- **`ctx_destroy` returns `int`.** `libp2p_mobile_check.c` now fails when teardown
  reports an error instead of discarding it.
- `genbindings_c`/`genbindings_cddl` use `--compileOnly` instead of
  `--app:lib -o:/dev/null`, matching the documented two-compile model.

## Affected Areas

- [x] Build / Tooling
  <!-- nim-ffi pin + nimble.lock + nix/cbind-deps.nix, cbind.nimble binding-generation flags -->

- [x] Other
  <!-- cbind/ C FFI bindings: annotations, generated C header surface, C examples -->

## Compatibility & Downstream Validation

Nothing outside `cbind/` changes — no libp2p core, transport or protocol code is
touched, so Nimbus / Waku / Codex are unaffected.

- **Nimbus:** N/A
- **Waku:** N/A
- **Codex:** N/A

**The downstream that does break is `logos-co/logos-libp2p-module`**, which
consumes `c_bindings/libp2p.h`. It needs the migration in the table below, and
this PR should not leave draft until there is a companion branch there proving it
builds and passes. That is the open item on this PR.

Verified locally: `nim check` passes, both binding generators emit, the FFI shared
library builds, and the `echo`, `gossipsub`, `kad`, `relay`, `peerstore` and
`metrics` examples build and run green against it. `nph --check` is clean.

## Impact on Library Users

No impact on Nim users of nim-libp2p. Breaking for C consumers of
`c_bindings/libp2p.h`:

| Before | After |
| --- | --- |
| `cfg.transport = 1; cfg.muxer = 0;` | `cfg.transport = TRANSPORT_TYPE_TCP; cfg.muxer = MUXER_TYPE_MPLEX;` |
| `libp2p_ctx_connected_peers(ctx, 0, ...)` | `libp2p_ctx_connected_peers(ctx, PEER_DIRECTION_INBOUND, ...)` |
| `libp2p_ctx_create_cid(ctx, &req, ...)` | `libp2p_static_create_cid(&req, ...)` |
| `libp2p_ctx_decode_xpr(ctx, &req, ...)` | `libp2p_static_decode_xpr(&req, ...)` |
| `void libp2p_ctx_destroy(ctx)` | `int libp2p_ctx_destroy(ctx)` (existing statement calls still compile) |

`CreateCidRequest.version` and `NewPrivateKeyRequest.scheme` keep their existing
integer values, so those calls are source- and wire-compatible; the new
`CID_VERSION_V*` / `KEY_SCHEME_*` constants only replace the literals.

Runtime behaviour change inherited from nim-ffi: a slow request is no longer timed
out. It runs to its natural `RET_OK`/`RET_ERR`, and the result callback receives a
non-terminal `RET_STALE_WARN` (3) every 5s while it is still in flight. The
generated typed wrappers already filter it; only a caller sitting on the raw
result-callback boundary needs to skip it.

## Risk Assessment

- **Backward compatibility:** breaking at the C ABI (see the table above); every
  in-tree example and the mobile smoke check are updated here, but the external
  module consumer is not yet validated.
- **Test coverage:** cbind's only CI coverage is `nimble examples`, and those
  examples never call `connected_peers`, `decode_xpr`, `create_xpr` or
  `new_private_key`. So the `PeerDirection` enum and the `decode_xpr` static
  conversion are exercised by nothing in CI — reviewed by inspection and by the
  generated header, not by a test.
- **Network behavior:** unchanged — enum values cross the wire as text, and the
  dial timeouts are still the caller-supplied `timeoutMs` / libp2p's own default.
- **Performance:** unchanged for the CBOR wire this library uses.
- **Security:** `MaxReadBytes` still gates every stream read; publishing it as a
  constant only tells the host the limit it was already subject to.
- The dependency is a **release candidate**, not a final 0.3.0 tag.

## References

- nim-ffi 0.3.0 changelog: https://github.com/logos-messaging/nim-ffi/blob/v0.3.0-rc.0/CHANGELOG.md
- `{.ffiStatic.}`: logos-messaging/nim-ffi#134 · `{.ffiConst.}` + `{.ffi.}` enums: logos-messaging/nim-ffi#140
- Doc-comment propagation: logos-messaging/nim-ffi#127 · `RET_STALE_WARN`: logos-messaging/nim-ffi#126

## Additional Notes

Known follow-ups deliberately left out of this PR:

- `libp2pConnectedPeersAnyDirection` stays a separate exported proc rather than a
  third `PeerDirection` value, to avoid removing a symbol hosts already call.
- `CLibp2pConfig` / `libp2p_new_default_config` (the hand-written plain-C config
  mirror) is referenced by nothing in this repo and is not layout-compatible with
  the generated `Libp2pConfig`. Its comment is corrected here; deleting the
  exported symbols is a separate call.

`c_bindings/` and `cddl_bindings/` are generated, not checked in — CI regenerates
them with `nimble genbindings_c` / `genbindings_cddl`.