### PR TITLE
fix(logs): adding logLevel to Libp2pConfig to avoid logs created in createLibp2pNode

### DIFF
--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -382,20 +382,27 @@ proc createLibp2pNode(config: Libp2pConfig): Result[LibP2P, string] =
 
   ok(lib)
 
-proc libp2pSetLogLevel*(level: int): Future[Result[bool, string]] {.ffiStatic.} =
-  ## Changes the process-wide nim-libp2p runtime log level.
+proc applyLogLevel(level: int): Result[void, string] =
   if level < ord(low(chronicles.LogLevel)) or level > ord(high(chronicles.LogLevel)):
     return err("invalid log level: " & $level)
 
   when chronicles.runtimeFilteringEnabled:
     logging.setLogLevel(chronicles.LogLevel(level))
-    ok(true)
+    ok()
   else:
     err("nim-libp2p runtime logs filtering is disabled")
+
+proc libp2pSetLogLevel*(level: int): Future[Result[bool, string]] {.ffiStatic.} =
+  ## Changes the process-wide nim-libp2p runtime log level.
+  ?applyLogLevel(level)
+  ok(true)
 
 proc libp2pNew*(config: Libp2pConfig): Future[Result[LibP2P, string]] {.ffiCtor.} =
   ## Builds the switch from `config` and mounts the requested protocols. The
   ## node is not listening yet; call `libp2p_ctx_start` for that.
+  if config.logLevel != ord(chronicles.LogLevel.NONE):
+    ?applyLogLevel(config.logLevel)
+
   try:
     createLibp2pNode(config)
   except LPError as e:
@@ -436,6 +443,7 @@ proc libp2pDestroy*(lib: LibP2P): Future[void] {.ffiDtor.} =
 # `Libp2pConfig` (strings and enums differ); `muxer`/`transport` carry the
 # `MuxerType`/`TransportType` ordinals. Keep the field list in sync.
 type CLibp2pConfig {.exportc: "libp2p_config", bycopy.} = object
+  logLevel: cint
   mountGossipsub: cint
   gossipsubTriggerSelf: cint
   mountKad: cint

--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -392,11 +392,6 @@ proc applyLogLevel(level: int): Result[void, string] =
   else:
     err("nim-libp2p runtime logs filtering is disabled")
 
-proc libp2pSetLogLevel*(level: int): Future[Result[bool, string]] {.ffiStatic.} =
-  ## Changes the process-wide nim-libp2p runtime log level.
-  ?applyLogLevel(level)
-  ok(true)
-
 proc libp2pNew*(config: Libp2pConfig): Future[Result[LibP2P, string]] {.ffiCtor.} =
   ## Builds the switch from `config` and mounts the requested protocols. The
   ## node is not listening yet; call `libp2p_ctx_start` for that.

--- a/cbind/libp2p/config.nim
+++ b/cbind/libp2p/config.nim
@@ -29,6 +29,8 @@ type BootstrapNode {.ffi.} = object
   multiaddrs: seq[string]
 
 type Libp2pConfig {.ffi.} = object
+  logLevel: int
+    ## Chronicles runtime log level to apply before node construction.
   mountGossipsub: bool
     ## Mount GossipSub for publishing and receiving messages via pubsub.
   gossipsubTriggerSelf: bool ## Deliver locally published GossipSub messages to self.

--- a/cbind/libp2p/config.nim
+++ b/cbind/libp2p/config.nim
@@ -29,8 +29,7 @@ type BootstrapNode {.ffi.} = object
   multiaddrs: seq[string]
 
 type Libp2pConfig {.ffi.} = object
-  logLevel: int
-    ## Chronicles runtime log level to apply before node construction.
+  logLevel: int ## Chronicles runtime log level to apply before node construction.
   mountGossipsub: bool
     ## Mount GossipSub for publishing and receiving messages via pubsub.
   gossipsubTriggerSelf: bool ## Deliver locally published GossipSub messages to self.


### PR DESCRIPTION
this is fix for case were `nim-ffi` initializes each context thread with `debug` text logging. some libp2p services can emit logs during `libp2p_ctx_create`:
> DBG ... Setting up WildcardAddressResolverService topics="libp2p wildcardresolverservice"

 before the host receives a context pointer and before it can reapply a desired log level.

to avoid this, this PR adds a `logLevel` field to the cbind `Libp2pConfig` and applies it at the start of `libp2pNew`, before `createLibp2pNode(config)` builds/mounts libp2p services.

this lets callers configure the chronicles runtime log level before node construction emits logs, instead of relying only on the existing post-construction `libp2pSetLogLevel` static call.

 
