### PR TITLE
chore(kad): batch reprovide by keyspace region

### DIFF
--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -6,11 +6,12 @@ import chronos, chronicles, results
 import ../utils/[heartbeat, future]
 import ../[peerid, switch, multihash]
 import ./protocol
-import ./kademlia/[routing_table, protobuf, types, find, get, put, provider, ping]
+import
+  ./kademlia/[routing_table, protobuf, types, find, get, put, keyspace, provider, ping]
 import ./kademlia/kademlia_metrics
 
 export
-  chronicles, routing_table, protobuf, types, find, get, put, provider, ping,
+  chronicles, routing_table, protobuf, types, find, get, put, keyspace, provider, ping,
   kademlia_metrics
 
 logScope:

--- a/libp2p/protocols/kademlia/kademlia_metrics.nim
+++ b/libp2p/protocols/kademlia/kademlia_metrics.nim
@@ -24,6 +24,9 @@ declarePublicCounter kad_provider_rejections_sent,
   "ADD_PROVIDER messages rejected due to per-key limit"
 declarePublicCounter kad_provider_spillover_rounds,
   "ADD_PROVIDER spillover rounds (batch of candidates fully rejected)"
+declarePublicCounter kad_provider_republish_regions,
+  "keyspace regions republished, one DHT walk each"
+declarePublicCounter kad_provider_republish_keys, "provided keys republished"
 
 # Routing table metrics
 declarePublicGauge kad_routing_table_peers, "total peers in routing table"

--- a/libp2p/protocols/kademlia/keyspace.nim
+++ b/libp2p/protocols/kademlia/keyspace.nim
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## Keyspace regions: keys whose hashes share a leading bit prefix. Once a region
+## holds ``replication`` peers, every key in it has all of its closest peers
+## inside the region, so one walk toward any member key serves them all.
+
+import std/[algorithm, sequtils, tables]
+import results
+import ../../peerid
+import ./[types, routing_table]
+
+type RegionPrefix* = seq[byte]
+  ## Leading bits of a hashed key, trailing bits of the last byte cleared.
+
+func regionPrefix*(key: Key, bits: int, hasher: Opt[XorDHasher]): RegionPrefix =
+  let hashed = key.hashFor(hasher)
+  let width = clamp(bits, 0, hashed.len * 8)
+  var prefix = hashed[0 ..< width div 8]
+  let partial = width mod 8
+  if partial > 0:
+    prefix.add(hashed[width div 8] and (0xFF'u8 shl (8 - partial)))
+  prefix
+
+func keyspaceRegions*(
+    keys: seq[Key], bits: int, hasher: Opt[XorDHasher]
+): seq[seq[Key]] =
+  ## Partition `keys` by prefix. `bits == 0` yields a single region.
+  var regions: Table[RegionPrefix, seq[Key]]
+  for key in keys:
+    regions.mgetOrPut(key.regionPrefix(bits, hasher), @[]).add(key)
+  regions.values().toSeq()
+
+func regionBits*(rtable: RoutingTable): Opt[int] =
+  ## Prefix length that splits the keyspace into regions of at least
+  ## ``replication`` peers each. Bucket ``d`` covers a ``2^-(d+1)`` slice, so a
+  ## deepest full bucket ``d`` sizes the network at ``replication * 2^(d+1)``
+  ## peers and ``d + 1`` bits cut it into regions of ``replication`` peers.
+  ## ``Opt.none`` while no bucket is full: the table has no size estimate yet.
+  var deepestFull = -1
+  for i in 0 ..< rtable.buckets.len:
+    if rtable.buckets[i].peers.len >= rtable.config.replication:
+      deepestFull = i
+
+  if deepestFull < 0:
+    return Opt.none(int)
+  Opt.some(min(deepestFull + 1, MaxRegionBits))
+
+func closestFirst*(peers: seq[PeerId], key: Key, hasher: Opt[XorDHasher]): seq[PeerId] =
+  ## `peers` ordered by XOR distance to `key`, closest first.
+  peers
+    .mapIt((it, xorDistance(it, key, hasher)))
+    .sorted(
+      proc(a, b: (PeerId, XorDistance)): int =
+        cmp(a[1], b[1])
+    )
+    .mapIt(it[0])

--- a/libp2p/protocols/kademlia/keyspace.nim
+++ b/libp2p/protocols/kademlia/keyspace.nim
@@ -25,11 +25,17 @@ func regionPrefix*(key: Key, bits: int, hasher: Opt[XorDHasher]): RegionPrefix =
 func keyspaceRegions*(
     keys: seq[Key], bits: int, hasher: Opt[XorDHasher]
 ): seq[seq[Key]] =
-  ## Partition `keys` by prefix. `bits == 0` yields a single region.
-  var regions: Table[RegionPrefix, seq[Key]]
+  ## Partition `keys` by prefix, each region in the order its first key appears.
+  ## `bits == 0` yields a single region.
+  var
+    order: seq[RegionPrefix]
+    regions: Table[RegionPrefix, seq[Key]]
   for key in keys:
-    regions.mgetOrPut(key.regionPrefix(bits, hasher), @[]).add(key)
-  regions.values().toSeq()
+    let prefix = key.regionPrefix(bits, hasher)
+    if prefix notin regions:
+      order.add(prefix)
+    regions.mgetOrPut(prefix, @[]).add(key)
+  order.mapIt(regions.getOrDefault(it))
 
 func regionBits*(rtable: RoutingTable): Opt[int] =
   ## Prefix length that splits the keyspace into regions of at least

--- a/libp2p/protocols/kademlia/keyspace.nim
+++ b/libp2p/protocols/kademlia/keyspace.nim
@@ -13,7 +13,9 @@ import ./[types, routing_table]
 type RegionPrefix* = seq[byte]
   ## Leading bits of a hashed key, trailing bits of the last byte cleared.
 
-func regionPrefix*(key: Key, bits: int, hasher: Opt[XorDHasher]): RegionPrefix =
+func init*(
+    T: typedesc[RegionPrefix], key: Key, bits: int, hasher: Opt[XorDHasher]
+): RegionPrefix =
   let hashed = key.hashFor(hasher)
   let width = clamp(bits, 0, hashed.len * 8)
   var prefix = hashed[0 ..< width div 8]
@@ -31,7 +33,7 @@ func keyspaceRegions*(
     order: seq[RegionPrefix]
     regions: Table[RegionPrefix, seq[Key]]
   for key in keys:
-    let prefix = key.regionPrefix(bits, hasher)
+    let prefix = RegionPrefix.init(key, bits, hasher)
     if prefix notin regions:
       order.add(prefix)
     regions.mgetOrPut(prefix, @[]).add(key)

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -14,7 +14,7 @@ import chronos, chronicles, results
 import ../../[peerid, switch, multihash, cid]
 import ../../utils/[heartbeat, future]
 import ../protocol
-import ./[protobuf, types, find, kademlia_metrics]
+import ./[protobuf, types, find, keyspace, kademlia_metrics]
 
 logScope:
   topics = "kad-dht provider"
@@ -169,13 +169,19 @@ proc countResults[T](rpcBatch: seq[T]): (int, int) =
         rejected.inc()
   (accepted, rejected)
 
-proc addProviderSpillover(kad: KadDHT, key: Key) {.async: (raises: [CancelledError]).} =
-  let allPeers = (
-    await kad.iterativeLookup(key, findNodeDispatch, noopReply, closestAvailableStop)
-  ).allSortedPeers()
+proc storeProviderAt(
+    kad: KadDHT, key: Key, peers: seq[PeerId]
+) {.async: (raises: [CancelledError]).} =
+  ## Store this node as a provider of `key` at `peers`, ordered closest first.
+  ## With `providerRejection`, a fully rejected batch spills over to the next,
+  ## farther batch until `replication` peers accepted.
+  if not kad.config.providerRejection:
+    for chunk in peers.take(kad.config.replication).toChunks(kad.config.alpha):
+      await kad.sendBatch(chunk, key).allFuturesWaitOrTimeout(kad.config.timeout)
+    return
 
   var stored = 0
-  for chunk in allPeers.toChunks(kad.config.alpha):
+  for chunk in peers.toChunks(kad.config.alpha):
     if stored >= kad.config.replication:
       break
     let batch = kad.sendBatch(chunk, key)
@@ -194,12 +200,17 @@ proc addProviderSpillover(kad: KadDHT, key: Key) {.async: (raises: [CancelledErr
         key = key, batchSize = chunk.len
 
 proc addProvider*(kad: KadDHT, key: Key) {.async: (raises: [CancelledError]), gcsafe.} =
-  if kad.config.providerRejection:
-    await kad.addProviderSpillover(key)
-  else:
-    let peers = await kad.findNode(key)
-    for chunk in peers.toChunks(kad.config.alpha):
-      await kad.sendBatch(chunk, key).allFuturesWaitOrTimeout(kad.config.timeout)
+  let peers =
+    if kad.config.providerRejection:
+      # Spillover needs the peers past the closest `replication` ones too.
+      (
+        await kad.iterativeLookup(
+          key, findNodeDispatch, noopReply, closestAvailableStop
+        )
+      ).allSortedPeers()
+    else:
+      await kad.findNode(key)
+  await kad.storeProviderAt(key, peers)
 
 proc addProvider*(kad: KadDHT, cid: Cid) {.async: (raises: [CancelledError]), gcsafe.} =
   await addProvider(kad, cid.toKey())
@@ -215,12 +226,68 @@ proc startProviding*(kad: KadDHT, c: Cid) {.async: (raises: [CancelledError]).} 
 proc stopProviding*(kad: KadDHT, c: Cid) =
   kad.providerManager.providedKeys.del(c.toKey())
 
-proc republishProvidedKeys(kad: KadDHT) {.async: (raises: [CancelledError]).} =
-  let providedKeys = kad.providerManager.providedKeys.provided
+proc providedKeyRegions*(kad: KadDHT): seq[seq[Key]] =
+  ## Provided keys grouped into keyspace regions, one group per DHT walk. Falls
+  ## back to a group per key while the routing table cannot size a region.
+  let keys = kad.providerManager.providedKeys.provided.keys().toSeq()
+  let bits = kad.config.republishRegionBits.valueOr:
+    kad.rtable.regionBits().valueOr:
+      return keys.mapIt(@[it])
+  keys.keyspaceRegions(bits, kad.rtable.config.hasher)
 
-  var futs = newSeqOfCap[Future[void]](providedKeys.len)
-  for key in providedKeys.keys():
-    futs.add(kad.addProvider(key))
+proc stillProvided(kad: KadDHT, keys: seq[Key]): seq[Key] =
+  ## A region waits for its slot, so `stopProviding` can drop a key between the
+  ## grouping and the walk.
+  keys.filterIt(kad.providerManager.providedKeys.hasKey(it))
+
+proc republishRegion(
+    kad: KadDHT, region: seq[Key]
+) {.async: (raises: [CancelledError]).} =
+  ## One walk for the whole region, then advertise every key to the peers it
+  ## found. Any member key is a valid walk target.
+  let keys = kad.stillProvided(region)
+  if keys.len == 0:
+    return
+
+  let regionPeers = (
+    await kad.iterativeLookup(
+      keys[0], findNodeDispatch, noopReply, closestAvailableStop
+    )
+  ).allSortedPeers()
+
+  kad_provider_republish_regions.inc()
+  kad_provider_republish_keys.inc(keys.len.int64)
+
+  let hasher = kad.rtable.config.hasher
+  let futs = keys.mapIt(kad.storeProviderAt(it, regionPeers.closestFirst(it, hasher)))
+  try:
+    await allFutures(futs)
+  except CancelledError as e:
+    await noCancel futs.cancelAndWait()
+    raise e
+
+func regionStartSpacing(interval: chronos.Duration, regions: int): chronos.Duration =
+  ## Regions start evenly spread over the first half of the republish interval;
+  ## the second half is headroom for the last region to finish.
+  if regions <= 1:
+    ZeroDuration
+  else:
+    (interval div 2) div regions
+
+proc republishRegionAfter(
+    kad: KadDHT, delay: chronos.Duration, keys: seq[Key]
+) {.async: (raises: [CancelledError]).} =
+  await sleepAsync(delay)
+  await kad.republishRegion(keys)
+
+proc republishProvidedKeys(kad: KadDHT) {.async: (raises: [CancelledError]).} =
+  let regions = kad.providedKeyRegions()
+  let spacing =
+    regionStartSpacing(kad.config.republishProvidedKeysInterval, regions.len)
+
+  var futs = newSeqOfCap[Future[void]](regions.len)
+  for i, region in regions:
+    futs.add(kad.republishRegionAfter(spacing * i, region))
 
   try:
     await allFutures(futs)

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -15,6 +15,8 @@ const
 
   MaxBucketsLimit* = IdLength * 8
     ## a bucket per shared prefix bit; deeper prefixes than the key is long cannot exist
+  MaxRegionBits* = IdLength * 8
+    ## a region prefix bit per key bit; a longer prefix narrows nothing further
   DefaultMaxBuckets* = MaxBucketsLimit
   MaxRefreshLeadingZeros* = 12
   DefaultTimeout* = 5.seconds
@@ -427,6 +429,11 @@ type KadDHTConfig* = object
     ## rejected. The per-key cap (``limits.maxProvidersPerKey``) is always
     ## enforced regardless of this flag — this only controls whether
     ## rejections are acknowledged on the wire.
+  republishRegionBits*: Opt[int]
+    ## Overrides the keyspace prefix length that groups provided keys into
+    ## republish regions, one DHT walk each. ``Opt.none`` derives it from the
+    ## routing table; too few bits advertise a key to peers that are not its
+    ## closest.
   limits*: KadDHTLimits
 
 proc new*(
@@ -450,10 +457,14 @@ proc new*(
     hideConnectionStatus: bool = true,
     disableBootstrapping: bool = false,
     providerRejection: bool = false,
+    republishRegionBits: Opt[int] = Opt.none(int),
     limits: Opt[KadDHTLimits] = Opt.none(KadDHTLimits),
 ): K {.raises: [].} =
   let actualLimits = limits.valueOr:
     KadDHTLimits.new(replication, quorum)
+  doAssert republishRegionBits.isNone or republishRegionBits.get() in 0 .. MaxRegionBits,
+    "republishRegionBits must be in 0 .. " & $MaxRegionBits &
+      "; use Opt.none(int) to derive it from the routing table"
   doAssert actualLimits.maxProvidersPerKey.isNone or
     actualLimits.maxProvidersPerKey.get() > 0,
     "maxProvidersPerKey must be > 0; use Opt.none(int) for unlimited"
@@ -491,6 +502,7 @@ proc new*(
     hideConnectionStatus: hideConnectionStatus,
     disableBootstrapping: disableBootstrapping,
     providerRejection: providerRejection,
+    republishRegionBits: republishRegionBits,
     limits: actualLimits,
   )
 

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -64,6 +64,12 @@ const
 
 type Key* = seq[byte]
 
+func init*(T: typedesc[Key], bytes: openArray[byte]): Key =
+  ## Key of `IdLength` bytes holding `bytes`, zero-padded.
+  var buf: array[IdLength, byte]
+  discard buf.copyFrom(bytes)
+  @buf
+
 proc toCid*(k: Key): Cid =
   let cidRes = Cid.init(k)
   if cidRes.isOk:

--- a/tests/libp2p/kademlia/test_add_provider.nim
+++ b/tests/libp2p/kademlia/test_add_provider.nim
@@ -472,6 +472,7 @@ suite "KadDHT - Republish By Keyspace Region":
 
     check:
       regions.len < keys.len
+      # 1 prefix bit cuts the keyspace in two, so no key falls outside 2 regions.
       regions.len <= 2
       regions.concat().toHashSet() == keys.toHashSet()
 

--- a/tests/libp2p/kademlia/test_add_provider.nim
+++ b/tests/libp2p/kademlia/test_add_provider.nim
@@ -455,11 +455,9 @@ suite "KadDHT - Republish By Keyspace Region":
 
   proc provideWithoutAnnouncing(kad: KadDHT, count: int): seq[Key] =
     ## Seed the store directly, so only the republish loop advertises the keys.
-    var keys: seq[Key]
-    for i in 0 ..< count:
-      let key = MultiHash.digest("sha2-256", @[i.byte]).get().toKey()
+    let keys = Key.makeKeys(count)
+    for key in keys:
       kad.providerManager.providedKeys.provided[key] = Moment.now()
-      keys.add(key)
     keys
 
   asyncTest "Provided keys are grouped into keyspace regions":
@@ -472,13 +470,13 @@ suite "KadDHT - Republish By Keyspace Region":
 
     check:
       regions.len < keys.len
-      # 1 prefix bit cuts the keyspace in two, so no key falls outside 2 regions.
+      # 1 prefix bit splits the keyspace in two, so the keys land in 2 regions at most.
       regions.len <= 2
       regions.concat().toHashSet() == keys.toHashSet()
 
     for region in regions:
       check region.allIt(
-        it.regionPrefix(1, hasher) == region[0].regionPrefix(1, hasher)
+        RegionPrefix.init(it, 1, hasher) == RegionPrefix.init(region[0], 1, hasher)
       )
 
   asyncTest "Each key gets its own region while the network size is unknown":

--- a/tests/libp2p/kademlia/test_add_provider.nim
+++ b/tests/libp2p/kademlia/test_add_provider.nim
@@ -449,6 +449,68 @@ suite "KadDHT - Add Provider":
       kads[1].providerManager.providerRecords[0].provider.id.get() ==
         kads[0].rtable.selfId
 
+suite "KadDHT - Republish By Keyspace Region":
+  teardown:
+    checkTrackers()
+
+  proc provideWithoutAnnouncing(kad: KadDHT, count: int): seq[Key] =
+    ## Seed the store directly, so only the republish loop advertises the keys.
+    var keys: seq[Key]
+    for i in 0 ..< count:
+      let key = MultiHash.digest("sha2-256", @[i.byte]).get().toKey()
+      kad.providerManager.providedKeys.provided[key] = Moment.now()
+      keys.add(key)
+    keys
+
+  asyncTest "Provided keys are grouped into keyspace regions":
+    let kad = setupKad(testKadConfig(republishRegionBits = Opt.some(1)))
+    startAndDeferStop(@[kad])
+
+    let keys = kad.provideWithoutAnnouncing(8)
+    let regions = kad.providedKeyRegions()
+    let hasher = kad.rtable.config.hasher
+
+    check:
+      regions.len < keys.len
+      regions.len <= 2
+      regions.concat().toHashSet() == keys.toHashSet()
+
+    for region in regions:
+      check region.allIt(
+        it.regionPrefix(1, hasher) == region[0].regionPrefix(1, hasher)
+      )
+
+  asyncTest "Each key gets its own region while the network size is unknown":
+    let kad = setupKad()
+    startAndDeferStop(@[kad])
+
+    check kad.rtable.regionBits().isNone()
+
+    let keys = kad.provideWithoutAnnouncing(4)
+    let regions = kad.providedKeyRegions()
+
+    check:
+      regions.len == keys.len
+      regions.concat().toHashSet() == keys.toHashSet()
+
+  asyncTest "A single region walk advertises every key it holds":
+    let senderKad = setupKad(
+      testKadConfig(
+        republishRegionBits = Opt.some(0), providerExpirationInterval = 30.seconds
+      )
+    )
+    let receiverKad = setupKad(testKadConfig(providerExpirationInterval = 30.seconds))
+
+    startAndDeferStop(@[senderKad, receiverKad])
+    await connect(senderKad, receiverKad)
+
+    let keys = senderKad.provideWithoutAnnouncing(5)
+    check senderKad.providedKeyRegions().len == 1
+
+    checkUntilTimeout:
+      receiverKad.providerManager.knownKeys.len == keys.len
+      keys.allIt(receiverKad.providerManager.knownKeys.hasKey(it))
+
 suite "KadDHT - ADD_PROVIDER Rejection":
   teardown:
     checkTrackers()

--- a/tests/libp2p/kademlia/test_keyspace.nim
+++ b/tests/libp2p/kademlia/test_keyspace.nim
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import std/[algorithm, sequtils, sets]
+import chronos, results
+import ../../../libp2p/[peerid, protocols/kademlia, crypto/crypto]
+import ../../tools/[unittest, crypto]
+
+let NoOp = Opt.some(noOpHasher)
+
+proc keyFrom(bytes: openArray[byte]): Key =
+  ## Key whose `noOpHasher` hash starts with `bytes`.
+  var buf: array[IdLength, byte]
+  for i, b in bytes:
+    buf[i] = b
+  @buf
+
+proc keyInBucket(bucket: int, tag: byte): Key =
+  ## Key landing in `bucket` of an all-zero selfId table. `tag` keeps keys apart.
+  var buf: array[IdLength, byte]
+  buf[bucket div 8] = 0x80'u8 shr (bucket mod 8)
+  buf[IdLength - 1] = tag
+  @buf
+
+proc emptyTable(replication: int): RoutingTable =
+  RoutingTable.new(
+    keyFrom([0'u8]),
+    RoutingTableConfig.new(
+      replication = replication, hasher = NoOp, selfIdPreHashed = true
+    ),
+  )
+
+proc fillBucket(rtable: RoutingTable, bucket: int, count: int) =
+  for i in 0 ..< count:
+    doAssert rtable.insert(keyInBucket(bucket, i.byte))
+
+suite "KadDHT Keyspace Regions":
+  test "region prefix keeps the leading bits and clears the rest":
+    let key = keyFrom([0b1011_0110'u8, 0b1111_0000])
+    check:
+      key.regionPrefix(0, NoOp) == newSeq[byte](0)
+      key.regionPrefix(1, NoOp) == @[0b1000_0000'u8]
+      key.regionPrefix(4, NoOp) == @[0b1011_0000'u8]
+      key.regionPrefix(8, NoOp) == @[0b1011_0110'u8]
+      key.regionPrefix(12, NoOp) == @[0b1011_0110'u8, 0b1111_0000]
+
+  test "region prefix is clamped to the hash length":
+    check keyFrom([0xFF'u8]).regionPrefix(MaxRegionBits + 8, NoOp).len == IdLength
+
+  test "keys share a region exactly when their leading bits match":
+    let
+      a = keyFrom([0b1010_0000'u8])
+      b = keyFrom([0b1011_0000'u8])
+    check:
+      a.regionPrefix(3, NoOp) == b.regionPrefix(3, NoOp)
+      a.regionPrefix(4, NoOp) != b.regionPrefix(4, NoOp)
+
+  test "zero bits groups every key into one region":
+    let keys = @[keyFrom([0x00'u8]), keyFrom([0x80'u8]), keyFrom([0xFF'u8])]
+    let regions = keys.keyspaceRegions(0, NoOp)
+    check:
+      regions.len == 1
+      regions[0].toHashSet() == keys.toHashSet()
+
+  test "regions partition the keys by prefix":
+    let keys = @[
+      keyFrom([0x00'u8]),
+      keyFrom([0x01'u8]),
+      keyFrom([0x80'u8]),
+      keyFrom([0xC0'u8]),
+      keyFrom([0xFF'u8]),
+    ]
+    let regions = keys.keyspaceRegions(1, NoOp)
+
+    check:
+      regions.len == 2
+      regions.mapIt(it.len).sorted() == @[2, 3]
+      regions.concat().toHashSet() == keys.toHashSet()
+
+    for region in regions:
+      check region.allIt(it.regionPrefix(1, NoOp) == region[0].regionPrefix(1, NoOp))
+
+  test "an empty key set yields no regions":
+    check newSeq[Key]().keyspaceRegions(4, NoOp).len == 0
+
+  test "region bits are unknown while no bucket is full":
+    let rtable = emptyTable(4)
+    check rtable.regionBits().isNone()
+
+    rtable.fillBucket(2, 3)
+    check rtable.regionBits().isNone()
+
+  test "region bits follow the deepest full bucket":
+    let rtable = emptyTable(4)
+
+    rtable.fillBucket(2, 4)
+    check rtable.regionBits() == Opt.some(3)
+
+    rtable.fillBucket(5, 4)
+    check rtable.regionBits() == Opt.some(6)
+
+    # A deeper bucket that is not full carries no evidence of network size.
+    rtable.fillBucket(7, 3)
+    check rtable.regionBits() == Opt.some(6)
+
+  test "closestFirst orders peers by distance to the key":
+    let hasher = Opt.none(XorDHasher)
+    let key = PeerId.random(rng()).get().toKey()
+    var peers: seq[PeerId]
+    for _ in 0 ..< 8:
+      peers.add(PeerId.random(rng()).get())
+
+    let ordered = peers.closestFirst(key, hasher)
+    check:
+      ordered.len == peers.len
+      ordered.toHashSet() == peers.toHashSet()
+
+    for i in 1 ..< ordered.len:
+      check xorDistance(ordered[i - 1], key, hasher) <=
+        xorDistance(ordered[i], key, hasher)

--- a/tests/libp2p/kademlia/test_keyspace.nim
+++ b/tests/libp2p/kademlia/test_keyspace.nim
@@ -8,7 +8,13 @@ import chronos, results
 import ../../../libp2p/[peerid, protocols/kademlia, crypto/crypto]
 import ../../tools/[unittest, crypto]
 
-let NoOp = Opt.some(noOpHasher)
+# The no-op hasher makes a key its own hash, so a test picks its bits directly.
+let NoHash = Opt.some(noOpHasher)
+# Opt.none picks the default sha256 hasher, the one a running node uses.
+let DefaultHash = Opt.none(XorDHasher)
+
+proc regionPrefixNoHash(key: Key, bits: int): RegionPrefix =
+  RegionPrefix.init(key, bits, NoHash)
 
 proc makeKeyInBucket(bucket: int, tag: byte): Key =
   ## Key landing in `bucket` of an all-zero selfId table. `tag` keeps keys apart.
@@ -21,7 +27,7 @@ proc makeEmptyTable(replication: int): RoutingTable =
   RoutingTable.new(
     Key.init([0'u8]),
     RoutingTableConfig.new(
-      replication = replication, hasher = NoOp, selfIdPreHashed = true
+      replication = replication, hasher = NoHash, selfIdPreHashed = true
     ),
   )
 
@@ -33,35 +39,37 @@ suite "KadDHT Keyspace Regions":
   test "region prefix keeps the leading bits and clears the rest":
     let key = Key.init([0b1011_0110'u8, 0b1111_0000])
     check:
-      key.regionPrefix(0, NoOp) == newSeq[byte](0)
-      key.regionPrefix(1, NoOp) == @[0b1000_0000'u8]
-      key.regionPrefix(4, NoOp) == @[0b1011_0000'u8]
-      key.regionPrefix(8, NoOp) == @[0b1011_0110'u8]
-      key.regionPrefix(12, NoOp) == @[0b1011_0110'u8, 0b1111_0000]
+      key.regionPrefixNoHash(0) == newSeq[byte](0)
+      key.regionPrefixNoHash(1) == @[0b1000_0000'u8]
+      key.regionPrefixNoHash(4) == @[0b1011_0000'u8]
+      key.regionPrefixNoHash(8) == @[0b1011_0110'u8]
+      key.regionPrefixNoHash(12) == @[0b1011_0110'u8, 0b1111_0000]
 
   test "region prefix is clamped to the hash length":
-    check Key.init([0xFF'u8]).regionPrefix(MaxRegionBits + 8, NoOp).len == IdLength
+    check Key.init([0xFF'u8]).regionPrefixNoHash(MaxRegionBits + 8).len == IdLength
 
   test "keys share a region exactly when their leading bits match":
     let
       a = Key.init([0b1010_0000'u8])
       b = Key.init([0b1011_0000'u8])
     check:
-      a.regionPrefix(3, NoOp) == b.regionPrefix(3, NoOp)
-      a.regionPrefix(4, NoOp) != b.regionPrefix(4, NoOp)
+      a.regionPrefixNoHash(3) == b.regionPrefixNoHash(3)
+      a.regionPrefixNoHash(4) != b.regionPrefixNoHash(4)
 
   test "zero bits groups every key into one region":
     let keys = @[Key.init([0x00'u8]), Key.init([0x80'u8]), Key.init([0xFF'u8])]
-    check keys.keyspaceRegions(0, NoOp) == @[keys]
+    check keys.keyspaceRegions(0, NoHash) == @[keys]
 
   test "regions partition the keys by prefix":
     let
       zeroPrefix = @[Key.init([0x00'u8]), Key.init([0x01'u8])]
       onePrefix = @[Key.init([0x80'u8]), Key.init([0xC0'u8]), Key.init([0xFF'u8])]
-    check (zeroPrefix & onePrefix).keyspaceRegions(1, NoOp) == @[zeroPrefix, onePrefix]
+    check (zeroPrefix & onePrefix).keyspaceRegions(1, NoHash) == @[
+      zeroPrefix, onePrefix
+    ]
 
   test "an empty key set yields no regions":
-    check newSeq[Key]().keyspaceRegions(4, NoOp).len == 0
+    check newSeq[Key]().keyspaceRegions(4, NoHash).len == 0
 
   test "region bits are unknown while no bucket is full":
     let rtable = makeEmptyTable(4)
@@ -84,15 +92,14 @@ suite "KadDHT Keyspace Regions":
     check rtable.regionBits() == Opt.some(6)
 
   test "closestFirst orders peers by distance to the key":
-    let hasher = Opt.none(XorDHasher)
     let key = PeerId.random(rng()).get().toKey()
     let peers = PeerId.random(8, rng()).get()
 
-    let ordered = peers.closestFirst(key, hasher)
+    let ordered = peers.closestFirst(key, DefaultHash)
     check:
       ordered.len == peers.len
       ordered.toHashSet() == peers.toHashSet()
 
     for i in 1 ..< ordered.len:
-      check xorDistance(ordered[i - 1], key, hasher) <=
-        xorDistance(ordered[i], key, hasher)
+      check xorDistance(ordered[i - 1], key, DefaultHash) <=
+        xorDistance(ordered[i], key, DefaultHash)

--- a/tests/libp2p/kademlia/test_keyspace.nim
+++ b/tests/libp2p/kademlia/test_keyspace.nim
@@ -108,9 +108,7 @@ suite "KadDHT Keyspace Regions":
   test "closestFirst orders peers by distance to the key":
     let hasher = Opt.none(XorDHasher)
     let key = PeerId.random(rng()).get().toKey()
-    var peers: seq[PeerId]
-    for _ in 0 ..< 8:
-      peers.add(PeerId.random(rng()).get())
+    let peers = PeerId.random(8, rng())
 
     let ordered = peers.closestFirst(key, hasher)
     check:

--- a/tests/libp2p/kademlia/test_keyspace.nim
+++ b/tests/libp2p/kademlia/test_keyspace.nim
@@ -3,30 +3,23 @@
 
 {.used.}
 
-import std/[algorithm, sequtils, sets]
+import std/sets
 import chronos, results
 import ../../../libp2p/[peerid, protocols/kademlia, crypto/crypto]
 import ../../tools/[unittest, crypto]
 
 let NoOp = Opt.some(noOpHasher)
 
-proc keyFrom(bytes: openArray[byte]): Key =
-  ## Key whose `noOpHasher` hash starts with `bytes`.
-  var buf: array[IdLength, byte]
-  for i, b in bytes:
-    buf[i] = b
-  @buf
-
-proc keyInBucket(bucket: int, tag: byte): Key =
+proc makeKeyInBucket(bucket: int, tag: byte): Key =
   ## Key landing in `bucket` of an all-zero selfId table. `tag` keeps keys apart.
   var buf: array[IdLength, byte]
   buf[bucket div 8] = 0x80'u8 shr (bucket mod 8)
   buf[IdLength - 1] = tag
   @buf
 
-proc emptyTable(replication: int): RoutingTable =
+proc makeEmptyTable(replication: int): RoutingTable =
   RoutingTable.new(
-    keyFrom([0'u8]),
+    Key.init([0'u8]),
     RoutingTableConfig.new(
       replication = replication, hasher = NoOp, selfIdPreHashed = true
     ),
@@ -34,11 +27,11 @@ proc emptyTable(replication: int): RoutingTable =
 
 proc fillBucket(rtable: RoutingTable, bucket: int, count: int) =
   for i in 0 ..< count:
-    doAssert rtable.insert(keyInBucket(bucket, i.byte))
+    doAssert rtable.insert(makeKeyInBucket(bucket, i.byte))
 
 suite "KadDHT Keyspace Regions":
   test "region prefix keeps the leading bits and clears the rest":
-    let key = keyFrom([0b1011_0110'u8, 0b1111_0000])
+    let key = Key.init([0b1011_0110'u8, 0b1111_0000])
     check:
       key.regionPrefix(0, NoOp) == newSeq[byte](0)
       key.regionPrefix(1, NoOp) == @[0b1000_0000'u8]
@@ -47,53 +40,38 @@ suite "KadDHT Keyspace Regions":
       key.regionPrefix(12, NoOp) == @[0b1011_0110'u8, 0b1111_0000]
 
   test "region prefix is clamped to the hash length":
-    check keyFrom([0xFF'u8]).regionPrefix(MaxRegionBits + 8, NoOp).len == IdLength
+    check Key.init([0xFF'u8]).regionPrefix(MaxRegionBits + 8, NoOp).len == IdLength
 
   test "keys share a region exactly when their leading bits match":
     let
-      a = keyFrom([0b1010_0000'u8])
-      b = keyFrom([0b1011_0000'u8])
+      a = Key.init([0b1010_0000'u8])
+      b = Key.init([0b1011_0000'u8])
     check:
       a.regionPrefix(3, NoOp) == b.regionPrefix(3, NoOp)
       a.regionPrefix(4, NoOp) != b.regionPrefix(4, NoOp)
 
   test "zero bits groups every key into one region":
-    let keys = @[keyFrom([0x00'u8]), keyFrom([0x80'u8]), keyFrom([0xFF'u8])]
-    let regions = keys.keyspaceRegions(0, NoOp)
-    check:
-      regions.len == 1
-      regions[0].toHashSet() == keys.toHashSet()
+    let keys = @[Key.init([0x00'u8]), Key.init([0x80'u8]), Key.init([0xFF'u8])]
+    check keys.keyspaceRegions(0, NoOp) == @[keys]
 
   test "regions partition the keys by prefix":
-    let keys = @[
-      keyFrom([0x00'u8]),
-      keyFrom([0x01'u8]),
-      keyFrom([0x80'u8]),
-      keyFrom([0xC0'u8]),
-      keyFrom([0xFF'u8]),
-    ]
-    let regions = keys.keyspaceRegions(1, NoOp)
-
-    check:
-      regions.len == 2
-      regions.mapIt(it.len).sorted() == @[2, 3]
-      regions.concat().toHashSet() == keys.toHashSet()
-
-    for region in regions:
-      check region.allIt(it.regionPrefix(1, NoOp) == region[0].regionPrefix(1, NoOp))
+    let
+      zeroPrefix = @[Key.init([0x00'u8]), Key.init([0x01'u8])]
+      onePrefix = @[Key.init([0x80'u8]), Key.init([0xC0'u8]), Key.init([0xFF'u8])]
+    check (zeroPrefix & onePrefix).keyspaceRegions(1, NoOp) == @[zeroPrefix, onePrefix]
 
   test "an empty key set yields no regions":
     check newSeq[Key]().keyspaceRegions(4, NoOp).len == 0
 
   test "region bits are unknown while no bucket is full":
-    let rtable = emptyTable(4)
+    let rtable = makeEmptyTable(4)
     check rtable.regionBits().isNone()
 
     rtable.fillBucket(2, 3)
     check rtable.regionBits().isNone()
 
   test "region bits follow the deepest full bucket":
-    let rtable = emptyTable(4)
+    let rtable = makeEmptyTable(4)
 
     rtable.fillBucket(2, 4)
     check rtable.regionBits() == Opt.some(3)
@@ -108,7 +86,7 @@ suite "KadDHT Keyspace Regions":
   test "closestFirst orders peers by distance to the key":
     let hasher = Opt.none(XorDHasher)
     let key = PeerId.random(rng()).get().toKey()
-    let peers = PeerId.random(8, rng())
+    let peers = PeerId.random(8, rng()).get()
 
     let ordered = peers.closestFirst(key, hasher)
     check:

--- a/tests/libp2p/kademlia/utils.nim
+++ b/tests/libp2p/kademlia/utils.nim
@@ -61,6 +61,7 @@ proc testKadConfig*(
     providerExpirationInterval: Duration = 1.seconds,
     recordExpirationInterval: Duration = DefaultRecordExpirationInterval,
     cleanupDataEntriesInterval: Duration = chronos.milliseconds(100),
+    republishRegionBits: Opt[int] = Opt.none(int),
 ): KadDHTConfig =
   KadDHTConfig.new(
     validator,
@@ -74,6 +75,7 @@ proc testKadConfig*(
     providerRejection = providerRejection,
     recordExpirationInterval = recordExpirationInterval,
     cleanupDataEntriesInterval = cleanupDataEntriesInterval,
+    republishRegionBits = republishRegionBits,
   )
 
 proc setupKad*(

--- a/tests/libp2p/kademlia/utils.nim
+++ b/tests/libp2p/kademlia/utils.nim
@@ -3,7 +3,8 @@
 {.used.}
 
 import algorithm, chronos, results, sequtils, sets, tables
-import ../../../libp2p/[protocols/kademlia, switch, builders, stream/connection]
+import
+  ../../../libp2p/[protocols/kademlia, switch, builders, multihash, stream/connection]
 import ../../tools/[crypto, unittest, switch_builder, multiaddress]
 import ./mock_kademlia
 
@@ -48,6 +49,13 @@ method select*(
   if values.len == 1:
     return ok(0)
   ok(1)
+
+proc makeKeys*(T: typedesc[Key], count: int): seq[Key] =
+  ## `count` distinct keys, one per index.
+  var keys: seq[Key]
+  for i in 0 ..< count:
+    keys.add(MultiHash.digest("sha2-256", @[i.byte]).get().toKey())
+  keys
 
 proc testKadConfig*(
     validator: EntryValidator = PermissiveValidator(),


### PR DESCRIPTION
## Summary

`manageRepublishProvidedKeys` called `addProvider` for every provided key, and each call ran a full `findNode` walk. A node that provides N keys ran N independent lookups on every republish cycle.

This PR groups the provided keys into keyspace regions and runs one walk per region. A region is the set of keys whose hashes share a leading bit prefix. The prefix length comes from the routing table: bucket `d` covers a `2^-(d+1)` slice of the keyspace, so a deepest full bucket `d` puts the network at about `replication * 2^(d+1)` peers, and `d + 1` prefix bits cut that into regions of about `replication` peers each. A peer that shares the prefix is always closer to a key in the region than a peer that does not, so once a region holds at least `replication` peers, every key in it has all of its closest peers inside the region. One walk toward any member key therefore finds the peers of every other member.

Each key still gets its own target set: `closestFirst` re-sorts the peers that the region walk discovered by distance to that key, so no key is advertised to a peer that is farther than its own closest set. Republish cost now scales with regions instead of keys.

The regions also start evenly spread over the first half of the republish interval. This trickles the walks out instead of firing them all at once, and it leaves the second half of the interval as headroom for the last region to finish.

While no bucket is full, the routing table carries no evidence of the network size. The republish then falls back to one walk per key, which is the behaviour before this PR. A region guessed too wide would advertise keys to peers that are not their closest, so the fallback is the safe default.

## Affected Areas

- [x] Peer Management / Discovery
- [x] Protocol Logic

New module `libp2p/protocols/kademlia/keyspace.nim` holds the region maths: `regionPrefix`, `keyspaceRegions`, `regionBits` and `closestFirst`.

`libp2p/protocols/kademlia/provider.nim` gains `providedKeyRegions`, `republishRegion` and the region schedule. The ADD_PROVIDER fan-out that `addProvider` shared with the spillover path moved into `storeProviderAt`, which both the single-key path and the region path now use. `addProvider` keeps its behaviour: with `providerRejection` it walks and spills over, without it it calls `findNode` and tells the `replication` closest peers.

`libp2p/protocols/kademlia/types.nim` gains the `republishRegionBits` config field and the `MaxRegionBits` constant.

## Compatibility & Downstream Validation

No wire format change and no protocol change. The node sends the same ADD_PROVIDER messages to the same kind of peer set; only the number of lookups that finds that set changes. Downstream validation is not needed.

- **Nimbus:** N/A
- **Waku:** N/A
- **Codex:** N/A

## Impact on Library Users

No breaking API change. `KadDHTConfig` gains one optional field, `republishRegionBits`, which defaults to `Opt.none(int)`. `Opt.none` derives the prefix length from the routing table.

`KadDHT` gains `providedKeyRegions`, which returns the plan for the next republish: the provided keys grouped into the regions that the loop will walk.

Two metrics report the batching: `kad_provider_republish_regions` counts the walks, and `kad_provider_republish_keys` counts the keys those walks served. The ratio between them shows the saving.

The performance gain is largest for nodes that provide many CIDs.

## Risk Assessment

Backward compatibility: no wire change, so a batching node and a non-batching node interoperate.

Network behaviour: a republish cycle now spreads its walks over half the interval instead of starting them together. The heartbeat keeps a fixed period, so the cycle rate does not change.

Correctness: the region argument holds only while a region contains at least `replication` peers. `republishRegionBits` lets an operator override the derived prefix length, and too few bits advertise keys to peers that are not their closest. The field doc states this, and the constructor bounds the value to `0 .. MaxRegionBits`.

Security: a peer that poisons one walk now steers the advertisements of a whole region instead of one key. The per-key limits do not change: the shortlist stays bounded by `maxShortlistSize`, `closestFirst` re-sorts per key, and the fan-out stays bounded by `replication`.

`stopProviding` during a region's scheduled delay is handled: `republishRegion` re-checks the live provided set after the delay and drops the keys that are gone.

## References

Closes #2857. Sub-issue of #1756.

Design follows go-libp2p `provider/provider.go`, which sweeps the keyspace into regions and batches the keys of each region into a single DHT walk.

## Additional Notes

Tests: `tests/libp2p/kademlia/test_keyspace.nim` covers the region maths, including the prefix masking, the partition property and the bucket-derived prefix length. `tests/libp2p/kademlia/test_add_provider.nim` gains a suite that covers the grouping, the one-region-per-key fallback and the delivery of every key in a single region walk.