### PR TITLE
chore(.gitignore): cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ nimble.paths
 
 # Ignore all test build files in tests folder (auto generated when running tests).
 # First rule (`tests/**/test*[^.]*`) will ignore all binaries: has prefix test +  does not have dot in name.
-# Second and third rule is here to un-ignore all files with an extension,
+# Second and third rules are here to un-ignore all files with an extension,
 # because it appears that vs code is skipping text search is some tests files without these rules.
 tests/**/test*[^.]*
 !tests/**/*.*

--- a/.gitignore
+++ b/.gitignore
@@ -29,10 +29,11 @@ nimble.paths
 
 # Ignore all test build files in tests folder (auto generated when running tests).
 # First rule (`tests/**/test*[^.]*`) will ignore all binaries: has prefix test +  does not have dot in name.
-# Second rule is here to un-ignore all files with an extension,
+# Second and third rule is here to un-ignore all files with an extension,
 # because it appears that vs code is skipping text search is some tests files without these rules.
 tests/**/test*[^.]*
 !tests/**/*.*
+!tests/**/.*
 
 # tests generated files
 /tests/*.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
-nimcache/
-nimbledeps/
-
-# Executables shall be put in an ignored build/ directory
-# Ignore dynamic, static libs and libtool archive files
-build/
 *.so
 *.dylib
 *.a
@@ -12,23 +6,40 @@ build/
 *.dll
 .vscode/
 .DS_Store
-tests/pubsub/testgossipsub
-examples/*.md
+
+# Executables shall be put in an ignored build/ directory
+# Ignore dynamic, static libs and libtool archive files
+build/
+
+# Generated Nim files
+nimcache/
+nimbledeps/
 nimble.develop
 nimble.paths
 /nimble.lock
-/tests/nimble.lock
-go-libp2p-daemon/
+
+# cbind generated files
+/cbind/c_bindings/
+/cbind/cddl_bindings/
+/cbind/nimcache/
+/cbind/nimcache_c/
+/cbind/nimcache_cddl/
+/cbind/nimbledeps/
+/cbind/nimble.paths
 
 # Ignore all test build files in tests folder (auto generated when running tests).
 # First rule (`tests/**/test*[^.]*`) will ignore all binaries: has prefix test +  does not have dot in name.
-# Second and third rules are here to un-ignores all files with extension and Docker file,
+# Second rule is here to un-ignore all files with an extension,
 # because it appears that vs code is skipping text search is some tests files without these rules.
-tests/**/test*[^.]* 
+tests/**/test*[^.]*
 !tests/**/*.*
-!tests/**/Dockerfile
-tests/*.xml
-tests/nimble.paths
+
+# tests generated files
+/tests/*.xml
+/tests/nimbledeps/
+/tests/nimcache/
+/tests/nimble.lock
+/tests/nimble.paths
 
 # nix builds
 result

--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,15 @@
+.vscode/
+.DS_Store
+
+# Ignore dynamic, static libs and libtool archive files
 *.so
 *.dylib
 *.a
 *.la
 *.exe
 *.dll
-.vscode/
-.DS_Store
 
 # Executables shall be put in an ignored build/ directory
-# Ignore dynamic, static libs and libtool archive files
 build/
 
 # Generated Nim files

--- a/cbind/.gitignore
+++ b/cbind/.gitignore
@@ -1,8 +1,0 @@
-nimble.develop
-nimble.paths
-nimbledeps
-nimcache
-nimcache_c
-nimcache_cddl
-c_bindings
-cddl_bindings


### PR DESCRIPTION
- some rules should not be there like `tests/pubsub/testgossipsub` or `examples/*.md`
- moved `cbind` rules to root `.gitignore`
- unified rules