### PR TITLE
refactor(pubsub): use protobuf proto editions

### DIFF
--- a/examples/tutorial_4_gossipsub.nim
+++ b/examples/tutorial_4_gossipsub.nim
@@ -79,7 +79,7 @@ proc oneNode(node: Node, rng: Rng) {.async.} =
   node.gossip.addValidator(
     ["metrics"],
     proc(topic: string, message: Message): Future[ValidationResult] {.async.} =
-      let decoded = MetricList.decode(message.data.get())
+      let decoded = MetricList.decode(message.data)
       if decoded.isErr:
         return ValidationResult.Reject
       return ValidationResult.Accept,

--- a/interop/gossipsub/src/node.nim
+++ b/interop/gossipsub/src/node.nim
@@ -47,9 +47,9 @@ proc interopMsgIdProvider*(m: Message): Result[MessageId, ValidationResult] =
   ## Message ID provider for interop tests.
   ## The message ID is the raw first MsgIdLen bytes of the message data (big-endian u64),
   ## matching the wire format used by the go and rust interop binaries.
-  if m.data.isNone or m.data.get().len < MsgIdLen:
+  if m.data.len < MsgIdLen:
     return err(ValidationResult.Reject)
-  ok(MessageId(@(m.data.get().toOpenArray(0, MsgIdLen - 1))))
+  ok(MessageId(@(m.data.toOpenArray(0, MsgIdLen - 1))))
 
 # Node
 

--- a/interop/gossipsub/src/runner.nim
+++ b/interop/gossipsub/src/runner.nim
@@ -45,10 +45,10 @@ proc addReceivedMessageLogger(runner: ScriptRunner) =
     PubSubObserver(
       onRecv: proc(peer: PubSubPeer, rpc: var RPCMsg) {.gcsafe, raises: [].} =
         for msg in rpc.messages:
-          if msg.topic notin runner.node.topics or msg.data.get(@[]).len < MsgIdLen:
+          if msg.topic notin runner.node.topics or msg.data.len < MsgIdLen:
             continue
 
-          let msgId = extractMsgId(msg.data.get())
+          let msgId = extractMsgId(msg.data)
           logReceivedMessage(logStream, $msgId, msg.topic)
     )
   )

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -12,7 +12,7 @@ requires "nim >= 2.2.4",
   "https://github.com/vacp2p/nim-boringssl >= 0.0.8", "chronicles >= 0.12.3",
   "chronos >= 4.2.2", "metrics >= 0.2.2", "secp256k1", "stew >= 0.4.2", "results",
   "serialization >= 0.5.0", "json_serialization >= 0.4.4", "lsquic >= 0.7.0",
-  "https://github.com/nitely/nim-protobuf-serialization#proto_editions",
+  "protobuf_serialization >= 0.6.0",
   "https://github.com/status-im/nim-websock >= 0.4.0",
   "https://github.com/logos-storage/nim-libplum#acefbe424cf9d1f05f2d93533790c9ac4e034df8"
 

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -12,7 +12,7 @@ requires "nim >= 2.2.4",
   "https://github.com/vacp2p/nim-boringssl >= 0.0.8", "chronicles >= 0.12.3",
   "chronos >= 4.2.2", "metrics >= 0.2.2", "secp256k1", "stew >= 0.4.2", "results",
   "serialization >= 0.5.0", "json_serialization >= 0.4.4", "lsquic >= 0.7.0",
-  "https://github.com/status-im/nim-protobuf-serialization#proto2-ext-plain-optional",
+  "https://github.com/nitely/nim-protobuf-serialization#proto_editions",
   "https://github.com/status-im/nim-websock >= 0.4.0",
   "https://github.com/logos-storage/nim-libplum#acefbe424cf9d1f05f2d93533790c9ac4e034df8"
 

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -12,7 +12,7 @@ requires "nim >= 2.2.4",
   "https://github.com/vacp2p/nim-boringssl >= 0.0.8", "chronicles >= 0.12.3",
   "chronos >= 4.2.2", "metrics >= 0.2.2", "secp256k1", "stew >= 0.4.2", "results",
   "serialization >= 0.5.0", "json_serialization >= 0.4.4", "lsquic >= 0.7.0",
-  "protobuf_serialization >= 0.5.3",
+  "https://github.com/status-im/nim-protobuf-serialization#proto2-ext-plain-optional",
   "https://github.com/status-im/nim-websock >= 0.4.0",
   "https://github.com/logos-storage/nim-libplum#acefbe424cf9d1f05f2d93533790c9ac4e034df8"
 

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -132,12 +132,12 @@ method rpcHandler*(
       debug "Dropping message due to topic not in floodsub topics", topic, msgId, peer
       continue
 
-    if (msg.signature.isSome or f.verifySignature) and not msg.verify():
+    if (msg.signature.len > 0 or f.verifySignature) and not msg.verify():
       # always validate if signature is present or required
       debug "Dropping message due to failed signature verification", msgId, peer
       continue
 
-    if msg.seqno.isSome and msg.seqno.get().len != 8:
+    if msg.seqno.len > 0 and msg.seqno.len != 8:
       # if we have seqno should be 8 bytes long
       debug "Dropping message due to invalid seqno length", msgId, peer
       continue
@@ -160,16 +160,12 @@ method rpcHandler*(
     of ValidationResult.Accept:
       discard
 
-    let data = msg.data.valueOr:
-      debug "Dropping message after validation, reason: data not set", msgId, peer
-      continue
-
     var toSendPeers = initHashSet[PubSubPeer]()
 
     f.floodsub.withValue(topic, peers):
       toSendPeers.incl(peers[])
 
-    await handleData(f, topic, data)
+    await handleData(f, topic, msg.data)
 
     # In theory, if topics are the same in all messages, we could batch - we'd
     # also have to be careful to only include validated messages

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -509,14 +509,13 @@ proc validateAndRelay(
         toSendPeers.incl(peers[])
       toSendPeers.excl(peer)
 
-    if isLargeMessage(msg.data.get(@[]).len, msgId):
+    if isLargeMessage(msg.data.len, msgId):
       var peersToSendIDontWant = HashSet[PubSubPeer]()
       addToSendPeers(peersToSendIDontWant)
       # Also exclude the original message publisher so we don't send IDontWant
       # to a peer we won't relay to after the fix below.
-      msg.fromPeer.withValue(fromPeer):
-        g.peers.withValue(fromPeer, sourcePeer):
-          peersToSendIDontWant.excl(sourcePeer[])
+      g.peers.withValue(msg.fromPeer, sourcePeer):
+        peersToSendIDontWant.excl(sourcePeer[])
       g.sendIDontWant(topic, msgId, peersToSendIDontWant)
 
     let validation = await g.validate(msg)
@@ -524,8 +523,7 @@ proc validateAndRelay(
     let seenPeers = g.validationSeen.getOrDefault(saltedId)
     libp2p_gossipsub_duplicate_during_validation.inc(seenPeers.len.int64)
     libp2p_gossipsub_saved_bytes.inc(
-      (msg.data.get(@[]).len * seenPeers.len).int64,
-      labelValues = ["validation_duplicate"],
+      (msg.data.len * seenPeers.len).int64, labelValues = ["validation_duplicate"]
     )
 
     case validation
@@ -561,16 +559,15 @@ proc validateAndRelay(
     # Also exclude the original message publisher to prevent relaying back to
     # them. This handles the case where the message arrived via an intermediate
     # relay node (e.g., A→B→C: when C relays, it should not send back to A).
-    msg.fromPeer.withValue(fromPeer):
-      g.peers.withValue(fromPeer, sourcePeer):
-        toSendPeers.excl(sourcePeer[])
+    g.peers.withValue(msg.fromPeer, sourcePeer):
+      toSendPeers.excl(sourcePeer[])
 
     proc isMsgInIdontWant(it: PubSubPeer): bool =
       for iDontWant in it.iDontWants:
         if saltedId in iDontWant:
           libp2p_gossipsub_idontwant_saved_messages.inc
           libp2p_gossipsub_saved_bytes.inc(
-            msg.data.get(@[]).len.int64, labelValues = ["idontwant"]
+            msg.data.len.int64, labelValues = ["idontwant"]
           )
           return true
       return false
@@ -578,8 +575,7 @@ proc validateAndRelay(
     toSendPeers.exclIfIt(isMsgInIdontWant(it))
 
     g.extensionsState.preambleBroadcastIfNotReceiving(
-      RPCMsg.withPreamble(topic, msgId, msg.data.get(@[]).len),
-      toSendPeers.mapIt(it.peerId),
+      RPCMsg.withPreamble(topic, msgId, msg.data.len), toSendPeers.mapIt(it.peerId)
     )
 
     # In theory, if topics are the same in all messages, we could batch - we'd
@@ -591,14 +587,14 @@ proc validateAndRelay(
       toSendPeers.len.int64, labelValues = [g.topicLabel(topic)]
     )
 
-    await handleData(g, topic, msg.data.get())
+    await handleData(g, topic, msg.data)
   except CancelledError:
     info "validateAndRelay cancelled"
   except PeerRateLimitError as exc:
     info "validateAndRelay failed", description = exc.msg
 
 proc dataAndTopicsIdSize(msgs: seq[Message]): int =
-  msgs.mapIt(it.data.get(@[]).len + it.topic.len).foldl(a + b, 0)
+  msgs.mapIt(it.data.len + it.topic.len).foldl(a + b, 0)
 
 proc messageOverhead(g: GossipSub, msg: RPCMsg, msgSize: int): int =
   # In this way we count even ignored fields by protobuf
@@ -697,20 +693,20 @@ method rpcHandler*(
         msgId = shortLog(msgId), peer
       continue
 
-    if (msg.signature.isSome or g.verifySignature) and not msg.verify():
+    if (msg.signature.len > 0 or g.verifySignature) and not msg.verify():
       debug "Dropping message due to failed signature verification", msg = msg
 
       await g.punishInvalidMessage(peer, msg)
       continue
 
-    if msg.seqno.isSome and msg.seqno.get().len != 8:
+    if msg.seqno.len > 0 and msg.seqno.len != 8:
       # if we have seqno should be 8 bytes long
       debug "Dropping message due to invalid seqno length",
         msgId = shortLog(msgId), peer
       await g.punishInvalidMessage(peer, msg)
       continue
 
-    g.extensionsState.preambleMsgReceived(peer.peerId, msgId, msg.data.get(@[]).len)
+    g.extensionsState.preambleMsgReceived(peer.peerId, msgId, msg.data.len)
 
     if g.addSeen(msgIdSalted):
       trace "Dropping already-seen message", msgId = shortLog(msgId), peer
@@ -923,12 +919,12 @@ method publish*(
     g.mcache.put(msgId, msg)
 
   if g.parameters.sendIDontWantOnPublish:
-    if not pubParams.skipIDontWant and isLargeMessage(msg.data.get().len, msgId):
+    if not pubParams.skipIDontWant and isLargeMessage(msg.data.len, msgId):
       g.sendIDontWant(topic, msgId, peers)
 
     if not pubParams.skipPreamble:
       g.extensionsState.preambleBroadcast(
-        RPCMsg.withPreamble(topic, msgId, msg.data.get().len), peers.mapIt(it.peerId)
+        RPCMsg.withPreamble(topic, msgId, msg.data.len), peers.mapIt(it.peerId)
       )
 
   g.broadcast(

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -133,9 +133,7 @@ proc handleGraft*(
 ): seq[ControlPrune] =
   var prunes: seq[ControlPrune]
   for graft in grafts:
-    let topic = graft.topicID.valueOr:
-      trace "topic not set: graft", peer
-      continue
+    let topic = graft.topicID
 
     trace "peer grafted topicID", peer, topic
 
@@ -148,10 +146,10 @@ proc handleGraft*(
       # and such an attempt should be logged and rejected with a PRUNE
       prunes.add(
         ControlPrune(
-          topicID: Opt.some(topic),
+          topicID: topic,
           peers: @[],
             # omitting heavy computation here as the remote did something illegal
-          backoff: Opt.some(g.parameters.pruneBackoff.seconds.uint64),
+          backoff: g.parameters.pruneBackoff.seconds.uint64,
         )
       )
 
@@ -177,10 +175,10 @@ proc handleGraft*(
       # and such an attempt should be logged and rejected with a PRUNE
       prunes.add(
         ControlPrune(
-          topicID: Opt.some(topic),
+          topicID: topic,
           peers: @[],
             # omitting heavy computation here as the remote did something illegal
-          backoff: Opt.some(g.parameters.pruneBackoff.seconds.uint64),
+          backoff: g.parameters.pruneBackoff.seconds.uint64,
         )
       )
 
@@ -215,9 +213,9 @@ proc handleGraft*(
           peer, topic, score = peer.score, mesh = g.mesh.peers(topic)
         prunes.add(
           ControlPrune(
-            topicID: Opt.some(topic),
+            topicID: topic,
             peers: g.peerExchangeList(topic),
-            backoff: Opt.some(g.parameters.pruneBackoff.seconds.uint64),
+            backoff: g.parameters.pruneBackoff.seconds.uint64,
           )
         )
 
@@ -253,9 +251,7 @@ proc getPeers(prune: ControlPrune, peer: PubSubPeer): seq[(PeerId, Opt[PeerRecor
 
 proc handlePrune*(g: GossipSub, peer: PubSubPeer, prunes: seq[ControlPrune]) =
   for prune in prunes:
-    let topic = prune.topicID.valueOr:
-      trace "topic not set: prune", peer
-      continue
+    let topic = prune.topicID
 
     trace "peer pruned topicID", peer, topic
 
@@ -268,11 +264,11 @@ proc handlePrune*(g: GossipSub, peer: PubSubPeer, prunes: seq[ControlPrune]) =
       continue
 
     # add peer backoff
-    if prune.backoff.isSome and prune.backoff.get() > 0:
+    if prune.backoff > 0:
       let
         # avoid overflows and clamp to reasonable value
         backoffSeconds =
-          clamp(prune.backoff.get() + BackoffSlackTime, 0'u64, 1.days.seconds.uint64)
+          clamp(prune.backoff + BackoffSlackTime, 0'u64, 1.days.seconds.uint64)
         backoff = Moment.fromNow(backoffSeconds.int64.seconds)
         current = g.backingOff.getOrDefault(topic).getOrDefault(peer.peerId)
       if backoff > current:
@@ -300,7 +296,8 @@ proc handleIHave*(
     trace "ihave: ignoring out of budget peer", peer, score = peer.score
   else:
     for ihave in ihaves:
-      let topic = ihave.topicID.valueOr:
+      let topic = ihave.topicID
+      if topic.len == 0:
         trace "topic not set: ihave", peer
         continue
       trace "peer sent ihave", peer, topicID = topic, msgs = ihave.messageIDs
@@ -677,7 +674,7 @@ proc makeGossipControlMessages*(g: GossipSub): Table[PubSubPeer, ControlMessage]
       midsSeq.setLen(IHaveMaxLength)
 
     let
-      ihave = ControlIHave(topicID: Opt.some(topic), messageIDs: midsSeq)
+      ihave = ControlIHave(topicID: topic, messageIDs: midsSeq)
       mesh = g.mesh.getOrDefault(topic)
       fanout = g.fanout.getOrDefault(topic)
       gossipPeers = mesh + fanout

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -344,7 +344,7 @@ proc punishInvalidMessage*(
     g: GossipSub, peer: PubSubPeer, msg: Message
 ) {.async: (raises: [PeerRateLimitError]).} =
   peer.overheadRateLimitOpt.withValue(overheadRateLimit):
-    let uselessAppBytesNum = msg.data.get(@[]).len
+    let uselessAppBytesNum = msg.data.len
     if not overheadRateLimit.tryConsume(uselessAppBytesNum):
       debug "Peer sent invalid message and it's above rate limit",
         peer, uselessAppBytesNum

--- a/libp2p/protocols/pubsub/rpc/message.nim
+++ b/libp2p/protocols/pubsub/rpc/message.nim
@@ -25,8 +25,8 @@ declareCounter(
 declareCounter(libp2p_pubsub_sig_verify_failure, "pubsub failed validated messages")
 
 func defaultMsgIdProvider*(m: Message): Result[MessageId, ValidationResult] =
-  if m.seqno.isSome and m.fromPeer.isSome:
-    let mid = byteutils.toHex(m.seqno.get()) & $m.fromPeer.get()
+  if m.seqno.len > 0 and m.fromPeer.data.len > 0:
+    let mid = byteutils.toHex(m.seqno) & $m.fromPeer
     ok mid.toBytes()
   else:
     err ValidationResult.Reject
@@ -36,16 +36,15 @@ proc sign*(msg: Message, privateKey: PrivateKey): CryptoResult[seq[byte]] =
 
 proc extractPublicKey(m: Message): Opt[PublicKey] =
   var pubkey: PublicKey
-  if m.fromPeer.isSome and m.fromPeer.get().hasPublicKey() and
-      m.fromPeer.get().extractPublicKey(pubkey):
+  if m.fromPeer.hasPublicKey() and m.fromPeer.extractPublicKey(pubkey):
     Opt.some(pubkey)
-  elif m.key.isSome and pubkey.init(m.key.get()):
+  elif m.key.len > 0 and pubkey.init(m.key):
     # check if peerId extracted from m.key is the same as m.fromPeer
     let derivedPeerId = PeerId.init(pubkey).valueOr:
       warn "could not derive peerId from key field"
       return Opt.none(PublicKey)
 
-    if m.fromPeer.isSome and derivedPeerId != m.fromPeer.get():
+    if derivedPeerId != m.fromPeer:
       warn "peerId derived from msg.key is not the same as msg.fromPeer",
         derivedPeerId = derivedPeerId, fromPeer = m.fromPeer
       return Opt.none(PublicKey)
@@ -55,17 +54,17 @@ proc extractPublicKey(m: Message): Opt[PublicKey] =
 
 proc verify*(m: Message): bool =
   var verified = false
-  if m.signature.isSome:
+  if m.signature.len > 0:
     var msg = m
-    msg.signature = Opt.none(seq[byte])
-    msg.key = Opt.none(seq[byte])
+    msg.signature = @[]
+    msg.key = @[]
 
     var remote: Signature
     let key = m.extractPublicKey().valueOr:
       warn "could not extract public key", msg = m
       return false
 
-    if remote.init(m.signature.get()):
+    if remote.init(m.signature):
       trace "verifying signature", remoteSignature = remote
       verified = remote.verify(PubSubPrefix & msg.encode(false), key)
 
@@ -86,18 +85,21 @@ proc init*(
   if sign and peer.isNone():
     doAssert(false, "Cannot sign message without peer info")
 
-  var msg = Message(data: Opt.some(move(data)), topic: topic)
+  var msg = Message(data: move(data), topic: topic)
 
   # order matters, we want to include seqno in the signature
   seqno.withValue(seqn):
-    msg.seqno = Opt.some(@(seqn.toBytesBE()))
+    msg.seqno = @(seqn.toBytesBE())
 
   peer.withValue(peer):
-    msg.fromPeer = Opt.some(peer.peerId)
+    msg.fromPeer = peer.peerId
     if sign:
-      msg.signature = sign(msg, peer.privateKey).toOpt()
-      msg.key =
-        peer.privateKey.getPublicKey().expect("Invalid private key!").getBytes().toOpt()
+      msg.signature = sign(msg, peer.privateKey).expect("Couldn't sign message!")
+      msg.key = peer.privateKey
+        .getPublicKey()
+        .expect("Invalid private key!")
+        .getBytes().valueOr:
+          @[]
 
   msg
 
@@ -108,9 +110,8 @@ proc init*(
     topic: string,
     seqno: Opt[uint64],
 ): Message {.gcsafe, raises: [].} =
-  var msg =
-    Message(fromPeer: Opt.some(peerId), data: Opt.some(move(data)), topic: topic)
+  var msg = Message(fromPeer: peerId, data: move(data), topic: topic)
 
   seqno.withValue(seqn):
-    msg.seqno = Opt.some(@(seqn.toBytesBE()))
+    msg.seqno = @(seqn.toBytesBE())
   msg

--- a/libp2p/protocols/pubsub/rpc/messages.nim
+++ b/libp2p/protocols/pubsub/rpc/messages.nim
@@ -52,12 +52,12 @@ type
     supportsSendingPartial* {.fieldNumber: 4.}: Opt[bool]
 
   Message* {.proto2.} = object
-    fromPeer* {.fieldNumber: 1, ext.}: Opt[PeerId]
-    data* {.fieldNumber: 2.}: Opt[seq[byte]]
-    seqno* {.fieldNumber: 3.}: Opt[seq[byte]]
+    fromPeer* {.fieldNumber: 1, ext, implicit.}: PeerId
+    data* {.fieldNumber: 2, implicit.}: seq[byte]
+    seqno* {.fieldNumber: 3, implicit.}: seq[byte]
     topic* {.fieldNumber: 4, required.}: string
-    signature* {.fieldNumber: 5.}: Opt[seq[byte]]
-    key* {.fieldNumber: 6.}: Opt[seq[byte]]
+    signature* {.fieldNumber: 5, implicit.}: seq[byte]
+    key* {.fieldNumber: 6, implicit.}: seq[byte]
 
   ControlExtensions* {.proto2.} = object
     partialMessageExtension* {.fieldNumber: 10.}: Opt[bool]
@@ -76,19 +76,19 @@ type
     extensions* {.fieldNumber: 6.}: Opt[ControlExtensions]
 
   ControlIHave* {.proto2.} = object
-    topicID* {.fieldNumber: 1.}: Opt[string]
+    topicID* {.fieldNumber: 1, implicit.}: string
     messageIDs* {.fieldNumber: 2.}: seq[MessageId]
 
   ControlIWant* {.proto2.} = object
     messageIDs* {.fieldNumber: 1.}: seq[MessageId]
 
   ControlGraft* {.proto2.} = object
-    topicID* {.fieldNumber: 1.}: Opt[string]
+    topicID* {.fieldNumber: 1, implicit.}: string
 
   ControlPrune* {.proto2.} = object
-    topicID* {.fieldNumber: 1.}: Opt[string]
+    topicID* {.fieldNumber: 1, implicit.}: string
     peers* {.fieldNumber: 2.}: seq[PeerInfoMsg]
-    backoff* {.fieldNumber: 3, pint.}: Opt[uint64]
+    backoff* {.fieldNumber: 3, pint, implicit.}: uint64
 
   TestExtensionRPC* {.proto2.} = object
 
@@ -384,12 +384,10 @@ proc withIDontWant*(_: typedesc[ControlMessage], msgId: MessageId): ControlMessa
 proc withIHave*(
     _: typedesc[ControlMessage], topicID: string, messageIDs: sink seq[MessageId]
 ): ControlMessage =
-  ControlMessage(
-    ihave: @[ControlIHave(topicID: Opt.some(topicID), messageIDs: move(messageIDs))]
-  )
+  ControlMessage(ihave: @[ControlIHave(topicID: topicID, messageIDs: move(messageIDs))])
 
 proc withGraft*(_: typedesc[ControlMessage], topicID: string): ControlMessage =
-  ControlMessage(graft: @[ControlGraft(topicID: Opt.some(topicID))])
+  ControlMessage(graft: @[ControlGraft(topicID: topicID)])
 
 proc withPrune*(
     _: typedesc[ControlMessage],
@@ -398,11 +396,7 @@ proc withPrune*(
     peers: sink seq[PeerInfoMsg],
 ): ControlMessage =
   ControlMessage(
-    prune: @[
-      ControlPrune(
-        topicID: Opt.some(topicID), peers: move(peers), backoff: Opt.some(backoff)
-      )
-    ]
+    prune: @[ControlPrune(topicID: topicID, peers: move(peers), backoff: backoff)]
   )
 
 proc withExtensions*(
@@ -485,10 +479,10 @@ func anonymize*(msg: RPCMsg, anonymize: bool): RPCMsg =
   if anonymize and msg.messages.len > 0:
     var anonMsg = msg
     for m in anonMsg.messages.mitems:
-      m.fromPeer = Opt.none(PeerId)
-      m.seqno = Opt.none(seq[byte])
-      m.signature = Opt.none(seq[byte])
-      m.key = Opt.none(seq[byte])
+      m.fromPeer = PeerId()
+      m.seqno = @[]
+      m.signature = @[]
+      m.key = @[]
     anonMsg
   else:
     msg

--- a/libp2p/protocols/pubsub/rpc/messages.nim
+++ b/libp2p/protocols/pubsub/rpc/messages.nim
@@ -51,13 +51,13 @@ type
     # When requestsPartial is true, this is assumed to be true.
     supportsSendingPartial* {.fieldNumber: 4.}: Opt[bool]
 
-  Message* {.proto2.} = object
-    fromPeer* {.fieldNumber: 1, ext, implicit.}: PeerId
-    data* {.fieldNumber: 2, implicit.}: seq[byte]
-    seqno* {.fieldNumber: 3, implicit.}: seq[byte]
+  Message* {.proto, implicit.} = object
+    fromPeer* {.fieldNumber: 1, ext.}: PeerId
+    data* {.fieldNumber: 2.}: seq[byte]
+    seqno* {.fieldNumber: 3.}: seq[byte]
     topic* {.fieldNumber: 4, required.}: string
-    signature* {.fieldNumber: 5, implicit.}: seq[byte]
-    key* {.fieldNumber: 6, implicit.}: seq[byte]
+    signature* {.fieldNumber: 5.}: seq[byte]
+    key* {.fieldNumber: 6.}: seq[byte]
 
   ControlExtensions* {.proto2.} = object
     partialMessageExtension* {.fieldNumber: 10.}: Opt[bool]
@@ -75,20 +75,20 @@ type
     idontwant* {.fieldNumber: 5.}: seq[ControlIWant]
     extensions* {.fieldNumber: 6.}: Opt[ControlExtensions]
 
-  ControlIHave* {.proto2.} = object
-    topicID* {.fieldNumber: 1, implicit.}: string
+  ControlIHave* {.proto, implicit.} = object
+    topicID* {.fieldNumber: 1.}: string
     messageIDs* {.fieldNumber: 2.}: seq[MessageId]
 
   ControlIWant* {.proto2.} = object
     messageIDs* {.fieldNumber: 1.}: seq[MessageId]
 
-  ControlGraft* {.proto2.} = object
-    topicID* {.fieldNumber: 1, implicit.}: string
+  ControlGraft* {.proto, implicit.} = object
+    topicID* {.fieldNumber: 1.}: string
 
-  ControlPrune* {.proto2.} = object
-    topicID* {.fieldNumber: 1, implicit.}: string
+  ControlPrune* {.proto, implicit.} = object
+    topicID* {.fieldNumber: 1.}: string
     peers* {.fieldNumber: 2.}: seq[PeerInfoMsg]
-    backoff* {.fieldNumber: 3, pint, implicit.}: uint64
+    backoff* {.fieldNumber: 3, pint.}: uint64
 
   TestExtensionRPC* {.proto2.} = object
 
@@ -496,4 +496,7 @@ func validate*(msg: RPCMsg): Result[void, string] =
   # validates RPCMsg after it is received and decoded.
   for sub in msg.subscriptions:
     ?sub.validate()
+  for message in msg.messages:
+    if message.topic.len == 0:
+      return err("Message topic must be set")
   ok()

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -27,8 +27,7 @@ proc encode*(msg: RPCMsg, anonymize: bool): seq[byte] =
 
 proc decodeRPCMessage(buf: seq[byte]): RPCMsg {.raises: [SerializationError].} =
   trackDecodeBytes(buf.len, RPCMsg, "gossipsub")
-  let msg = decode(Protobuf, buf, RPCMsg)
-  msg
+  decode(Protobuf, buf, RPCMsg)
 
 proc decode*(_: type RPCMsg, buf: seq[byte]): Result[RPCMsg, string] =
   try:

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -103,8 +103,8 @@
 
   protobuf_serialization = pkgs.fetchgit {
     url = "https://github.com/status-im/nim-protobuf-serialization";
-    rev = "8406e7287196661614ce6a8e8be20f755376af7f";
-    sha256 = "0lb4756a77vr1x1khy3dxl97kyxy7w09ap92ylkkgjp093dic59k";
+    rev = "764a698def8495f287b8cbff373b252acfcfbe18";
+    sha256 = "1idj01rrnw5j31wqflradb893v4xhbjakjz0qpr4r0lz3gxn4n6v";
     fetchSubmodules = true;
   };
 

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -102,9 +102,9 @@
   };
 
   protobuf_serialization = pkgs.fetchgit {
-    url = "https://github.com/status-im/nim-protobuf-serialization";
-    rev = "764a698def8495f287b8cbff373b252acfcfbe18";
-    sha256 = "1idj01rrnw5j31wqflradb893v4xhbjakjz0qpr4r0lz3gxn4n6v";
+    url = "https://github.com/nitely/nim-protobuf-serialization";
+    rev = "61949b84adfe05e2ce0afd25596c73b753048e7e";
+    sha256 = "08mgriagg20915v9sbxzib4palfl8jm1gvdirmxcn6wd1yc7ip80";
     fetchSubmodules = true;
   };
 

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -102,9 +102,9 @@
   };
 
   protobuf_serialization = pkgs.fetchgit {
-    url = "https://github.com/nitely/nim-protobuf-serialization";
-    rev = "61949b84adfe05e2ce0afd25596c73b753048e7e";
-    sha256 = "08mgriagg20915v9sbxzib4palfl8jm1gvdirmxcn6wd1yc7ip80";
+    url = "https://github.com/status-im/nim-protobuf-serialization";
+    rev = "7861570c5182bd69f6b7c151028ffd5d0134b9ab";
+    sha256 = "07c2d5853k26rjqsrg4vq0kv0i5brzlbh0pj3v0qw0h929y5m54z";
     fetchSubmodules = true;
   };
 

--- a/nix/libp2p.lock
+++ b/nix/libp2p.lock
@@ -195,9 +195,9 @@
       }
     },
     "protobuf_serialization": {
-      "version": "#proto2-ext-plain-optional",
-      "vcsRevision": "764a698def8495f287b8cbff373b252acfcfbe18",
-      "url": "https://github.com/status-im/nim-protobuf-serialization",
+      "version": "#proto_editions",
+      "vcsRevision": "61949b84adfe05e2ce0afd25596c73b753048e7e",
+      "url": "https://github.com/nitely/nim-protobuf-serialization",
       "downloadMethod": "git",
       "dependencies": [
         "nim",
@@ -208,7 +208,7 @@
         "unittest2"
       ],
       "checksums": {
-        "sha1": "df8ac63eab114e9abf704163084895d18b0a402b"
+        "sha1": "3440e6f435f4b6468e83f48d32d7a2b83106b542"
       }
     },
     "json_serialization": {

--- a/nix/libp2p.lock
+++ b/nix/libp2p.lock
@@ -195,8 +195,8 @@
       }
     },
     "protobuf_serialization": {
-      "version": "0.5.3",
-      "vcsRevision": "8406e7287196661614ce6a8e8be20f755376af7f",
+      "version": "#proto2-ext-plain-optional",
+      "vcsRevision": "764a698def8495f287b8cbff373b252acfcfbe18",
       "url": "https://github.com/status-im/nim-protobuf-serialization",
       "downloadMethod": "git",
       "dependencies": [
@@ -208,7 +208,7 @@
         "unittest2"
       ],
       "checksums": {
-        "sha1": "3307412f9755f7ec2079e12cf036fc103aa130b0"
+        "sha1": "df8ac63eab114e9abf704163084895d18b0a402b"
       }
     },
     "json_serialization": {

--- a/nix/libp2p.lock
+++ b/nix/libp2p.lock
@@ -195,9 +195,9 @@
       }
     },
     "protobuf_serialization": {
-      "version": "#proto_editions",
-      "vcsRevision": "61949b84adfe05e2ce0afd25596c73b753048e7e",
-      "url": "https://github.com/nitely/nim-protobuf-serialization",
+      "version": "0.6.0",
+      "vcsRevision": "7861570c5182bd69f6b7c151028ffd5d0134b9ab",
+      "url": "https://github.com/status-im/nim-protobuf-serialization",
       "downloadMethod": "git",
       "dependencies": [
         "nim",
@@ -208,7 +208,7 @@
         "unittest2"
       ],
       "checksums": {
-        "sha1": "3440e6f435f4b6468e83f48d32d7a2b83106b542"
+        "sha1": "42d1fcecc4efff1319378c52b582dc1591b79221"
       }
     },
     "json_serialization": {

--- a/tests/interop/gossipsub/test_gossipsub.nim
+++ b/tests/interop/gossipsub/test_gossipsub.nim
@@ -33,7 +33,7 @@ suite "GossipSub Interop":
     var data = newSeq[byte](1024)
     # Message ID 42: big-endian encoding
     data[7] = 42
-    let msg = Message(data: Opt.some(data), topic: "foobar")
+    let msg = Message(data: data, topic: "foobar")
     let res = interopMsgIdProvider(msg)
     check:
       res.isOk

--- a/tests/interop/gossipsub/test_runner.nim
+++ b/tests/interop/gossipsub/test_runner.nim
@@ -296,7 +296,7 @@ suite "GossipSub Interop - Script runner - Component":
     var data = newSeq[byte](sizeof(uint64))
     data[0 ..< sizeof(uint64)] = toBytesBE(123'u64)
 
-    let duplicateRpc = RPCMsg.withMessages(Message(topic: topic, data: Opt.some(data)))
+    let duplicateRpc = RPCMsg.withMessages(Message(topic: topic, data: data))
     let peer = sender.peers[receiver.node.peerInfo.peerId]
 
     sender.broadcast(@[peer], duplicateRpc, MessagePriority.High)

--- a/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
@@ -427,7 +427,7 @@ suite "GossipSub Component - Scoring":
         topic: string, message: Message
     ): Future[ValidationResult] {.async.} =
       validatedMessageCount.inc
-      if string.fromBytes(message.data.get()).contains("invalid"):
+      if string.fromBytes(message.data).contains("invalid"):
         return ValidationResult.Reject # reject invalid messages
       else:
         return ValidationResult.Accept

--- a/tests/libp2p/pubsub/component/test_gossipsub_signature_flags.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_signature_flags.nim
@@ -39,10 +39,10 @@ suite "GossipSub Component - Signature Flags":
     let rm = receivedMessages[][0]
     check:
       rm.data == testData
-      rm.fromPeer.isSome
-      rm.seqno.isSome and rm.seqno.get().len > 0
-      rm.signature.isSome and rm.signature.get().len > 0
-      rm.key.isSome and rm.key.get().len > 0
+      rm.fromPeer.data.len > 0
+      rm.seqno.len > 0
+      rm.signature.len > 0
+      rm.key.len > 0
 
   asyncTest "Sign flag - messages are not signed when sign=false":
     let nodes = generateNodes(
@@ -66,9 +66,9 @@ suite "GossipSub Component - Signature Flags":
 
     let rm = receivedMessages[][0]
     check:
-      rm.data.get() == testData
-      rm.signature.isNone
-      rm.key.isNone
+      rm.data == testData
+      rm.signature.len == 0
+      rm.key.len == 0
 
   asyncTest "Anonymize flag - messages are anonymous when anonymize=true":
     let nodes = generateNodes(
@@ -92,11 +92,11 @@ suite "GossipSub Component - Signature Flags":
 
     let rm = receivedMessages[][0]
     check:
-      rm.data.get() == testData
-      rm.fromPeer.isNone
-      rm.seqno.isNone
-      rm.signature.isNone
-      rm.key.isNone
+      rm.data == testData
+      rm.fromPeer.data.len == 0
+      rm.seqno.len == 0
+      rm.signature.len == 0
+      rm.key.len == 0
 
   type NodeConfig = object
     sign: bool

--- a/tests/libp2p/pubsub/test_message.nim
+++ b/tests/libp2p/pubsub/test_message.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import chronos, strutils, stew/byteutils, results
+import chronos, strutils, stew/byteutils, results, nimcrypto/sha2
 import
   ../../../libp2p/[
     peerid,
@@ -79,7 +79,7 @@ suite "Message":
       peer = PeerInfo.new(seckey)
 
     var msg = Message.init(Opt.some(peer), @[], topic, Opt.some(seqno), sign = true)
-    msg.fromPeer = Opt.none(PeerId)
+    msg.fromPeer = PeerId()
     let msgIdResult = msg.defaultMsgIdProvider()
 
     check:
@@ -174,6 +174,79 @@ suite "Message":
     )
     check byteSize(rpcMsg) == 30 + 32 + 38 + 4 + 4 # Total: 108 bytes
 
+  test "downstream-compatible public pubsub fields":
+    let
+      peerId = PeerId(data: @[1'u8, 2, 3])
+      message = Message(data: @[4'u8, 5, 6], topic: topic, fromPeer: peerId)
+      digest = sha256.digest(message.data)
+      ihave = ControlIHave(topicID: topic, messageIDs: @[])
+      graft = ControlGraft(topicID: topic)
+      prune = ControlPrune(topicID: topic, backoff: 10.uint64)
+
+    proc validator(message: Message): ValidationResult =
+      if message.fromPeer == peerId and message.data.len > 0:
+        ValidationResult.Accept
+      else:
+        ValidationResult.Reject
+
+    proc observe(
+        ihave: ControlIHave, graft: ControlGraft, prune: ControlPrune
+    ): string =
+      ihave.topicID & graft.topicID & prune.topicID & $prune.backoff
+
+    check:
+      message.topic == topic
+      message.data == @[4'u8, 5, 6]
+      digest.data.len == sha256.sizeDigest
+      validator(message) == ValidationResult.Accept
+      observe(ihave, graft, prune) == topic & topic & topic & "10"
+
+  test "Message decode defaults absent restored wire fields":
+    let encoded: seq[byte] = @[34, 6, 102, 111, 111, 98, 97, 114]
+    let message = Message.decode(encoded).get()
+
+    check:
+      message.topic == topic
+      message.data == @[]
+      message.fromPeer == PeerId()
+      message.seqno == @[]
+      message.signature == @[]
+      message.key == @[]
+
+  test "RPCMsg decode defaults absent restored wire fields":
+    let
+      encodedMessage: seq[byte] = @[18, 8, 34, 6, 102, 111, 111, 98, 97, 114]
+      messageRpc = RPCMsg.decode(encodedMessage).get()
+      encodedIHave: seq[byte] = @[26, 2, 10, 0]
+      ihaveRpc = RPCMsg.decode(encodedIHave).get()
+      encodedGraft: seq[byte] = @[26, 2, 26, 0]
+      graftRpc = RPCMsg.decode(encodedGraft).get()
+      encodedPrune: seq[byte] = @[26, 2, 34, 0]
+      pruneRpc = RPCMsg.decode(encodedPrune).get()
+
+    check:
+      messageRpc.messages.len == 1
+      messageRpc.messages[0].topic == topic
+      messageRpc.messages[0].data == @[]
+      messageRpc.messages[0].fromPeer == PeerId()
+      ihaveRpc.control.isSome
+      ihaveRpc.control.get().ihave.len == 1
+      ihaveRpc.control.get().ihave[0].topicID == ""
+      ihaveRpc.control.get().ihave[0].messageIDs.len == 0
+      graftRpc.control.isSome
+      graftRpc.control.get().graft.len == 1
+      graftRpc.control.get().graft[0].topicID == ""
+      pruneRpc.control.isSome
+      pruneRpc.control.get().prune.len == 1
+      pruneRpc.control.get().prune[0].topicID == ""
+      pruneRpc.control.get().prune[0].backoff == 0
+
+  test "Message decode still requires topic":
+    check Message.decode(@[]).isErr
+
+  test "RPCMsg decode still requires nested Message topic":
+    check RPCMsg.decode(@[18.byte, 0]).isErr
+
   # check correctly parsed ihave/iwant/graft/prune/idontwant messages
   # check value before & after decoding equal using protoc cmd tool for reference
   asyncTest "RPCMsg:ControlMessage - encoding and decoding":
@@ -221,10 +294,10 @@ suite "Message":
     check:
       anon.data == msg.data
       anon.topic == msg.topic
-      anon.fromPeer.isNone
-      anon.seqno.isNone
-      anon.signature.isNone
-      anon.key.isNone
+      anon.fromPeer.data.len == 0
+      anon.seqno.len == 0
+      anon.signature.len == 0
+      anon.key.len == 0
 
   test "anonymize Message - anonymize=false returns message unchanged":
     let peer = PeerInfo.new(PrivateKey.random(ECDSA, rng()).get())
@@ -249,10 +322,10 @@ suite "Message":
     let anon = rpc.anonymize(true)
     for m in anon.messages:
       check:
-        m.fromPeer.isNone
-        m.seqno.isNone
-        m.signature.isNone
-        m.key.isNone
+        m.fromPeer.data.len == 0
+        m.seqno.len == 0
+        m.signature.len == 0
+        m.key.len == 0
     check:
       anon.messages[0].data == msg1.data
       anon.messages[1].data == msg2.data

--- a/tests/libp2p/pubsub/utils.nim
+++ b/tests/libp2p/pubsub/utils.nim
@@ -161,8 +161,8 @@ proc teardownGossipSub*(gossipSub: TestGossipSub, conns: seq[Stream]) {.async.} 
 
 func defaultMsgIdProvider*(m: Message): Result[MessageId, ValidationResult] =
   let mid =
-    if m.seqno.isSome and m.fromPeer.isSome:
-      byteutils.toHex(m.seqno.get()) & $m.fromPeer.get()
+    if m.seqno.len > 0 and m.fromPeer.data.len > 0:
+      byteutils.toHex(m.seqno) & $m.fromPeer
     else:
       # This part is irrelevant because it's not standard,
       # We use it exclusively for testing basically and users should


### PR DESCRIPTION
## Summary

This PR updates the pubsub protobuf-ser migration from the temporary proto2 implicit-field branch to the proto editions implementation from status-im/nim-protobuf-serialization#109.

It keeps the intent of #2893: avoid exposing protobuf presence as `Opt` on hot-path public pubsub fields when absence has no API meaning. The restored plain fields now use proto editions with implicit field presence.

`Message.topic` remains semantically required. Since the current protobuf-ser #109 branch still accepts an empty nested message during raw `RPCMsg` decode, `RPCMsg.validate()` now rejects decoded publish messages with an empty topic.


> [!WARNING]
> Should be merged after https://github.com/status-im/nim-protobuf-serialization/pull/109 and a new tag is released containing that PR


## Affected Areas

- [x] Gossipsub / Pubsub RPC message encoding and decoding
- [x] Protocol Logic
- [x] Build / Tooling

## Impact on Library Users

The public pubsub RPC field shapes preserved by #2893 remain plain values instead of `Opt`, including:

- `Message.fromPeer`
- `Message.data`
- `Message.seqno`
- `Message.signature`
- `Message.key`
- `ControlIHave.topicID`
- `ControlGraft.topicID`
- `ControlPrune.topicID`
- `ControlPrune.backoff`

Absent protobuf fields for these values decode to Nim defaults. Default values are omitted when encoding.

Invalid decoded publish messages with an empty topic are rejected by `RPCMsg.decode()` validation.

## Risk Assessment

The main risk is the temporary dependency on the protobuf-ser #109 branch from `nitely/nim-protobuf-serialization` until that work lands upstream.

The explicit `RPCMsg.validate()` topic check preserves the required topic invariant for nested messages even though raw protobuf-ser decode currently accepts empty nested objects.

## References

- https://github.com/vacp2p/nim-libp2p/pull/2638#issuecomment-5102949032
- https://github.com/vacp2p/nim-libp2p/pull/2893
- https://github.com/status-im/nim-protobuf-serialization/pull/108
- https://github.com/status-im/nim-protobuf-serialization/pull/109
- https://github.com/libp2p/specs/tree/master/pubsub#the-message
