### PR TITLE
feat(kad): send optimistic ADD_PROVIDER during lookup

### DIFF
--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -8,11 +8,11 @@ import ../[peerid, switch, multihash]
 import ./protocol
 import
   ./kademlia/[routing_table, protobuf, types, find, get, put, keyspace, provider, ping]
-import ./kademlia/kademlia_metrics
+import ./kademlia/[kademlia_metrics, netsize]
 
 export
   chronicles, routing_table, protobuf, types, find, get, put, keyspace, provider, ping,
-  kademlia_metrics
+  kademlia_metrics, netsize
 
 logScope:
   topics = "kad-dht"
@@ -176,6 +176,7 @@ proc new*(
     config: config,
     providerManager:
       ProviderManager.new(config.providerRecordCapacity, config.providedKeyCapacity),
+    nsEstimator: NetworkSizeEstimator.new(config.replication),
     rpcSem: newAsyncSemaphore(config.limits.maxConcurrentRpcs),
     probeSem: newAsyncSemaphore(config.limits.maxConcurrentProbes),
   )
@@ -277,3 +278,7 @@ method stop*(kad: KadDHT) {.async: (raises: []).} =
   while kad.admissionProbes.len > 0:
     let admissionProbes = move kad.admissionProbes
     await noCancel admissionProbes.values.toSeq().cancelAndWait()
+
+  # Optimistic provide returns before its ADD_PROVIDER RPCs finish.
+  let provideTasks = move kad.provideTasks
+  await noCancel provideTasks.cancelAndWait()

--- a/libp2p/protocols/kademlia/kademlia_metrics.nim
+++ b/libp2p/protocols/kademlia/kademlia_metrics.nim
@@ -31,6 +31,8 @@ declarePublicCounter kad_provider_spillover_rounds,
 declarePublicCounter kad_provider_republish_regions,
   "keyspace regions republished, one DHT walk each"
 declarePublicCounter kad_provider_republish_keys, "provided keys republished"
+declarePublicGauge kad_network_size_estimate,
+  "estimated network size from lookup closest-peer distances"
 
 # Routing table metrics
 declarePublicGauge kad_routing_table_peers, "total peers in routing table"

--- a/libp2p/protocols/kademlia/netsize.nim
+++ b/libp2p/protocols/kademlia/netsize.nim
@@ -19,6 +19,7 @@ const
   MinMeasurementsThreshold = 5 ## per index, before an estimate is produced
   MaxMeasurementsThreshold = 150 ## newest kept per index
   TopBytesScale = 18446744073709551616.0 ## 2^64, the float64-usable distance part
+  MinStdDev = 1e-12 ## floor that keeps an inverse-variance weight finite
 
 func new*(T: typedesc[NetworkSizeEstimator], bucketSize: int): T =
   NetworkSizeEstimator(
@@ -83,7 +84,8 @@ func weightedStats(obs: seq[NetSizeMeasurement]): (float64, float64) =
 
 proc networkSize*(est: NetworkSizeEstimator): Result[int, string] =
   ## Current estimate, or an error while there is not enough data yet.
-  # Linear regression through the origin, standard deviations as fit weights.
+  # Linear regression through the origin, inverse variances as fit weights: a
+  # noisier index pulls the fit less than a stable one.
   let maxAgeTs = Moment.now() - MaxMeasurementAge
   var x2Sum, xySum = 0.0
   for i in 0 ..< est.bucketSize:
@@ -92,9 +94,11 @@ proc networkSize*(est: NetworkSizeEstimator): Result[int, string] =
       return err("not enough data")
 
     let (avg, stddev) = est.measurements[i].weightedStats()
+    let stddevFloored = max(stddev, MinStdDev)
+    let fitWeight = 1.0 / (stddevFloored * stddevFloored)
     let x = float64(i + 1)
-    xySum += stddev * x * avg
-    x2Sum += stddev * x * x
+    xySum += fitWeight * x * avg
+    x2Sum += fitWeight * x * x
 
   if xySum <= 0.0:
     return err("degenerate regression")

--- a/libp2p/protocols/kademlia/netsize.nim
+++ b/libp2p/protocols/kademlia/netsize.nim
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## Estimate the size of the Kademlia network.
+## Ported from go-libp2p-kad-dht's ``netsize`` package.
+## A converged lookup yields ``k`` closest peers,
+## where peer ``i`` sits at an expected normalized distance ``i / (N + 1)``.
+## ``provider.nim`` turns that estimate into distance thresholds through ``gammaIncRegInv``.
+
+{.push raises: [].}
+
+import std/[math, sequtils]
+import chronos, results
+import ../../peerid
+import ./[types, routing_table]
+
+const
+  MaxMeasurementAge = 2.hours
+  MinMeasurementsThreshold = 5 ## per index, before an estimate is produced
+  MaxMeasurementsThreshold = 150 ## newest kept per index
+  TopBytesScale = 18446744073709551616.0 ## 2^64, the float64-usable distance part
+
+func new*(T: typedesc[NetworkSizeEstimator], bucketSize: int): T =
+  NetworkSizeEstimator(
+    bucketSize: bucketSize, measurements: newSeq[seq[NetSizeMeasurement]](bucketSize)
+  )
+
+func normedDistance*(dist: XorDistance): float64 =
+  ## XOR distance on the unit interval, ``dist / 2^256``. Bytes past the top 8
+  ## exceed float64 precision, so they are dropped.
+  var acc = 0.0
+  for i in 0 ..< 8:
+    acc = acc * 256.0 + dist[i].float64
+  acc / TopBytesScale
+
+func calcWeight(
+    est: NetworkSizeEstimator, rtable: RoutingTable, target: Key, peers: seq[PeerId]
+): float64 =
+  ## Down-weight a measurement drawn from a non-full bucket exponentially: it is
+  ## a less reliable distance sample than one from a full bucket.
+  let cpl = rtable.commonPrefixLen(target)
+  var level = rtable.nPeersForCpl(cpl)
+  if level < est.bucketSize:
+    level = max(level, peers.countIt(rtable.commonPrefixLen(it.toKey()) == cpl))
+  pow(2.0, float64(level - est.bucketSize))
+
+proc track*(
+    est: NetworkSizeEstimator, rtable: RoutingTable, target: Key, peers: seq[PeerId]
+): Result[void, string] =
+  ## Record the `peers` of a converged lookup on `target`, closest first. They
+  ## must be exactly ``bucketSize`` many.
+  if peers.len != est.bucketSize:
+    return err("expected bucket size number of peers")
+
+  let now = Moment.now()
+  let maxAgeTs = now - MaxMeasurementAge
+  let weight = est.calcWeight(rtable, target, peers)
+  let hasher = rtable.config.hasher
+
+  for i, p in peers:
+    let dist = normedDistance(xorDistance(p, target, hasher))
+    est.measurements[i].add(
+      NetSizeMeasurement(distance: dist, weight: weight, timestamp: now)
+    )
+    let kept = est.measurements[i].filterIt(it.timestamp > maxAgeTs)
+    est.measurements[i] = kept[max(0, kept.len - MaxMeasurementsThreshold) .. ^1]
+
+  ok()
+
+func weightedStats(obs: seq[NetSizeMeasurement]): (float64, float64) =
+  ## Weighted mean distance and its weighted standard deviation.
+  var sumDistances, sumWeights = 0.0
+  for m in obs:
+    sumDistances += m.weight * m.distance
+    sumWeights += m.weight
+  let avg = sumDistances / sumWeights
+
+  var sumWeightedDiffs = 0.0
+  for m in obs:
+    sumWeightedDiffs += m.weight * (m.distance - avg) * (m.distance - avg)
+  let denom = float64(obs.len - 1) / float64(obs.len) * sumWeights
+  (avg, sqrt(sumWeightedDiffs / denom))
+
+proc networkSize*(est: NetworkSizeEstimator): Result[int, string] =
+  ## Current estimate, or an error while there is not enough data yet.
+  # Linear regression through the origin, standard deviations as fit weights.
+  let maxAgeTs = Moment.now() - MaxMeasurementAge
+  var x2Sum, xySum = 0.0
+  for i in 0 ..< est.bucketSize:
+    est.measurements[i] = est.measurements[i].filterIt(it.timestamp > maxAgeTs)
+    if est.measurements[i].len < MinMeasurementsThreshold:
+      return err("not enough data")
+
+    let (avg, stddev) = est.measurements[i].weightedStats()
+    let x = float64(i + 1)
+    xySum += stddev * x * avg
+    x2Sum += stddev * x * x
+
+  if xySum <= 0.0:
+    return err("degenerate regression")
+
+  let netSize = int(x2Sum / xySum - 1.0)
+  if netSize < 1:
+    return err("network size estimate below one")
+
+  ok(netSize)
+
+func gammp(a, x: float64): float64 =
+  ## Regularized lower incomplete gamma P(a, x), summed as a series. Every term
+  ## is positive, so it stays accurate over the range `gammaIncRegInv` searches.
+  if x <= 0.0:
+    return 0.0
+  var
+    ap = a
+    del = 1.0 / a
+    sum = del
+  for _ in 0 ..< 1000:
+    ap += 1.0
+    del *= x / ap
+    sum += del
+    if abs(del) < abs(sum) * 1e-15:
+      break
+  sum * exp(-x + a * ln(x) - lgamma(a))
+
+func gammaIncRegInv*(a, p: float64): float64 =
+  ## Inverse of the regularized lower incomplete gamma: ``x`` such that
+  ## ``P(a, x) == p``, by bisection since ``P`` rises monotonically in ``x``.
+  if p <= 0.0:
+    return 0.0
+
+  var hi = max(1.0, a)
+  while hi < 4.0 * a + 64.0 and gammp(a, hi) < p:
+    hi *= 2.0
+
+  var lo = 0.0
+  while hi - lo > 1e-12 * hi:
+    let mid = 0.5 * (lo + hi)
+    if gammp(a, mid) < p:
+      lo = mid
+    else:
+      hi = mid
+  0.5 * (lo + hi)

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -262,15 +262,20 @@ proc optimisticStop(
   let k = os.kad.config.replication
   let hasher = os.kad.rtable.config.hasher
 
-  # Zero-padded to k so an under-filled shortlist keeps the average meaningful.
-  var distances = newSeq[float64](k)
-  for i, pid in state.allSortedPeers().take(k):
+  let closest = state.allSortedPeers().take(k)
+  var distances = newSeq[float64](closest.len)
+  for i, pid in closest:
     distances[i] = normedDistance(xorDistance(pid, state.target, hasher))
     if pid notin os.scheduled and distances[i] <= os.individualThreshold:
       os.schedulePut(pid)
 
   if os.scheduled.len - os.failed >= k:
     return true
+
+  # Judge the set only on k real distances. A shorter shortlist has to grow
+  # first, otherwise the missing entries would end the walk too early.
+  if closest.len < k:
+    return false
 
   (distances.sum() / float64(distances.len)) < os.setThreshold
 

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -9,12 +9,12 @@
 ## advertisements are dropped without a reply.
 ## Re-advertisements are always accepted.
 
-import std/[sequtils, tables, sets, heapqueue]
+import std/[math, sequtils, tables, sets, heapqueue]
 import chronos, chronicles, results
 import ../../[peerid, switch, multihash, cid]
-import ../../utils/[heartbeat, future]
+import ../../utils/[collections, heartbeat, future]
 import ../protocol
-import ./[protobuf, types, find, keyspace, kademlia_metrics]
+import ./[protobuf, types, find, keyspace, netsize, kademlia_metrics]
 
 logScope:
   topics = "kad-dht provider"
@@ -199,13 +199,127 @@ proc storeProviderAt(
       debug "ADD_PROVIDER batch fully rejected, spilling over",
         key = key, batchSize = chunk.len
 
+const
+  CertaintyPeerIsInClosestSet = 0.9
+  ProbabilityOfStoppingWhileCloserPeersExist = 0.1
+  FractionOfPutsAwaitedBeforeReturn = 0.75
+
+type OptimisticState = ref object
+  kad: KadDHT
+  key: Key
+  individualThreshold: float64 ## a peer closer than this is stored with right away
+  setThreshold: float64 ## once the k closest average below this, the walk stops
+  returnThreshold: int ## completed RPCs to wait for before returning
+  scheduled: HashSet[PeerId]
+  failed: int
+  puts: seq[Future[void]]
+  completed: int
+  doneEvent: AsyncEvent
+
+proc new(
+    T: typedesc[OptimisticState], kad: KadDHT, key: Key, netSize: int
+): T {.raises: [].} =
+  let k = float64(kad.config.replication)
+  let scale = 1.0 / float64(netSize)
+  T(
+    kad: kad,
+    key: key,
+    individualThreshold: gammaIncRegInv(k, 1.0 - CertaintyPeerIsInClosestSet) * scale,
+    setThreshold:
+      gammaIncRegInv(k / 2.0 + 1.0, 1.0 - ProbabilityOfStoppingWhileCloserPeersExist) *
+      scale,
+    returnThreshold: int(ceil(k * FractionOfPutsAwaitedBeforeReturn)),
+    doneEvent: newAsyncEvent(),
+  )
+
+proc putProviderRecord(
+    os: OptimisticState, pid: PeerId
+) {.async: (raises: [CancelledError]).} =
+  ## A rejected record still counts: the walk only needs the peer to answer.
+  if (await os.kad.dispatchAddProvider(pid, os.key)).isErr():
+    os.failed.inc()
+  os.completed.inc()
+  os.doneEvent.fire()
+
+proc schedulePut(os: OptimisticState, pid: PeerId) {.raises: [].} =
+  os.scheduled.incl(pid)
+  os.puts.add(os.putProviderRecord(pid))
+
+proc maybeTrackNetsize(kad: KadDHT, key: Key, closest: seq[PeerId]) =
+  ## Feed a converged lookup's closest-first peers into the estimator, so classic
+  ## provides bootstrap the estimate that optimistic provide needs. `track`
+  ## rejects a short list on its own.
+  discard kad.nsEstimator.track(kad.rtable, key, closest.take(kad.config.replication))
+  kad.nsEstimator.networkSize().withValue(ns):
+    kad_network_size_estimate.set(ns.float64)
+
+proc optimisticStop(
+    os: OptimisticState, state: LookupState
+): bool {.raises: [], gcsafe.} =
+  ## Stop condition that doubles as the mid-walk store trigger: schedule
+  ## ADD_PROVIDER with any new peer inside the individual threshold, and stop
+  ## once enough peers are covered.
+  let k = os.kad.config.replication
+  let hasher = os.kad.rtable.config.hasher
+
+  # Zero-padded to k so an under-filled shortlist keeps the average meaningful.
+  var distances = newSeq[float64](k)
+  for i, pid in state.allSortedPeers().take(k):
+    distances[i] = normedDistance(xorDistance(pid, state.target, hasher))
+    if pid notin os.scheduled and distances[i] <= os.individualThreshold:
+      os.schedulePut(pid)
+
+  if os.scheduled.len - os.failed >= k:
+    return true
+
+  (distances.sum() / float64(distances.len)) < os.setThreshold
+
+proc waitForReturn(os: OptimisticState) {.async: (raises: [CancelledError]).} =
+  ## Return once ``returnThreshold`` RPCs completed, or all of them if fewer ran.
+  ## `completed` only grows and is re-read after each clear, so no wakeup is lost.
+  let target = min(os.returnThreshold, os.puts.len)
+  while os.completed < target:
+    await os.doneEvent.wait()
+    os.doneEvent.clear()
+
+proc optimisticProvide(
+    kad: KadDHT, key: Key, netSize: int
+) {.async: (raises: [CancelledError]), gcsafe.} =
+  let os = OptimisticState.new(kad, key, netSize)
+  let stop = proc(state: LookupState): bool {.raises: [], gcsafe.} =
+    os.optimisticStop(state)
+
+  let state = await kad.iterativeLookup(key, findNodeDispatch, noopReply, stop)
+
+  # Store with any of the final closest peers we did not reach during the walk.
+  let closest = state.allSortedPeers()
+  for pid in closest.take(kad.config.replication):
+    if pid notin os.scheduled:
+      os.schedulePut(pid)
+
+  await os.waitForReturn()
+  kad.maybeTrackNetsize(key, closest)
+
+  # Keep the still-running puts alive and cancellable on `stop`.
+  for fut in os.puts:
+    kad.provideTasks.trackFut(fut)
+
 proc addProvider*(kad: KadDHT, key: Key) {.async: (raises: [CancelledError]), gcsafe.} =
+  if kad.config.optimisticProvide:
+    kad.nsEstimator.networkSize().withValue(ns):
+      await kad.optimisticProvide(key, ns)
+      return
+
+  let state = await kad.iterativeLookup(key, findNodeDispatch, noopReply)
+  let closest = state.allSortedPeers()
+  kad.maybeTrackNetsize(key, closest)
+
   let peers =
     if kad.config.providerRejection:
       # Spillover needs the peers past the closest `replication` ones too.
-      (await kad.iterativeLookup(key, findNodeDispatch, noopReply)).allSortedPeers()
+      closest
     else:
-      await kad.findNode(key)
+      state.selectCloserPeers(kad.config.replication, excludeResponded = false)
   await kad.storeProviderAt(key, peers)
 
 proc addProvider*(kad: KadDHT, cid: Cid) {.async: (raises: [CancelledError]), gcsafe.} =

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -63,6 +63,17 @@ func bucketIndexFor(rtable: RoutingTable, selfHash: Key, key: Key): int =
 func bucketIndex*(rtable: RoutingTable, key: Key): int =
   rtable.bucketIndexFor(rtable.selfHash(), key)
 
+func commonPrefixLen*(rtable: RoutingTable, key: Key): int =
+  ## Leading bits `key` shares with self: the bucket index before clamping.
+  xorDistance(rtable.selfHash(), key.hashFor(rtable.config.hasher)).leadingZeros()
+
+func nPeersForCpl*(rtable: RoutingTable, cpl: int): int =
+  ## Fullness of the bucket holding the peers that share `cpl` bits with self.
+  var count = 0
+  for bucket in rtable.buckets:
+    count += bucket.peers.countIt(rtable.commonPrefixLen(it.nodeId) == cpl)
+  count
+
 proc peerIndexInBucket(bucket: Bucket, nodeId: Key): Opt[int] =
   for i, p in bucket.peers:
     if p.nodeId == nodeId:

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -266,6 +266,18 @@ proc new*(
 
   return pm
 
+type
+  NetSizeMeasurement* = object
+    distance*: float64 ## normalized XOR distance to a lookup target, in ``[0, 1]``
+    weight*: float64
+    timestamp*: Moment
+
+  NetworkSizeEstimator* = ref object
+    ## Network size from the distances of the closest peers seen across lookups.
+    ## See ``netsize.nim`` for the math.
+    bucketSize*: int
+    measurements*: seq[seq[NetSizeMeasurement]] ## one bucket per closest-peer index
+
 proc toPeerIds*(entries: seq[NodeEntry]): seq[PeerId] =
   var peerIds = newSeqOfCap[PeerId](entries.len)
   for e in entries:
@@ -451,6 +463,11 @@ type KadDHTConfig* = object
     ## republish regions, one DHT walk each. ``Opt.none`` derives it from the
     ## routing table; too few bits advertise a key to peers that are not its
     ## closest.
+  optimisticProvide*: bool
+    ## Dispatch ADD_PROVIDER mid-lookup to peers that pass an "in the k-closest
+    ## set" probability threshold, and return once a fraction of the RPCs
+    ## complete. Provides fall back to the classic path while the estimator has
+    ## no network size yet.
   limits*: KadDHTLimits
 
 proc new*(
@@ -479,6 +496,7 @@ proc new*(
     disableBootstrapping: bool = false,
     providerRejection: bool = false,
     republishRegionBits: Opt[int] = Opt.none(int),
+    optimisticProvide: bool = true,
     limits: Opt[KadDHTLimits] = Opt.none(KadDHTLimits),
 ): K {.raises: [].} =
   let actualLimits = limits.valueOr:
@@ -531,6 +549,7 @@ proc new*(
     disableBootstrapping: disableBootstrapping,
     providerRejection: providerRejection,
     republishRegionBits: republishRegionBits,
+    optimisticProvide: optimisticProvide,
     limits: actualLimits,
   )
 
@@ -548,6 +567,10 @@ type KadDHT* = ref object of LPProtocol
   recordExpirationLoop*: Future[void]
   dataTable*: LocalTable
   providerManager*: ProviderManager
+  nsEstimator*: NetworkSizeEstimator
+    ## Drives the optimistic-provide distance thresholds.
+  provideTasks*: seq[Future[void]]
+    ## ADD_PROVIDER RPCs still running after an early ``optimisticProvide``.
   config*: KadDHTConfig
   rpcSem*: AsyncSemaphore
     ## Bounds in-flight outbound RPCs to ``config.limits.maxConcurrentRpcs``.

--- a/tests/libp2p/kademlia/test_add_provider.nim
+++ b/tests/libp2p/kademlia/test_add_provider.nim
@@ -449,6 +449,33 @@ suite "KadDHT - Add Provider":
       kads[1].providerManager.providerRecords[0].provider.id.get() ==
         kads[0].rtable.selfId
 
+  template optimisticProvideStores(seedEstimate: bool) =
+    ## Without a seeded estimate `addProvider` takes the classic path, with one
+    ## the optimistic path. Both must store the record.
+    var cfg = testKadConfig()
+    cfg.optimisticProvide = true
+    let kads = @[setupKad(cfg), setupKad(cfg)]
+    startAndDeferStop(kads)
+
+    await connect(kads[0], kads[1])
+
+    if seedEstimate:
+      kads[1].nsEstimator.seedLinearMeasurements(1000)
+    check kads[1].nsEstimator.networkSize().isOk() == seedEstimate
+
+    await kads[1].addProvider(kads[0].rtable.selfId.toCid())
+
+    checkUntilTimeout:
+      kads[0].providerManager.providerRecords.len == 1
+      kads[0].providerManager.providerRecords[0].provider.id.get() ==
+        kads[1].rtable.selfId
+
+  asyncTest "Optimistic provide falls back to classic without a size estimate":
+    optimisticProvideStores(seedEstimate = false)
+
+  asyncTest "Optimistic provide stores records once the estimator has data":
+    optimisticProvideStores(seedEstimate = true)
+
 suite "KadDHT - Republish By Keyspace Region":
   teardown:
     checkTrackers()

--- a/tests/libp2p/kademlia/test_netsize.nim
+++ b/tests/libp2p/kademlia/test_netsize.nim
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import std/math
+import chronos, results
+import ../../../libp2p/protocols/kademlia
+import ../../tools/unittest
+import ./utils
+
+suite "KadDHT - Network Size Estimator":
+  test "gamma inverse matches reference values":
+    # From mpmath's inverse regularized lower incomplete gamma, solving
+    # P(a, x) == p at 30-digit precision.
+    check:
+      abs(gammaIncRegInv(20.0, 0.1) - 14.5252614653) < 1e-6
+      abs(gammaIncRegInv(11.0, 0.9) - 15.4066411720) < 1e-6
+      abs(gammaIncRegInv(5.0, 0.5) - 4.6709088828) < 1e-6
+      abs(gammaIncRegInv(2.0, 0.25) - 0.9612787631) < 1e-6
+      abs(gammaIncRegInv(50.0, 0.1) - 41.1790679062) < 1e-6
+      # For a == 1 the inverse is the closed form -ln(1 - p).
+      abs(gammaIncRegInv(1.0, 0.75) - (-ln(0.25))) < 1e-8
+      gammaIncRegInv(20.0, 0.0) == 0.0
+
+  test "normed distance spans the unit interval":
+    var zero, half, all: XorDistance
+    half[0] = 0x80 # top bit set → exactly one half of the keyspace
+    for i in 0 ..< IdLength:
+      all[i] = 0xFF
+    check:
+      normedDistance(zero) == 0.0
+      abs(normedDistance(half) - 0.5) < 1e-12
+      # The top 8 bytes hold 2^64-1, which float64 rounds up to 2^64.
+      normedDistance(all) > 0.9999
+      normedDistance(all) <= 1.0
+
+  test "recovers the network size from a linear distance profile":
+    for netSize in [200, 1000, 5000]:
+      let est = NetworkSizeEstimator.new(20)
+      check est.networkSize().isErr() # no measurements yet
+      est.seedLinearMeasurements(netSize)
+      let res = est.networkSize()
+      check res.isOk()
+      if res.isOk():
+        # Float rounding around the integer truncation can shift it by one.
+        check abs(res.get() - netSize) <= 2
+
+  test "track rejects a peer list that is not bucket-sized":
+    let key = Key.init(@[1.byte, 2, 3, 4])
+    check NetworkSizeEstimator.new(4).track(RoutingTable.new(key), key, @[]).isErr()

--- a/tests/libp2p/kademlia/utils.nim
+++ b/tests/libp2p/kademlia/utils.nim
@@ -348,3 +348,15 @@ proc sendAddProviderAndGetStatus*(
   let reply = Message.decode(readRes.value).valueOr:
     return ok(AddProviderStatus.accepted)
   return ok(reply.providerStatus.get(AddProviderStatus.accepted))
+
+proc seedLinearMeasurements*(est: NetworkSizeEstimator, netSize: int) =
+  ## Fill every closest-peer index with the profile the estimator models: index
+  ## `i` (1-based) at distance `i / (netSize + 1)`, plus a spread so the
+  ## regression is well posed.
+  let now = Moment.now()
+  for i in 0 ..< est.bucketSize:
+    let base = float64(i + 1) / float64(netSize + 1)
+    for delta in [-2e-4, -1e-4, 0.0, 1e-4, 2e-4]:
+      est.measurements[i].add(
+        NetSizeMeasurement(distance: base + delta, weight: 1.0, timestamp: now)
+      )


### PR DESCRIPTION
## Summary

Implements optimistic provide for the Kademlia DHT (issue #2860). Today `addProvider` sends `ADD_PROVIDER` only after the lookup fully converges, so provide latency includes the whole walk. This PR dispatches `ADD_PROVIDER` mid-lookup to peers that are statistically likely to be in the k-closest set. `addProvider` then returns once a fraction of the RPCs complete, and the remainder finish in the background. This cuts the long tail off provide latency.

The approach follows go-libp2p-kad-dht's `netsize` + `lookup_optim`:

- A network-size estimator (`netsize.nim`) tracks the normalized XOR distances of each converged lookup's k closest peers, grouped by closest-first index, and recovers the size by a weighted linear regression through the origin (`N = 1/slope - 1`).
- The estimate drives two distance thresholds through the inverse regularized lower incomplete gamma function. During a provide lookup, any newly found peer inside the individual threshold gets `ADD_PROVIDER` right away. The walk stops once k peers are covered, or once the k-closest average drops below the set threshold.
- `addProvider` returns after `ceil(k * 0.75)` RPCs complete. The rest run in the background, and `stop` cancels them.

The path is controlled by the new `optimisticProvide` config flag, which defaults to `true`. It needs a size estimate first, so early provides fall back to the classic path. Both paths feed the estimator, so it bootstraps without a chicken-and-egg dependency (a small, documented divergence from go-libp2p, which tracks only in the optimistic path).

## Affected Areas

- [x] Peer Management / Discovery
  <!-- Kademlia DHT provider records and iterative lookup -->

- [x] Protocol Logic
  <!-- ADD_PROVIDER dispatch timing; new network-size estimator -->

Scope is confined to `libp2p/protocols/kademlia/`. No changes to transports, gossipsub, or the switch.

## Compatibility & Downstream Validation

No downstream validation required. Kademlia is explicitly marked unstable / under active development. The flag is on by default, so an upgraded node changes its provide behavior as soon as its estimator has enough data; until then `addProvider` runs the classic path plus a passive network-size measurement. Set `optimisticProvide: false` to keep the classic path.

- **Nimbus:** N/A
- **Waku:** N/A
- **Codex:** N/A

## Impact on Library Users

- New config field `KadDHTConfig.optimisticProvide`, default `true`.
- `optimisticProvide` and `providerRejection` do not combine: once an estimate exists, the optimistic path runs and does not spill over to farther peers when a peer rejects the record. Turn `optimisticProvide` off if you rely on spillover.
- New public surface in the `kademlia` module: `NetworkSizeEstimator`, `NetSizeMeasurement`, `netsize.nim` (`track`, `networkSize`, `normedDistance`, `gammaIncRegInv`), a `kad_network_size_estimate` gauge, and `RoutingTable.commonPrefixLen` / `nPeersForCpl`.
- No migration required.

## Risk Assessment

- **Backward compatibility:** the config is additive, but the default is on, so provide behavior changes for every user once the estimator resolves.
- **Network behavior:** `ADD_PROVIDER` goes to more peers earlier, and `addProvider` returns before all RPCs settle. The background RPCs share the existing `maxConcurrentRpcs` semaphore, so total in-flight RPCs stay bounded, and `stop` cancels them.
- **Numerics:** the network-size estimate and the gamma thresholds are floating point. A bad estimate only shifts how eagerly records are stored; the correctness of a stored record is unaffected. `gammaIncRegInv` inverts the regularized lower incomplete gamma by bisection, and the tests pin it to `mpmath` reference values.
- **Security:** no new untrusted input paths; distances come from peer IDs already in the shortlist.

## References

- Closes #2860
- Parent: #1756
- go-libp2p-kad-dht `netsize/netsize.go` and `lookup_optim.go`

## Additional Notes

Optimistic mode treats a completed RPC as a success even if the peer replied `rejected`, which matches go-libp2p. Tests cover the gamma inverse (against `mpmath` references), `normedDistance`, estimator recovery of a seeded linear profile, and both the fallback and the optimistic provide path. The Kademlia suites pass locally, and CI runs the full suite.
