### PR TITLE
feat(kad): dynamic client/server mode via reachability

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -41,7 +41,8 @@ export
   natservice.NATService, natservice.natConfig, natservice.upnpConfig,
   natservice.natPmpConfig, natservice.explicitIpConfig, natservice.autonatConfig,
   natservice.holePunchingConfig, natservice.AutonatV2ServiceConfig,
-  natservice.AutonatV2Service, natservice.natService
+  natservice.AutonatV2Service, natservice.natService, natservice.ReachabilityHandler,
+  natservice.addReachabilityHandler
 
 const MemoryAutoAddress* = memorytransport.MemoryAutoAddress
 
@@ -534,6 +535,23 @@ proc setupServices(b: SwitchBuilder, switch: Switch) {.raises: [LPError].} =
   for service in switch.services:
     service.setup(switch)
 
+proc kadReachabilityHandler*(kad: KadDHT): ReachabilityHandler =
+  ## Handler for ``KadMode.Auto``: the node serves queries while it is
+  ## reachable, and stops serving when it is not. ``Unknown`` keeps the current
+  ## mode, since it means autonat has no verdict yet.
+  proc(
+      reachability: NetworkReachability,
+      confidence: Opt[float],
+      dialBackAddr: Opt[MultiAddress],
+  ) {.async: (raises: [CancelledError]).} =
+    case reachability
+    of NetworkReachability.Reachable:
+      discard await kad.changeMode(isServer = true)
+    of NetworkReachability.NotReachable:
+      discard await kad.changeMode(isServer = false)
+    of NetworkReachability.Unknown:
+      discard
+
 proc mountProtocols(b: SwitchBuilder, switch: Switch) {.raises: [LPError].} =
   if not switch.peerStore.identify.isNil:
     switch.mount(switch.peerStore.identify)
@@ -563,21 +581,15 @@ proc mountProtocols(b: SwitchBuilder, switch: Switch) {.raises: [LPError].} =
       bootstrapNodes = kadInfo.bootstrapNodes,
       config = config,
       rng = b.rng,
-      mode = kadInfo.mode,
+      # Auto starts as a client until autonat proves the node reachable.
+      isServer = kadInfo.mode == KadMode.Server,
     )
     switch.mount(kad)
 
     if kadInfo.mode == KadMode.Auto:
       var wired = false
       switch.natService().withValue(nat):
-        wired = nat.addReachabilityHandler(
-          proc(
-              reachability: NetworkReachability,
-              confidence: Opt[float],
-              dialBackAddr: Opt[MultiAddress],
-          ) {.async: (raises: [CancelledError]).} =
-            await kad.onReachabilityChanged(reachability)
-        )
+        wired = nat.addReachabilityHandler(kadReachabilityHandler(kad))
       if not wired:
         warn "Kad-DHT auto mode has no reachability service; it stays a client",
           hint = "configure withNAT reachability or hole-punching"

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -41,8 +41,7 @@ export
   natservice.NATService, natservice.natConfig, natservice.upnpConfig,
   natservice.natPmpConfig, natservice.explicitIpConfig, natservice.autonatConfig,
   natservice.holePunchingConfig, natservice.AutonatV2ServiceConfig,
-  natservice.AutonatV2Service, natservice.natService, natservice.ReachabilityHandler,
-  natservice.addReachabilityHandler
+  natservice.AutonatV2Service, natservice.natService
 
 const MemoryAutoAddress* = memorytransport.MemoryAutoAddress
 
@@ -60,6 +59,11 @@ type
 
   SecureProtocol* {.pure.} = enum
     Noise
+
+  KadMode* {.pure.} = enum
+    Client ## never serves queries; only issues them
+    Server ## always serves queries
+    Auto ## serves queries while autonat reports the node reachable
 
   KadInfo = object
     config*: KadDHTConfig
@@ -535,7 +539,7 @@ proc setupServices(b: SwitchBuilder, switch: Switch) {.raises: [LPError].} =
   for service in switch.services:
     service.setup(switch)
 
-proc kadReachabilityHandler*(kad: KadDHT): ReachabilityHandler =
+proc makeKadReachabilityHandler(kad: KadDHT): ReachabilityHandler =
   ## Handler for ``KadMode.Auto``: the node serves queries while it is
   ## reachable, and stops serving when it is not. ``Unknown`` keeps the current
   ## mode, since it means autonat has no verdict yet.
@@ -589,7 +593,7 @@ proc mountProtocols(b: SwitchBuilder, switch: Switch) {.raises: [LPError].} =
     if kadInfo.mode == KadMode.Auto:
       var wired = false
       switch.natService().withValue(nat):
-        wired = nat.addReachabilityHandler(kadReachabilityHandler(kad))
+        wired = nat.addReachabilityHandler(makeKadReachabilityHandler(kad))
       if not wired:
         warn "Kad-DHT auto mode has no reachability service; it stays a client",
           hint = "configure withNAT reachability or hole-punching"

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -63,6 +63,7 @@ type
   KadInfo = object
     config*: KadDHTConfig
     bootstrapNodes*: seq[(PeerId, seq[MultiAddress])]
+    mode*: KadMode
 
   SwitchBuilder* = ref object
     privKey: Opt[PrivateKey]
@@ -395,8 +396,9 @@ proc withKademlia*(
     b: SwitchBuilder,
     bootstrapNodes: seq[(PeerId, seq[MultiAddress])] = @[],
     config: KadDHTConfig = KadDHTConfig.new(),
+    mode: KadMode = KadMode.Server,
 ): SwitchBuilder =
-  b.kad = Opt.some(KadInfo(config: config, bootstrapNodes: bootstrapNodes))
+  b.kad = Opt.some(KadInfo(config: config, bootstrapNodes: bootstrapNodes, mode: mode))
   b
 
 proc withIdentifyPusher*(b: SwitchBuilder, enabled: bool = true): SwitchBuilder =
@@ -557,9 +559,28 @@ proc mountProtocols(b: SwitchBuilder, switch: Switch) {.raises: [LPError].} =
     var config = kadInfo.config
     config.addressPolicy = b.addressPolicy
     let kad = KadDHT.new(
-      switch, bootstrapNodes = kadInfo.bootstrapNodes, config = config, rng = b.rng
+      switch,
+      bootstrapNodes = kadInfo.bootstrapNodes,
+      config = config,
+      rng = b.rng,
+      mode = kadInfo.mode,
     )
     switch.mount(kad)
+
+    if kadInfo.mode == KadMode.Auto:
+      var wired = false
+      switch.natService().withValue(nat):
+        wired = nat.addReachabilityHandler(
+          proc(
+              reachability: NetworkReachability,
+              confidence: Opt[float],
+              dialBackAddr: Opt[MultiAddress],
+          ) {.async: (raises: [CancelledError]).} =
+            await kad.onReachabilityChanged(reachability)
+        )
+      if not wired:
+        warn "Kad-DHT auto mode has no reachability service; it stays a client",
+          hint = "configure withNAT reachability or hole-punching"
 
 proc build*(b: SwitchBuilder): Switch {.raises: [LPError].} =
   var switch = b.buildSwitch()

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -6,14 +6,13 @@ import chronos, chronicles, results
 import ../utils/[heartbeat, future]
 import ../[peerid, switch, multihash]
 import ./protocol
-import ./connectivity/autonat/types as autonat_types
 import
   ./kademlia/[routing_table, protobuf, types, find, get, put, keyspace, provider, ping]
 import ./kademlia/[kademlia_metrics, netsize]
 
 export
   chronicles, routing_table, protobuf, types, find, get, put, keyspace, provider, ping,
-  kademlia_metrics, netsize, NetworkReachability
+  kademlia_metrics, netsize
 
 logScope:
   topics = "kad-dht"
@@ -159,7 +158,7 @@ proc new*(
     bootstrapNodes: seq[(PeerId, seq[MultiAddress])] = @[],
     config: KadDHTConfig = KadDHTConfig.new(),
     rng: Rng,
-    mode: KadMode = KadMode.Server,
+    isServer: bool = true,
     codec: string = KadCodec,
 ): K {.raises: [].} =
   var rtable = RoutingTable.new(
@@ -180,9 +179,7 @@ proc new*(
     nsEstimator: NetworkSizeEstimator.new(config.replication),
     rpcSem: newAsyncSemaphore(config.limits.maxConcurrentRpcs),
     probeSem: newAsyncSemaphore(config.limits.maxConcurrentProbes),
-    # Auto starts as a client until autonat proves the node reachable.
-    mode: if mode == KadMode.Auto: KadMode.Client else: mode,
-    autoMode: mode == KadMode.Auto,
+    isServer: isServer,
   )
 
   # Fill up buckets with initial bootstrap nodes
@@ -193,8 +190,8 @@ proc new*(
   kad.handler = proc(
       stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
-    if kad.mode != KadMode.Server:
-      trace "Refusing inbound query while not in server mode", stream, mode = kad.mode
+    if not kad.isServer:
+      trace "Refusing inbound query while not serving", stream
       await stream.reset()
       return
 
@@ -244,41 +241,23 @@ proc new*(
   return kad
 
 proc resetServerStreams(kad: KadDHT) {.async: (raises: []).} =
-  # HashSet has no mapIt, so collect the streams into a seq first.
-  let streams = kad.serverStreams.toSeq()
+  let streams = kad.serverStreams.toSeq() # HashSet has no mapIt
   kad.serverStreams.clear()
   await noCancel allFutures(streams.mapIt(it.reset()))
   debug "Reset inbound Kad DHT streams", streams = streams.len
 
-proc changeMode*(kad: KadDHT, newMode: KadMode): Future[bool] {.async: (raises: []).} =
-  ## Move the node to ``newMode`` and report whether the mode changed. ``Auto``
-  ## is a configuration value only, so it changes nothing here. Moving to
-  ## ``Client`` resets the in-flight inbound streams; the codec stays mounted
-  ## (no unmount exists), so peers drop us once the handler refuses to serve.
-  if newMode == KadMode.Auto or newMode == kad.mode:
+proc changeMode*(kad: KadDHT, isServer: bool): Future[bool] {.async: (raises: []).} =
+  ## Start or stop serving inbound queries, and report whether the mode changed.
+  ## Stopping resets the in-flight inbound streams; the codec stays mounted (no
+  ## unmount exists), so peers drop us once the handler refuses to serve.
+  if isServer == kad.isServer:
     return false
 
-  kad.mode = newMode
-  if newMode == KadMode.Client:
+  kad.isServer = isServer
+  if not isServer:
     await kad.resetServerStreams()
-  debug "Kad DHT changed mode", mode = newMode
+  debug "Kad DHT changed mode", isServer
   true
-
-proc onReachabilityChanged*(
-    kad: KadDHT, reachability: NetworkReachability
-) {.async: (raises: []).} =
-  ## Wire this to the autonat reachability handler. Only a node configured as
-  ## ``Auto`` reacts; ``Client`` and ``Server`` ignore reachability changes.
-  if not kad.autoMode:
-    return
-
-  case reachability
-  of NetworkReachability.Reachable:
-    discard await kad.changeMode(KadMode.Server)
-  of NetworkReachability.NotReachable:
-    discard await kad.changeMode(KadMode.Client)
-  of NetworkReachability.Unknown:
-    discard
 
 method start*(kad: KadDHT) {.async: (raises: [CancelledError]).} =
   if kad.started:

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -6,13 +6,14 @@ import chronos, chronicles, results
 import ../utils/[heartbeat, future]
 import ../[peerid, switch, multihash]
 import ./protocol
+import ./connectivity/autonat/types as autonat_types
 import
   ./kademlia/[routing_table, protobuf, types, find, get, put, keyspace, provider, ping]
 import ./kademlia/[kademlia_metrics, netsize]
 
 export
   chronicles, routing_table, protobuf, types, find, get, put, keyspace, provider, ping,
-  kademlia_metrics, netsize
+  kademlia_metrics, netsize, NetworkReachability
 
 logScope:
   topics = "kad-dht"
@@ -158,7 +159,7 @@ proc new*(
     bootstrapNodes: seq[(PeerId, seq[MultiAddress])] = @[],
     config: KadDHTConfig = KadDHTConfig.new(),
     rng: Rng,
-    client: bool = false,
+    mode: KadMode = KadMode.Server,
     codec: string = KadCodec,
 ): K {.raises: [].} =
   var rtable = RoutingTable.new(
@@ -179,19 +180,27 @@ proc new*(
     nsEstimator: NetworkSizeEstimator.new(config.replication),
     rpcSem: newAsyncSemaphore(config.limits.maxConcurrentRpcs),
     probeSem: newAsyncSemaphore(config.limits.maxConcurrentProbes),
+    mode: mode,
+    # Auto starts as a client until autonat proves the node reachable.
+    serving: mode == KadMode.Server,
   )
 
   # Fill up buckets with initial bootstrap nodes
   kad.updatePeers(bootstrapNodes)
 
   kad.codec = codec
-  if client:
-    return kad
 
   kad.handler = proc(
       stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
+    if not kad.serving:
+      trace "Refusing inbound query while not in server mode", stream, mode = kad.mode
+      await stream.reset()
+      return
+
+    kad.serverStreams.incl(stream)
     defer:
+      kad.serverStreams.excl(stream)
       await stream.close()
     while not stream.atEof:
       var buf =
@@ -233,6 +242,46 @@ proc new*(
         continue
 
   return kad
+
+func isServer*(kad: KadDHT): bool =
+  ## Whether the node currently answers inbound queries.
+  kad.serving
+
+proc moveToServerMode*(kad: KadDHT) =
+  ## Start answering inbound queries. The handler is always mounted, so this
+  ## only flips the serving flag.
+  if kad.serving:
+    return
+  kad.serving = true
+  debug "Kad DHT moved to server mode"
+
+proc moveToClientMode*(kad: KadDHT) {.async: (raises: []).} =
+  ## Stop serving inbound queries and reset any in-flight server streams. The
+  ## codec stays mounted (no unmount exists), so peers drop us once we stop serving.
+  if not kad.serving:
+    return
+  kad.serving = false
+
+  let streams = kad.serverStreams.toSeq()
+  kad.serverStreams.clear()
+  await noCancel allFutures(streams.mapIt(it.reset()))
+  debug "Kad DHT moved to client mode", resetStreams = streams.len
+
+proc onReachabilityChanged*(
+    kad: KadDHT, reachability: NetworkReachability
+) {.async: (raises: []).} =
+  ## Wire this to the autonat reachability handler. Only ``Auto`` mode reacts;
+  ## ``Client`` and ``Server`` ignore reachability changes.
+  if kad.mode != KadMode.Auto:
+    return
+
+  case reachability
+  of NetworkReachability.Reachable:
+    kad.moveToServerMode()
+  of NetworkReachability.NotReachable:
+    await kad.moveToClientMode()
+  of NetworkReachability.Unknown:
+    discard
 
 method start*(kad: KadDHT) {.async: (raises: [CancelledError]).} =
   if kad.started:

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -180,9 +180,9 @@ proc new*(
     nsEstimator: NetworkSizeEstimator.new(config.replication),
     rpcSem: newAsyncSemaphore(config.limits.maxConcurrentRpcs),
     probeSem: newAsyncSemaphore(config.limits.maxConcurrentProbes),
-    mode: mode,
     # Auto starts as a client until autonat proves the node reachable.
-    serving: mode == KadMode.Server,
+    mode: if mode == KadMode.Auto: KadMode.Client else: mode,
+    autoMode: mode == KadMode.Auto,
   )
 
   # Fill up buckets with initial bootstrap nodes
@@ -193,7 +193,7 @@ proc new*(
   kad.handler = proc(
       stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
-    if not kad.serving:
+    if kad.mode != KadMode.Server:
       trace "Refusing inbound query while not in server mode", stream, mode = kad.mode
       await stream.reset()
       return
@@ -243,43 +243,40 @@ proc new*(
 
   return kad
 
-func isServer*(kad: KadDHT): bool =
-  ## Whether the node currently answers inbound queries.
-  kad.serving
-
-proc moveToServerMode*(kad: KadDHT) =
-  ## Start answering inbound queries. The handler is always mounted, so this
-  ## only flips the serving flag.
-  if kad.serving:
-    return
-  kad.serving = true
-  debug "Kad DHT moved to server mode"
-
-proc moveToClientMode*(kad: KadDHT) {.async: (raises: []).} =
-  ## Stop serving inbound queries and reset any in-flight server streams. The
-  ## codec stays mounted (no unmount exists), so peers drop us once we stop serving.
-  if not kad.serving:
-    return
-  kad.serving = false
-
+proc resetServerStreams(kad: KadDHT) {.async: (raises: []).} =
+  # HashSet has no mapIt, so collect the streams into a seq first.
   let streams = kad.serverStreams.toSeq()
   kad.serverStreams.clear()
   await noCancel allFutures(streams.mapIt(it.reset()))
-  debug "Kad DHT moved to client mode", resetStreams = streams.len
+  debug "Reset inbound Kad DHT streams", streams = streams.len
+
+proc changeMode*(kad: KadDHT, newMode: KadMode): Future[bool] {.async: (raises: []).} =
+  ## Move the node to ``newMode`` and report whether the mode changed. ``Auto``
+  ## is a configuration value only, so it changes nothing here. Moving to
+  ## ``Client`` resets the in-flight inbound streams; the codec stays mounted
+  ## (no unmount exists), so peers drop us once the handler refuses to serve.
+  if newMode == KadMode.Auto or newMode == kad.mode:
+    return false
+
+  kad.mode = newMode
+  if newMode == KadMode.Client:
+    await kad.resetServerStreams()
+  debug "Kad DHT changed mode", mode = newMode
+  true
 
 proc onReachabilityChanged*(
     kad: KadDHT, reachability: NetworkReachability
 ) {.async: (raises: []).} =
-  ## Wire this to the autonat reachability handler. Only ``Auto`` mode reacts;
-  ## ``Client`` and ``Server`` ignore reachability changes.
-  if kad.mode != KadMode.Auto:
+  ## Wire this to the autonat reachability handler. Only a node configured as
+  ## ``Auto`` reacts; ``Client`` and ``Server`` ignore reachability changes.
+  if not kad.autoMode:
     return
 
   case reachability
   of NetworkReachability.Reachable:
-    kad.moveToServerMode()
+    discard await kad.changeMode(KadMode.Server)
   of NetworkReachability.NotReachable:
-    await kad.moveToClientMode()
+    discard await kad.changeMode(KadMode.Client)
   of NetworkReachability.Unknown:
     discard
 

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -241,7 +241,7 @@ proc new*(
   return kad
 
 proc resetServerStreams(kad: KadDHT) {.async: (raises: []).} =
-  let streams = kad.serverStreams.toSeq() # HashSet has no mapIt
+  let streams = kad.serverStreams
   kad.serverStreams.clear()
   await noCancel allFutures(streams.mapIt(it.reset()))
   debug "Reset inbound Kad DHT streams", streams = streams.len

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -557,12 +557,6 @@ type ProbeKey* = tuple[tableId: Key, peerId: PeerId]
 
 type AdmitHook* = proc(peerId: PeerId) {.gcsafe, raises: [].}
 
-type KadMode* {.pure.} = enum
-  ## Configuration only: how the switch builder sets up the Kad-DHT node.
-  Client ## never serves queries; only issues them
-  Server ## always serves queries
-  Auto ## serves queries while autonat reports the node reachable
-
 type KadDHT* = ref object of LPProtocol
   switch*: Switch
   rng*: Rng

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -557,6 +557,11 @@ type ProbeKey* = tuple[tableId: Key, peerId: PeerId]
 
 type AdmitHook* = proc(peerId: PeerId) {.gcsafe, raises: [].}
 
+type KadMode* {.pure.} = enum
+  Client ## never serves queries; only issues them
+  Server ## always serves queries
+  Auto ## serves queries only while the node is reachable (driven by autonat)
+
 type KadDHT* = ref object of LPProtocol
   switch*: Switch
   rng*: Rng
@@ -582,6 +587,16 @@ type KadDHT* = ref object of LPProtocol
     ## Set once ``stop`` begins so racing handlers stop launching new probes,
     ## letting the shutdown drain terminate. Distinct from ``started``, which is
     ## still false while bootstrap admits its seed peers during ``start``.
+  mode*: KadMode
+    ## Configured client/server mode.
+    ## ``Auto`` changes to ``Server`` when node is reachable
+    ## or to ``Client`` when not is not reachable;
+    ## ``Client`` and ``Server`` pin it.
+  serving*: bool
+    ## Whether the node currently answers inbound queries. Under ``Auto`` this
+    ## tracks reachability; otherwise it is fixed by ``mode``.
+  serverStreams*: HashSet[Stream]
+    ## Open inbound server streams, reset on a downgrade to client mode.
 
 template withRpcSlot*(kad: KadDHT) =
   ## Acquire one ``rpcSem`` slot until the enclosing scope exits. The slot is

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -558,9 +558,11 @@ type ProbeKey* = tuple[tableId: Key, peerId: PeerId]
 type AdmitHook* = proc(peerId: PeerId) {.gcsafe, raises: [].}
 
 type KadMode* {.pure.} = enum
-  Client ## never serves queries; only issues them
-  Server ## always serves queries
-  Auto ## serves queries only while the node is reachable (driven by autonat)
+  Client ## does not serve queries; only issues them
+  Server ## serves queries
+  Auto
+    ## configuration only: serves queries while the node is reachable (driven by
+    ## autonat). ``KadDHT.mode`` never holds this value.
 
 type KadDHT* = ref object of LPProtocol
   switch*: Switch
@@ -588,15 +590,12 @@ type KadDHT* = ref object of LPProtocol
     ## letting the shutdown drain terminate. Distinct from ``started``, which is
     ## still false while bootstrap admits its seed peers during ``start``.
   mode*: KadMode
-    ## Configured client/server mode.
-    ## ``Auto`` changes to ``Server`` when node is reachable
-    ## or to ``Client`` when not is not reachable;
-    ## ``Client`` and ``Server`` pin it.
-  serving*: bool
-    ## Whether the node currently answers inbound queries. Under ``Auto`` this
-    ## tracks reachability; otherwise it is fixed by ``mode``.
+    ## Current mode, either ``Client`` or ``Server``, never ``Auto``. ``Server``
+    ## means the node answers inbound queries. A node configured as ``Auto``
+    ## starts as ``Client`` and follows reachability from there.
+  autoMode*: bool ## Whether autonat reachability drives ``mode``.
   serverStreams*: HashSet[Stream]
-    ## Open inbound server streams, reset on a downgrade to client mode.
+    ## Open inbound server streams, reset when the mode changes to ``Client``.
 
 template withRpcSlot*(kad: KadDHT) =
   ## Acquire one ``rpcSem`` slot until the enclosing scope exits. The slot is

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -558,11 +558,10 @@ type ProbeKey* = tuple[tableId: Key, peerId: PeerId]
 type AdmitHook* = proc(peerId: PeerId) {.gcsafe, raises: [].}
 
 type KadMode* {.pure.} = enum
-  Client ## does not serve queries; only issues them
-  Server ## serves queries
-  Auto
-    ## configuration only: serves queries while the node is reachable (driven by
-    ## autonat). ``KadDHT.mode`` never holds this value.
+  ## Configuration only: how the switch builder sets up the Kad-DHT node.
+  Client ## never serves queries; only issues them
+  Server ## always serves queries
+  Auto ## serves queries while autonat reports the node reachable
 
 type KadDHT* = ref object of LPProtocol
   switch*: Switch
@@ -589,13 +588,9 @@ type KadDHT* = ref object of LPProtocol
     ## Set once ``stop`` begins so racing handlers stop launching new probes,
     ## letting the shutdown drain terminate. Distinct from ``started``, which is
     ## still false while bootstrap admits its seed peers during ``start``.
-  mode*: KadMode
-    ## Current mode, either ``Client`` or ``Server``, never ``Auto``. ``Server``
-    ## means the node answers inbound queries. A node configured as ``Auto``
-    ## starts as ``Client`` and follows reachability from there.
-  autoMode*: bool ## Whether autonat reachability drives ``mode``.
+  isServer*: bool ## Whether the node answers inbound queries.
   serverStreams*: HashSet[Stream]
-    ## Open inbound server streams, reset when the mode changes to ``Client``.
+    ## Open inbound server streams, reset when the node stops serving.
 
 template withRpcSlot*(kad: KadDHT) =
   ## Acquire one ``rpcSem`` slot until the enclosing scope exits. The slot is

--- a/tests/libp2p/kademlia/test_builder.nim
+++ b/tests/libp2p/kademlia/test_builder.nim
@@ -9,9 +9,33 @@ import ../../../libp2p/protocols/kademlia
 import ../../tools/[unittest, crypto]
 import ./utils.nim
 
+proc buildKadSwitch(mode: KadMode): Switch {.raises: [LPError].} =
+  SwitchBuilder
+    .new()
+    .withRng(rng())
+    .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
+    .withTcpTransport()
+    .withMplex()
+    .withNoise()
+    .withKademlia(mode = mode)
+    .build()
+
+proc mountedKad(switch: Switch): Opt[KadDHT] =
+  for handler in switch.ms.handlers:
+    if KadCodec in handler.protos:
+      return Opt.some(KadDHT(handler.protocol))
+  Opt.none(KadDHT)
+
 suite "KadDHT Switch Builder":
   teardown:
     checkTrackers()
+
+  test "Configured mode sets the initial serving flag":
+    check:
+      buildKadSwitch(KadMode.Server).mountedKad().get().isServer
+      not buildKadSwitch(KadMode.Client).mountedKad().get().isServer
+      # Auto serves nothing until autonat proves the node reachable.
+      not buildKadSwitch(KadMode.Auto).mountedKad().get().isServer
 
   asyncTest "Build switch with withKademlia":
     var switch1 = SwitchBuilder
@@ -66,7 +90,7 @@ suite "KadDHT Switch Builder":
       switch2,
       bootstrapNodes = @[(switch1.peerInfo.peerId, switch1.peerInfo.addrs)],
       rng = rng(),
-      mode = KadMode.Client,
+      isServer = false,
     )
 
     await allFutures(switch1.start(), switch2.start())

--- a/tests/libp2p/kademlia/test_builder.nim
+++ b/tests/libp2p/kademlia/test_builder.nim
@@ -6,19 +6,23 @@
 import chronos, std/sequtils
 import ../../../libp2p/[switch, builders]
 import ../../../libp2p/protocols/kademlia
-import ../../tools/[unittest, crypto]
+import ../../tools/[unittest, crypto, multiaddress, switch_builder]
 import ./utils.nim
 
 proc buildKadSwitch(mode: KadMode): Switch {.raises: [LPError].} =
-  SwitchBuilder
-    .new()
-    .withRng(rng())
-    .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
-    .withTcpTransport()
-    .withMplex()
-    .withNoise()
-    .withKademlia(mode = mode)
+  makeStandardSwitchBuilder(TcpAutoAddress).withKademlia(mode = mode).build()
+
+proc buildAutoKadSwitch(): Switch {.raises: [LPError].} =
+  ## Auto mode plus the AutoNAT v1 probing that drives it.
+  makeStandardSwitchBuilder(TcpAutoAddress)
+    .withAutonat()
+    .withNAT(autonatConfig(AutonatV1, Opt.some(1.seconds)))
+    .withKademlia(mode = KadMode.Auto)
     .build()
+
+proc buildAutonatPeer(): Switch {.raises: [LPError].} =
+  ## Answers the dial-back probes of `buildAutoKadSwitch`.
+  makeStandardSwitchBuilder(TcpAutoAddress).withAutonat().build()
 
 proc mountedKad(switch: Switch): Opt[KadDHT] =
   for handler in switch.ms.handlers:
@@ -37,24 +41,26 @@ suite "KadDHT Switch Builder":
       # Auto serves nothing until autonat proves the node reachable.
       not buildKadSwitch(KadMode.Auto).mountedKad().get().isServer
 
-  asyncTest "Build switch with withKademlia":
-    var switch1 = SwitchBuilder
-      .new()
-      .withRng(rng())
-      .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
-      .withTcpTransport()
-      .withMplex()
-      .withNoise()
-      .withKademlia()
-      .build()
+  asyncTest "Auto mode starts serving once autonat reports the node reachable":
+    let node = buildAutoKadSwitch()
+    let peers = @[buildAutonatPeer(), buildAutonatPeer(), buildAutonatPeer()]
+    let kad = node.mountedKad().get()
+    check not kad.isServer
 
-    var switch2 = SwitchBuilder
-      .new()
-      .withRng(rng())
-      .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
-      .withTcpTransport()
-      .withMplex()
-      .withNoise()
+    await allFutures(@[node.start()] & peers.mapIt(it.start()))
+    defer:
+      await allFutures(@[node.stop()] & peers.mapIt(it.stop()))
+
+    for peer in peers:
+      await node.connect(peer.peerInfo.peerId, peer.peerInfo.addrs)
+
+    checkUntilTimeout:
+      kad.isServer
+
+  asyncTest "Build switch with withKademlia":
+    var switch1 = makeStandardSwitchBuilder(TcpAutoAddress).withKademlia().build()
+
+    var switch2 = makeStandardSwitchBuilder(TcpAutoAddress)
       .withKademlia(
         bootstrapNodes = @[(switch1.peerInfo.peerId, switch1.peerInfo.addrs)]
       )
@@ -67,24 +73,8 @@ suite "KadDHT Switch Builder":
       switch1.ms.handlers.anyIt(KadCodec in it.protos)
 
   asyncTest "Use Kad as a client only":
-    var switch1 = SwitchBuilder
-      .new()
-      .withRng(rng())
-      .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
-      .withTcpTransport()
-      .withMplex()
-      .withNoise()
-      .withKademlia()
-      .build()
-
-    var switch2 = SwitchBuilder
-      .new()
-      .withRng(rng())
-      .withAddresses(@[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()])
-      .withTcpTransport()
-      .withMplex()
-      .withNoise()
-      .build()
+    var switch1 = makeStandardSwitchBuilder(TcpAutoAddress).withKademlia().build()
+    var switch2 = makeStandardSwitch(TcpAutoAddress)
 
     let kad2 = KadDHT.new(
       switch2,

--- a/tests/libp2p/kademlia/test_builder.nim
+++ b/tests/libp2p/kademlia/test_builder.nim
@@ -66,7 +66,7 @@ suite "KadDHT Switch Builder":
       switch2,
       bootstrapNodes = @[(switch1.peerInfo.peerId, switch1.peerInfo.addrs)],
       rng = rng(),
-      client = true,
+      mode = KadMode.Client,
     )
 
     await allFutures(switch1.start(), switch2.start())

--- a/tests/libp2p/kademlia/test_mode.nim
+++ b/tests/libp2p/kademlia/test_mode.nim
@@ -4,8 +4,7 @@
 {.used.}
 
 import chronos
-import ../../../libp2p/[builders, protocols/kademlia, switch]
-import ../../../libp2p/protocols/connectivity/autonat/types
+import ../../../libp2p/[protocols/kademlia, stream/connection, switch]
 import ../../tools/[lifecycle, unittest]
 import ./utils
 
@@ -60,25 +59,6 @@ suite "KadDHT dynamic mode":
     check kad.isServer
 
     check (await kad.changeMode(isServer = false))
-    check not kad.isServer
-
-  asyncTest "the reachability handler drives the mode":
-    let kad = setupKad(isServer = false)
-    let onReachability = kadReachabilityHandler(kad)
-
-    template notify(reachability: NetworkReachability): untyped =
-      await onReachability(reachability, Opt.none(float), Opt.none(MultiAddress))
-
-    notify(NetworkReachability.Unknown)
-    check not kad.isServer # no verdict yet, so the mode stays untouched
-
-    notify(NetworkReachability.Reachable)
-    check kad.isServer
-
-    notify(NetworkReachability.Unknown)
-    check kad.isServer
-
-    notify(NetworkReachability.NotReachable)
     check not kad.isServer
 
   asyncTest "server answers queries, client resets them":

--- a/tests/libp2p/kademlia/test_mode.nim
+++ b/tests/libp2p/kademlia/test_mode.nim
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import chronos
+import ../../../libp2p/[protocols/kademlia, switch]
+import ../../tools/[lifecycle, unittest]
+import ./utils
+
+proc dialFindNode(
+    querier, target: KadDHT
+): Future[Opt[Message]] {.async: (raises: [CancelledError]).} =
+  ## Dial the target's Kad codec, send a FIND_NODE and return the reply, or
+  ## `Opt.none` when the target refuses to serve (stream reset, no reply).
+  let stream =
+    try:
+      await querier.switch.dial(
+        target.switch.peerInfo.peerId, target.switch.peerInfo.addrs, querier.codec
+      )
+    except CatchableError:
+      return Opt.none(Message)
+  defer:
+    await stream.close()
+
+  let msg = Message(
+    msgType: Opt.some(MessageType.findNode), key: Opt.some(target.rtable.selfId)
+  )
+  try:
+    await stream.writeLp(msg.encode(querier.config.hideConnectionStatus))
+    let replyBuf = await stream.readLp(MaxMsgSize).wait(1.seconds)
+    let reply = Message.decode(replyBuf).valueOr:
+      return Opt.none(Message)
+    # A served query yields a well-formed FIND_NODE reply; anything else is a
+    # broken server masquerading as one, so do not count it as served.
+    if reply.msgType != Opt.some(MessageType.findNode):
+      return Opt.none(Message)
+    return Opt.some(reply)
+  except CatchableError:
+    return Opt.none(Message)
+
+suite "KadDHT dynamic mode":
+  teardown:
+    checkTrackers()
+
+  test "initial serving state follows the configured mode":
+    check:
+      setupKad(mode = KadMode.Server).isServer()
+      not setupKad(mode = KadMode.Client).isServer()
+      not setupKad(mode = KadMode.Auto).isServer() # client until reachable
+
+  test "moveToServerMode/moveToClientMode flip the serving flag":
+    let kad = setupKad(mode = KadMode.Client)
+    check not kad.isServer()
+
+    kad.moveToServerMode()
+    check kad.isServer()
+
+    waitFor kad.moveToClientMode()
+    check not kad.isServer()
+
+  test "onReachabilityChanged only drives Auto mode":
+    let auto = setupKad(mode = KadMode.Auto)
+    waitFor auto.onReachabilityChanged(NetworkReachability.Reachable)
+    check auto.isServer()
+    waitFor auto.onReachabilityChanged(NetworkReachability.NotReachable)
+    check not auto.isServer()
+    waitFor auto.onReachabilityChanged(NetworkReachability.Unknown)
+    check not auto.isServer() # Unknown leaves the current mode untouched
+
+    # Pinned modes ignore reachability changes.
+    let server = setupKad(mode = KadMode.Server)
+    waitFor server.onReachabilityChanged(NetworkReachability.NotReachable)
+    check server.isServer()
+
+    let client = setupKad(mode = KadMode.Client)
+    waitFor client.onReachabilityChanged(NetworkReachability.Reachable)
+    check not client.isServer()
+
+  asyncTest "server answers queries, client resets them":
+    let querier = setupKad()
+    let server = setupKad(mode = KadMode.Server)
+    let client = setupKad(mode = KadMode.Client)
+    startAndDeferStop(@[querier, server, client])
+
+    check (await querier.dialFindNode(server)).isSome()
+    check (await querier.dialFindNode(client)).isNone()
+
+  asyncTest "downgrade to client mode stops serving and drops peers":
+    let querier = setupKad()
+    let server = setupKad(mode = KadMode.Server)
+    startAndDeferStop(@[querier, server])
+
+    check (await querier.dialFindNode(server)).isSome()
+
+    await server.moveToClientMode()
+    check (await querier.dialFindNode(server)).isNone()
+
+    server.moveToServerMode()
+    check (await querier.dialFindNode(server)).isSome()
+
+  asyncTest "downgrade resets an in-flight inbound stream":
+    let querier = setupKad()
+    let server = setupKad(mode = KadMode.Server)
+    startAndDeferStop(@[querier, server])
+
+    let stream = await querier.switch.dial(
+      server.switch.peerInfo.peerId, server.switch.peerInfo.addrs, querier.codec
+    )
+    defer:
+      await stream.close()
+
+    # One round-trip parks the server handler on the next read, so the stream is
+    # held open and tracked as a server stream.
+    let msg = Message(
+      msgType: Opt.some(MessageType.findNode), key: Opt.some(server.rtable.selfId)
+    )
+    await stream.writeLp(msg.encode(querier.config.hideConnectionStatus))
+    discard await stream.readLp(MaxMsgSize).wait(1.seconds)
+
+    checkUntilTimeout:
+      server.serverStreams.len == 1
+
+    await server.moveToClientMode()
+    check server.serverStreams.len == 0
+
+    # The downgrade must reset the parked stream: the querier's next read ends in
+    # EOF, not a timeout (a timeout would mean the reset never propagated).
+    var gotEof = false
+    try:
+      discard await stream.readLp(MaxMsgSize).wait(3.seconds)
+    except AsyncTimeoutError:
+      gotEof = false
+    except CatchableError:
+      gotEof = true
+    check gotEof

--- a/tests/libp2p/kademlia/test_mode.nim
+++ b/tests/libp2p/kademlia/test_mode.nim
@@ -4,7 +4,8 @@
 {.used.}
 
 import chronos
-import ../../../libp2p/[protocols/kademlia, switch]
+import ../../../libp2p/[builders, protocols/kademlia, switch]
+import ../../../libp2p/protocols/connectivity/autonat/types
 import ../../tools/[lifecycle, unittest]
 import ./utils
 
@@ -43,48 +44,47 @@ suite "KadDHT dynamic mode":
   teardown:
     checkTrackers()
 
-  test "initial mode follows the configured mode":
+  test "initial mode follows the configured flag":
     check:
-      setupKad(mode = KadMode.Server).mode == KadMode.Server
-      setupKad(mode = KadMode.Client).mode == KadMode.Client
-      setupKad(mode = KadMode.Auto).mode == KadMode.Client # client until reachable
+      setupKad(isServer = true).isServer
+      not setupKad(isServer = false).isServer
 
-  test "changeMode reports whether the mode changed":
-    let kad = setupKad(mode = KadMode.Client)
+  asyncTest "changeMode reports whether the mode changed":
+    let kad = setupKad(isServer = false)
 
-    check (waitFor kad.changeMode(KadMode.Server))
-    check kad.mode == KadMode.Server
+    check (await kad.changeMode(isServer = true))
+    check kad.isServer
 
-    # Same mode twice changes nothing, and Auto is a configuration value only.
-    check not (waitFor kad.changeMode(KadMode.Server))
-    check not (waitFor kad.changeMode(KadMode.Auto))
-    check kad.mode == KadMode.Server
+    # The same mode twice changes nothing.
+    check not (await kad.changeMode(isServer = true))
+    check kad.isServer
 
-    check (waitFor kad.changeMode(KadMode.Client))
-    check kad.mode == KadMode.Client
+    check (await kad.changeMode(isServer = false))
+    check not kad.isServer
 
-  test "onReachabilityChanged only drives a node configured as Auto":
-    let auto = setupKad(mode = KadMode.Auto)
-    waitFor auto.onReachabilityChanged(NetworkReachability.Reachable)
-    check auto.mode == KadMode.Server
-    waitFor auto.onReachabilityChanged(NetworkReachability.NotReachable)
-    check auto.mode == KadMode.Client
-    waitFor auto.onReachabilityChanged(NetworkReachability.Unknown)
-    check auto.mode == KadMode.Client # Unknown leaves the current mode untouched
+  asyncTest "the reachability handler drives the mode":
+    let kad = setupKad(isServer = false)
+    let onReachability = kadReachabilityHandler(kad)
 
-    # Pinned modes ignore reachability changes.
-    let server = setupKad(mode = KadMode.Server)
-    waitFor server.onReachabilityChanged(NetworkReachability.NotReachable)
-    check server.mode == KadMode.Server
+    template notify(reachability: NetworkReachability): untyped =
+      await onReachability(reachability, Opt.none(float), Opt.none(MultiAddress))
 
-    let client = setupKad(mode = KadMode.Client)
-    waitFor client.onReachabilityChanged(NetworkReachability.Reachable)
-    check client.mode == KadMode.Client
+    notify(NetworkReachability.Unknown)
+    check not kad.isServer # no verdict yet, so the mode stays untouched
+
+    notify(NetworkReachability.Reachable)
+    check kad.isServer
+
+    notify(NetworkReachability.Unknown)
+    check kad.isServer
+
+    notify(NetworkReachability.NotReachable)
+    check not kad.isServer
 
   asyncTest "server answers queries, client resets them":
     let querier = setupKad()
-    let server = setupKad(mode = KadMode.Server)
-    let client = setupKad(mode = KadMode.Client)
+    let server = setupKad(isServer = true)
+    let client = setupKad(isServer = false)
     startAndDeferStop(@[querier, server, client])
 
     check (await querier.dialFindNode(server)).isSome()
@@ -92,20 +92,20 @@ suite "KadDHT dynamic mode":
 
   asyncTest "downgrade to client mode stops serving and drops peers":
     let querier = setupKad()
-    let server = setupKad(mode = KadMode.Server)
+    let server = setupKad(isServer = true)
     startAndDeferStop(@[querier, server])
 
     check (await querier.dialFindNode(server)).isSome()
 
-    check (await server.changeMode(KadMode.Client))
+    check (await server.changeMode(isServer = false))
     check (await querier.dialFindNode(server)).isNone()
 
-    check (await server.changeMode(KadMode.Server))
+    check (await server.changeMode(isServer = true))
     check (await querier.dialFindNode(server)).isSome()
 
   asyncTest "downgrade resets an in-flight inbound stream":
     let querier = setupKad()
-    let server = setupKad(mode = KadMode.Server)
+    let server = setupKad(isServer = true)
     startAndDeferStop(@[querier, server])
 
     let stream = await querier.switch.dial(
@@ -125,16 +125,10 @@ suite "KadDHT dynamic mode":
     checkUntilTimeout:
       server.serverStreams.len == 1
 
-    check (await server.changeMode(KadMode.Client))
+    check (await server.changeMode(isServer = false))
     check server.serverStreams.len == 0
 
     # The downgrade must reset the parked stream: the querier's next read ends in
     # EOF, not a timeout (a timeout would mean the reset never propagated).
-    var gotEof = false
-    try:
+    expect LPStreamEOFError:
       discard await stream.readLp(MaxMsgSize).wait(3.seconds)
-    except AsyncTimeoutError:
-      gotEof = false
-    except CatchableError:
-      gotEof = true
-    check gotEof

--- a/tests/libp2p/kademlia/test_mode.nim
+++ b/tests/libp2p/kademlia/test_mode.nim
@@ -43,39 +43,43 @@ suite "KadDHT dynamic mode":
   teardown:
     checkTrackers()
 
-  test "initial serving state follows the configured mode":
+  test "initial mode follows the configured mode":
     check:
-      setupKad(mode = KadMode.Server).isServer()
-      not setupKad(mode = KadMode.Client).isServer()
-      not setupKad(mode = KadMode.Auto).isServer() # client until reachable
+      setupKad(mode = KadMode.Server).mode == KadMode.Server
+      setupKad(mode = KadMode.Client).mode == KadMode.Client
+      setupKad(mode = KadMode.Auto).mode == KadMode.Client # client until reachable
 
-  test "moveToServerMode/moveToClientMode flip the serving flag":
+  test "changeMode reports whether the mode changed":
     let kad = setupKad(mode = KadMode.Client)
-    check not kad.isServer()
 
-    kad.moveToServerMode()
-    check kad.isServer()
+    check (waitFor kad.changeMode(KadMode.Server))
+    check kad.mode == KadMode.Server
 
-    waitFor kad.moveToClientMode()
-    check not kad.isServer()
+    # Same mode twice changes nothing, and Auto is a configuration value only.
+    check not (waitFor kad.changeMode(KadMode.Server))
+    check not (waitFor kad.changeMode(KadMode.Auto))
+    check kad.mode == KadMode.Server
 
-  test "onReachabilityChanged only drives Auto mode":
+    check (waitFor kad.changeMode(KadMode.Client))
+    check kad.mode == KadMode.Client
+
+  test "onReachabilityChanged only drives a node configured as Auto":
     let auto = setupKad(mode = KadMode.Auto)
     waitFor auto.onReachabilityChanged(NetworkReachability.Reachable)
-    check auto.isServer()
+    check auto.mode == KadMode.Server
     waitFor auto.onReachabilityChanged(NetworkReachability.NotReachable)
-    check not auto.isServer()
+    check auto.mode == KadMode.Client
     waitFor auto.onReachabilityChanged(NetworkReachability.Unknown)
-    check not auto.isServer() # Unknown leaves the current mode untouched
+    check auto.mode == KadMode.Client # Unknown leaves the current mode untouched
 
     # Pinned modes ignore reachability changes.
     let server = setupKad(mode = KadMode.Server)
     waitFor server.onReachabilityChanged(NetworkReachability.NotReachable)
-    check server.isServer()
+    check server.mode == KadMode.Server
 
     let client = setupKad(mode = KadMode.Client)
     waitFor client.onReachabilityChanged(NetworkReachability.Reachable)
-    check not client.isServer()
+    check client.mode == KadMode.Client
 
   asyncTest "server answers queries, client resets them":
     let querier = setupKad()
@@ -93,10 +97,10 @@ suite "KadDHT dynamic mode":
 
     check (await querier.dialFindNode(server)).isSome()
 
-    await server.moveToClientMode()
+    check (await server.changeMode(KadMode.Client))
     check (await querier.dialFindNode(server)).isNone()
 
-    server.moveToServerMode()
+    check (await server.changeMode(KadMode.Server))
     check (await querier.dialFindNode(server)).isSome()
 
   asyncTest "downgrade resets an in-flight inbound stream":
@@ -121,7 +125,7 @@ suite "KadDHT dynamic mode":
     checkUntilTimeout:
       server.serverStreams.len == 1
 
-    await server.moveToClientMode()
+    check (await server.changeMode(KadMode.Client))
     check server.serverStreams.len == 0
 
     # The downgrade must reset the parked stream: the querier's next read ends in

--- a/tests/libp2p/kademlia/utils.nim
+++ b/tests/libp2p/kademlia/utils.nim
@@ -93,10 +93,10 @@ proc testKadConfig*(
 proc setupKad*(
     config: KadDHTConfig = testKadConfig(),
     bootstrapNodes: seq[(PeerId, seq[MultiAddress])] = @[],
-    mode: KadMode = KadMode.Server,
+    isServer: bool = true,
 ): KadDHT =
   let switch = makeStandardSwitch(TcpAutoAddress)
-  let kad = KadDHT.new(switch, bootstrapNodes, config, rng = rng(), mode = mode)
+  let kad = KadDHT.new(switch, bootstrapNodes, config, rng(), isServer)
   kad.switch.mount(kad)
   kad
 

--- a/tests/libp2p/kademlia/utils.nim
+++ b/tests/libp2p/kademlia/utils.nim
@@ -93,9 +93,10 @@ proc testKadConfig*(
 proc setupKad*(
     config: KadDHTConfig = testKadConfig(),
     bootstrapNodes: seq[(PeerId, seq[MultiAddress])] = @[],
+    mode: KadMode = KadMode.Server,
 ): KadDHT =
   let switch = makeStandardSwitch(TcpAutoAddress)
-  let kad = KadDHT.new(switch, bootstrapNodes, config, rng = rng())
+  let kad = KadDHT.new(switch, bootstrapNodes, config, rng = rng(), mode = mode)
   kad.switch.mount(kad)
   kad
 

--- a/tests/libp2p/protocols/test_autonat_service.nim
+++ b/tests/libp2p/protocols/test_autonat_service.nim
@@ -15,7 +15,7 @@ import
   ]
 import ../../../libp2p/utils/future
 import ../../stubs/autonatclientstub
-import ../../tools/[unittest, futures, crypto]
+import ../../tools/[unittest, futures, crypto, reachability]
 
 proc createSwitch(
     autonatSvc: Opt[AutonatService] = Opt.none(AutonatService),
@@ -159,8 +159,7 @@ suite "Autonat Service":
         confidence: Opt[float],
         dialBackAddr: Opt[MultiAddress],
     ) {.async: (raises: [CancelledError]).} =
-      if networkReachability == NetworkReachability.Reachable and confidence.isSome() and
-          confidence.get() >= 0.3:
+      if settled(networkReachability, NetworkReachability.Reachable, confidence):
         awaiter.completeOnce()
 
     check autonatService.networkReachability == NetworkReachability.Unknown
@@ -211,12 +210,11 @@ suite "Autonat Service":
         confidence: Opt[float],
         dialBackAddr: Opt[MultiAddress],
     ) {.async: (raises: [CancelledError]).} =
-      if networkReachability == NetworkReachability.NotReachable and confidence.isSome() and
-          confidence.get() >= 0.3:
+      if settled(networkReachability, NetworkReachability.NotReachable, confidence):
         autonatClientStub.answer = Reachable
         notReachableAwaiter.completeOnce()
-      elif networkReachability == NetworkReachability.Reachable and confidence.isSome() and
-          confidence.get() >= 0.3 and reachableConfidence.isNone():
+      elif settled(networkReachability, NetworkReachability.Reachable, confidence) and
+          reachableConfidence.isNone():
         reachableConfidence = confidence
         reachableAwaiter.completeOnce()
 
@@ -311,8 +309,7 @@ suite "Autonat Service":
         confidence: Opt[float],
         dialBackAddr: Opt[MultiAddress],
     ) {.async: (raises: [CancelledError]).} =
-      if networkReachability == NetworkReachability.NotReachable and confidence.isSome() and
-          confidence.get() >= 0.3:
+      if settled(networkReachability, NetworkReachability.NotReachable, confidence):
         autonatClientStub.answer = Unknown
         awaiter.completeOnce()
 

--- a/tests/tools/reachability.nim
+++ b/tests/tools/reachability.nim
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+import results
+import ../../libp2p/protocols/connectivity/autonat/types
+
+export types
+
+const MinTestConfidence* = 0.3
+  ## Confidence that a test waits for before it trusts a verdict. The value is
+  ## empirically chosen: the autonat services pass it after the first answers of
+  ## a probe window, so a test does not wait for full confidence.
+
+func settled*(
+    reachability, expected: NetworkReachability, confidence: Opt[float]
+): bool =
+  ## Whether autonat settled on ``expected`` with enough confidence for a test.
+  reachability == expected and confidence.isSome() and
+    confidence.get() >= MinTestConfidence


### PR DESCRIPTION
## Summary

Kad-DHT mode was fixed at construction (`client: bool`). An undialable NAT'd node started in server mode keeps answering queries and pollutes other nodes' routing tables; a node that later becomes reachable cannot start serving.

This PR makes the mode dynamic and drives it from autonat reachability:

- `KadDHT` keeps one `isServer` flag. The DHT stream handler is always mounted and gated on that flag. When the node does not serve, it resets inbound streams instead of answering.
- `changeMode(isServer)` flips the flag and reports whether the mode changed. The downgrade resets in-flight inbound server streams, so peers stop treating the node as a server.
- `KadMode` (`Client`, `Server`, `Auto`) is a configuration type for the switch builder only. `withKademlia(mode = ...)` selects the initial flag; `Auto` starts as a client.
- The builder owns the wiring between reachability and Kad-DHT: with `Auto` it subscribes `kadReachabilityHandler(kad)` to the active reachability service (AutoNAT v1/v2 or hole-punching). Kad-DHT itself knows nothing about autonat.
- `AutonatService` / `AutonatV2Service` gained an additive `addStatusAndConfidenceHandler`, so Kad-DHT can subscribe without displacing HPService's handler.

Closes #2858.

## Affected Areas

- [x] Peer Management / Discovery
- [x] Protocol Logic
  <!-- Kad-DHT client/server mode; AutoNAT reachability fan-out -->

## Compatibility & Downstream Validation

No downstream integration yet. The AutoNAT changes are additive (a second subscriber slot); existing single-handler behavior is untouched. The Kad-DHT constructor replaces `client: bool = false` with `isServer: bool = true`; no in-tree caller passed `client`, so the default preserves prior behavior.

- **Nimbus:** n/a
- **Waku:** n/a
- **Codex:** n/a

## Impact on Library Users

- API change: `KadDHT.new(..., client: bool)` becomes `KadDHT.new(..., isServer: bool = true)`. `withKademlia` gains a `mode: KadMode` parameter. The default keeps server behavior.
- New API: `KadDHT.changeMode`, `kadReachabilityHandler`, `AutonatService.addStatusAndConfidenceHandler`, `AutonatV2Service.addStatusAndConfidenceHandler`, `HPService.addStatusAndConfidenceHandler`, `NATService.addReachabilityHandler`.
- Behavior change: a client node (or an `Auto` node before it is proven reachable) resets inbound DHT streams instead of serving them.

## Risk Assessment

- Backward compatibility: AutoNAT changes are purely additive; the Kad-DHT constructor default still serves.
- Network behavior: `Auto` starts as a client until autonat proves the node reachable, which matches go-libp2p `ModeAuto`.
- `Auto` with no reachability service configured stays a client and logs a warning at build time.

## References

- Issue: #2858
- Parent: #1756
- go-libp2p `ModeAuto` (`moveToServerMode` / `moveToClientMode`)

## Additional Notes

There is no multistream unmount, so a client node keeps the codec mounted and advertised. The refusal to serve (and the stream reset) is what removes the node from peers' routing tables over time.
