### PR TITLE
chore(kad): reuse per-peer streams instead of dialing a fresh stream per RPC

### DIFF
--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -151,7 +151,12 @@ proc maintainBuckets(kad: KadDHT) {.async: (raises: [CancelledError]).} =
     )
 
 proc initKadBase*(
-    kad: KadDHT, switch: Switch, config: KadDHTConfig, rng: Rng, isServer: bool
+    kad: KadDHT,
+    switch: Switch,
+    config: KadDHTConfig,
+    rng: Rng,
+    isServer: bool,
+    codec: string,
 ) {.raises: [].} =
   ## Set the shared fields in one place, so a new base field cannot miss a constructor.
   kad.rng = rng
@@ -171,6 +176,8 @@ proc initKadBase*(
   kad.rpcSem = newAsyncSemaphore(config.limits.maxConcurrentRpcs)
   kad.probeSem = newAsyncSemaphore(config.limits.maxConcurrentProbes)
   kad.isServer = isServer
+  kad.codec = codec
+  kad.msgSender = MessageSender.new(switch, codec, MaxMsgSize)
 
 # K instead of T to avoid clashing with the T type param in withValue[T] when
 # called inside a withValue block, which causes a compiler error under --lineDir:on
@@ -184,12 +191,10 @@ proc new*(
     codec: string = KadCodec,
 ): K {.raises: [].} =
   let kad = K()
-  kad.initKadBase(switch, config, rng, isServer)
+  kad.initKadBase(switch, config, rng, isServer, codec)
 
   # Fill up buckets with initial bootstrap nodes
   kad.updatePeers(bootstrapNodes)
-
-  kad.codec = codec
 
   kad.handler = proc(
       stream: Stream, proto: string
@@ -269,6 +274,7 @@ method start*(kad: KadDHT) {.async: (raises: [CancelledError]).} =
     return
 
   kad.stopping = false
+  kad.msgSender.start()
 
   if not kad.config.disableBootstrapping:
     discard
@@ -311,3 +317,6 @@ method stop*(kad: KadDHT) {.async: (raises: []).} =
   # Optimistic provide returns before its ADD_PROVIDER RPCs finish.
   let provideTasks = move kad.provideTasks
   await noCancel provideTasks.cancelAndWait()
+
+  # After the drain: nothing is left to reuse a stream, and `stop` refuses new ones.
+  await kad.msgSender.stop()

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -6,7 +6,7 @@ import chronos, chronicles, results
 import ../../[peerid, peerinfo, switch, multihash, peeraddrpolicy, wire]
 import ../protocol
 import ../../utils/future
-import ./[routing_table, protobuf, types, kademlia_metrics]
+import ./[routing_table, protobuf, types, rpc, kademlia_metrics]
 
 logScope:
   topics = "kad-dht find"
@@ -176,54 +176,10 @@ proc dispatchFindNode*(
     target: Key,
     addrs: Opt[seq[MultiAddress]] = Opt.none(seq[MultiAddress]),
 ): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
-  withRpcSlot(kad)
-  let addrs = addrs.valueOr(kad.switch.peerStore[AddressBook][peer])
-  # Shield the dial from cancellation: interrupting switch.dial mid-handshake
-  # leaks the half-opened channel, since the reset defer below is not yet armed.
-  # Letting the dial settle first means a racing cancel unwinds through that
-  # defer instead, which resets the stream.
-  let streamRes = catch:
-    await noCancel kad.switch.dial(peer, addrs, kad.codec)
-  if streamRes.isErr:
-    return err(streamRes.error.msg)
-  let stream = streamRes.value()
-  var replyRead = false
-  defer:
-    # Closing only half-closes the channel: an abandoned RPC leaves its unread
-    # reply in the read buffer, which blocks the muxer for every other channel
-    # on that connection. Only a reset drops it.
-    if replyRead:
-      await noCancel stream.close()
-    else:
-      await noCancel stream.reset()
-
   let msg = Message(msgType: Opt.some(MessageType.findNode), key: Opt.some(target))
-  let encoded = msg.encode(kad.config.hideConnectionStatus)
-
-  kad_messages_sent.inc(labelValues = [$MessageType.findNode])
-  kad_message_bytes_sent.inc(encoded.len.int64, labelValues = [$MessageType.findNode])
-
-  var replyBuf: seq[byte]
-  var ioRes: Result[void, ref CatchableError]
-  kad_message_duration_ms.time(labelValues = [$MessageType.findNode]):
-    ioRes = catch:
-      await stream.writeLp(encoded)
-      replyBuf = await stream.readLp(MaxMsgSize)
-  if ioRes.isErr:
-    return err(ioRes.error.msg)
-  replyRead = true
-
-  kad_message_bytes_received.inc(
-    replyBuf.len.int64, labelValues = [$MessageType.findNode]
+  await kad.dispatchRpc(
+    peer, addrs.valueOr(kad.switch.peerStore[AddressBook][peer]), msg
   )
-
-  let reply = Message.decode(replyBuf).valueOr:
-    return err("FindNode reply decode fail")
-
-  if reply.closerPeers.len > 0:
-    kad_responses_with_closer_peers.inc(labelValues = [$MessageType.findNode])
-
-  return ok(reply)
 
 type
   Ipv4Address = array[4, byte]

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -177,9 +177,7 @@ proc dispatchFindNode*(
     addrs: Opt[seq[MultiAddress]] = Opt.none(seq[MultiAddress]),
 ): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
   let msg = Message(msgType: Opt.some(MessageType.findNode), key: Opt.some(target))
-  await kad.dispatchRpc(
-    peer, addrs.valueOr(kad.switch.peerStore[AddressBook][peer]), msg
-  )
+  await kad.dispatchRpc(peer, msg, addrs)
 
 type
   Ipv4Address = array[4, byte]

--- a/libp2p/protocols/kademlia/get.nim
+++ b/libp2p/protocols/kademlia/get.nim
@@ -6,7 +6,7 @@ import chronos, chronicles, results
 import ../../[peerid, switch, multihash]
 import ../../utils/future
 import ../protocol
-import ./[protobuf, types, find, put, kademlia_metrics]
+import ./[protobuf, types, find, put, rpc, kademlia_metrics]
 
 logScope:
   topics = "kad-dht get"
@@ -14,43 +14,8 @@ logScope:
 proc dispatchGetVal*(
     kad: KadDHT, peer: PeerId, key: Key
 ): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
-  withRpcSlot(kad)
-  let streamRes = catch:
-    await noCancel kad.switch.dial(
-      peer, kad.switch.peerStore[AddressBook][peer], kad.codec
-    )
-  if streamRes.isErr:
-    return err(streamRes.error.msg)
-  let stream = streamRes.value()
-  defer:
-    await noCancel stream.close()
-
   let msg = Message(msgType: Opt.some(MessageType.getValue), key: Opt.some(key))
-  let encoded = msg.encode(kad.config.hideConnectionStatus)
-
-  kad_messages_sent.inc(labelValues = [$MessageType.getValue])
-  kad_message_bytes_sent.inc(encoded.len.int64, labelValues = [$MessageType.getValue])
-
-  var replyBuf: seq[byte]
-  var ioRes: Result[void, ref CatchableError]
-  kad_message_duration_ms.time(labelValues = [$MessageType.getValue]):
-    ioRes = catch:
-      await stream.writeLp(encoded)
-      replyBuf = await stream.readLp(MaxMsgSize)
-  if ioRes.isErr:
-    return err(ioRes.error.msg)
-
-  kad_message_bytes_received.inc(
-    replyBuf.len.int64, labelValues = [$MessageType.getValue]
-  )
-
-  let reply = Message.decode(replyBuf).valueOr:
-    return err("GetValue reply decode fail")
-
-  if reply.closerPeers.len > 0:
-    kad_responses_with_closer_peers.inc(labelValues = [$MessageType.getValue])
-
-  return ok(reply)
+  await kad.dispatchRpc(peer, kad.switch.peerStore[AddressBook][peer], msg)
 
 proc bestValidRecord(
     kad: KadDHT, key: Key, received: ReceivedTable, quorum: int

--- a/libp2p/protocols/kademlia/get.nim
+++ b/libp2p/protocols/kademlia/get.nim
@@ -15,7 +15,7 @@ proc dispatchGetVal*(
     kad: KadDHT, peer: PeerId, key: Key
 ): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
   let msg = Message(msgType: Opt.some(MessageType.getValue), key: Opt.some(key))
-  await kad.dispatchRpc(peer, kad.switch.peerStore[AddressBook][peer], msg)
+  await kad.dispatchRpc(peer, msg)
 
 proc bestValidRecord(
     kad: KadDHT, key: Key, received: ReceivedTable, quorum: int

--- a/libp2p/protocols/kademlia/kademlia_metrics.nim
+++ b/libp2p/protocols/kademlia/kademlia_metrics.nim
@@ -19,6 +19,12 @@ declarePublicHistogram kad_message_duration_ms,
 declarePublicCounter kad_responses_with_closer_peers,
   "responses with closer peers", ["type"]
 
+# Outbound stream reuse metrics
+declarePublicCounter kad_streams_opened, "outbound RPC streams opened"
+declarePublicCounter kad_stream_reuses, "outbound RPCs sent on an already open stream"
+declarePublicCounter kad_stream_reuse_failures,
+  "reused outbound streams that failed and were retried on a fresh stream"
+
 # Lookup metrics
 declarePublicCounter kad_lookup_followups,
   "iterative lookups that entered the k-closest follow-up phase"

--- a/libp2p/protocols/kademlia/message_sender.nim
+++ b/libp2p/protocols/kademlia/message_sender.nim
@@ -272,8 +272,19 @@ proc send(
   # deadline, and the retry the caller sends next would spend its whole budget
   # waiting for the stream, never reaching the peer.
   let deadline = Moment.now() + timeout
-  if not await ps.lock.acquire().withTimeout(timeout):
-    return err(SendError.init(dialStage, "timed out waiting for the peer's stream"))
+  # `withTimeout` on an `acquire` can drop the wait at the instant chronos hands
+  # the lock off, leaving it held with no owner. Release it if the acquire won
+  # that race, so a cancelled or timed-out wait never leaks the peer's lock.
+  let acquireFut = ps.lock.acquire()
+  try:
+    if not await acquireFut.withTimeout(timeout):
+      if acquireFut.completed():
+        ps.releaseLock()
+      return err(SendError.init(dialStage, "timed out waiting for the peer's stream"))
+  except CancelledError as e:
+    if acquireFut.completed():
+      ps.releaseLock()
+    raise e
   defer:
     ps.releaseLock()
 

--- a/libp2p/protocols/kademlia/message_sender.nim
+++ b/libp2p/protocols/kademlia/message_sender.nim
@@ -14,6 +14,7 @@ import std/tables
 import chronos, chronicles, results
 import ../../[peerid, switch]
 import ../../stream/connection
+import ../../utils/future
 import ./kademlia_metrics
 
 export results
@@ -55,6 +56,8 @@ type
     maxMsgSize: int
     maxReuseFailures: int
     senders: Table[PeerId, PeerMessageSender]
+    cleanups: seq[Future[void]]
+      ## Streams given up outside an RPC's own turn: `stop` waits for them.
     stopped: bool
 
   PreparedStream = tuple[stream: Stream, reused: bool]
@@ -81,17 +84,26 @@ proc discardStream(
     ps.stream = nil
   await stream.reset()
 
-proc retireStream(
-    ps: PeerMessageSender, stream: Stream, deadline: Moment
-) {.async: (raises: []), gcsafe.} =
+proc retireStream(stream: Stream, deadline: Moment) {.async: (raises: []), gcsafe.} =
   ## Close rather than reset, so a message written just before still reaches the
   ## remote, then wait for the remote's EOF so nothing stays buffered on the
   ## muxer. A remote that never answers the close gets a reset instead of an
   ## unbounded wait.
-  if ps.stream == stream:
-    ps.stream = nil
   if not await noCancel stream.closeWithEOF().withTimeout(deadline.timeLeft()):
     await stream.reset()
+
+proc trackCleanup(ms: MessageSender, fut: Future[void]) {.raises: [].} =
+  ms.cleanups.trackFut(fut)
+
+proc retire(
+    ms: MessageSender, ps: PeerMessageSender, stream: Stream, timeout: Duration
+) {.raises: [].} =
+  ## Give the stream up in the background. Retiring it in place would make the
+  ## next RPC to this peer wait for the remote's EOF before it even starts, and
+  ## a batch of one-way messages would then go out one round trip at a time.
+  if ps.stream == stream:
+    ps.stream = nil
+  ms.trackCleanup(retireStream(stream, Moment.now() + timeout))
 
 proc dropPeer*(ms: MessageSender, peerId: PeerId) {.async: (raises: []), gcsafe.} =
   ## Forget a peer's stream. The RPC holding it, if any, fails on its next
@@ -106,12 +118,17 @@ proc dropPeer*(ms: MessageSender, peerId: PeerId) {.async: (raises: []), gcsafe.
     await stream.reset()
 
 proc start*(ms: MessageSender) {.raises: [].} =
+  ## `new` already registered the handler, so only a restart re-registers it.
+  if not ms.stopped:
+    return
   ms.stopped = false
   ms.switch.addConnEventHandler(ms.onDisconnect, ConnEventKind.Disconnected)
 
 proc stop*(ms: MessageSender) {.async: (raises: []), gcsafe.} =
   ## Reject further sends, take the disconnect handler back off the switch and
   ## reset every open stream. `start` reopens it.
+  if ms.stopped:
+    return
   ms.stopped = true
   ms.switch.removeConnEventHandler(ms.onDisconnect, ConnEventKind.Disconnected)
   let senders = move ms.senders
@@ -120,6 +137,10 @@ proc stop*(ms: MessageSender) {.async: (raises: []), gcsafe.} =
     let stream = move ps.stream
     if not stream.isNil():
       await stream.reset()
+
+  # Streams given up outside an RPC's turn close on their own budget; leaving
+  # them behind would outlive the sender and trip the stream trackers.
+  await noCancel allFutures(move ms.cleanups)
 
 proc new*(
     T: typedesc[MessageSender],
@@ -135,10 +156,13 @@ proc new*(
     maxReuseFailures: maxReuseFailures,
   )
   # A dead connection takes its streams with it; drop the entry so the table
-  # stays bounded by the number of connected peers.
+  # stays bounded by the number of connected peers. A peer can hold more than
+  # one connection, and the stream on the surviving one is still good.
   ms.onDisconnect = proc(
       peerId: PeerId, event: ConnEvent
   ) {.async: (raises: [CancelledError]).} =
+    if ms.switch.isConnected(peerId):
+      return
     await ms.dropPeer(peerId)
 
   switch.addConnEventHandler(ms.onDisconnect, ConnEventKind.Disconnected)
@@ -161,6 +185,16 @@ proc releaseLock(ps: PeerMessageSender) {.raises: [].} =
     ps.lock.release()
   except AsyncLockError as e:
     raiseAssert "peer message sender lock released without acquire: " & e.msg
+
+proc dropLateDial(dialFut: Future[Stream]) {.async: (raises: []), gcsafe.} =
+  ## Wait out a dial we stopped waiting for and reset what it opened.
+  ## Cancelling it instead would close the connection the dialer reused, which
+  ## takes down every other stream the peer holds on it.
+  try:
+    let stream = await noCancel dialFut
+    await stream.reset()
+  except CatchableError:
+    discard
 
 proc prepStream(
     ms: MessageSender,
@@ -185,21 +219,21 @@ proc prepStream(
   if timeLeft.isZero():
     return err(SendError.init(dialStage, "timed out before dialing"))
 
-  # `Dialer.dial` closes whatever it opened when the dial is cancelled, so
-  # neither the timeout nor a cancellation leaves a half-opened channel behind.
   let dialFut = ms.switch.dial(peerId, addrs, ms.codec)
+  let shielded = noCancel dialFut
   let dialed =
     try:
-      await dialFut.withTimeout(timeLeft)
+      await shielded.withTimeout(timeLeft)
     except CancelledError as e:
-      await noCancel dialFut.cancelAndWait()
+      ms.trackCleanup(dropLateDial(dialFut))
       raise e
   if not dialed:
+    ms.trackCleanup(dropLateDial(dialFut))
     return err(SendError.init(dialStage, "timed out dialing the peer"))
 
   let stream =
     try:
-      await dialFut
+      await shielded
     except DialFailedError as e:
       return err(SendError.init(dialStage, e.msg))
 
@@ -220,8 +254,25 @@ proc exchange(
     deadline: Moment,
     awaitReply: bool,
 ): Future[Result[seq[byte], SendError]] {.async: (raises: [CancelledError]), gcsafe.} =
+  # A write that outruns the deadline leaves a half-written frame on the stream,
+  # so the caller resets it rather than handing it to the next RPC.
+  let writeLeft = deadline.timeLeft()
+  if writeLeft.isZero():
+    return err(SendError.init(writeStage, "timed out before writing"))
+
+  let writeFut = stream.writeLp(payload)
+  let written =
+    try:
+      await writeFut.withTimeout(writeLeft)
+    except CancelledError as e:
+      await noCancel writeFut.cancelAndWait()
+      raise e
+  if not written:
+    await noCancel writeFut.cancelAndWait()
+    return err(SendError.init(writeStage, "timed out writing"))
+
   try:
-    await stream.writeLp(payload)
+    await writeFut
   except LPStreamError as e:
     return err(SendError.init(writeStage, e.msg))
 
@@ -315,7 +366,7 @@ proc send(
     # nothing back may have left a reply buffered that would desync the next
     # RPC, and a peer that keeps breaking reuse is served one stream per RPC.
     if not awaitReply or ps.reuseFailures >= ms.maxReuseFailures:
-      await ps.retireStream(stream, deadline)
+      ms.retire(ps, stream, timeout)
     return sendRes
 
 proc sendRequest*(

--- a/libp2p/protocols/kademlia/message_sender.nim
+++ b/libp2p/protocols/kademlia/message_sender.nim
@@ -40,7 +40,6 @@ type
     msg*: string
 
   PeerMessageSender = ref object
-    peerId: PeerId
     lock: AsyncLock ## serializes the RPCs sharing `stream`
     stream: Stream ## nil while no stream is open
     users: int ## RPCs holding or waiting for `lock`
@@ -51,6 +50,7 @@ type
 
   MessageSender* = ref object
     switch: Switch
+    onDisconnect: ConnEventHandler
     codec: string
     maxMsgSize: int
     maxReuseFailures: int
@@ -59,7 +59,9 @@ type
 
   PreparedStream = tuple[stream: Stream, reused: bool]
 
-func sendError(stage: SendStage, msg: string): SendError {.raises: [].} =
+func init(
+    T: typedesc[SendError], stage: SendStage, msg: string
+): SendError {.raises: [].} =
   SendError(stage: stage, msg: msg)
 
 func `$`*(e: SendError): string {.raises: [].} =
@@ -80,12 +82,16 @@ proc discardStream(
   await stream.reset()
 
 proc retireStream(
-    ps: PeerMessageSender, stream: Stream
+    ps: PeerMessageSender, stream: Stream, deadline: Moment
 ) {.async: (raises: []), gcsafe.} =
-  ## Give up a stream whose reply was fully read, leaving nothing buffered.
+  ## Close rather than reset, so a message written just before still reaches the
+  ## remote, then wait for the remote's EOF so nothing stays buffered on the
+  ## muxer. A remote that never answers the close gets a reset instead of an
+  ## unbounded wait.
   if ps.stream == stream:
     ps.stream = nil
-  await stream.close()
+  if not await noCancel stream.closeWithEOF().withTimeout(deadline.timeLeft()):
+    await stream.reset()
 
 proc dropPeer*(ms: MessageSender, peerId: PeerId) {.async: (raises: []), gcsafe.} =
   ## Forget a peer's stream. The RPC holding it, if any, fails on its next
@@ -95,22 +101,23 @@ proc dropPeer*(ms: MessageSender, peerId: PeerId) {.async: (raises: []), gcsafe.
     return
   ms.senders.del(peerId)
   ps.invalidated = true
-  let stream = ps.stream
-  ps.stream = nil
+  let stream = move ps.stream
   if not stream.isNil():
     await stream.reset()
 
 proc start*(ms: MessageSender) {.raises: [].} =
   ms.stopped = false
+  ms.switch.addConnEventHandler(ms.onDisconnect, ConnEventKind.Disconnected)
 
 proc stop*(ms: MessageSender) {.async: (raises: []), gcsafe.} =
-  ## Reject further sends and reset every open stream. `start` reopens it.
+  ## Reject further sends, take the disconnect handler back off the switch and
+  ## reset every open stream. `start` reopens it.
   ms.stopped = true
+  ms.switch.removeConnEventHandler(ms.onDisconnect, ConnEventKind.Disconnected)
   let senders = move ms.senders
   for ps in senders.values():
     ps.invalidated = true
-    let stream = ps.stream
-    ps.stream = nil
+    let stream = move ps.stream
     if not stream.isNil():
       await stream.reset()
 
@@ -129,25 +136,25 @@ proc new*(
   )
   # A dead connection takes its streams with it; drop the entry so the table
   # stays bounded by the number of connected peers.
-  let onDisconnect = proc(
+  ms.onDisconnect = proc(
       peerId: PeerId, event: ConnEvent
   ) {.async: (raises: [CancelledError]).} =
     await ms.dropPeer(peerId)
 
-  switch.addConnEventHandler(onDisconnect, ConnEventKind.Disconnected)
+  switch.addConnEventHandler(ms.onDisconnect, ConnEventKind.Disconnected)
   ms
 
 proc senderFor(ms: MessageSender, peerId: PeerId): PeerMessageSender {.raises: [].} =
-  ms.senders.mgetOrPut(peerId, PeerMessageSender(peerId: peerId, lock: newAsyncLock()))
+  ms.senders.mgetOrPut(peerId, PeerMessageSender(lock: newAsyncLock()))
 
-proc forget(ms: MessageSender, ps: PeerMessageSender) {.raises: [].} =
+proc forget(ms: MessageSender, peerId: PeerId, ps: PeerMessageSender) {.raises: [].} =
   ## Drop an idle entry. Peers we never reached leave no stream and raise no
   ## disconnect event, so without this the table grows with every peer id a
   ## lookup ever named.
   if ps.users > 0 or not ps.stream.isNil():
     return
-  if ms.senders.getOrDefault(ps.peerId) == ps:
-    ms.senders.del(ps.peerId)
+  if ms.senders.getOrDefault(peerId) == ps:
+    ms.senders.del(peerId)
 
 proc releaseLock(ps: PeerMessageSender) {.raises: [].} =
   try:
@@ -156,12 +163,16 @@ proc releaseLock(ps: PeerMessageSender) {.raises: [].} =
     raiseAssert "peer message sender lock released without acquire: " & e.msg
 
 proc prepStream(
-    ms: MessageSender, ps: PeerMessageSender, addrs: seq[MultiAddress]
+    ms: MessageSender,
+    peerId: PeerId,
+    ps: PeerMessageSender,
+    addrs: seq[MultiAddress],
+    deadline: Moment,
 ): Future[Result[PreparedStream, SendError]] {.
     async: (raises: [CancelledError]), gcsafe
 .} =
   if ps.invalidated:
-    return err(sendError(dialStage, "peer message sender invalidated"))
+    return err(SendError.init(dialStage, "peer message sender invalidated"))
 
   let existing = ps.stream
   if not existing.isNil():
@@ -170,13 +181,34 @@ proc prepStream(
       return ok((existing, true))
     await ps.discardStream(existing)
 
-  # Shield the dial from cancellation: interrupting it mid-handshake leaks the
-  # half-opened channel, because nothing holds the stream yet to reset it.
+  let timeLeft = deadline.timeLeft()
+  if timeLeft.isZero():
+    return err(SendError.init(dialStage, "timed out before dialing"))
+
+  # `Dialer.dial` closes whatever it opened when the dial is cancelled, so
+  # neither the timeout nor a cancellation leaves a half-opened channel behind.
+  let dialFut = ms.switch.dial(peerId, addrs, ms.codec)
+  let dialed =
+    try:
+      await dialFut.withTimeout(timeLeft)
+    except CancelledError as e:
+      await noCancel dialFut.cancelAndWait()
+      raise e
+  if not dialed:
+    return err(SendError.init(dialStage, "timed out dialing the peer"))
+
   let stream =
     try:
-      await noCancel ms.switch.dial(ps.peerId, addrs, ms.codec)
+      await dialFut
     except DialFailedError as e:
-      return err(sendError(dialStage, e.msg))
+      return err(SendError.init(dialStage, e.msg))
+
+  # `stop` and `dropPeer` reset the peer's stream, and this one did not exist
+  # yet when they ran. Sending on it would use a sender that is already gone.
+  if ps.invalidated:
+    await stream.reset()
+    return err(SendError.init(dialStage, "peer message sender invalidated"))
+
   ps.stream = stream
   kad_streams_opened.inc()
   ok((stream, false))
@@ -191,7 +223,7 @@ proc exchange(
   try:
     await stream.writeLp(payload)
   except LPStreamError as e:
-    return err(sendError(writeStage, e.msg))
+    return err(SendError.init(writeStage, e.msg))
 
   if not awaitReply:
     return ok(newSeq[byte]())
@@ -200,7 +232,7 @@ proc exchange(
   # the next RPC on this stream, so a timeout always retires the stream.
   let timeLeft = deadline.timeLeft()
   if timeLeft.isZero():
-    return err(sendError(readStage, "timed out waiting for reply"))
+    return err(SendError.init(readStage, "timed out waiting for reply"))
 
   let readFut = stream.readLp(maxMsgSize)
   let replied =
@@ -210,29 +242,29 @@ proc exchange(
       await noCancel readFut.cancelAndWait()
       raise e
   if not replied:
-    return err(sendError(readStage, "timed out waiting for reply"))
+    return err(SendError.init(readStage, "timed out waiting for reply"))
 
   try:
     ok(await readFut)
   except LPStreamError as e:
-    err(sendError(readStage, e.msg))
+    err(SendError.init(readStage, e.msg))
 
 proc send(
     ms: MessageSender,
     peerId: PeerId,
     addrs: seq[MultiAddress],
-    payload: seq[byte],
+    payload: sink seq[byte],
     timeout: Duration,
     awaitReply: bool,
 ): Future[Result[seq[byte], SendError]] {.async: (raises: [CancelledError]), gcsafe.} =
   if ms.stopped:
-    return err(sendError(dialStage, "message sender stopped"))
+    return err(SendError.init(dialStage, "message sender stopped"))
 
   let ps = ms.senderFor(peerId)
   ps.users.inc()
   defer:
     ps.users.dec()
-    ms.forget(ps)
+    ms.forget(peerId, ps)
 
   # One deadline covers the wait for the peer's turn and the exchange itself, so
   # an RPC gives the stream up as soon as its own budget runs out. Charging each
@@ -241,12 +273,12 @@ proc send(
   # waiting for the stream, never reaching the peer.
   let deadline = Moment.now() + timeout
   if not await ps.lock.acquire().withTimeout(timeout):
-    return err(sendError(dialStage, "timed out waiting for the peer's stream"))
+    return err(SendError.init(dialStage, "timed out waiting for the peer's stream"))
   defer:
     ps.releaseLock()
 
   while true:
-    let (stream, reused) = (await ms.prepStream(ps, addrs)).valueOr:
+    let (stream, reused) = (await ms.prepStream(peerId, ps, addrs, deadline)).valueOr:
       return err(error)
 
     let sendRes =
@@ -258,10 +290,12 @@ proc send(
 
     if sendRes.isErr():
       await ps.discardStream(stream)
-      if not reused:
-        return err(sendRes.error())
       # A reused stream also fails when the remote quietly dropped it while it
       # sat idle; one fresh attempt tells that apart from a real RPC failure.
+      # A spent deadline is not that case: the peer is slow, and a second dial
+      # plus a repeat of the same RPC would only add to its load.
+      if not reused or deadline.timeLeft().isZero():
+        return err(sendRes.error())
       ps.reuseFailures.inc()
       kad_stream_reuse_failures.inc()
       continue
@@ -270,29 +304,29 @@ proc send(
     # nothing back may have left a reply buffered that would desync the next
     # RPC, and a peer that keeps breaking reuse is served one stream per RPC.
     if not awaitReply or ps.reuseFailures >= ms.maxReuseFailures:
-      await ps.retireStream(stream)
+      await ps.retireStream(stream, deadline)
     return sendRes
 
 proc sendRequest*(
     ms: MessageSender,
     peerId: PeerId,
     addrs: seq[MultiAddress],
-    payload: seq[byte],
+    payload: sink seq[byte],
     timeout: Duration,
 ): Future[Result[seq[byte], SendError]] {.async: (raises: [CancelledError]), gcsafe.} =
   ## Send `payload` on the peer's stream and wait for one reply. `timeout` is the
   ## whole budget: the wait for the peer's turn on that stream comes out of it.
-  await ms.send(peerId, addrs, payload, timeout, awaitReply = true)
+  await ms.send(peerId, addrs, move payload, timeout, awaitReply = true)
 
 proc sendMessage*(
     ms: MessageSender,
     peerId: PeerId,
     addrs: seq[MultiAddress],
-    payload: seq[byte],
+    payload: sink seq[byte],
     timeout: Duration,
 ): Future[Result[void, SendError]] {.async: (raises: [CancelledError]), gcsafe.} =
   ## Send `payload` without waiting for a reply. `timeout` bounds the wait for
   ## the peer's turn on its stream. The stream is retired afterwards, so a reply
   ## from a remote that does answer cannot be picked up by a later RPC.
-  discard ?await ms.send(peerId, addrs, payload, timeout, awaitReply = false)
+  discard ?await ms.send(peerId, addrs, move payload, timeout, awaitReply = false)
   ok()

--- a/libp2p/protocols/kademlia/message_sender.nim
+++ b/libp2p/protocols/kademlia/message_sender.nim
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## Per-peer outbound stream reuse for Kademlia RPCs.
+##
+## One stream is kept open per peer and shared by every RPC to that peer, so a
+## lookup pays the stream negotiation cost once instead of once per message.
+## RPCs on a peer's stream are serialized by a lock, because the wire format
+## carries no request ids to match interleaved replies with.
+##
+## Mirrors go-libp2p's ``internal/net/message_manager.go``.
+
+import std/tables
+import chronos, chronicles, results
+import ../../[peerid, switch]
+import ../../stream/connection
+import ./kademlia_metrics
+
+export results
+
+logScope:
+  topics = "kad-dht message-sender"
+
+const DefaultMaxStreamReuseFailures* = 3
+  ## Once reuse has broken this many times for a peer, treat it as unable to
+  ## serve more than one RPC per stream and give it a fresh stream every time.
+  ## Mirrors go-libp2p's ``streamReuseTries``.
+
+type
+  SendStage* = enum
+    ## How far a send got before it gave up. Callers distinguish these: an RPC
+    ## that reached the remote but drew no reply differs from one that never
+    ## left the node.
+    dialStage
+    writeStage
+    readStage
+
+  SendError* = object
+    stage*: SendStage
+    msg*: string
+
+  PeerMessageSender = ref object
+    peerId: PeerId
+    lock: AsyncLock ## serializes the RPCs sharing `stream`
+    stream: Stream ## nil while no stream is open
+    users: int ## RPCs holding or waiting for `lock`
+    reuseFailures: int
+    invalidated: bool
+      ## Set when the peer disconnects or the sender shuts down, so an RPC that
+      ## is mid-flight at that moment does not open a replacement stream.
+
+  MessageSender* = ref object
+    switch: Switch
+    codec: string
+    maxMsgSize: int
+    maxReuseFailures: int
+    senders: Table[PeerId, PeerMessageSender]
+    stopped: bool
+
+  PreparedStream = tuple[stream: Stream, reused: bool]
+
+func sendError(stage: SendStage, msg: string): SendError {.raises: [].} =
+  SendError(stage: stage, msg: msg)
+
+func `$`*(e: SendError): string {.raises: [].} =
+  $e.stage & ": " & e.msg
+
+proc timeLeft(deadline: Moment): Duration {.raises: [].} =
+  ## Zero once the deadline passed: chronos clamps a negative `Duration`.
+  deadline - Moment.now()
+
+proc discardStream(
+    ps: PeerMessageSender, stream: Stream
+) {.async: (raises: []), gcsafe.} =
+  ## Reset rather than close: closing only half-closes the channel, so an
+  ## unread reply stays in the read buffer and blocks the muxer for every other
+  ## channel on that connection.
+  if ps.stream == stream:
+    ps.stream = nil
+  await stream.reset()
+
+proc retireStream(
+    ps: PeerMessageSender, stream: Stream
+) {.async: (raises: []), gcsafe.} =
+  ## Give up a stream whose reply was fully read, leaving nothing buffered.
+  if ps.stream == stream:
+    ps.stream = nil
+  await stream.close()
+
+proc dropPeer*(ms: MessageSender, peerId: PeerId) {.async: (raises: []), gcsafe.} =
+  ## Forget a peer's stream. The RPC holding it, if any, fails on its next
+  ## read or write and does not reopen.
+  let ps = ms.senders.getOrDefault(peerId)
+  if ps.isNil():
+    return
+  ms.senders.del(peerId)
+  ps.invalidated = true
+  let stream = ps.stream
+  ps.stream = nil
+  if not stream.isNil():
+    await stream.reset()
+
+proc start*(ms: MessageSender) {.raises: [].} =
+  ms.stopped = false
+
+proc stop*(ms: MessageSender) {.async: (raises: []), gcsafe.} =
+  ## Reject further sends and reset every open stream. `start` reopens it.
+  ms.stopped = true
+  let senders = move ms.senders
+  for ps in senders.values():
+    ps.invalidated = true
+    let stream = ps.stream
+    ps.stream = nil
+    if not stream.isNil():
+      await stream.reset()
+
+proc new*(
+    T: typedesc[MessageSender],
+    switch: Switch,
+    codec: string,
+    maxMsgSize: int,
+    maxReuseFailures: int = DefaultMaxStreamReuseFailures,
+): T {.raises: [].} =
+  let ms = T(
+    switch: switch,
+    codec: codec,
+    maxMsgSize: maxMsgSize,
+    maxReuseFailures: maxReuseFailures,
+  )
+  # A dead connection takes its streams with it; drop the entry so the table
+  # stays bounded by the number of connected peers.
+  let onDisconnect = proc(
+      peerId: PeerId, event: ConnEvent
+  ) {.async: (raises: [CancelledError]).} =
+    await ms.dropPeer(peerId)
+
+  switch.addConnEventHandler(onDisconnect, ConnEventKind.Disconnected)
+  ms
+
+proc senderFor(ms: MessageSender, peerId: PeerId): PeerMessageSender {.raises: [].} =
+  ms.senders.mgetOrPut(peerId, PeerMessageSender(peerId: peerId, lock: newAsyncLock()))
+
+proc forget(ms: MessageSender, ps: PeerMessageSender) {.raises: [].} =
+  ## Drop an idle entry. Peers we never reached leave no stream and raise no
+  ## disconnect event, so without this the table grows with every peer id a
+  ## lookup ever named.
+  if ps.users > 0 or not ps.stream.isNil():
+    return
+  if ms.senders.getOrDefault(ps.peerId) == ps:
+    ms.senders.del(ps.peerId)
+
+proc releaseLock(ps: PeerMessageSender) {.raises: [].} =
+  try:
+    ps.lock.release()
+  except AsyncLockError as e:
+    raiseAssert "peer message sender lock released without acquire: " & e.msg
+
+proc prepStream(
+    ms: MessageSender, ps: PeerMessageSender, addrs: seq[MultiAddress]
+): Future[Result[PreparedStream, SendError]] {.
+    async: (raises: [CancelledError]), gcsafe
+.} =
+  if ps.invalidated:
+    return err(sendError(dialStage, "peer message sender invalidated"))
+
+  let existing = ps.stream
+  if not existing.isNil():
+    if not (existing.closed() or existing.atEof()):
+      kad_stream_reuses.inc()
+      return ok((existing, true))
+    await ps.discardStream(existing)
+
+  # Shield the dial from cancellation: interrupting it mid-handshake leaks the
+  # half-opened channel, because nothing holds the stream yet to reset it.
+  let stream =
+    try:
+      await noCancel ms.switch.dial(ps.peerId, addrs, ms.codec)
+    except DialFailedError as e:
+      return err(sendError(dialStage, e.msg))
+  ps.stream = stream
+  kad_streams_opened.inc()
+  ok((stream, false))
+
+proc exchange(
+    stream: Stream,
+    payload: seq[byte],
+    maxMsgSize: int,
+    deadline: Moment,
+    awaitReply: bool,
+): Future[Result[seq[byte], SendError]] {.async: (raises: [CancelledError]), gcsafe.} =
+  try:
+    await stream.writeLp(payload)
+  except LPStreamError as e:
+    return err(sendError(writeStage, e.msg))
+
+  if not awaitReply:
+    return ok(newSeq[byte]())
+
+  # A reply that arrives after we stopped waiting would be read as the answer to
+  # the next RPC on this stream, so a timeout always retires the stream.
+  let timeLeft = deadline.timeLeft()
+  if timeLeft.isZero():
+    return err(sendError(readStage, "timed out waiting for reply"))
+
+  let readFut = stream.readLp(maxMsgSize)
+  let replied =
+    try:
+      await readFut.withTimeout(timeLeft)
+    except CancelledError as e:
+      await noCancel readFut.cancelAndWait()
+      raise e
+  if not replied:
+    return err(sendError(readStage, "timed out waiting for reply"))
+
+  try:
+    ok(await readFut)
+  except LPStreamError as e:
+    err(sendError(readStage, e.msg))
+
+proc send(
+    ms: MessageSender,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    payload: seq[byte],
+    timeout: Duration,
+    awaitReply: bool,
+): Future[Result[seq[byte], SendError]] {.async: (raises: [CancelledError]), gcsafe.} =
+  if ms.stopped:
+    return err(sendError(dialStage, "message sender stopped"))
+
+  let ps = ms.senderFor(peerId)
+  ps.users.inc()
+  defer:
+    ps.users.dec()
+    ms.forget(ps)
+
+  # One deadline covers the wait for the peer's turn and the exchange itself, so
+  # an RPC gives the stream up as soon as its own budget runs out. Charging each
+  # phase a full `timeout` instead would let every RPC overrun the caller's
+  # deadline, and the retry the caller sends next would spend its whole budget
+  # waiting for the stream, never reaching the peer.
+  let deadline = Moment.now() + timeout
+  if not await ps.lock.acquire().withTimeout(timeout):
+    return err(sendError(dialStage, "timed out waiting for the peer's stream"))
+  defer:
+    ps.releaseLock()
+
+  while true:
+    let (stream, reused) = (await ms.prepStream(ps, addrs)).valueOr:
+      return err(error)
+
+    let sendRes =
+      try:
+        await exchange(stream, payload, ms.maxMsgSize, deadline, awaitReply)
+      except CancelledError as e:
+        await noCancel ps.discardStream(stream)
+        raise e
+
+    if sendRes.isErr():
+      await ps.discardStream(stream)
+      if not reused:
+        return err(sendRes.error())
+      # A reused stream also fails when the remote quietly dropped it while it
+      # sat idle; one fresh attempt tells that apart from a real RPC failure.
+      ps.reuseFailures.inc()
+      kad_stream_reuse_failures.inc()
+      continue
+
+    # Keep the stream only when it is safe and worth keeping: a send that read
+    # nothing back may have left a reply buffered that would desync the next
+    # RPC, and a peer that keeps breaking reuse is served one stream per RPC.
+    if not awaitReply or ps.reuseFailures >= ms.maxReuseFailures:
+      await ps.retireStream(stream)
+    return sendRes
+
+proc sendRequest*(
+    ms: MessageSender,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    payload: seq[byte],
+    timeout: Duration,
+): Future[Result[seq[byte], SendError]] {.async: (raises: [CancelledError]), gcsafe.} =
+  ## Send `payload` on the peer's stream and wait for one reply. `timeout` is the
+  ## whole budget: the wait for the peer's turn on that stream comes out of it.
+  await ms.send(peerId, addrs, payload, timeout, awaitReply = true)
+
+proc sendMessage*(
+    ms: MessageSender,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    payload: seq[byte],
+    timeout: Duration,
+): Future[Result[void, SendError]] {.async: (raises: [CancelledError]), gcsafe.} =
+  ## Send `payload` without waiting for a reply. `timeout` bounds the wait for
+  ## the peer's turn on its stream. The stream is retired afterwards, so a reply
+  ## from a remote that does answer cannot be picked up by a later RPC.
+  discard ?await ms.send(peerId, addrs, payload, timeout, awaitReply = false)
+  ok()

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -115,22 +115,24 @@ proc dispatchAddProvider(
     key: Opt.some(key),
     providerPeers: @[kad.switch.peerInfo.toPeer()],
   )
-  let encoded = msg.encode(kad.config.hideConnectionStatus)
-  kad_messages_sent.inc(labelValues = [$MessageType.addProvider])
-  kad_message_bytes_sent.inc(
-    encoded.len.int64, labelValues = [$MessageType.addProvider]
-  )
+  var encoded = msg.encode(kad.config.hideConnectionStatus)
+  let sentBytes = encoded.len.int64
 
   if not kad.config.providerRejection:
-    (await kad.msgSender.sendMessage(peer, addrs, encoded, kad.config.timeout)).isOkOr:
+    let sendRes =
+      await kad.msgSender.sendMessage(peer, addrs, move encoded, kad.config.timeout)
+    sendRes.countSent(MessageType.addProvider, sentBytes)
+    sendRes.isOkOr:
       return err($error)
     return ok(AddProviderStatus.accepted)
 
+  let sendRes =
+    await kad.msgSender.sendRequest(peer, addrs, move encoded, kad.config.timeout)
+  sendRes.countSent(MessageType.addProvider, sentBytes)
+
   # Remotes without the accepted/rejected reply simply never answer, so only a
   # failure to reach the peer is an error; a silent read counts as accepted.
-  let replyBuf = (
-    await kad.msgSender.sendRequest(peer, addrs, encoded, kad.config.timeout)
-  ).valueOr:
+  let replyBuf = sendRes.valueOr:
     if error.stage != readStage:
       return err($error)
     return ok(AddProviderStatus.accepted)
@@ -487,7 +489,7 @@ proc dispatchGetProviders*(
     kad: KadDHT, peer: PeerId, key: Key
 ): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
   let msg = Message(msgType: Opt.some(MessageType.getProviders), key: Opt.some(key))
-  let reply = ?await kad.dispatchRpc(peer, kad.switch.peerStore[AddressBook][peer], msg)
+  let reply = ?await kad.dispatchRpc(peer, msg)
 
   debug "Received reply for GetProviders", peer = peer, reply = reply
 

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -14,7 +14,7 @@ import chronos, chronicles, results
 import ../../[peerid, switch, multihash, cid]
 import ../../utils/[collections, heartbeat, future]
 import ../protocol
-import ./[protobuf, types, find, keyspace, netsize, kademlia_metrics]
+import ./[protobuf, types, find, rpc, keyspace, netsize, kademlia_metrics]
 
 logScope:
   topics = "kad-dht provider"
@@ -108,15 +108,7 @@ proc dispatchAddProvider(
     kad: KadDHT, peer: PeerId, key: Key
 ): Future[Result[AddProviderStatus, string]] {.async: (raises: [CancelledError]).} =
   withRpcSlot(kad)
-  let streamRes = catch:
-    await noCancel kad.switch.dial(
-      peer, kad.switch.peerStore[AddressBook][peer], kad.codec
-    )
-  if streamRes.isErr:
-    return err(streamRes.error.msg)
-  let stream = streamRes.value()
-  defer:
-    await noCancel stream.close()
+  let addrs = kad.switch.peerStore[AddressBook][peer]
 
   let msg = Message(
     msgType: Opt.some(MessageType.addProvider),
@@ -128,23 +120,22 @@ proc dispatchAddProvider(
   kad_message_bytes_sent.inc(
     encoded.len.int64, labelValues = [$MessageType.addProvider]
   )
-  let writeRes = catch:
-    await stream.writeLp(encoded)
-  if writeRes.isErr:
-    return err(writeRes.error.msg)
 
   if not kad.config.providerRejection:
+    (await kad.msgSender.sendMessage(peer, addrs, encoded, kad.config.timeout)).isOkOr:
+      return err($error)
     return ok(AddProviderStatus.accepted)
 
-  let readFut = stream.readLp(MaxMsgSize)
-  if not (await readFut.withTimeout(kad.config.timeout)):
-    return ok(AddProviderStatus.accepted)
-  let readRes = catch:
-    await readFut
-  if readRes.isErr:
+  # Remotes without the accepted/rejected reply simply never answer, so only a
+  # failure to reach the peer is an error; a silent read counts as accepted.
+  let replyBuf = (
+    await kad.msgSender.sendRequest(peer, addrs, encoded, kad.config.timeout)
+  ).valueOr:
+    if error.stage != readStage:
+      return err($error)
     return ok(AddProviderStatus.accepted)
 
-  let reply = Message.decode(readRes.value).valueOr:
+  let reply = Message.decode(replyBuf).valueOr:
     return ok(AddProviderStatus.accepted)
 
   return ok(reply.providerStatus.get(AddProviderStatus.accepted))
@@ -495,46 +486,12 @@ method handleAddProvider*(
 proc dispatchGetProviders*(
     kad: KadDHT, peer: PeerId, key: Key
 ): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
-  withRpcSlot(kad)
-  let streamRes = catch:
-    await noCancel kad.switch.dial(
-      peer, kad.switch.peerStore[AddressBook][peer], kad.codec
-    )
-  if streamRes.isErr:
-    return err(streamRes.error.msg)
-  let stream = streamRes.value()
-  defer:
-    await noCancel stream.close()
   let msg = Message(msgType: Opt.some(MessageType.getProviders), key: Opt.some(key))
-  let encoded = msg.encode(kad.config.hideConnectionStatus)
-
-  kad_messages_sent.inc(labelValues = [$MessageType.getProviders])
-  kad_message_bytes_sent.inc(
-    encoded.len.int64, labelValues = [$MessageType.getProviders]
-  )
-
-  var replyBuf: seq[byte]
-  var ioRes: Result[void, ref CatchableError]
-  kad_message_duration_ms.time(labelValues = [$MessageType.getProviders]):
-    ioRes = catch:
-      await stream.writeLp(encoded)
-      replyBuf = await stream.readLp(MaxMsgSize)
-  if ioRes.isErr:
-    return err(ioRes.error.msg)
-
-  kad_message_bytes_received.inc(
-    replyBuf.len.int64, labelValues = [$MessageType.getProviders]
-  )
-
-  let reply = Message.decode(replyBuf).valueOr:
-    return err("GetProviders reply decode fail")
-
-  if reply.closerPeers.len > 0:
-    kad_responses_with_closer_peers.inc(labelValues = [$MessageType.getProviders])
+  let reply = ?await kad.dispatchRpc(peer, kad.switch.peerStore[AddressBook][peer], msg)
 
   debug "Received reply for GetProviders", peer = peer, reply = reply
 
-  return ok(reply)
+  ok(reply)
 
 proc getProviders*(
     kad: KadDHT, key: Key

--- a/libp2p/protocols/kademlia/put.nim
+++ b/libp2p/protocols/kademlia/put.nim
@@ -6,7 +6,7 @@ import chronos, chronicles, results
 import ../../[peerid, switch, multihash]
 import ../../utils/[heartbeat, future]
 import ../protocol
-import ./[protobuf, types, find, kademlia_metrics]
+import ./[protobuf, types, find, rpc, kademlia_metrics]
 
 logScope:
   topics = "kad-dht put"
@@ -50,49 +50,20 @@ proc manageExpiredRecords*(kad: KadDHT) {.async: (raises: [CancelledError]).} =
 proc dispatchPutVal*(
     kad: KadDHT, peer: PeerId, key: Key, value: seq[byte]
 ): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
-  withRpcSlot(kad)
-  let streamRes = catch:
-    await noCancel kad.switch.dial(
-      peer, kad.switch.peerStore[AddressBook][peer], kad.codec
-    )
-  if streamRes.isErr:
-    return err(streamRes.error.msg)
-  let stream = streamRes.value()
-  defer:
-    await noCancel stream.close()
   let msg = Message(
     msgType: Opt.some(MessageType.putValue),
     key: Opt.some(key),
     record: Opt.some(Record(key: Opt.some(key), value: Opt.some(value))),
   )
-  let encoded = msg.encode()
+  let reply = ?await kad.dispatchRpc(peer, kad.switch.peerStore[AddressBook][peer], msg)
 
-  kad_messages_sent.inc(labelValues = [$MessageType.putValue])
-  kad_message_bytes_sent.inc(encoded.len.int64, labelValues = [$MessageType.putValue])
-
-  var replyBuf: seq[byte]
-  var ioRes: Result[void, ref CatchableError]
-  kad_message_duration_ms.time(labelValues = [$MessageType.putValue]):
-    ioRes = catch:
-      await stream.writeLp(encoded)
-      replyBuf = await stream.readLp(MaxMsgSize)
-  if ioRes.isErr:
-    return err(ioRes.error.msg)
-
-  kad_message_bytes_received.inc(
-    replyBuf.len.int64, labelValues = [$MessageType.putValue]
-  )
-
-  let reply = Message.decode(replyBuf).valueOr:
-    return err("PutValue reply decode fail")
-
-  debug "Got PutValue reply", msg = msg, reply = reply, stream = stream
+  debug "Got PutValue reply", msg = msg, reply = reply, peer = peer
 
   if reply != msg:
     error "Unexpected change between msg and reply: ",
-      msg = msg, reply = reply, stream = stream
+      msg = msg, reply = reply, peer = peer
 
-  return ok()
+  ok()
 
 proc canStoreLocalRecord*(kad: KadDHT, key: Key): bool {.raises: [].} =
   if kad.dataTable.hasKey(key):

--- a/libp2p/protocols/kademlia/put.nim
+++ b/libp2p/protocols/kademlia/put.nim
@@ -55,7 +55,7 @@ proc dispatchPutVal*(
     key: Opt.some(key),
     record: Opt.some(Record(key: Opt.some(key), value: Opt.some(value))),
   )
-  let reply = ?await kad.dispatchRpc(peer, kad.switch.peerStore[AddressBook][peer], msg)
+  let reply = ?await kad.dispatchRpc(peer, msg)
 
   debug "Got PutValue reply", msg = msg, reply = reply, peer = peer
 

--- a/libp2p/protocols/kademlia/rpc.nim
+++ b/libp2p/protocols/kademlia/rpc.nim
@@ -9,21 +9,40 @@ import chronos, results
 import ../../[peerid, switch]
 import ./[protobuf, types, kademlia_metrics]
 
+proc countSent*[T](
+    res: Result[T, SendError], msgType: MessageType, sentBytes: int64
+) {.gcsafe, raises: [].} =
+  ## Count what left the node: a send that gave up at the dial sent nothing.
+  if res.isErr() and res.error().stage == dialStage:
+    return
+  kad_messages_sent.inc(labelValues = [$msgType])
+  kad_message_bytes_sent.inc(sentBytes, labelValues = [$msgType])
+
 proc dispatchRpc*(
-    kad: KadDHT, peer: PeerId, addrs: seq[MultiAddress], msg: Message
+    kad: KadDHT,
+    peer: PeerId,
+    msg: Message,
+    addrs: Opt[seq[MultiAddress]] = Opt.none(seq[MultiAddress]),
 ): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  ## Addresses default to the peer store; `addrs` overrides them for a peer the
+  ## caller learned about elsewhere.
   let msgType = msg.msgType.valueOr:
     return err("outbound RPC without a message type")
 
   withRpcSlot(kad)
-  let encoded = msg.encode(kad.config.hideConnectionStatus)
-
-  kad_messages_sent.inc(labelValues = [$msgType])
-  kad_message_bytes_sent.inc(encoded.len.int64, labelValues = [$msgType])
+  var encoded = msg.encode(kad.config.hideConnectionStatus)
+  let sentBytes = encoded.len.int64
 
   var sendRes: Result[seq[byte], SendError]
   kad_message_duration_ms.time(labelValues = [$msgType]):
-    sendRes = await kad.msgSender.sendRequest(peer, addrs, encoded, kad.config.timeout)
+    sendRes = await kad.msgSender.sendRequest(
+      peer,
+      addrs.valueOr(kad.switch.peerStore[AddressBook][peer]),
+      move encoded,
+      kad.config.timeout,
+    )
+  sendRes.countSent(msgType, sentBytes)
+
   let replyBuf = sendRes.valueOr:
     return err($error)
 
@@ -31,6 +50,12 @@ proc dispatchRpc*(
 
   let reply = Message.decode(replyBuf).valueOr:
     return err($msgType & " reply decode fail")
+
+  # Peers share one stream and the wire format carries no request ids, so a reply
+  # of another type means the stream desynced. Taking it would answer this RPC
+  # with the response to a different one.
+  if reply.msgType.valueOr(msgType) != msgType:
+    return err($msgType & " reply type mismatch")
 
   if reply.closerPeers.len > 0:
     kad_responses_with_closer_peers.inc(labelValues = [$msgType])

--- a/libp2p/protocols/kademlia/rpc.nim
+++ b/libp2p/protocols/kademlia/rpc.nim
@@ -6,7 +6,7 @@
 ## decode the reply.
 
 import chronos, results
-import ../../[peerid, switch]
+import ../../[multiaddress, peerid, switch]
 import ./[protobuf, types, kademlia_metrics]
 
 proc countSent*[T](

--- a/libp2p/protocols/kademlia/rpc.nim
+++ b/libp2p/protocols/kademlia/rpc.nim
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## The outbound path every Kademlia request/response RPC shares: take an RPC
+## slot, encode, send on the peer's reused stream, count the message metrics and
+## decode the reply.
+
+import chronos, results
+import ../../[peerid, switch]
+import ./[protobuf, types, kademlia_metrics]
+
+proc dispatchRpc*(
+    kad: KadDHT, peer: PeerId, addrs: seq[MultiAddress], msg: Message
+): Future[Result[Message, string]] {.async: (raises: [CancelledError]), gcsafe.} =
+  let msgType = msg.msgType.valueOr:
+    return err("outbound RPC without a message type")
+
+  withRpcSlot(kad)
+  let encoded = msg.encode(kad.config.hideConnectionStatus)
+
+  kad_messages_sent.inc(labelValues = [$msgType])
+  kad_message_bytes_sent.inc(encoded.len.int64, labelValues = [$msgType])
+
+  var sendRes: Result[seq[byte], SendError]
+  kad_message_duration_ms.time(labelValues = [$msgType]):
+    sendRes = await kad.msgSender.sendRequest(peer, addrs, encoded, kad.config.timeout)
+  let replyBuf = sendRes.valueOr:
+    return err($error)
+
+  kad_message_bytes_received.inc(replyBuf.len.int64, labelValues = [$msgType])
+
+  let reply = Message.decode(replyBuf).valueOr:
+    return err($msgType & " reply decode fail")
+
+  if reply.closerPeers.len > 0:
+    kad_responses_with_closer_peers.inc(labelValues = [$msgType])
+
+  ok(reply)

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -6,9 +6,9 @@ from std/times import format, now, parse, toTime, toUnix, utc
 import chronos, chronicles, results, sugar, stew/arrayOps, nimcrypto/sha2
 import ../../[peerid, switch, multihash, cid, multicodec, peeraddrpolicy]
 import ../protocol
-import ./protobuf
+import ./[protobuf, message_sender]
 
-export tables, sets, heapqueue
+export tables, sets, heapqueue, message_sender
 
 const
   IdLength* = 32 # 256-bit IDs
@@ -572,6 +572,8 @@ type KadDHT* = ref object of LPProtocol
   provideTasks*: seq[Future[void]]
     ## ADD_PROVIDER RPCs still running after an early ``optimisticProvide``.
   config*: KadDHTConfig
+  msgSender*: MessageSender
+    ## Reuses one outbound stream per peer across every RPC sent to it.
   rpcSem*: AsyncSemaphore
     ## Bounds in-flight outbound RPCs to ``config.limits.maxConcurrentRpcs``.
   probeSem*: AsyncSemaphore

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -83,7 +83,7 @@ proc new*(
     discoConfig: discoConfig,
     xprPublishing: xprPublishing,
   )
-  disco.initKadBase(switch, config, rng, isServer = not client)
+  disco.initKadBase(switch, config, rng, isServer = not client, codec = codec)
 
   # Fill up buckets with initial bootstrap nodes
   disco.updatePeers(bootstrapNodes)
@@ -93,8 +93,6 @@ proc new*(
       return
 
     disco.serviceBootstrapFuts.trackFut(disco.bootstrapServiceTable(serviceId))
-
-  disco.codec = codec
 
   disco.handler = proc(
       stream: Stream, proto: string

--- a/tests/libp2p/kademlia/test_get_providers.nim
+++ b/tests/libp2p/kademlia/test_get_providers.nim
@@ -105,7 +105,8 @@ suite "KadDHT - Get Providers":
       kads[2].hasKey(kads[1].rtable.selfId)
 
   asyncTest "Get providers uses multihash for CID convergence":
-    let kads = setupKadSwitches(2)
+    # Long republish interval so the background heartbeat doesn't race getProviders dials.
+    let kads = setupKadSwitches(2, republishProvidedKeysInterval = chronos.hours(1))
     startAndDeferStop(kads)
 
     await connect(kads[0], kads[1])
@@ -134,7 +135,8 @@ suite "KadDHT - Get Providers":
       providers.containsPeer(kads[1])
 
   asyncTest "Get providers includes self when querying node is a provider":
-    let kads = setupKadSwitches(2)
+    # Long republish interval so the background heartbeat doesn't race getProviders dials.
+    let kads = setupKadSwitches(2, republishProvidedKeysInterval = chronos.hours(1))
     startAndDeferStop(kads)
 
     await connect(kads[0], kads[1])

--- a/tests/libp2p/kademlia/test_message_sender.nim
+++ b/tests/libp2p/kademlia/test_message_sender.nim
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import chronos, results, sequtils
+import
+  ../../../libp2p/[protocols/kademlia, protocols/protocol, switch, builders],
+  ../../../libp2p/stream/connection
+import ../../tools/[crypto, lifecycle, multiaddress, switch_builder, unittest]
+
+const
+  TestCodec = "/test/kad-message-sender/1.0.0"
+  MaxTestMsgSize = 4096
+
+type CountingEcho = ref object of LPProtocol
+  streams: int ## inbound streams the remote opened
+  messages: int ## messages received across all of them
+  reply: bool
+  closeAfter: int ## close the stream once this many messages arrived; 0 keeps it open
+
+proc newCountingEcho(reply = true, closeAfter = 0): CountingEcho =
+  let echoProto = CountingEcho(reply: reply, closeAfter: closeAfter)
+  echoProto.codec = TestCodec
+  echoProto.handler = proc(
+      stream: Stream, proto: string
+  ) {.async: (raises: [CancelledError]).} =
+    echoProto.streams.inc()
+    defer:
+      await stream.close()
+
+    while not stream.atEof:
+      let buf =
+        try:
+          await stream.readLp(MaxTestMsgSize)
+        except LPStreamError:
+          return
+      echoProto.messages.inc()
+
+      if echoProto.reply:
+        try:
+          await stream.writeLp(buf)
+        except LPStreamError:
+          return
+
+      if echoProto.closeAfter > 0 and echoProto.messages >= echoProto.closeAfter:
+        return
+
+  echoProto
+
+proc setupPair(
+    proto: CountingEcho
+): tuple[client: Switch, server: Switch] {.raises: [LPError].} =
+  let client = makeStandardSwitch(TcpAutoAddress)
+  let server = makeStandardSwitch(TcpAutoAddress)
+  server.mount(proto)
+  (client, server)
+
+suite "KadDHT message sender":
+  teardown:
+    checkTrackers()
+
+  asyncTest "reuses a single stream across RPCs to the same peer":
+    let proto = newCountingEcho()
+    let (client, server) = setupPair(proto)
+    startAndDeferStop(@[client, server])
+
+    let sender = MessageSender.new(client, TestCodec, MaxTestMsgSize)
+    defer:
+      await sender.stop()
+
+    for i in 0 ..< 3:
+      let reply = await sender.sendRequest(
+        server.peerInfo.peerId, server.peerInfo.addrs, @[byte i], 1.seconds
+      )
+      check reply.tryGet() == @[byte i]
+
+    check:
+      proto.streams == 1
+      proto.messages == 3
+
+  asyncTest "reopens transparently after the remote drops the stream":
+    let proto = newCountingEcho(closeAfter = 1)
+    let (client, server) = setupPair(proto)
+    startAndDeferStop(@[client, server])
+
+    let sender = MessageSender.new(client, TestCodec, MaxTestMsgSize)
+    defer:
+      await sender.stop()
+
+    for i in 0 ..< 2:
+      let reply = await sender.sendRequest(
+        server.peerInfo.peerId, server.peerInfo.addrs, @[byte i], 1.seconds
+      )
+      check reply.tryGet() == @[byte i]
+
+    check proto.streams == 2
+
+  asyncTest "serializes concurrent RPCs on one stream":
+    let proto = newCountingEcho()
+    let (client, server) = setupPair(proto)
+    startAndDeferStop(@[client, server])
+
+    let sender = MessageSender.new(client, TestCodec, MaxTestMsgSize)
+    defer:
+      await sender.stop()
+
+    let replies = (0 ..< 4).mapIt(
+      sender.sendRequest(
+        server.peerInfo.peerId, server.peerInfo.addrs, @[byte it], 5.seconds
+      )
+    )
+    await allFutures(replies)
+
+    # Each RPC reads back its own payload, so no reply was mistaken for another.
+    for i, fut in replies:
+      check fut.read().tryGet() == @[byte i]
+    check proto.streams == 1
+
+  asyncTest "a reply-less send retires its stream":
+    let proto = newCountingEcho(reply = false)
+    let (client, server) = setupPair(proto)
+    startAndDeferStop(@[client, server])
+
+    let sender = MessageSender.new(client, TestCodec, MaxTestMsgSize)
+    defer:
+      await sender.stop()
+
+    for i in 0 ..< 2:
+      check (
+        await sender.sendMessage(
+          server.peerInfo.peerId, server.peerInfo.addrs, @[byte i], 1.seconds
+        )
+      ).isOk()
+
+    # A remote that does answer would leave its reply buffered, so a
+    # fire-and-forget send must never hand its stream to the next RPC.
+    checkUntilTimeout:
+      proto.streams == 2
+      proto.messages == 2
+
+  asyncTest "an unanswered request fails at the read stage":
+    let proto = newCountingEcho(reply = false)
+    let (client, server) = setupPair(proto)
+    startAndDeferStop(@[client, server])
+
+    let sender = MessageSender.new(client, TestCodec, MaxTestMsgSize)
+    defer:
+      await sender.stop()
+
+    let reply = await sender.sendRequest(
+      server.peerInfo.peerId, server.peerInfo.addrs, @[byte 1], 100.milliseconds
+    )
+    check:
+      reply.isErr()
+      reply.error().stage == readStage
+
+  asyncTest "an unreachable peer fails at the dial stage":
+    let client = makeStandardSwitch(TcpAutoAddress)
+    startAndDeferStop(@[client])
+
+    let sender = MessageSender.new(client, TestCodec, MaxTestMsgSize)
+    defer:
+      await sender.stop()
+
+    let unreachable = PeerId.random(rng()).tryGet()
+    let reply = await sender.sendRequest(
+      unreachable,
+      @[MultiAddress.init("/ip4/127.0.0.1/tcp/1").tryGet()],
+      @[byte 1],
+      1.seconds,
+    )
+    check:
+      reply.isErr()
+      reply.error().stage == dialStage
+
+  asyncTest "dropPeer forces the next RPC onto a fresh stream":
+    let proto = newCountingEcho()
+    let (client, server) = setupPair(proto)
+    startAndDeferStop(@[client, server])
+
+    let sender = MessageSender.new(client, TestCodec, MaxTestMsgSize)
+    defer:
+      await sender.stop()
+
+    check (
+      await sender.sendRequest(
+        server.peerInfo.peerId, server.peerInfo.addrs, @[byte 1], 1.seconds
+      )
+    ).isOk()
+
+    await sender.dropPeer(server.peerInfo.peerId)
+
+    check (
+      await sender.sendRequest(
+        server.peerInfo.peerId, server.peerInfo.addrs, @[byte 2], 1.seconds
+      )
+    ).isOk()
+    check proto.streams == 2

--- a/tests/libp2p/kademlia/test_message_sender.nim
+++ b/tests/libp2p/kademlia/test_message_sender.nim
@@ -149,7 +149,7 @@ suite "KadDHT message sender":
       await sender.stop()
 
     let reply = await sender.sendRequest(
-      server.peerInfo.peerId, server.peerInfo.addrs, @[byte 1], 100.milliseconds
+      server.peerInfo.peerId, server.peerInfo.addrs, @[byte 1], 1.seconds
     )
     check:
       reply.isErr()
@@ -197,3 +197,19 @@ suite "KadDHT message sender":
       )
     ).isOk()
     check proto.streams == 2
+
+  asyncTest "a stopped sender refuses to dial":
+    let proto = newCountingEcho()
+    let (client, server) = setupPair(proto)
+    startAndDeferStop(@[client, server])
+
+    let sender = MessageSender.new(client, TestCodec, MaxTestMsgSize)
+    await sender.stop()
+
+    let reply = await sender.sendRequest(
+      server.peerInfo.peerId, server.peerInfo.addrs, @[byte 1], 1.seconds
+    )
+    check:
+      reply.isErr()
+      reply.error().stage == dialStage
+      proto.streams == 0

--- a/tests/libp2p/kademlia/test_message_sender.nim
+++ b/tests/libp2p/kademlia/test_message_sender.nim
@@ -198,6 +198,32 @@ suite "KadDHT message sender":
     ).isOk()
     check proto.streams == 2
 
+  asyncTest "a cancelled RPC leaves the peer's connection up":
+    let proto = newCountingEcho()
+    let (client, server) = setupPair(proto)
+    startAndDeferStop(@[client, server])
+
+    let sender = MessageSender.new(client, TestCodec, MaxTestMsgSize)
+    defer:
+      await sender.stop()
+
+    await client.connect(server.peerInfo.peerId, server.peerInfo.addrs)
+
+    # The cancellation lands in the dial, which is where it hurts: `Dialer.dial`
+    # closes the connection it reused when it is cancelled, which would take
+    # down every other stream the peer holds on that connection.
+    let cancelled = sender.sendRequest(
+      server.peerInfo.peerId, server.peerInfo.addrs, @[byte 1], 5.seconds
+    )
+    await cancelled.cancelAndWait()
+
+    check client.isConnected(server.peerInfo.peerId)
+
+    let reply = await sender.sendRequest(
+      server.peerInfo.peerId, server.peerInfo.addrs, @[byte 2], 5.seconds
+    )
+    check reply.tryGet() == @[byte 2]
+
   asyncTest "a stopped sender refuses to dial":
     let proto = newCountingEcho()
     let (client, server) = setupPair(proto)


### PR DESCRIPTION
## Summary

Every Kademlia RPC opened its own stream, sent one message, and closed it. Stream negotiation was paid once per message, so a single iterative lookup could open dozens of streams to the same set of peers.

This adds a per-peer message-sender layer (`libp2p/protocols/kademlia/message_sender.nim`) that lazily opens one stream per peer, serializes RPCs on it with a lock, reuses it across calls, and resets plus retries once when a reused stream turns out to be dead. It mirrors go-libp2p's `internal/net/message_manager.go` (`peerMessageSender`, `streamReuseTries`). All five dispatch procs — FIND_NODE, GET_VALUE, PUT_VALUE, ADD_PROVIDER, GET_PROVIDERS — now go through it.

The five dispatch bodies were nearly identical, so the shared path (take an RPC slot, encode, send, count metrics, decode) moved into `libp2p/protocols/kademlia/rpc.nim` as `dispatchRpc`. Each dispatcher is now two to six lines.

Closes #2856.

## Affected Areas

- [x] Protocol Logic
  Kademlia outbound RPC path only. Inbound handlers are unchanged — the existing handler loop already reads messages from one stream until EOF, so it serves reused streams without modification.

- [x] Other
  New Prometheus counters: `kad_streams_opened`, `kad_stream_reuses`, `kad_stream_reuse_failures`.

## Compatibility & Downstream Validation

No wire-format change: the same messages are sent, on fewer streams. Reuse is transparent to remotes that already handle multiple messages per stream (go-libp2p, js-libp2p, and this implementation's own handler), and a remote that drops the stream between RPCs is handled by the reset-and-retry path.

- **Nimbus:** N/A — Kademlia DHT is not used.
- **Waku:** N/A — no integration branch needed; no API or wire change.
- **Codex:** N/A — no integration branch needed; no API or wire change.

## Impact on Library Users

No public API change to `KadDHT`. `KadDHT` gains a `msgSender` field, and `libp2p/protocols/kademlia/types.nim` re-exports the new `message_sender` module (`MessageSender`, `SendError`, `SendStage`).

Behaviour changes users may notice:

- Fewer outbound streams and fewer protocol negotiations per lookup, which is the point of the change.
- FIND_NODE, GET_VALUE, PUT_VALUE and GET_PROVIDERS now apply `config.timeout` to the reply read. Previously only ADD_PROVIDER did, and the other four relied on the caller's deadline; an unanswered RPC could hang until the lookup abandoned it.
- RPCs to the same peer serialize instead of running on parallel streams. In practice a lookup dispatches to distinct peers, so concurrency is unaffected; the wait for a peer's turn is bounded by the same `config.timeout`.
- PUT_VALUE now honours `config.hideConnectionStatus`. It called `Message.encode()` with the default while the other four passed the configured value.
- A reply whose message type differs from the request's is rejected with `"<type> reply type mismatch"`. One stream per peer carries no request ids, so a reply of the wrong type means the stream desynced and the answer belongs to another RPC. A reply that omits the type field is still accepted, which keeps remotes that leave it unset working.
- Decode-failure error strings are derived from the message type, so `"FindNode reply decode fail"` becomes `"findNode reply decode fail"`. RPC error strings now carry the stage that failed, for example `"dialStage: ..."`.
- `kad_message_duration_ms` now covers the wait for the peer's stream as well as the round trip, so it reports queueing behind a slow peer instead of hiding it.
- `kad_messages_sent` and `kad_message_bytes_sent` count only messages that got past the dial. A message to an unreachable peer is no longer counted as sent.
- The dial is bounded by what is left of `config.timeout`, so an RPC to a peer that accepts connections slowly can no longer outlive its own budget.

## Risk Assessment

**Backward compatibility:** no wire change. A remote that answers ADD_PROVIDER when this node has `providerRejection` disabled would leave its reply buffered on a shared stream, so a fire-and-forget send closes its stream and drops it from the pool instead of handing it to the next RPC.

**Correctness of stream state:** a stream is reset, never closed, on any failure or cancellation — a half-closed stream keeps its unread reply buffered and blocks the muxer for every other channel on the connection. A read timeout also resets, so a late reply cannot be picked up as the answer to the next RPC. A stream that is given up after a successful exchange is closed with `closeWithEOF`, bounded by the RPC's remaining budget, and reset if the remote never answers the close. A reply of an unexpected type is refused rather than returned to the caller.

**Dial lifetime:** `Dialer.dial` closes whatever it opened when it is cancelled, so the dial runs under the RPC's deadline instead of a cancellation shield. `stop` and `dropPeer` can still run while a dial is in flight, so the sender is checked again once the dial returns and the new stream is reset rather than used.

**Resource bounds:** the per-peer table is pruned two ways. A `Disconnected` conn-event handler drops the peer's entry, and an entry with no live stream and no in-flight RPC is deleted when its last user leaves — otherwise every peer id a lookup ever named would leave a permanent entry, including peers that were never reachable.

**Degradation:** a peer whose stream reuse keeps breaking falls back to one stream per RPC after `DefaultMaxStreamReuseFailures` (3), matching go-libp2p's `streamReuseTries`. The one retry after a broken reuse is skipped when the deadline is already spent, so a slow peer is not dialled again and sent a duplicate of the same RPC.

**Shutdown:** `MessageSender.stop()` refuses further sends, takes its `Disconnected` handler back off the switch and resets every open stream; `KadDHT.start` re-registers the handler, so restart still works.

**Head-of-line blocking:** `dispatchRpc` takes an `rpcSem` slot before it queues for the peer's stream, so RPCs waiting on one slow peer hold global slots for up to `config.timeout`. Master held a slot for an unbounded time instead, because four of the five RPC types read the reply with no timeout at all.

**Reference cycle:** the switch holds the conn-event closure, which holds the `MessageSender`, which holds the switch, and under `--mm:refc` that cycle is not collected. `stop` deregisters the handler, so a stopped DHT breaks the cycle. A running one keeps it, which matches the existing `KadDHT` and `Switch` relationship.

## References

- Closes #2856
- Parent issue #1756
- go-libp2p `internal/net/message_manager.go`

## Additional Notes

New test file `tests/libp2p/kademlia/test_message_sender.nim` covers stream reuse across RPCs, transparent reopen after the remote drops the stream, serialization of concurrent RPCs, stream retirement for reply-less sends, `dialStage` and `readStage` error reporting, `dropPeer`, and a stopped sender refusing to dial.

The fallback after `maxReuseFailures` is not covered by a test yet. It needs a stream that passes the liveness check and then breaks, which races the `atEof()` check.
