### PR TITLE
fix(service-disco): self registration ticket carry over

### DIFF
--- a/libp2p/protocols/service_discovery/advertiser.nim
+++ b/libp2p/protocols/service_discovery/advertiser.nim
@@ -260,6 +260,10 @@ proc advertiseToRegistrar*(
     of kademlia_protobuf.RegistrationStatus.Confirmed:
       debug "advert accepted", serviceId, registrar
 
+      # Drop any ticket used for this Confirm.
+      # Self-registration reuses this loop after advertExpiry.
+      currentTicket = Opt.none(Ticket)
+
       await sleepAsync(disco.discoConfig.advertExpiry)
 
       if isSelf:

--- a/tests/libp2p/service_discovery/component/test_register.nim
+++ b/tests/libp2p/service_discovery/component/test_register.nim
@@ -249,12 +249,13 @@ suite "Service Discovery Component - Register":
 
     let fut = disco.advertiseToRegistrar(serviceId, selfPeer, Opt.none(Ticket), adBytes)
 
+    let minTaskTime = conf.advertExpiry * 3
     # Timeline with this config:
     #   ~0s: Wait (tWaitFor ≈ 2s)
     #   ~2s: retry with ticket → Confirmed (ticket cleared)
     #   ~4s: sleep advertExpiry done; re-register with no ticket
     # Task must still be running after the refresh.
-    await sleepAsync(6.seconds)
+    await sleepAsync(minTaskTime)
 
     check not fut.finished
 

--- a/tests/libp2p/service_discovery/component/test_register.nim
+++ b/tests/libp2p/service_discovery/component/test_register.nim
@@ -255,8 +255,6 @@ suite "Service Discovery Component - Register":
     #   ~2s: retry with ticket → Confirmed (ticket cleared)
     #   ~4s: sleep advertExpiry done; re-register with no ticket
     # Task must still be running after the refresh.
-    await sleepAsync(minTaskTime)
-
-    check not fut.finished
+    check not (await fut.withTimeout(minTaskTime))
 
     await fut.cancelAndWait()

--- a/tests/libp2p/service_discovery/component/test_register.nim
+++ b/tests/libp2p/service_discovery/component/test_register.nim
@@ -221,3 +221,41 @@ suite "Service Discovery Component - Register":
       await legitimateNode.sendRegister(registrarPeerId, serviceId, legitimateAdBytes)
     check legitimateResp.isOk()
     check legitimateResp.get().status == kad_protobuf.RegistrationStatus.Wait
+
+  asyncTest "self-registration refresh after Wait-Confirmed does not present a stale ticket":
+    ## Regression: after Wait → Confirmed, `currentTicket` must be cleared. If the
+    ## next refresh reuses that ticket past its eligibility window
+    ## [tMod + tWaitFor, tMod + tWaitFor + registrationWindow], the registrar
+    ## rejects it as "ticket outside valid time window" and the local task exits.
+    let conf = ServiceDiscoveryConfig.new(
+      # empty-cache wait ≈ advertExpiry * safetyParam = 2s → first REGISTER is Wait
+      advertExpiry = 2.secs,
+      safetyParam = 1.0,
+      registrationWindow = 1.secs,
+    )
+    let disco = setupServiceDiscoveryNode(discoConfig = conf)
+    startAndDeferStop(@[disco])
+
+    let serviceName = "self-stale-ticket"
+    let serviceId = serviceName.hashServiceId()
+    check disco.rtManager.addService(
+      serviceId, disco.rtable, disco.config.replication, disco.discoConfig.bucketsCount,
+      Provided,
+    )
+
+    let adBytes =
+      makeAdvertisement(serviceName, disco.switch.peerInfo.privateKey).encode().get()
+    let selfPeer = disco.switch.peerInfo.peerId
+
+    let fut = disco.advertiseToRegistrar(serviceId, selfPeer, Opt.none(Ticket), adBytes)
+
+    # Timeline with this config:
+    #   ~0s: Wait (tWaitFor ≈ 2s)
+    #   ~2s: retry with ticket → Confirmed (ticket cleared)
+    #   ~4s: sleep advertExpiry done; re-register with no ticket
+    # Task must still be running after the refresh.
+    await sleepAsync(6.seconds)
+
+    check not fut.finished
+
+    await fut.cancelAndWait()


### PR DESCRIPTION
When an advertiser successfully registered with itself the ticket used was wrongly reused after the previous ad expired.

We now clear the ticket on success and added a test.