### PR TITLE
fix(interop): retry the nimble install and fail the build when it does not install

### DIFF
--- a/interop/hole-punching-v2/Dockerfile
+++ b/interop/hole-punching-v2/Dockerfile
@@ -14,7 +14,8 @@ COPY interop/hole-punching-v2/interop_hole_punching_v2.nimble nim-libp2p/interop
 RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y --no-install-recommends ca-certificates binutils libssl-dev \
   && rm -rf /var/lib/apt/lists/*
 
-RUN nimble install "nimble@#${NIMBLE_COMMIT}" -y
+COPY interop/install-nimble.sh nim-libp2p/interop/
+RUN bash nim-libp2p/interop/install-nimble.sh "${NIMBLE_COMMIT}"
 
 COPY . nim-libp2p/
 

--- a/interop/hole-punching/Dockerfile
+++ b/interop/hole-punching/Dockerfile
@@ -14,7 +14,8 @@ COPY interop/hole-punching/interop_hole_punching.nimble nim-libp2p/interop/hole-
 RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y --no-install-recommends ca-certificates binutils libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN nimble install "nimble@#${NIMBLE_COMMIT}" -y
+COPY interop/install-nimble.sh nim-libp2p/interop/
+RUN bash nim-libp2p/interop/install-nimble.sh "${NIMBLE_COMMIT}"
 
 COPY . nim-libp2p/
 

--- a/interop/install-nimble.sh
+++ b/interop/install-nimble.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Installs nimble into the interop Docker builder. `nimble install` exits 0 when the build
+# of the package fails, and the clone of the submodules of nimble hits transient GitHub 503s.
+set -euo pipefail
+
+commit="${1:?usage: install-nimble.sh <commit>}"
+bin="/root/.nimble/bin/nimble"
+attempts=3
+
+# The interop builds need `--resolver:minver`, which the nimble of the base image rejects.
+installedWithResolver() {
+  [ -x "$bin" ] && "$bin" --resolver:minver --version >/dev/null
+}
+
+rm -f "$bin"
+
+attempt=1
+while [ "$attempt" -le "$attempts" ]; do
+  if [ "$attempt" -gt 1 ]; then
+    sleep 15
+  fi
+  nimble install "nimble@#${commit}" -y || true
+  if installedWithResolver; then
+    exit 0
+  fi
+  echo "install-nimble: attempt ${attempt} of ${attempts} installed no usable ${bin}" >&2
+  attempt=$((attempt + 1))
+done
+
+echo "install-nimble: cannot install nimble@#${commit}" >&2
+exit 1

--- a/interop/kad-dht-v2/Dockerfile
+++ b/interop/kad-dht-v2/Dockerfile
@@ -14,7 +14,8 @@ COPY interop/kad-dht-v2/interop_kad_dht_v2.nimble nim-libp2p/interop/kad-dht-v2/
 RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y --no-install-recommends ca-certificates binutils \
     && rm -rf /var/lib/apt/lists/*
 
-RUN nimble install "nimble@#${NIMBLE_COMMIT}" -y
+COPY interop/install-nimble.sh nim-libp2p/interop/
+RUN bash nim-libp2p/interop/install-nimble.sh "${NIMBLE_COMMIT}"
 
 COPY . nim-libp2p/
 

--- a/interop/perf/Dockerfile
+++ b/interop/perf/Dockerfile
@@ -14,7 +14,8 @@ COPY interop/perf/interop_perf.nimble nim-libp2p/interop/perf/
 RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y --no-install-recommends ca-certificates binutils \
     && rm -rf /var/lib/apt/lists/*
 
-RUN nimble install "nimble@#${NIMBLE_COMMIT}" -y
+COPY interop/install-nimble.sh nim-libp2p/interop/
+RUN bash nim-libp2p/interop/install-nimble.sh "${NIMBLE_COMMIT}"
 
 COPY . nim-libp2p/
 

--- a/interop/transport-v2/Dockerfile
+++ b/interop/transport-v2/Dockerfile
@@ -14,7 +14,8 @@ COPY interop/transport-v2/interop_transport_v2.nimble nim-libp2p/interop/transpo
 RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y --no-install-recommends ca-certificates binutils \
     && rm -rf /var/lib/apt/lists/*
 
-RUN nimble install "nimble@#${NIMBLE_COMMIT}" -y
+COPY interop/install-nimble.sh nim-libp2p/interop/
+RUN bash nim-libp2p/interop/install-nimble.sh "${NIMBLE_COMMIT}"
 
 COPY . nim-libp2p/
 

--- a/interop/transport/Dockerfile
+++ b/interop/transport/Dockerfile
@@ -14,7 +14,8 @@ COPY interop/transport/interop_transport.nimble nim-libp2p/interop/transport/
 RUN --mount=type=cache,target=/var/cache/apt apt-get update && apt-get install -y --no-install-recommends ca-certificates binutils \
     && rm -rf /var/lib/apt/lists/*
 
-RUN nimble install "nimble@#${NIMBLE_COMMIT}" -y
+COPY interop/install-nimble.sh nim-libp2p/interop/
+RUN bash nim-libp2p/interop/install-nimble.sh "${NIMBLE_COMMIT}"
 
 COPY . nim-libp2p/
 


### PR DESCRIPTION
## Summary

The daily interop job `Build unified-testing interop image (kad-dht-v2)` failed: https://github.com/vacp2p/nim-libp2p/actions/runs/30798298277/job/91695421108

The reported error, `Unknown option: --resolver:minver`, is a symptom. The build breaks 15 minutes earlier, in the `RUN nimble install "nimble@#${NIMBLE_COMMIT}" -y` layer:

1. GitHub returned HTTP 503 while nimble cloned its own vendored submodules: `fatal: unable to access 'https://github.com/status-im/nim-bearssl/': The requested URL returned error: 503`.
2. nimble downgraded that failure to a warning, then re-fetched the submodules one at a time. It fetched 7 of the 8 and skipped `vendor/results`.
3. The build of nimble then failed: `vendor/chronos/chronos/internal/asyncengine.nim(19, 8) Error: cannot open file: results`.
4. `nimble install` still exited 0. The Docker layer passed, and `/root/.nimble/bin/nimble` was never created.
5. The next step therefore ran the old nimble of the base image, which does not know `--resolver:minver`. The `nimble setup` step did nothing, and the compile failed with `peer.nim(16, 8) Error: cannot open file: chronos`.

The 3 sibling jobs passed only because they did not get the 503. All 6 interop Dockerfiles share the same install line, so all 6 have the same flake.

This PR adds `interop/install-nimble.sh`. The script removes the target binary, runs `nimble install`, then probes the result with `nimble --resolver:minver --version`. That probe is the capability the next build step needs: `--resolver` and `--version` are both global flags of the same parser (`src/nimblepkg/options.nim`), and `handleUnknownFlags` runs after the full parse, so the old nimble exits non-zero on it and the pinned one prints its version. If the probe fails, the script retries up to 3 times, then fails the layer with a clear message. All 6 interop Dockerfiles call it.

This gives 2 benefits. A transient GitHub 503 no longer breaks the image build. A real install failure now stops at the install step with an accurate error, instead of 15 minutes later with a misleading one.

## Affected Areas

- [x] Build / Tooling
  Only the interop Docker images: `hole-punching`, `hole-punching-v2`, `kad-dht-v2`, `perf`, `transport`, `transport-v2`.

## Compatibility & Downstream Validation

N/A. The change touches no library code, so no downstream project is affected.

## Impact on Library Users

No impact. The change is limited to the interop Docker build.

## Risk Assessment

Low. The pinned `NIMBLE_COMMIT`, the Nim version, and the compile flags stay the same, so a successful build produces the same image as before.

The worst case is a longer job when GitHub is unreachable: each retry re-clones the nimble repository and its submodules, so 3 failed attempts add about 30 minutes before the job stops. The job then fails with a clear message instead of a misleading one.

Validation, and its limits:

- The `run-daily-ci` label ran the real image builds on this branch. `kad-dht-v2`, the job that failed, now passes in 4m23s, together with `hole-punching-v2` and `perf`.
- That green run proves the script does not break a normal build. It does not prove the retry path, because the 503 is transient and cannot be reproduced on demand.
- Docker cannot run in the environment where this branch was written, so the retry path was tested against a stub `nimble` on 4 cases: the install produces an old nimble that rejects `--resolver` (3 attempts, exit 1), the install produces a nimble that accepts it (exit 0), the install produces no binary at all (3 attempts, exit 1), and the commit argument is missing (exit 1 with a usage message).

## References

- Failing run: https://github.com/vacp2p/nim-libp2p/actions/runs/30798298277/job/91695421108
- Upstream cause: `nimble install` exits 0 when the build of the package fails.

## Additional Notes

`NIMBLE_COMMIT` is pinned to `aa8e6ea09ecac774b6fad42552569ce07bef37ec`, and the GitHub API answers `422 No commit found for SHA` for it in `nim-lang/nimble`, while it resolves `master` normally. CI clones and builds that commit today, so git still serves it, but a commit that no branch reaches can disappear. This PR does not change the pin. Somebody should repin nimble to a reachable commit in a separate PR.

The 6 Dockerfiles still duplicate the `NIM_VERSION` and `NIMBLE_COMMIT` pins and the whole builder stage. A shared base image would remove that, and it is a bigger change than this CI fix.