### PR TITLE
chore(cbind): change procs to static

### DIFF
--- a/cbind/examples/metrics.c
+++ b/cbind/examples/metrics.c
@@ -1,6 +1,6 @@
 // Metrics: a running node dumps the process-wide Prometheus registry as JSON
-// via libp2p_static_collect_metrics. The registry is global, so one started node
-// is enough to populate it. Calls are made blocking with the helpers in
+// via libp2p_static_collect_metrics. The registry is global, so one started 
+// node is enough to populate it. Calls are made blocking with the helpers in
 // common.h.
 #include "common.h"
 

--- a/cbind/examples/metrics.c
+++ b/cbind/examples/metrics.c
@@ -1,5 +1,5 @@
 // Metrics: a running node dumps the process-wide Prometheus registry as JSON
-// via libp2p_ctx_collect_metrics. The registry is global, so one started node
+// via libp2p_static_collect_metrics. The registry is global, so one started node
 // is enough to populate it. Calls are made blocking with the helpers in
 // common.h.
 #include "common.h"
@@ -48,7 +48,7 @@ int main(void) {
 
   MetricsWaiter mw;
   memset(&mw, 0, sizeof(mw));
-  libp2p_ctx_collect_metrics(node, on_metrics, &mw);
+  libp2p_static_collect_metrics(on_metrics, &mw);
   if (!wait_done(&mw.done) || mw.err_code != 0) {
     fprintf(stderr, "collect_metrics: %s\n", mw.err[0] ? mw.err : "unknown");
     goto cleanup;

--- a/cbind/examples/metrics.c
+++ b/cbind/examples/metrics.c
@@ -1,5 +1,5 @@
 // Metrics: a running node dumps the process-wide Prometheus registry as JSON
-// via libp2p_static_collect_metrics. The registry is global, so one started 
+// via libp2p_static_collect_metrics. The registry is global, so one started
 // node is enough to populate it. Calls are made blocking with the helpers in
 // common.h.
 #include "common.h"

--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -1243,7 +1243,7 @@ proc collectRegistryMetrics(registry: Registry): seq[MetricEntry] {.gcsafe.} =
         )
   entries
 
-proc libp2pCollectMetrics*(lib: LibP2P): Future[Result[string, string]] {.ffi.} =
+proc libp2pCollectMetrics*(): Future[Result[string, string]] {.ffiStatic.} =
   ## A JSON snapshot of the Prometheus registry, one object per metric sample.
   var jsonText: string
   try:

--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -1144,15 +1144,16 @@ proc libp2pCreateCid*(
   ok($cid)
 
 proc libp2pNewPrivateKey*(
-    lib: LibP2P, req: NewPrivateKeyRequest
-): Future[Result[seq[byte], string]] {.ffi.} =
-  ## Generates a private key from the node's RNG. `scheme` is one of the
+    req: NewPrivateKeyRequest
+): Future[Result[seq[byte], string]] {.ffiStatic.} =
+  ## Generates a private key. `scheme` is one of the
   ## `KEY_SCHEME_*` constants.
   if req.scheme < ord(low(PKScheme)) or req.scheme > ord(high(PKScheme)):
     return err("invalid key scheme")
   let scheme = PKScheme(req.scheme)
 
-  let key = PrivateKey.random(scheme, lib.rng).valueOr:
+  let rng = newRng()
+  let key = PrivateKey.random(scheme, rng).valueOr:
     return err("could not generate private key")
 
   let keyData = key.getBytes().valueOr:


### PR DESCRIPTION
procs `libp2pNewPrivateKey` and `libp2pCollectMetrics` were depended on `LibP2P` although they didn't really used it. in this pr these procs have been changed to `ffiStatic` to avoid `LibP2P` argument.

closes:  #2906