### PR TITLE
fix(daily): provision nim-libplum for Compile Nimbus

### DIFF
--- a/.github/workflows/daily_nimbus.yml
+++ b/.github/workflows/daily_nimbus.yml
@@ -32,4 +32,9 @@ jobs:
           git checkout FETCH_HEAD
           cd ../..
 
+          libplum_ref=$(grep -oE 'nim-libplum#[0-9a-fA-F]+' vendor/nim-libp2p/libp2p.nimble | cut -d'#' -f2)
+          git clone https://github.com/logos-storage/nim-libplum.git vendor/nim-libplum
+          git -C vendor/nim-libplum checkout "$libplum_ref"
+          git -C vendor/nim-libplum submodule update --init --recursive
+
           make -j"$(nproc)" nimbus_beacon_node


### PR DESCRIPTION
## Problem

The `Compile Nimbus (linux-amd64)` daily canary (`daily_nimbus.yml`) builds `nimbus_beacon_node` against nim-libp2p HEAD. It surfaces three independent skews between nim-libp2p master and nimbus-eth2 unstable (compilation aborts at the first error, so each fix reveals the next):

1. **lsquic 3-arg dial** — #2880 made `quictransport.nim` call `endpoint.dial(addr, certVerifier)`, requiring `nim-lsquic` ≥ v0.6.0. Self-healed once nimbus-eth2 bumped its `vendor/nim-lsquic` submodule to v0.6.0.

2. **nim-libplum missing** — #2821 replaced nim-nat-traversal with `import libplum/plum` in `libp2p/services/nat/plum_mapper.nim` (reached transitively via `builders.nim` → `natservice`). nimbus-eth2 does not vendor `nim-libplum`, so the build fails with `plum_mapper.nim(15, 15) Error: cannot open file: libplum/plum`. **Fixed by this PR.**

3. **`Message.data` is now `Opt[seq[byte]]`** — #2638 (`chore(pubsub)!: protobuf_serialization`) changed the gossip payload field type. nimbus's `eth2_network.nim` `execValidator` procs call `snappy.decode(message.data, …)` / `message.data.len` assuming a plain byte seq. This is a **breaking change nimbus-eth2 must adapt to in its own source** — the canary clones nimbus read-only and cannot fix it cleanly, so it remains red until nimbus adopts the new API.

## Fix (scope of this PR)

Addresses **#2** only, which is in nim-libp2p's control. After checking out nim-libp2p, the workflow clones `nim-libplum` into `nimbus-eth2/vendor/` at the exact pin parsed from the checked-out `libp2p.nimble` (so it never drifts when nim-libp2p bumps the dependency), and initializes its C submodule.

nimbus-build-system's `create_nbs_paths.sh` regenerates `nimbus-build-system.paths` (gitignored, not committed) on every build by scanning `vendor/*` and emitting a `--path:` per entry, so dropping the package into `vendor/` is enough for `import libplum/plum` to resolve. The package's C sources self-locate via `currentSourcePath`.

Verified in CI: with this change the build proceeds ~11 minutes past the previous libplum failure and now stops on #3 (`eth2_network.nim(2715)` type mismatch), confirming the libplum provisioning works.

Drop this workaround once nimbus-eth2 vendors `nim-libplum` itself.

## Remaining

The canary will not go fully green until nimbus-eth2 adapts to (`Message.data: Opt[seq[byte]]`). That adaptation belongs in nimbus-eth2, not here. 
https://github.com/status-im/nimbus-eth2/pull/8809