### PR TITLE
chore(cbind): use nim-ffi 0.3.0

### DIFF
--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -8,9 +8,7 @@ license = "MIT"
 
 import os, strutils
 
-requires "taskpools >= 0.1.0",
-  "ffi >= 0.3.0",
-  "https://github.com/vacp2p/nim-cbor-serialization#1664160e04d153573373afddc552b9cbf6fbe4dc"
+requires "taskpools >= 0.1.0", "ffi >= 0.3.0", "cbor_serialization == 0.3.0"
 
 proc findInstalledPkgDir(prefix: string): string =
   ## Path of an installed dep dir matching `prefix` (e.g. "ffi-"). Lockfile
@@ -35,8 +33,8 @@ proc findInstalledPkgDir(prefix: string): string =
   )
 
 proc ffiDepPaths(): string =
-  # `setup` does not put direct Git URL deps on nimble.paths; point the compiler
-  # at the installed copies.
+  # A global install writes no nimble.paths; point the compiler at the installed
+  # copies.
   " --path:" & findInstalledPkgDir("ffi-") & " --path:" &
     findInstalledPkgDir("cbor_serialization-")
 

--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -8,10 +8,8 @@ license = "MIT"
 
 import os, strutils
 
-requires "taskpools >= 0.1.0",
-  "https://github.com/vacp2p/nim-cbor-serialization#1664160e04d153573373afddc552b9cbf6fbe4dc",
-  # nim-ffi v0.3.0-rc.2
-  "https://github.com/logos-messaging/nim-ffi#53515de17af0ef3e88b2aec9675b8163dddc14ae"
+requires "taskpools >= 0.1.0", "ffi >= 0.3.0",
+  "https://github.com/vacp2p/nim-cbor-serialization#1664160e04d153573373afddc552b9cbf6fbe4dc"
 
 proc findInstalledPkgDir(prefix: string): string =
   ## Path of an installed dep dir matching `prefix` (e.g. "ffi-"). Lockfile

--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -10,8 +10,8 @@ import os, strutils
 
 requires "taskpools >= 0.1.0",
   "https://github.com/vacp2p/nim-cbor-serialization#1664160e04d153573373afddc552b9cbf6fbe4dc",
-  # nim-ffi v0.3.0-rc.1
-  "https://github.com/logos-messaging/nim-ffi#aad9374354a5e3d98964a9adf80766a12f8f200d"
+  # nim-ffi v0.3.0-rc.2
+  "https://github.com/logos-messaging/nim-ffi#53515de17af0ef3e88b2aec9675b8163dddc14ae"
 
 proc findInstalledPkgDir(prefix: string): string =
   ## Path of an installed dep dir matching `prefix` (e.g. "ffi-"). Lockfile

--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -8,7 +8,8 @@ license = "MIT"
 
 import os, strutils
 
-requires "taskpools >= 0.1.0", "ffi >= 0.3.0",
+requires "taskpools >= 0.1.0",
+  "ffi >= 0.3.0",
   "https://github.com/vacp2p/nim-cbor-serialization#1664160e04d153573373afddc552b9cbf6fbe4dc"
 
 proc findInstalledPkgDir(prefix: string): string =

--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -10,8 +10,8 @@ import os, strutils
 
 requires "taskpools >= 0.1.0",
   "https://github.com/vacp2p/nim-cbor-serialization#1664160e04d153573373afddc552b9cbf6fbe4dc",
-  # nim-ffi head of the unmerged `fix/cbor-non-canonical`; repin to a tag on merge
-  "https://github.com/logos-messaging/nim-ffi#b95e2b04a63fbd417938bf3ec0ac14be7935e21b"
+  # nim-ffi v0.3.0-rc.1
+  "https://github.com/logos-messaging/nim-ffi#aad9374354a5e3d98964a9adf80766a12f8f200d"
 
 proc findInstalledPkgDir(prefix: string): string =
   ## Path of an installed dep dir matching `prefix` (e.g. "ffi-"). Lockfile

--- a/cbind/nimble.lock
+++ b/cbind/nimble.lock
@@ -199,7 +199,7 @@
     },
     "ffi": {
       "version": "0.3.0",
-      "vcsRevision": "b95e2b04a63fbd417938bf3ec0ac14be7935e21b",
+      "vcsRevision": "aad9374354a5e3d98964a9adf80766a12f8f200d",
       "url": "https://github.com/logos-messaging/nim-ffi",
       "downloadMethod": "git",
       "dependencies": [
@@ -210,7 +210,7 @@
         "cbor_serialization"
       ],
       "checksums": {
-        "sha1": "a8d244364b3a00614566b5009f9e7888b1cfd7f2"
+        "sha1": "db5fc50aa4717418e481cb0b1f7ca36f2d76586c"
       }
     }
   },

--- a/cbind/nimble.lock
+++ b/cbind/nimble.lock
@@ -199,7 +199,7 @@
     },
     "ffi": {
       "version": "0.3.0",
-      "vcsRevision": "aad9374354a5e3d98964a9adf80766a12f8f200d",
+      "vcsRevision": "53515de17af0ef3e88b2aec9675b8163dddc14ae",
       "url": "https://github.com/logos-messaging/nim-ffi",
       "downloadMethod": "git",
       "dependencies": [
@@ -210,7 +210,7 @@
         "cbor_serialization"
       ],
       "checksums": {
-        "sha1": "db5fc50aa4717418e481cb0b1f7ca36f2d76586c"
+        "sha1": "1d84ceaf8594f4970c5a37f916003ffc0531dc4e"
       }
     }
   },

--- a/interop/transport/main.nim
+++ b/interop/transport/main.nim
@@ -14,6 +14,17 @@ let testTimeout =
   except CatchableError:
     3.minutes
 
+proc openRedis(host: string, port: Port): Redis =
+  # redis may not be listening yet when this container starts
+  let deadline = Moment.now() + 30.seconds
+  while true:
+    try:
+      return open(host, port)
+    except CatchableError as e:
+      if Moment.now() >= deadline:
+        raise e
+      sleep(200)
+
 proc main() {.async.} =
   let
     transport = getEnv("transport")
@@ -36,7 +47,7 @@ proc main() {.async.} =
 
     # using synchronous redis because async redis is based on
     # asyncdispatch instead of chronos
-    redisClient = open(redisAddr[0], Port(parseInt(redisAddr[1])))
+    redisClient = openRedis(redisAddr[0], Port(parseInt(redisAddr[1])))
 
     switchBuilder = SwitchBuilder.new()
 

--- a/interop/unified_testing.nim
+++ b/interop/unified_testing.nim
@@ -96,7 +96,15 @@ proc setupRedis*(redisAddr: string): Redis =
       Port(parseInt(parts[1]))
     except ValueError as e:
       raise newException(CatchableError, "Invalid REDIS_ADDR port: " & parts[1], e)
-  open(parts[0], port)
+  # redis may not be listening yet when this container starts
+  let deadline = Moment.now() + 30.seconds
+  while true:
+    try:
+      return open(parts[0], port)
+    except CatchableError as e:
+      if Moment.now() >= deadline:
+        raise e
+      sleep(200)
 
 template pollUntil*(
     condition: untyped,

--- a/nix/cbind-deps.nix
+++ b/nix/cbind-deps.nix
@@ -19,8 +19,8 @@
 
   ffi = pkgs.fetchgit {
     url = "https://github.com/logos-messaging/nim-ffi";
-    rev = "aad9374354a5e3d98964a9adf80766a12f8f200d";
-    sha256 = "075ax4spvzr7idd5b5sncpkr7b3163qncr8fsxv9d02dix4ailqc";
+    rev = "53515de17af0ef3e88b2aec9675b8163dddc14ae";
+    sha256 = "0ncf9j7fhgd3nswr4rh19jx77dl974sajphdl04cb602hshgj5ij";
     fetchSubmodules = true;
   };
 

--- a/nix/cbind-deps.nix
+++ b/nix/cbind-deps.nix
@@ -19,8 +19,8 @@
 
   ffi = pkgs.fetchgit {
     url = "https://github.com/logos-messaging/nim-ffi";
-    rev = "b95e2b04a63fbd417938bf3ec0ac14be7935e21b";
-    sha256 = "16iynxgls3w9gsy79m1z29s6r8d09xpzsm7rl29q72gs0n9i26m0";
+    rev = "aad9374354a5e3d98964a9adf80766a12f8f200d";
+    sha256 = "075ax4spvzr7idd5b5sncpkr7b3163qncr8fsxv9d02dix4ailqc";
     fetchSubmodules = true;
   };
 


### PR DESCRIPTION
## Summary

Repin cbind's `nim-ffi` dependency from the unmerged `fix/cbor-non-canonical` branch head (`b95e2b04`) to nim-ffi `v0.3.0-rc.2` (commit `53515de`).

The old pin was a workaround: the CBOR seq fix that cbind's bare `seq[byte]` returns rely on lived only on an unmerged branch, and `cbind.nimble` carried a "repin to a tag on merge" note. `v0.3.0-rc.2` now contains that fix (nim-ffi #141) plus the additive 0.3.0 feature integration (nim-ffi #142), so the workaround is no longer needed.

Upgrading also brings, for free:
- **Foreign-thread GC registration on method entry** — nim-ffi #146, the single commit between `v0.3.0-rc.1` and `v0.3.0-rc.2`. An `abi = c` method entry point now registers its calling thread with the GC, which only static entry points did before. cbind builds with `--mm:refc`, and the wrapper unpacks the request into GC memory on the calling thread, so a host that calls a `LibP2P` method from a thread-pool worker could die in the GC on that thread's first call.
- **Context recycling** — pooled slots reuse their worker thread, event thread and signal fds instead of churning them, which bounds `ThreadSignalPtr` fds so `select()` in `waitSync` stops failing with `EINVAL` under create/destroy load. This matters for cbind's per-context lifecycle.
- The merged canonical-seq CBOR generation fix that `libp2pPublicKey`, `libp2pCreateXpr` and `libp2pNewPrivateKey` (bare `seq[byte]` returns) depend on.
- The nil-library ctor guard and other #142 hardening.

The 0.3.0 feature PR is purely additive over master, so no cbind source changes are required. Every pragma cbind uses (`ffi`, `ffiCtor`, `ffiStatic`, `ffiDtor`, `ffiEvent`, `ffiConst`, `ffiHandle`, `declareLibrary`, `genBindings`) still exists at the tagged commit.

cbind keeps its explicit pragmas and its two single-field event payload objects, so it adopts none of the new spellings 0.3.0 offers. The `{.ffi.}` shape router only re-derives the pragma that the code already names, and a multi-parameter `{.ffiEvent.}` would replace `IncomingStreamEvent` and `PubsubMessageEvent` with generated envelope structs under new names, which breaks the C API that `examples/echo.c`, `examples/relay.c` and `examples/gossipsub.c` and every downstream consumer bind to.

## Affected Areas

- [x] Build / Tooling
  - `cbind/cbind.nimble`: `ffi` dep pinned by commit `53515de` (the `v0.3.0-rc.2` tag), with a comment naming the tag. Pins the commit rather than the movable tag name, matching the neighboring `nim-cbor-serialization` pin and the lock/nix entries.
  - `cbind/nimble.lock`: `ffi` entry updated to the tag's `vcsRevision` and nimble checksum.
  - `nix/cbind-deps.nix`: `ffi` `fetchgit` `rev` and `sha256` updated to match.

All three files pin the same commit `53515de`. The lock checksum and nix hash were computed with the exact algorithms nimble and `fetchgit` use, then cross-checked by regenerating the previous commit's values and confirming they match the entries they replace. `nimble -l setup` resolves the lock and validates the ffi checksum with no error.

## Compatibility & Downstream Validation

- **Nimbus:** N/A
- **Waku:** N/A
- **Codex:** N/A

cbind is a self-contained C-bindings package; this dependency bump does not change nim-libp2p core behavior.

## Impact on Library Users

No impact on the nim-libp2p API. cbind's generated C/CDDL bindings are unchanged: no `{.ffi.}` type or proc signature changed, and no generated bindings are checked in, so nothing drifts.

## Risk Assessment

- Low. It is a dependency version bump with no source changes.
- `v0.3.0-rc.2` is a release candidate, not a final `v0.3.0` tag (no final tag exists yet). nim-ffi's `ffi.nimble` still declares version `0.3.0` at this commit, so `nimble.lock` records `"version": "0.3.0"`.
- The three dependency files (nimble requires, `nimble.lock`, nix deps) all pin the same commit, so `nimble setup` and the Nix build resolve the same revision.

## References

- nim-ffi tag `v0.3.0-rc.2`
- nim-ffi #141 (fix: non-canonical seq CBOR generation)
- nim-ffi #142 (integrate the 0.2 line: shape router, `{.ffiExport.}`, context recycling)
- nim-ffi #146 (fix: register the calling thread with the GC on `abi = c` method entry)
