### PR TITLE
test: improve checkTrackers

### DIFF
--- a/tests/tools/trackers.nim
+++ b/tests/tools/trackers.nim
@@ -22,15 +22,26 @@ const AllTrackerNames* = [
   ChronosStreamTrackerName,
 ]
 
+proc reconcileTracker(name: string, opened: int, closed: int) =
+  if opened >= closed:
+    for _ in 0 ..< opened - closed:
+      untrackCounter(name)
+  else:
+    for _ in 0 ..< closed - opened:
+      trackCounter(name)
+
 template checkTracker*(name: string) =
   if isCounterLeaked(name):
-    let
-      tracker = getTrackerCounter(name)
-      trackerDescription =
-        "Opened " & name & ": " & $tracker.opened & "\n" & "Closed " & name & ": " &
-        $tracker.closed
-    checkpoint trackerDescription
+    let tracker = getTrackerCounter(name)
+    let opened = int(tracker.opened)
+    let closed = int(tracker.closed)
+
+    checkpoint "\t" & name & ": opened " & $opened & ", closed " & $closed & " (delta " &
+      $(opened - closed) & ")"
     fail()
+
+    # Reconcile the counter so the leak does not cascade into following tests.
+    reconcileTracker(name, opened, closed)
 
 template checkTrackers*() =
   for name in AllTrackerNames:


### PR DESCRIPTION
## Summary

`checkTracker` now resets the chronos counter after it reports a leak.

The counters live on the thread dispatcher and are global, so a single leaked resource used to make every later `checkTrackers()` call in the same test binary fail as well.

`reconcileTracker` evens out `opened` and `closed` with `trackCounter` / `untrackCounter`, and it runs after `fail()` has already recorded the failure. The next test starts from a clean counter and only reports what it leaks itself.

The checkpoint output is now one line per tracker instead of two:
```
stream.transport: opened 3, closed 2 (delta 1)
```