### PR TITLE
fix(service-disco): let a caller advertise a full XPR

### DIFF
--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -171,6 +171,7 @@ type ExtendedRecordsResponse {.ffi.} = object
 type StartAdvertisingRequest {.ffi.} = object
   serviceId: string
   serviceData: seq[byte]
+  advertisement: seq[byte]
 
 type CreateXprRequest {.ffi.} = object
   addrs: seq[string]
@@ -914,12 +915,24 @@ proc libp2pServiceDiscoStop*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} 
 proc libp2pServiceDiscoStartAdvertising*(
     lib: LibP2P, req: StartAdvertisingRequest
 ): Future[Result[bool, string]] {.ffi.} =
-  ## Advertises `serviceId` (with optional `serviceData`) in this node's record.
+  ## Advertises `serviceId` (with `serviceData`, which may be empty) in this
+  ## node's record. A non-empty `advertisement` is a signed extended peer record,
+  ## published verbatim instead of this node's own record; it fails when that
+  ## record does not decode, is oversized, or does not list `serviceId`.
   let disco = resolveServiceDiscovery(lib).valueOr:
     return err(error)
+
+  let advert =
+    if req.advertisement.len == 0:
+      Opt.none(seq[byte])
+    else:
+      Opt.some(req.advertisement)
+
   disco.startAdvertising(
-    ServiceInfo(id: req.serviceId, data: Opt.some(req.serviceData))
-  )
+    ServiceInfo(id: req.serviceId, data: Opt.some(req.serviceData)), advert
+  ).isOkOr:
+    return err(error)
+
   ok(true)
 
 proc libp2pServiceDiscoStopAdvertising*(

--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -922,14 +922,9 @@ proc libp2pServiceDiscoStartAdvertising*(
   let disco = resolveServiceDiscovery(lib).valueOr:
     return err(error)
 
-  let advert =
-    if req.advertisement.len == 0:
-      Opt.none(seq[byte])
-    else:
-      Opt.some(req.advertisement)
-
   disco.startAdvertising(
-    ServiceInfo(id: req.serviceId, data: Opt.some(req.serviceData)), advert
+    ServiceInfo(id: req.serviceId, data: Opt.some(req.serviceData)),
+    Opt.noneWhenEmpty(req.advertisement),
   ).isOkOr:
     return err(error)
 

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -168,7 +168,8 @@ method start*(disco: ServiceDiscovery) {.async: (raises: [CancelledError]).} =
     disco.selfSignedPeerRecordLoop = disco.maintainSelfSignedPeerRecord()
 
   for serviceInfo in disco.services:
-    disco.addProvidedService(serviceInfo)
+    disco.addProvidedService(serviceInfo).isOkOr:
+      error "cannot advertise configured service", service = serviceInfo.id, error
 
   disco.pruneExpiredAdsLoop = disco.maintainRegistrar()
   disco.refreshServiceTablesLoop = disco.maintainServiceTables()

--- a/libp2p/protocols/service_discovery/advertiser.nim
+++ b/libp2p/protocols/service_discovery/advertiser.nim
@@ -292,17 +292,35 @@ proc advertiseToRegistrar*(
       debug "registrar rejection, aborting", serviceId, registrar
       return
 
+proc validateAdvert(advert: seq[byte], service: ServiceInfo): Result[void, string] =
+  ## Applies the checks a registrar applies in `isValidAdvertisement`, so a bad
+  ## record fails here instead of being republished on every rotation.
+  let ad = Advertisement.decode(advert).valueOr:
+    return err("cannot decode advertisement: " & $error)
+
+  if not ad.isValid():
+    return err(
+      "oversized advertisement: the record must stay under " & $MaxXPRSize &
+        " bytes and each service data under " & $MaxServiceDataSize & " bytes"
+    )
+
+  if not ad.advertisesService(service.id.hashServiceId()):
+    return err("advertisement does not advertise service '" & service.id & "'")
+
+  ok()
+
 proc addProvidedService*(
     disco: ServiceDiscovery,
     service: ServiceInfo,
     advert: Opt[seq[byte]] = Opt.none(seq[byte]),
-) =
+): Result[void, string] =
   doAssert not disco.clientMode, "not supported in client mode"
 
   if not service.isValid():
-    error "rejecting service with oversized data",
-      service = service.id, dataLen = service.data.get().len, max = MaxServiceDataSize
-    return
+    return err("service data exceeds the maximum of " & $MaxServiceDataSize & " bytes")
+
+  if advert.isSome():
+    ?validateAdvert(advert.get(), service)
 
   let serviceId = service.id.hashServiceId()
 
@@ -310,7 +328,7 @@ proc addProvidedService*(
     serviceId, disco.rtable, disco.config.replication, disco.discoConfig.bucketsCount,
     Provided,
   ):
-    return
+    return ok()
 
   debug "added provided service", service = service.id, serviceId
 
@@ -318,8 +336,7 @@ proc addProvidedService*(
   cd_advertiser_services_added.inc()
 
   let advTable = disco.rtManager.getTable(serviceId).valueOr:
-    error "service not found", serviceId
-    return
+    return err("routing table missing for service '" & service.id & "'")
 
   # When a caller supplied an explicit advert we store it so that future
   # rotations / replacements (maintenance) reuse exactly the same bytes.
@@ -327,7 +344,7 @@ proc addProvidedService*(
     disco.advertiser.providedAdverts[serviceId] = advert.get()
 
   let advertBytes = disco.getAdvertBytes(advert).valueOr:
-    return
+    return err("cannot build the extended peer record to advertise")
 
   for bucketIdx, bucket in advTable.buckets.pairs:
     if bucket.peers.len == 0:
@@ -353,6 +370,8 @@ proc addProvidedService*(
   # We start it when we add the first provided service.
   if disco.services.len == 1: # we just added the first one
     disco.startLocalRegistration()
+
+  ok()
 
 proc removeProvidedService*(
     disco: ServiceDiscovery, serviceId: string
@@ -390,7 +409,7 @@ proc startAdvertising*(
     disco: ServiceDiscovery,
     service: ServiceInfo,
     advert: Opt[seq[byte]] = Opt.none(seq[byte]),
-) =
+): Result[void, string] =
   disco.addProvidedService(service, advert = advert)
 
 proc stopAdvertising*(

--- a/libp2p/utils/opt.nim
+++ b/libp2p/utils/opt.nim
@@ -28,6 +28,13 @@ proc toOpt*[T: ref object](x: T): Opt[T] =
   else:
     Opt.some(x)
 
+func noneWhenEmpty*[T](O: type Opt, v: seq[T]): Opt[seq[T]] =
+  ## `Opt.none` for an empty `v`, `Opt.some(v)` otherwise.
+  if v.len == 0:
+    Opt.none(seq[T])
+  else:
+    Opt.some(v)
+
 template withValue*[T](self: Opt[T], value, body: untyped): untyped =
   ## This template provides a convenient way to work with `Opt` types in Nim.
   ## It allows you to execute a block of code (`body`) only when the `Opt` is not empty.

--- a/tests/libp2p/service_discovery/component/test_advertise_discover.nim
+++ b/tests/libp2p/service_discovery/component/test_advertise_discover.nim
@@ -39,7 +39,7 @@ suite "Service Discovery Component - Advertise Discover":
     let service = makeServiceInfo("e2e-test-service")
     let serviceId = service.id.hashServiceId()
 
-    advertiserNode.addProvidedService(service)
+    check advertiserNode.addProvidedService(service).isOk()
 
     checkUntilTimeout:
       registrarNode1.countAdsInCache(serviceId) == 1 or
@@ -99,8 +99,8 @@ suite "Service Discovery Component - Advertise Discover":
     let service = makeServiceInfo("shared-service")
     let serviceId = service.id.hashServiceId()
 
-    advertiserA.addProvidedService(service)
-    advertiserB.addProvidedService(service)
+    check advertiserA.addProvidedService(service).isOk()
+    check advertiserB.addProvidedService(service).isOk()
 
     checkUntilTimeout:
       block:
@@ -129,12 +129,12 @@ suite "Service Discovery Component - Advertise Discover":
     let svcAId = svcA.id.hashServiceId()
     let svcBId = svcB.id.hashServiceId()
 
-    advertiserNode.addProvidedService(svcA)
+    check advertiserNode.addProvidedService(svcA).isOk()
 
     checkUntilTimeout:
       registrarNode.countAdsInCache(svcAId) == 1
 
-    advertiserNode.addProvidedService(svcB)
+    check advertiserNode.addProvidedService(svcB).isOk()
 
     checkUntilTimeout:
       registrarNode.countAdsInCache(svcBId) == 1
@@ -208,7 +208,7 @@ suite "Service Discovery Component - Advertise Discover":
     let service = makeServiceInfo("service-A")
     let serviceId = service.id.hashServiceId()
 
-    advertiserNode.addProvidedService(service)
+    check advertiserNode.addProvidedService(service).isOk()
 
     let otherKey = otherNode.switch.peerInfo.peerId.toKey()
     checkUntilTimeout:
@@ -227,7 +227,7 @@ suite "Service Discovery Component - Advertise Discover":
     let service = makeServiceInfo("service")
     let serviceId = service.id.hashServiceId()
 
-    advertiserNode.addProvidedService(service)
+    check advertiserNode.addProvidedService(service).isOk()
 
     checkUntilTimeout:
       registrarNode.countAdsInCache(serviceId) == 1
@@ -245,7 +245,7 @@ suite "Service Discovery Component - Advertise Discover":
     let service = makeServiceInfo("service")
     let serviceId = service.id.hashServiceId()
 
-    advertiserNode.addProvidedService(service)
+    check advertiserNode.addProvidedService(service).isOk()
 
     # Wait for the first registration to succeed on the remote registrar
     checkUntilTimeout:
@@ -376,7 +376,7 @@ suite "Service Discovery Component - Advertise Discover":
     let service = makeServiceInfo("service")
     let serviceId = service.id.hashServiceId()
 
-    advertiserNode.addProvidedService(service)
+    check advertiserNode.addProvidedService(service).isOk()
 
     checkUntilTimeout:
       initialRegistrar.countAdsInCache(serviceId) == 1
@@ -403,13 +403,13 @@ suite "Service Discovery Component - Advertise Discover":
 
     let firstService = makeServiceInfo("ipv6-service-1")
     let firstServiceId = firstService.id.hashServiceId()
-    advertiserNode.addProvidedService(firstService)
+    check advertiserNode.addProvidedService(firstService).isOk()
     checkUntilTimeout:
       registrarNode.countAdsInCache(firstServiceId) == 1
 
     let secondService = makeServiceInfo("ipv6-service-2")
     let secondServiceId = secondService.id.hashServiceId()
-    advertiserNode.addProvidedService(secondService)
+    check advertiserNode.addProvidedService(secondService).isOk()
     checkUntilTimeout:
       registrarNode.registrar.boundService.hasKey(secondServiceId)
     check registrarNode.countAdsInCache(secondServiceId) == 0
@@ -423,13 +423,13 @@ suite "Service Discovery Component - Advertise Discover":
 
     let firstService = makeServiceInfo("dual-stack-service-1")
     let firstServiceId = firstService.id.hashServiceId()
-    advertiserNode.addProvidedService(firstService)
+    check advertiserNode.addProvidedService(firstService).isOk()
     checkUntilTimeout:
       registrarNode.countAdsInCache(firstServiceId) == 1
 
     let secondService = makeServiceInfo("dual-stack-service-2")
     let secondServiceId = secondService.id.hashServiceId()
-    advertiserNode.addProvidedService(secondService)
+    check advertiserNode.addProvidedService(secondService).isOk()
     # The registrar answered Wait, not Confirmed: it records the Wait in
     # boundService and does not admit the second ad to the cache.
     checkUntilTimeout:

--- a/tests/libp2p/service_discovery/component/test_client_mode.nim
+++ b/tests/libp2p/service_discovery/component/test_client_mode.nim
@@ -68,7 +68,7 @@ suite "Service Discovery Component - Client Mode":
     let service = makeServiceInfo("service")
     let serviceId = service.id.hashServiceId()
 
-    serverAdvertiser.addProvidedService(service)
+    check serverAdvertiser.addProvidedService(service).isOk()
 
     checkUntilTimeout:
       serverRegistrar.countAdsInCache(serviceId) == 1

--- a/tests/libp2p/service_discovery/test_advertiser.nim
+++ b/tests/libp2p/service_discovery/test_advertiser.nim
@@ -2,7 +2,7 @@
 # Copyright (c) Status Research & Development GmbH
 {.used.}
 
-import chronos, results, sets
+import chronos, results, sets, tables
 import
   ../../../libp2p/[
     extended_peer_record,
@@ -24,7 +24,7 @@ suite "Advertiser - addProvidedService":
     let serviceId = service.id.hashServiceId()
 
     disco.populateRoutingTable(1)
-    disco.addProvidedService(service)
+    check disco.addProvidedService(service).isOk()
 
     check disco.rtManager.hasService(serviceId)
 
@@ -33,7 +33,7 @@ suite "Advertiser - addProvidedService":
     let service = makeServiceInfo()
     let serviceId = service.id.hashServiceId()
 
-    disco.addProvidedService(service)
+    check disco.addProvidedService(service).isOk()
 
     check disco.rtManager.hasService(serviceId)
     check disco.advertiser.running.len() == 0
@@ -44,7 +44,7 @@ suite "Advertiser - addProvidedService":
     let serviceId = service.id.hashServiceId()
 
     disco.populateAdvertisementTable(serviceId)
-    disco.addProvidedService(service)
+    check disco.addProvidedService(service).isOk()
 
     check disco.advertiser.running.len() == disco.discoConfig.kRegister
 
@@ -71,7 +71,7 @@ suite "Advertiser - addProvidedService":
         overpopulatedBuckets.inc
     check overpopulatedBuckets > 0
 
-    disco.addProvidedService(service)
+    check disco.addProvidedService(service).isOk()
 
     check disco.advertiser.running.len() == overpopulatedBuckets * kRegister
 
@@ -81,10 +81,10 @@ suite "Advertiser - addProvidedService":
     let serviceId = service.id.hashServiceId()
 
     disco.populateRoutingTable(1)
-    disco.addProvidedService(service)
+    check disco.addProvidedService(service).isOk()
     let runningAfterFirst = disco.advertiser.running.len()
 
-    disco.addProvidedService(service)
+    check disco.addProvidedService(service).isOk()
 
     check disco.rtManager.hasService(serviceId)
     check disco.advertiser.running.len() == runningAfterFirst
@@ -96,14 +96,51 @@ suite "Advertiser - addProvidedService":
     let s3 = makeServiceInfo("svc-3")
 
     disco.populateRoutingTable(1)
-    disco.addProvidedService(s1)
-    disco.addProvidedService(s2)
-    disco.addProvidedService(s3)
+    check disco.addProvidedService(s1).isOk()
+    check disco.addProvidedService(s2).isOk()
+    check disco.addProvidedService(s3).isOk()
 
     check disco.rtManager.hasService(s1.id.hashServiceId())
     check disco.rtManager.hasService(s2.id.hashServiceId())
     check disco.rtManager.hasService(s3.id.hashServiceId())
     check disco.advertiser.running.len() == 3
+
+suite "Advertiser - caller-supplied advertisement":
+  teardown:
+    checkTrackers()
+
+  test "stores a valid advertisement for reuse on rotation":
+    let disco = setupServiceDiscoveryNode()
+    let service = makeServiceInfo()
+    let advert = makeAdvertisement(service.id).encode()
+
+    disco.populateRoutingTable(1)
+
+    check disco.addProvidedService(service, Opt.some(advert)).isOk()
+    check disco.advertiser.providedAdverts[service.id.hashServiceId()] == advert
+
+  test "rejects an advertisement that does not decode":
+    let disco = setupServiceDiscoveryNode()
+    let service = makeServiceInfo()
+
+    check disco.addProvidedService(service, Opt.some(@[1'u8, 2, 3, 4])).isErr()
+    check not disco.rtManager.hasService(service.id.hashServiceId())
+
+  test "rejects an advertisement for another service":
+    let disco = setupServiceDiscoveryNode()
+    let service = makeServiceInfo("wanted-service")
+    let advert = makeAdvertisement("other-service").encode()
+
+    check disco.addProvidedService(service, Opt.some(advert)).isErr()
+    check not disco.rtManager.hasService(service.id.hashServiceId())
+
+  test "rejects an advertisement with oversized service data":
+    let disco = setupServiceDiscoveryNode()
+    let service = makeServiceInfo()
+    let advert = makeOversizedAdvertisement(service.id).encode()
+
+    check disco.addProvidedService(service, Opt.some(advert)).isErr()
+    check not disco.rtManager.hasService(service.id.hashServiceId())
 
 suite "Advertiser - removeProvidedService":
   teardown:
@@ -117,8 +154,8 @@ suite "Advertiser - removeProvidedService":
     let sid2 = s2.id.hashServiceId()
 
     disco.populateRoutingTable(1)
-    disco.addProvidedService(s1)
-    disco.addProvidedService(s2)
+    check disco.addProvidedService(s1).isOk()
+    check disco.addProvidedService(s2).isOk()
 
     await disco.removeProvidedService(s1.id)
     disco.unregisterInterest(s1.id) # local registrar has interest too
@@ -141,8 +178,8 @@ suite "Advertiser - removeProvidedService":
     let s2 = makeServiceInfo("svc-2")
 
     disco.populateRoutingTable(1)
-    disco.addProvidedService(s1)
-    disco.addProvidedService(s2)
+    check disco.addProvidedService(s1).isOk()
+    check disco.addProvidedService(s2).isOk()
 
     await disco.removeProvidedService(s1.id)
     disco.unregisterInterest(s1.id) # local registrar has interest too

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -89,6 +89,18 @@ proc makeAdvertisement*(
   )
   SignedExtendedPeerRecord.init(privateKey, extRecord).get()
 
+proc makeOversizedAdvertisement*(
+    serviceId: string, privateKey: PrivateKey = PrivateKey.random(rng()).get()
+): Advertisement =
+  ## Decodes cleanly but fails `isValid`: its service data exceeds `MaxServiceDataSize`.
+  let extRecord = ExtendedPeerRecord(
+    peerId: PeerId.init(privateKey).get(),
+    seqNo: 1,
+    addresses: @[],
+    services: @[ServiceInfo(id: serviceId, data: newSeq[byte](MaxServiceDataSize + 1))],
+  )
+  SignedExtendedPeerRecord.init(privateKey, extRecord).get()
+
 proc createSwitch*(
     privateKey: Opt[PrivateKey] = Opt.none(PrivateKey),
     addresses: seq[MultiAddress] = @[TcpAutoAddress()],


### PR DESCRIPTION
## Summary

`libp2pServiceDiscoStartAdvertising` could only advertise this node's own record. A caller that runs its service on a different switch had no way to publish that switch's peer id and addresses.

The core library already carried the plumbing. `startAdvertising(disco, service, advert: Opt[seq[byte]])` stores the caller's bytes in `advertiser.providedAdverts` and republishes them verbatim on every rotation. Only the FFI wrapper dropped the argument: `StartAdvertisingRequest` in `cbind/libp2p.nim` carried `serviceId` and `serviceData` alone, so there was no way to pass a signed extended peer record across the C boundary.

This PR adds `advertisement: seq[byte]` to that request and forwards it when it is non-empty. An empty field keeps the old behaviour.

It also closes the hole that feature opens. `addProvidedService` accepted its `advert` argument without checking it, so any caller could store arbitrary bytes in `providedAdverts` and have the node rebroadcast them to registrars on every rotation. `validateAdvert` now applies the same checks a registrar applies in `isValidAdvertisement`: the record must decode as a signed extended peer record, stay inside `MaxXPRSize` and `MaxServiceDataSize`, and list the service id among its services.

Reporting that rejection needs an error channel, so `addProvidedService` and `startAdvertising` now return `Result[void, string]`. That also surfaces three failures they previously swallowed: oversized service data, a missing routing table, and a record that cannot be built.

## Affected Areas

- [x] Peer Management / Discovery
  `addProvidedService` and `startAdvertising` in `libp2p/protocols/service_discovery/advertiser.nim` gain validation and a return type.

- [x] Build / Tooling
  `StartAdvertisingRequest` gains the field; `libp2pServiceDiscoStartAdvertising` propagates the core error.

## Compatibility & Downstream Validation

- **Nimbus:** N/A — does not consume service discovery.
- **Waku:** N/A — same reason.
- **Codex:** N/A — same reason.

Downstream consumer of the C bindings: https://github.com/logos-co/logos-libp2p-module/pull/99 needs this field. That PR adds a third `advertisement` argument (a base64 signed XPR) to its `discoStartAdvertising` API and does not build until this lands.

## Impact on Library Users

Nim users: `addProvidedService` and `startAdvertising` change from `void` to `Result[void, string]`. A caller that ignored the outcome now handles it or discards it explicitly. Both procs are new to the service-discovery protocol and have no downstream consumers in Nimbus, Waku, or Codex.

C binding users: additive. `StartAdvertisingRequest` gains one optional field. A caller that omits it, or sends an empty byte string, gets the previous behaviour. A caller that sets it gets an error string instead of a false success when the record is malformed, unsigned, oversized, or advertises a different service. The generated C header and CDDL schema change, so a consumer regenerates or updates its bindings.

## Risk Assessment

- Backward compatibility: the FFI field is additive and an empty value selects the old path. The Nim-side return-type change is source-breaking for any caller that ignored the result; all in-tree callers are updated.
- Network behaviour: unchanged when the field is empty. When it is set and valid, the node publishes the caller's record instead of its own, which is the intent. An invalid record is now rejected before it reaches `providedAdverts`, where it would otherwise have been rebroadcast on every rotation.
- Security: the supplied bytes cross a trust boundary and are checked at that boundary. `Advertisement.decode` verifies the envelope signature and runs `checkValid()`, `isValid()` bounds the sizes, and `advertisesService` confirms the service id.
- Performance: one decode per `startAdvertising` call that supplies a record. The bytes are stored once and reused on each rotation.

## References

- Issue: https://github.com/logos-co/logos-libp2p-module/issues/98
- Downstream PR: https://github.com/logos-co/logos-libp2p-module/pull/99

## Additional Notes

`tests/libp2p/service_discovery/test_advertiser.nim` gains a suite covering the four outcomes: a valid record is stored for reuse, and bytes that do not decode, that name another service, or that carry oversized service data are each rejected without registering the service. `makeOversizedAdvertisement` in the test utils builds the last case.