### PR TITLE
chore(kad): evict stale peer on refresh

### DIFF
--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -34,9 +34,11 @@ proc livenessCandidates(
 
 proc checkAndEvictPeer(
     kad: KadDHT, rtable: RoutingTable, peerId: PeerId
-) {.async: (raises: []).} =
+) {.async: (raises: [CancelledError]).} =
   ## Probe one routing-table peer; remove it if unreachable or not speaking DHT.
   ## Takes ownership of one ``probeSem`` slot already acquired by the caller.
+  await kad.probeSem.acquire()
+
   defer:
     try:
       kad.probeSem.release()
@@ -77,13 +79,8 @@ proc pingAndEvictPeers*(
   if candidates.len == 0:
     return
 
-  var futs: seq[Future[void]]
+  var futs = newSeqOfCap[Future[void]](candidates.len)
   for peerId in candidates:
-    if kad.stopping:
-      break
-    if not kad.probeSem.tryAcquire():
-      # Remaining candidates are retried on the next maintenance pass.
-      break
     futs.add(kad.checkAndEvictPeer(rtable, peerId))
 
   if futs.len > 0:

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -18,11 +18,84 @@ logScope:
 
 const KadCodec* = "/ipfs/kad/1.0.0"
 
+proc livenessCandidates(
+    rtable: RoutingTable, gracePeriod: Duration
+): seq[PeerId] {.raises: [].} =
+  ## Peers past the liveness grace period that should be probed.
+  let now = Moment.now()
+  var peers: seq[PeerId]
+  for bucket in rtable.buckets:
+    for entry in bucket.peers:
+      if not entry.needsLivenessCheck(gracePeriod, now):
+        continue
+      entry.nodeId.toPeerId().withValue(pid):
+        peers.add(pid)
+  peers
+
+proc checkAndEvictPeer(
+    kad: KadDHT, rtable: RoutingTable, peerId: PeerId
+) {.async: (raises: []).} =
+  ## Probe one routing-table peer; remove it if unreachable or not speaking DHT.
+  ## Takes ownership of one ``probeSem`` slot already acquired by the caller.
+  defer:
+    try:
+      kad.probeSem.release()
+    except AsyncSemaphoreError:
+      raiseAssert "probeSem released without acquire"
+
+  let addrs = kad.switch.peerStore[AddressBook][peerId]
+  if addrs.len == 0:
+    trace "Evicting peer with no known addresses", peer = peerId.shortLog()
+    discard rtable.removePeer(peerId, reason = "liveness")
+    kad_routing_table_liveness_probes.inc(labelValues = ["no_addrs"])
+    return
+
+  let alive =
+    try:
+      await kad.lookupCheck(peerId, addrs)
+    except CancelledError:
+      return
+
+  if alive:
+    rtable.markUseful(peerId)
+    kad_routing_table_liveness_probes.inc(labelValues = ["ok"])
+    return
+
+  trace "Evicting unresponsive peer after liveness probe", peer = peerId.shortLog()
+  discard rtable.removePeer(peerId, reason = "liveness")
+  kad_routing_table_liveness_probes.inc(labelValues = ["fail"])
+
+proc pingAndEvictPeers*(
+    kad: KadDHT, rtable: RoutingTable
+) {.async: (raises: [CancelledError]).} =
+  ## Probes routing-table peers that have been quiet longer than the liveness
+  ## grace period and removes those that fail to answer a FIND_NODE.
+  if kad.stopping:
+    return
+
+  let candidates = rtable.livenessCandidates(kad.config.livenessGracePeriod)
+  if candidates.len == 0:
+    return
+
+  var futs: seq[Future[void]]
+  for peerId in candidates:
+    if kad.stopping:
+      break
+    if not kad.probeSem.tryAcquire():
+      # Remaining candidates are retried on the next maintenance pass.
+      break
+    futs.add(kad.checkAndEvictPeer(rtable, peerId))
+
+  if futs.len > 0:
+    await noCancel allFutures(futs)
+
 proc refreshTable*(
     kad: KadDHT, rtable: RoutingTable, forceRefresh = false
 ) {.async: (raises: [CancelledError]).} =
   ## Sends a findNode to find itself to keep nearby peers up to date
   ## Also sends a findNode to find a random key for each non-empty k-bucket
+
+  await kad.pingAndEvictPeers(rtable)
 
   discard await kad.findNode(rtable.selfId)
 
@@ -35,7 +108,7 @@ proc refreshTable*(
       continue
 
     # skip if refresh conditions not met (forceRefresh OR stale bucket)
-    if not (forceRefresh or bucket.isStale()):
+    if not (forceRefresh or bucket.isStale(rtable.config.bucketStaleTime)):
       continue
 
     let target = rtable.refreshTarget(i, kad.rng).valueOr:
@@ -77,7 +150,11 @@ proc new*(
 ): K {.raises: [].} =
   var rtable = RoutingTable.new(
     switch.peerInfo.peerId.toKey(),
-    config = RoutingTableConfig.new(replication = config.replication),
+    config = RoutingTableConfig.new(
+      replication = config.replication,
+      usefulnessGracePeriod = config.usefulnessGracePeriod,
+      bucketStaleTime = config.bucketStaleTime,
+    ),
   )
   let kad = K(
     rng: rng,

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -32,15 +32,6 @@ proc livenessCandidates(
         peers.add(pid)
   peers
 
-proc checkAndEvictPeer(
-    kad: KadDHT, rtable: RoutingTable, peerId: PeerId
-) {.async: (raises: [CancelledError]).} =
-  ## Probe one routing-table peer; remove it if unreachable or not speaking DHT.
-  await kad.probeSem.acquire()
-
-  defer:
-    try:
-      kad.probeSem.release()
 template withProbeSlotOrReturn*(kad: KadDHT) =
   ## Acquire one ``probeSem`` slot for the enclosing scope, or return without
   ## probing. Non-blocking: candidates that find no free slot are retried on a
@@ -56,9 +47,8 @@ template withProbeSlotOrReturn*(kad: KadDHT) =
 
 proc checkAndEvictPeer(
     kad: KadDHT, rtable: RoutingTable, peerId: PeerId
-) {.async: (raises: []).} =
+) {.async: (raises: [CancelledError]).} =
   withProbeSlotOrReturn(kad)
-      raiseAssert "probeSem released without acquire"
 
   # Candidate list is a snapshot; by the time a slot is free the peer may have
   # been refreshed (markUseful) or removed, and stop may have begun.
@@ -75,9 +65,7 @@ proc checkAndEvictPeer(
     kad_routing_table_liveness_probes.inc(labelValues = ["no_addrs"])
     return
 
-  let alive = await kad.lookupCheck(peerId, addrs)
-
-  if alive:
+  if (await kad.lookupCheck(peerId, addrs)):
     rtable.markUseful(peerId)
     kad_routing_table_liveness_probes.inc(labelValues = ["ok"])
     return

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -26,7 +26,7 @@ proc livenessCandidates(
   var peers: seq[PeerId]
   for bucket in rtable.buckets:
     for entry in bucket.peers:
-      if not entry.needsLivenessCheck(gracePeriod, now):
+      if not entry.isReplaceable(gracePeriod, now):
         continue
       entry.nodeId.toPeerId().withValue(pid):
         peers.add(pid)
@@ -36,7 +36,6 @@ proc checkAndEvictPeer(
     kad: KadDHT, rtable: RoutingTable, peerId: PeerId
 ) {.async: (raises: [CancelledError]).} =
   ## Probe one routing-table peer; remove it if unreachable or not speaking DHT.
-  ## Takes ownership of one ``probeSem`` slot already acquired by the caller.
   await kad.probeSem.acquire()
 
   defer:
@@ -45,6 +44,14 @@ proc checkAndEvictPeer(
     except AsyncSemaphoreError:
       raiseAssert "probeSem released without acquire"
 
+  # Candidate list is a snapshot; by the time a slot is free the peer may have
+  # been refreshed (markUseful) or removed, and stop may have begun.
+  if kad.stopping:
+    return
+  let grace = kad.config.livenessGracePeriod
+  if not rtable.isReplaceable(peerId, grace, Moment.now()):
+    return
+
   let addrs = kad.switch.peerStore[AddressBook][peerId]
   if addrs.len == 0:
     trace "Evicting peer with no known addresses", peer = peerId.shortLog()
@@ -52,22 +59,22 @@ proc checkAndEvictPeer(
     kad_routing_table_liveness_probes.inc(labelValues = ["no_addrs"])
     return
 
-  let alive =
-    try:
-      await kad.lookupCheck(peerId, addrs)
-    except CancelledError:
-      return
+  let alive = await kad.lookupCheck(peerId, addrs)
 
   if alive:
     rtable.markUseful(peerId)
     kad_routing_table_liveness_probes.inc(labelValues = ["ok"])
     return
 
+  # Probe can race with unrelated traffic that markUseful'd the peer mid-flight.
+  if not rtable.isReplaceable(peerId, grace, Moment.now()):
+    return
+
   trace "Evicting unresponsive peer after liveness probe", peer = peerId.shortLog()
   discard rtable.removePeer(peerId, reason = "liveness")
   kad_routing_table_liveness_probes.inc(labelValues = ["fail"])
 
-proc pingAndEvictPeers*(
+proc probeAndEvictPeers*(
     kad: KadDHT, rtable: RoutingTable
 ) {.async: (raises: [CancelledError]).} =
   ## Probes routing-table peers that have been quiet longer than the liveness
@@ -84,7 +91,11 @@ proc pingAndEvictPeers*(
     futs.add(kad.checkAndEvictPeer(rtable, peerId))
 
   if futs.len > 0:
-    await noCancel allFutures(futs)
+    try:
+      await allFutures(futs)
+    except CancelledError as exc:
+      await noCancel futs.cancelAndWait()
+      raise exc
 
 proc refreshTable*(
     kad: KadDHT, rtable: RoutingTable, forceRefresh = false
@@ -92,7 +103,7 @@ proc refreshTable*(
   ## Sends a findNode to find itself to keep nearby peers up to date
   ## Also sends a findNode to find a random key for each non-empty k-bucket
 
-  await kad.pingAndEvictPeers(rtable)
+  await kad.probeAndEvictPeers(rtable)
 
   discard await kad.findNode(rtable.selfId)
 

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -41,7 +41,23 @@ proc checkAndEvictPeer(
   defer:
     try:
       kad.probeSem.release()
+template withProbeSlotOrReturn*(kad: KadDHT) =
+  ## Acquire one ``probeSem`` slot for the enclosing scope, or return without
+  ## probing. Non-blocking: candidates that find no free slot are retried on a
+  ## later pass rather than queued.
+  if not kad.probeSem.tryAcquire():
+    kad_routing_table_liveness_probes.inc(labelValues = ["skipped"])
+    return
+  defer:
+    try:
+      kad.probeSem.release()
     except AsyncSemaphoreError:
+      raiseAssert "probeSem released without acquire"
+
+proc checkAndEvictPeer(
+    kad: KadDHT, rtable: RoutingTable, peerId: PeerId
+) {.async: (raises: []).} =
+  withProbeSlotOrReturn(kad)
       raiseAssert "probeSem released without acquire"
 
   # Candidate list is a snapshot; by the time a slot is free the peer may have

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -403,10 +403,11 @@ proc updatePeers*(kad: KadDHT, peers: seq[(PeerId, seq[MultiAddress])]) {.raises
   let peerInfos = peers.mapIt(PeerInfo(peerId: it[0], addrs: it[1]))
   kad.updatePeers(peerInfos)
 
-proc lookupCheck(
+proc lookupCheck*(
     kad: KadDHT, peerId: PeerId, addrs: seq[MultiAddress]
 ): Future[bool] {.async: (raises: [CancelledError]).} =
   ## A FIND_NODE for the peer's own key proves it is reachable and speaks DHT.
+  ## Used for admission probes and for routing-table liveness checks.
   let probe = kad.dispatchFindNode(peerId, peerId.toKey(), Opt.some(addrs))
   # A probe abandoned on timeout keeps its stream open, so always settle it.
   defer:

--- a/libp2p/protocols/kademlia/kademlia_metrics.nim
+++ b/libp2p/protocols/kademlia/kademlia_metrics.nim
@@ -31,3 +31,6 @@ declarePublicGauge kad_routing_table_buckets, "number of buckets"
 declarePublicGauge kad_routing_table_bucket_size, "peers per bucket", ["bucket"]
 declarePublicCounter kad_routing_table_insertions, "peer insertions"
 declarePublicCounter kad_routing_table_replacements, "peer replacements"
+declarePublicCounter kad_routing_table_evictions, "peer evictions", ["reason"]
+declarePublicCounter kad_routing_table_liveness_probes,
+  "routing-table liveness probes", ["result"]

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -20,6 +20,7 @@ proc new*(
     maxBuckets: int = DefaultMaxBuckets,
     selfIdPreHashed = false,
     usefulnessGracePeriod: Duration = DefaultUsefulnessGracePeriod,
+    bucketStaleTime: Duration = DefaultBucketStaleTime,
 ): T =
   doAssert maxBuckets > 0 and maxBuckets <= MaxBucketsLimit,
     "maxBuckets must be in 1 .. " & $MaxBucketsLimit
@@ -29,6 +30,7 @@ proc new*(
     maxBuckets: maxBuckets,
     selfIdPreHashed: selfIdPreHashed,
     usefulnessGracePeriod: usefulnessGracePeriod,
+    bucketStaleTime: bucketStaleTime,
   )
 
 proc `$`*(rt: RoutingTable): string =
@@ -76,10 +78,19 @@ proc oldestPeer*(bucket: Bucket): (NodeEntry, int) =
       oldestIdx = i
   (oldest, oldestIdx)
 
+func lastActivity*(entry: NodeEntry): Moment =
+  ## Most recent time the peer answered a DHT query, or when it was admitted.
+  entry.lastUsefulAt.get(entry.addedAt)
+
 func isReplaceable*(entry: NodeEntry, gracePeriod: Duration, now: Moment): bool =
   ## Replaceable once past `gracePeriod` in the table without proving useful; a
   ## peer that answered recently or was just added is retained.
-  now - entry.lastUsefulAt.get(entry.addedAt) > gracePeriod
+  now - entry.lastActivity() > gracePeriod
+
+func needsLivenessCheck*(entry: NodeEntry, gracePeriod: Duration, now: Moment): bool =
+  ## True when the peer has had no successful DHT activity within `gracePeriod`
+  ## and should be probed (and possibly removed) during maintenance.
+  now - entry.lastActivity() > gracePeriod
 
 proc replaceableCandidate(bucket: Bucket, gracePeriod: Duration): Opt[int] =
   ## Least-recently-seen peer past the grace period, i.e. the best eviction
@@ -157,6 +168,28 @@ proc insert*(rtable: RoutingTable, nodeId: Key): bool =
 
 proc insert*(rtable: RoutingTable, peerId: PeerId): bool =
   insert(rtable, peerId.toKey())
+
+proc removePeer*(rtable: RoutingTable, nodeId: Key, reason = "remove"): bool =
+  ## Removes `nodeId` from the routing table. Returns true if it was present.
+  ## ``reason`` labels the ``kad_routing_table_evictions`` metric
+  ## (e.g. ``"liveness"``, ``"remove"``).
+  if nodeId == rtable.selfId or nodeId == rtable.localNodeId:
+    return false
+
+  let idx = rtable.bucketIndex(nodeId)
+  if idx >= rtable.buckets.len:
+    return false
+
+  let pos = peerIndexInBucket(rtable.buckets[idx], nodeId).valueOr:
+    return false
+
+  rtable.buckets[idx].peers.delete(pos)
+  kad_routing_table_evictions.inc(labelValues = [reason])
+  updateRoutingTableMetrics(rtable)
+  true
+
+proc removePeer*(rtable: RoutingTable, peerId: PeerId, reason = "remove"): bool =
+  removePeer(rtable, peerId.toKey(), reason)
 
 proc contains*(rtable: RoutingTable, nodeId: Key): bool =
   ## Scans only the node's bucket, not the whole table.
@@ -249,13 +282,21 @@ proc randomPeersClosestFirstPeerIds*(
     .filterIt(it.isOk)
     .mapIt(it.value())
 
-proc isStale*(bucket: Bucket): bool =
+proc isStale*(bucket: Bucket, staleTime: Duration = DefaultBucketStaleTime): bool =
+  ## True when the bucket is empty or any peer has not been seen for longer than
+  ## `staleTime`. Used only to decide whether to refresh the bucket, not to
+  ## remove peers.
   if bucket.peers.len == 0:
     return true
   for p in bucket.peers:
-    if Moment.now() - p.lastSeen > DefaultBucketStaleTime:
+    if Moment.now() - p.lastSeen > staleTime:
       return true
   return false
+
+proc isStale*(rtable: RoutingTable, bucketIndex: int): bool =
+  if bucketIndex notin 0 ..< rtable.buckets.len:
+    return true
+  rtable.buckets[bucketIndex].isStale(rtable.config.bucketStaleTime)
 
 proc randomKeyInBucket*(rtable: RoutingTable, bucketIndex: int, rng: Rng): Opt[Key] =
   let lz = clamp(bucketIndex, 0, bucketCount(rtable.config.maxBuckets) - 1)

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -84,13 +84,21 @@ func lastActivity*(entry: NodeEntry): Moment =
 
 func isReplaceable*(entry: NodeEntry, gracePeriod: Duration, now: Moment): bool =
   ## Replaceable once past `gracePeriod` in the table without proving useful; a
-  ## peer that answered recently or was just added is retained.
+  ## peer that answered recently or was just added is retained. Also used to
+  ## select peers for liveness probes during maintenance.
   now - entry.lastActivity() > gracePeriod
 
-func needsLivenessCheck*(entry: NodeEntry, gracePeriod: Duration, now: Moment): bool =
-  ## True when the peer has had no successful DHT activity within `gracePeriod`
-  ## and should be probed (and possibly removed) during maintenance.
-  now - entry.lastActivity() > gracePeriod
+proc isReplaceable*(
+    rtable: RoutingTable, peerId: PeerId, gracePeriod: Duration, now: Moment
+): bool =
+  ## Live-table check: false when the peer is missing or still within grace.
+  let nodeId = peerId.toKey()
+  let idx = rtable.bucketIndex(nodeId)
+  if idx >= rtable.buckets.len:
+    return false
+  let pos = peerIndexInBucket(rtable.buckets[idx], nodeId).valueOr:
+    return false
+  rtable.buckets[idx].peers[pos].isReplaceable(gracePeriod, now)
 
 proc replaceableCandidate(bucket: Bucket, gracePeriod: Duration): Opt[int] =
   ## Least-recently-seen peer past the grace period, i.e. the best eviction

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -18,10 +18,13 @@ const
   DefaultTimeout* = 5.seconds
   DefaultBucketRefreshTime* = 10.minutes
   DefaultBucketStaleTime* = 30.minutes
-    # peer not seen for this duration marks bucket stale
+    ## Peer not seen for this duration marks the bucket stale (refresh trigger).
   DefaultUsefulnessGracePeriod* = 1.hours
     ## New peers resist eviction until in the table this long without proving
-    ## useful; mirrors go-libp2p's k-bucket usefulness grace.
+  DefaultLivenessGracePeriod* = 1.hours
+    ## Peers with no successful outbound DHT activity within this window are
+    ## probed for liveness during maintenance; failures are removed from the
+    ## routing table.
   DefaultRetries* = 5
   DefaultReplication* = 20 ## aka `k` in the spec
   DefaultAlpha* = 10 # concurrency parameter
@@ -214,6 +217,7 @@ type
     maxBuckets*: int
     selfIdPreHashed*: bool
     usefulnessGracePeriod*: Duration
+    bucketStaleTime*: Duration
 
   RoutingTable* = ref object
     selfId*: Key
@@ -404,6 +408,9 @@ type KadDHTConfig* = object
   selector*: EntrySelector
   timeout*: chronos.Duration
   bucketRefreshTime*: chronos.Duration
+  bucketStaleTime*: chronos.Duration
+  usefulnessGracePeriod*: chronos.Duration
+  livenessGracePeriod*: chronos.Duration
   retries*: int
   replication*: int
   alpha*: int
@@ -433,6 +440,9 @@ proc new*(
     selector: EntrySelector = DefaultEntrySelector(),
     timeout: chronos.Duration = DefaultTimeout,
     bucketRefreshTime: chronos.Duration = DefaultBucketRefreshTime,
+    bucketStaleTime: chronos.Duration = DefaultBucketStaleTime,
+    usefulnessGracePeriod: chronos.Duration = DefaultUsefulnessGracePeriod,
+    livenessGracePeriod: chronos.Duration = DefaultLivenessGracePeriod,
     retries: int = DefaultRetries,
     replication: int = DefaultReplication,
     alpha: int = DefaultAlpha,
@@ -474,6 +484,9 @@ proc new*(
     selector: selector,
     timeout: timeout,
     bucketRefreshTime: bucketRefreshTime,
+    bucketStaleTime: bucketStaleTime,
+    usefulnessGracePeriod: usefulnessGracePeriod,
+    livenessGracePeriod: livenessGracePeriod,
     retries: retries,
     replication: replication,
     alpha: alpha,

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -77,7 +77,11 @@ proc new*(
 ): T {.raises: [].} =
   var rtable = RoutingTable.new(
     switch.peerInfo.peerId.toKey(),
-    config = RoutingTableConfig.new(replication = config.replication),
+    config = RoutingTableConfig.new(
+      replication = config.replication,
+      usefulnessGracePeriod = config.usefulnessGracePeriod,
+      bucketStaleTime = config.bucketStaleTime,
+    ),
   )
 
   let disco = ServiceDiscovery(

--- a/tests/libp2p/kademlia/test_bootstrap.nim
+++ b/tests/libp2p/kademlia/test_bootstrap.nim
@@ -147,7 +147,7 @@ suite "KadDHT Bootstrap Component":
       kad.hasKey(fakePeerId.toKey()) # fake peer should be in routing table
       kad.started # node should be operational
 
-  asyncTest "pingAndEvictPeers removes peers past liveness grace that fail probe":
+  asyncTest "probeAndEvictPeers removes peers past liveness grace that fail probe":
     let hub = setupKad()
     let leaf = setupKad(config = testKadConfig(timeout = chronos.milliseconds(200)))
     startAndDeferStop(@[hub, leaf])
@@ -162,11 +162,11 @@ suite "KadDHT Bootstrap Component":
 
     agePeerPastLivenessGrace(hub.rtable, leafId.toKey())
 
-    await hub.pingAndEvictPeers(hub.rtable)
+    await hub.probeAndEvictPeers(hub.rtable)
 
     check not hub.hasKey(leafId.toKey())
 
-  asyncTest "pingAndEvictPeers retains peers that answer the probe":
+  asyncTest "probeAndEvictPeers retains peers that answer the probe":
     let hub = setupKad()
     let leaf = setupKad()
     startAndDeferStop(@[hub, leaf])
@@ -178,13 +178,13 @@ suite "KadDHT Bootstrap Component":
     # Age past grace so a probe is required; leaf is still alive.
     agePeerPastLivenessGrace(hub.rtable, leafId.toKey())
 
-    await hub.pingAndEvictPeers(hub.rtable)
+    await hub.probeAndEvictPeers(hub.rtable)
 
     check hub.hasKey(leafId.toKey())
     # Successful probe marks the peer useful again.
     check hub.isPeerUseful(leafId.toKey())
 
-  asyncTest "pingAndEvictPeers skips peers still within liveness grace":
+  asyncTest "probeAndEvictPeers skips peers still within liveness grace":
     let hub = setupKad()
     let leaf = setupKad(config = testKadConfig(timeout = chronos.milliseconds(200)))
     startAndDeferStop(@[hub, leaf])
@@ -195,10 +195,10 @@ suite "KadDHT Bootstrap Component":
     await leaf.switch.stop()
 
     # Fresh insert times: within grace, so no probe and no eviction.
-    await hub.pingAndEvictPeers(hub.rtable)
+    await hub.probeAndEvictPeers(hub.rtable)
     check hub.hasKey(leafId.toKey())
 
-  asyncTest "pingAndEvictPeers removes peers with no known addresses":
+  asyncTest "probeAndEvictPeers removes peers with no known addresses":
     let kad = setupMockKad()
     startAndDeferStop(@[kad])
 
@@ -208,5 +208,31 @@ suite "KadDHT Bootstrap Component":
 
     agePeerPastLivenessGrace(kad.rtable, orphan.toKey())
 
-    await kad.pingAndEvictPeers(kad.rtable)
+    await kad.probeAndEvictPeers(kad.rtable)
     check not kad.hasKey(orphan.toKey())
+
+  asyncTest "probeAndEvictPeers keeps useful peer even with no addresses":
+    ## Re-check after the candidate snapshot: a peer that is still within grace
+    ## (or was markUseful'd) must not be removed on the no-addrs path.
+    let kad = setupMockKad()
+    startAndDeferStop(@[kad])
+
+    let peer = randomPeerId()
+    check kad.rtable.insert(peer)
+    # Fresh insert: within grace, and no AddressBook entry.
+    await kad.probeAndEvictPeers(kad.rtable)
+    check kad.hasKey(peer.toKey())
+
+  asyncTest "probeAndEvictPeers skips peer refreshed after aging":
+    ## Age past grace then markUseful before the maintenance pass: candidate
+    ## selection (and the post-acquire re-check) must leave the peer in place.
+    let kad = setupMockKad()
+    startAndDeferStop(@[kad])
+
+    let peer = randomPeerId()
+    check kad.rtable.insert(peer)
+    agePeerPastLivenessGrace(kad.rtable, peer.toKey())
+    kad.rtable.markUseful(peer)
+
+    await kad.probeAndEvictPeers(kad.rtable)
+    check kad.hasKey(peer.toKey())

--- a/tests/libp2p/kademlia/test_bootstrap.nim
+++ b/tests/libp2p/kademlia/test_bootstrap.nim
@@ -146,3 +146,89 @@ suite "KadDHT Bootstrap Component":
     check:
       kad.hasKey(fakePeerId.toKey()) # fake peer should be in routing table
       kad.started # node should be operational
+
+  asyncTest "pingAndEvictPeers removes peers past liveness grace that fail probe":
+    let hub = setupKad()
+    let leaf = setupKad(config = testKadConfig(timeout = chronos.milliseconds(200)))
+    startAndDeferStop(@[hub, leaf])
+    await connect(hub, leaf)
+
+    let leafId = leaf.switch.peerInfo.peerId
+    check hub.hasKey(leafId.toKey())
+
+    # Stop the leaf so the next probe fails, then age hub's entry past grace.
+    await leaf.stop()
+    await leaf.switch.stop()
+
+    let past = Moment.now() - (DefaultLivenessGracePeriod + 1.minutes)
+    for b in hub.rtable.buckets.mitems:
+      for p in b.peers.mitems:
+        if p.nodeId == leafId.toKey():
+          p.addedAt = past
+          p.lastUsefulAt = Opt.none(Moment)
+          p.lastSeen = past
+
+    await hub.pingAndEvictPeers(hub.rtable)
+
+    check not hub.hasKey(leafId.toKey())
+
+  asyncTest "pingAndEvictPeers retains peers that answer the probe":
+    let hub = setupKad()
+    let leaf = setupKad()
+    startAndDeferStop(@[hub, leaf])
+    await connect(hub, leaf)
+
+    let leafId = leaf.switch.peerInfo.peerId
+    check hub.hasKey(leafId.toKey())
+
+    # Age past grace so a probe is required; leaf is still alive.
+    let past = Moment.now() - (DefaultLivenessGracePeriod + 1.minutes)
+    for b in hub.rtable.buckets.mitems:
+      for p in b.peers.mitems:
+        if p.nodeId == leafId.toKey():
+          p.addedAt = past
+          p.lastUsefulAt = Opt.none(Moment)
+          p.lastSeen = past
+
+    await hub.pingAndEvictPeers(hub.rtable)
+
+    check hub.hasKey(leafId.toKey())
+    # Successful probe marks the peer useful again.
+    var useful = false
+    for b in hub.rtable.buckets:
+      for p in b.peers:
+        if p.nodeId == leafId.toKey():
+          useful = p.lastUsefulAt.isSome()
+    check useful
+
+  asyncTest "pingAndEvictPeers skips peers still within liveness grace":
+    let hub = setupKad()
+    let leaf = setupKad(config = testKadConfig(timeout = chronos.milliseconds(200)))
+    startAndDeferStop(@[hub, leaf])
+    await connect(hub, leaf)
+
+    let leafId = leaf.switch.peerInfo.peerId
+    await leaf.stop()
+    await leaf.switch.stop()
+
+    # Fresh insert times: within grace, so no probe and no eviction.
+    await hub.pingAndEvictPeers(hub.rtable)
+    check hub.hasKey(leafId.toKey())
+
+  asyncTest "pingAndEvictPeers removes peers with no known addresses":
+    let kad = setupMockKad()
+    startAndDeferStop(@[kad])
+
+    let orphan = randomPeerId()
+    discard kad.rtable.insert(orphan)
+    # No AddressBook entry.
+
+    let past = Moment.now() - (DefaultLivenessGracePeriod + 1.minutes)
+    for b in kad.rtable.buckets.mitems:
+      for p in b.peers.mitems:
+        if p.nodeId == orphan.toKey():
+          p.addedAt = past
+          p.lastUsefulAt = Opt.none(Moment)
+
+    await kad.pingAndEvictPeers(kad.rtable)
+    check not kad.hasKey(orphan.toKey())

--- a/tests/libp2p/kademlia/test_bootstrap.nim
+++ b/tests/libp2p/kademlia/test_bootstrap.nim
@@ -160,13 +160,7 @@ suite "KadDHT Bootstrap Component":
     await leaf.stop()
     await leaf.switch.stop()
 
-    let past = Moment.now() - (DefaultLivenessGracePeriod + 1.minutes)
-    for b in hub.rtable.buckets.mitems:
-      for p in b.peers.mitems:
-        if p.nodeId == leafId.toKey():
-          p.addedAt = past
-          p.lastUsefulAt = Opt.none(Moment)
-          p.lastSeen = past
+    agePeerPastLivenessGrace(hub.rtable, leafId.toKey())
 
     await hub.pingAndEvictPeers(hub.rtable)
 
@@ -182,24 +176,13 @@ suite "KadDHT Bootstrap Component":
     check hub.hasKey(leafId.toKey())
 
     # Age past grace so a probe is required; leaf is still alive.
-    let past = Moment.now() - (DefaultLivenessGracePeriod + 1.minutes)
-    for b in hub.rtable.buckets.mitems:
-      for p in b.peers.mitems:
-        if p.nodeId == leafId.toKey():
-          p.addedAt = past
-          p.lastUsefulAt = Opt.none(Moment)
-          p.lastSeen = past
+    agePeerPastLivenessGrace(hub.rtable, leafId.toKey())
 
     await hub.pingAndEvictPeers(hub.rtable)
 
     check hub.hasKey(leafId.toKey())
     # Successful probe marks the peer useful again.
-    var useful = false
-    for b in hub.rtable.buckets:
-      for p in b.peers:
-        if p.nodeId == leafId.toKey():
-          useful = p.lastUsefulAt.isSome()
-    check useful
+    check hub.isPeerUseful(leafId.toKey())
 
   asyncTest "pingAndEvictPeers skips peers still within liveness grace":
     let hub = setupKad()
@@ -220,15 +203,10 @@ suite "KadDHT Bootstrap Component":
     startAndDeferStop(@[kad])
 
     let orphan = randomPeerId()
-    discard kad.rtable.insert(orphan)
+    check kad.rtable.insert(orphan)
     # No AddressBook entry.
 
-    let past = Moment.now() - (DefaultLivenessGracePeriod + 1.minutes)
-    for b in kad.rtable.buckets.mitems:
-      for p in b.peers.mitems:
-        if p.nodeId == orphan.toKey():
-          p.addedAt = past
-          p.lastUsefulAt = Opt.none(Moment)
+    agePeerPastLivenessGrace(kad.rtable, orphan.toKey())
 
     await kad.pingAndEvictPeers(kad.rtable)
     check not kad.hasKey(orphan.toKey())

--- a/tests/libp2p/kademlia/test_routing_table.nim
+++ b/tests/libp2p/kademlia/test_routing_table.nim
@@ -239,7 +239,7 @@ suite "KadDHT Routing Table":
       not rt.removePeer(selfId)
       not rt.removePeer(localNodeId)
 
-  test "needsLivenessCheck follows grace period from last activity":
+  test "isReplaceable follows grace period from last activity":
     let now = Moment.now()
     var entry = NodeEntry(
       nodeId: testKey(1),
@@ -247,7 +247,7 @@ suite "KadDHT Routing Table":
       addedAt: now - 2.hours,
       lastUsefulAt: Opt.none(Moment),
     )
-    check entry.needsLivenessCheck(1.hours, now)
+    check entry.isReplaceable(1.hours, now)
 
     entry = NodeEntry(
       nodeId: testKey(1),
@@ -255,7 +255,7 @@ suite "KadDHT Routing Table":
       addedAt: now - 2.hours,
       lastUsefulAt: Opt.some(now - 30.minutes),
     )
-    check not entry.needsLivenessCheck(1.hours, now)
+    check not entry.isReplaceable(1.hours, now)
 
   test "randomKeyInBucket returns id at correct distance":
     let selfId = testKey(0)

--- a/tests/libp2p/kademlia/test_routing_table.nim
+++ b/tests/libp2p/kademlia/test_routing_table.nim
@@ -215,6 +215,38 @@ suite "KadDHT Routing Table":
     bucket.peers = @[NodeEntry(nodeId: testKey(1), lastSeen: Moment.now())]
     check isStale(bucket) == false
 
+  test "removePeer removes an existing entry":
+    let selfId = testKey(0)
+    var rt = RoutingTable.new(
+      selfId, config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
+    )
+    let key = rt.keyInBucket(TargetBucket)
+    check rt.insert(key)
+    check key in rt
+    check rt.removePeer(key)
+    check key notin rt
+    check not rt.removePeer(key) # already gone
+
+  test "removePeer rejects self and localNodeId":
+    let selfId = testKey(0)
+    let localNodeId = testKey(99)
+    var rt = RoutingTable.new(selfId, localNodeId = Opt.some(localNodeId))
+    check:
+      not rt.removePeer(selfId)
+      not rt.removePeer(localNodeId)
+
+  test "needsLivenessCheck follows grace period from last activity":
+    let now = Moment.now()
+    var entry = NodeEntry(
+      nodeId: testKey(1),
+      lastSeen: now,
+      addedAt: now - 2.hours,
+      lastUsefulAt: Opt.none(Moment),
+    )
+    check entry.needsLivenessCheck(1.hours, now)
+    entry.lastUsefulAt = Opt.some(now - 30.minutes)
+    check not entry.needsLivenessCheck(1.hours, now)
+
   test "randomKeyInBucket returns id at correct distance":
     let selfId = testKey(0)
     var rt =

--- a/tests/libp2p/kademlia/test_routing_table.nim
+++ b/tests/libp2p/kademlia/test_routing_table.nim
@@ -221,10 +221,14 @@ suite "KadDHT Routing Table":
       selfId, config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     )
     let key = rt.keyInBucket(TargetBucket)
-    check rt.insert(key)
-    check key in rt
-    check rt.removePeer(key)
-    check key notin rt
+    check:
+      rt.insert(key)
+      key in rt
+
+    check:
+      rt.removePeer(key)
+      key notin rt
+
     check not rt.removePeer(key) # already gone
 
   test "removePeer rejects self and localNodeId":
@@ -244,7 +248,13 @@ suite "KadDHT Routing Table":
       lastUsefulAt: Opt.none(Moment),
     )
     check entry.needsLivenessCheck(1.hours, now)
-    entry.lastUsefulAt = Opt.some(now - 30.minutes)
+
+    entry = NodeEntry(
+      nodeId: testKey(1),
+      lastSeen: now,
+      addedAt: now - 2.hours,
+      lastUsefulAt: Opt.some(now - 30.minutes),
+    )
     check not entry.needsLivenessCheck(1.hours, now)
 
   test "randomKeyInBucket returns id at correct distance":

--- a/tests/libp2p/kademlia/utils.nim
+++ b/tests/libp2p/kademlia/utils.nim
@@ -233,6 +233,24 @@ proc makeBucketStale*(bucket: var Bucket) =
   for peer in bucket.peers.mitems:
     peer.lastSeen = Moment.now() - (DefaultBucketStaleTime + 1.minutes)
 
+proc agePeerPastLivenessGrace*(rtable: var RoutingTable, key: Key) =
+  ## Age a routing-table entry past the default liveness grace so the next
+  ## maintenance pass will probe it.
+  let past = Moment.now() - (DefaultLivenessGracePeriod + 1.minutes)
+  for b in rtable.buckets.mitems:
+    for p in b.peers.mitems:
+      if p.nodeId == key:
+        p.addedAt = past
+        p.lastUsefulAt = Opt.none(Moment)
+        p.lastSeen = past
+
+proc isPeerUseful*(kad: KadDHT, key: Key): bool =
+  for b in kad.rtable.buckets:
+    for p in b.peers:
+      if p.nodeId == key:
+        return p.lastUsefulAt.isSome()
+  false
+
 proc sortPeers*(
     peers: seq[PeerId], targetKey: Key, hasher: Opt[XorDHasher]
 ): seq[PeerId] =


### PR DESCRIPTION
Fixes #2890 by adding a new mechanism that track the "liveness" of peers in a table. When a table is refreshed this runs first, evict stale peers and then the usual `findnode` is called to fill each bucket.