### PR TITLE
refactor(kad): tables into virtual system

### DIFF
--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -212,11 +212,9 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
   ## bucket refresh so dead peers are not held until the next refresh tick.
   ## At most one probe is in flight per peer across all maintainable tables.
 
-  var idle = true
   while not kad.stopping:
-    if idle:
-      # Initial idle: let start() finish bootstrap before the first scan.
-      await sleepAsync(kad.config.livenessIdleInterval)
+    # Initial idle: let start() finish bootstrap before the first scan.
+    await sleepAsync(kad.config.livenessIdleInterval)
 
     let grace = kad.config.livenessGracePeriod
 
@@ -240,9 +238,6 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
       except CancelledError as exc:
         await noCancel inFlight.cancelAndWait()
         raise exc
-      idle = false
-    else:
-      idle = true
 
 proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
   ## Continuous background task: drain replaceable peers via liveness probes

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -264,8 +264,7 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
         kad.launchLivenessProbe(peerId)
 
     if kad.livenessProbes.len > 0:
-      debug "Waiting for in-flight liveness probes",
-        inFlight = kad.livenessProbes.len
+      debug "Waiting for in-flight liveness probes", inFlight = kad.livenessProbes.len
       let inFlight = kad.livenessProbes.values.toSeq()
       try:
         discard await one(inFlight)

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -65,6 +65,17 @@ proc checkAndEvictPeer(
     debug "Liveness probe skipped: no free slot", peer = peerId.shortLog()
     kad_routing_table_liveness_probes.inc(labelValues = ["skipped"])
     return
+  kad.livenessProbes[probeKey] = probe
+  probe.addCallback(
+    proc(udata: pointer) {.gcsafe, raises: [].} =
+      if kad.livenessProbes.getOrDefault(probeKey) == probe:
+        kad.livenessProbes.del(probeKey)
+  )
+
+proc checkAndEvictPeer(
+    kad: KadDHT, rtable: RoutingTable, peerId: PeerId
+) {.async: (raises: [CancelledError]).} =
+  ## Takes ownership of one ``probeSem`` slot already acquired by the caller.
   defer:
     try:
       kad.livenessSem.release()
@@ -83,11 +94,6 @@ proc checkAndEvictPeer(
   if dueTables.len == 0:
     debug "Liveness probe skipped: peer no longer replaceable", peer = peerId.shortLog()
     return
-
-proc checkAndEvictPeer(
-    kad: KadDHT, rtable: RoutingTable, peerId: PeerId
-) {.async: (raises: [CancelledError]).} =
-  withProbeSlotOrReturn(kad)
 
   # Candidate list is a snapshot; by the time a slot is free the peer may have
   # been refreshed (markUseful) or removed, and stop may have begun.
@@ -221,6 +227,40 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
       idle = false
     else:
       idle = true
+
+proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
+  ## Continuous background task: drain replaceable peers via liveness probes
+  ## as soon as they become due, bounded by ``probeSem``. Independent of
+  ## bucket refresh so dead peers are not held until the next refresh tick.
+  # Yield once so start() can finish bootstrap before the first scan.
+  await sleepAsync(kad.config.livenessIdleInterval)
+
+  while not kad.stopping:
+    let grace = kad.config.livenessGracePeriod
+    var saturated = false
+
+    for rtable in kad.maintainableTables():
+      if kad.stopping:
+        return
+      for peerId in rtable.livenessCandidates(grace):
+        if not kad.tryLaunchLivenessProbe(rtable, peerId):
+          saturated = true
+          break
+      if saturated:
+        break
+
+    if kad.livenessProbes.len > 0:
+      let inFlight = kad.livenessProbes.values.toSeq()
+      try:
+        discard await one(inFlight)
+      except ValueError:
+        # All futures already finished between the snapshot and the wait.
+        discard
+      except CancelledError as exc:
+        await noCancel inFlight.cancelAndWait()
+        raise exc
+    else:
+      await sleepAsync(kad.config.livenessIdleInterval)
 
 proc refreshTable*(
     kad: KadDHT, rtable: RoutingTable, forceRefresh = false

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -68,17 +68,20 @@ proc checkAndEvictPeer(
   kad.livenessProbes[probeKey] = probe
   probe.addCallback(
     proc(udata: pointer) {.gcsafe, raises: [].} =
-      if kad.livenessProbes.getOrDefault(probeKey) == probe:
-        kad.livenessProbes.del(probeKey)
+      if kad.livenessProbes.getOrDefault(peerId) == probe:
+        kad.livenessProbes.del(peerId)
   )
 
 proc checkAndEvictPeer(
-    kad: KadDHT, rtable: RoutingTable, peerId: PeerId
+    kad: KadDHT, peerId: PeerId
 ) {.async: (raises: [CancelledError]).} =
-  ## Returns immediately when all liveness probe slots are occupied.
+  ## Probes a peer once and applies the result to every maintainable table
+  ## where that peer is past the liveness grace period. Returns immediately
+  ## when all liveness probe slots are occupied.
   if kad.stopping:
     return
-  if not kad.probeSem.tryAcquire():
+  if not kad.livenessSem.tryAcquire():
+    debug "Liveness probe skipped: no free slot", peer = peerId.shortLog()
     kad_routing_table_liveness_probes.inc(labelValues = ["skipped"])
     return
   defer:
@@ -105,7 +108,13 @@ proc checkAndEvictPeer(
   if kad.stopping:
     return
   let grace = kad.config.livenessGracePeriod
-  if not rtable.isReplaceable(peerId, grace, Moment.now()):
+  var dueTables: seq[RoutingTable]
+  for rtable in kad.maintainableTables():
+    if rtable.isReplaceable(peerId, grace, Moment.now()):
+      dueTables.add(rtable)
+  if dueTables.len == 0:
+    debug "Liveness probe skipped: peer no longer replaceable",
+      peer = peerId.shortLog()
     return
 
   let addrs = kad.switch.peerStore[AddressBook][peerId]
@@ -235,21 +244,28 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
 
 proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
   ## Continuous background task: drain replaceable peers via liveness probes
-  ## as soon as they become due, bounded by ``probeSem``. Independent of
+  ## as soon as they become due, bounded by ``livenessSem``. Independent of
   ## bucket refresh so dead peers are not held until the next refresh tick.
-  # Yield once so start() can finish bootstrap before the first scan.
-  await sleepAsync(kad.config.livenessIdleInterval)
+  ## At most one probe is in flight per peer across all maintainable tables.
 
   while not kad.stopping:
+    # Initial idle: let start() finish bootstrap before the first scan.
+    await sleepAsync(kad.config.livenessIdleInterval)
+
     let grace = kad.config.livenessGracePeriod
 
     for rtable in kad.maintainableTables():
       if kad.stopping:
         return
-      for peerId in rtable.livenessCandidates(grace):
-        kad.launchLivenessProbe(rtable, peerId)
+      let peers = rtable.peersInGracePeriod(grace)
+      if peers.len > 0:
+        debug "Liveness scan found replaceable peers", peers = peers.len
+      for peerId in peers:
+        kad.launchLivenessProbe(peerId)
 
     if kad.livenessProbes.len > 0:
+      debug "Waiting for in-flight liveness probes",
+        inFlight = kad.livenessProbes.len
       let inFlight = kad.livenessProbes.values.toSeq()
       try:
         discard await one(inFlight)
@@ -259,8 +275,6 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
       except CancelledError as exc:
         await noCancel inFlight.cancelAndWait()
         raise exc
-    else:
-      await sleepAsync(kad.config.livenessIdleInterval)
 
 proc refreshTable*(
     kad: KadDHT, rtable: RoutingTable, forceRefresh = false

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -75,7 +75,12 @@ proc checkAndEvictPeer(
 proc checkAndEvictPeer(
     kad: KadDHT, rtable: RoutingTable, peerId: PeerId
 ) {.async: (raises: [CancelledError]).} =
-  ## Takes ownership of one ``probeSem`` slot already acquired by the caller.
+  ## Returns immediately when all liveness probe slots are occupied.
+  if kad.stopping:
+    return
+  if not kad.probeSem.tryAcquire():
+    kad_routing_table_liveness_probes.inc(labelValues = ["skipped"])
+    return
   defer:
     try:
       kad.livenessSem.release()
@@ -95,8 +100,8 @@ proc checkAndEvictPeer(
     debug "Liveness probe skipped: peer no longer replaceable", peer = peerId.shortLog()
     return
 
-  # Candidate list is a snapshot; by the time a slot is free the peer may have
-  # been refreshed (markUseful) or removed, and stop may have begun.
+  # Candidate list is a snapshot; the peer may have been refreshed (markUseful)
+  # or removed since it was selected.
   if kad.stopping:
     return
   let grace = kad.config.livenessGracePeriod
@@ -237,17 +242,12 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
 
   while not kad.stopping:
     let grace = kad.config.livenessGracePeriod
-    var saturated = false
 
     for rtable in kad.maintainableTables():
       if kad.stopping:
         return
       for peerId in rtable.livenessCandidates(grace):
-        if not kad.tryLaunchLivenessProbe(rtable, peerId):
-          saturated = true
-          break
-      if saturated:
-        break
+        kad.launchLivenessProbe(rtable, peerId)
 
     if kad.livenessProbes.len > 0:
       let inFlight = kad.livenessProbes.values.toSeq()

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -86,9 +86,8 @@ proc checkAndEvictPeer(
 
 proc checkAndEvictPeer(
     kad: KadDHT, rtable: RoutingTable, peerId: PeerId
-) {.async: (raises: []).} =
+) {.async: (raises: [CancelledError]).} =
   withProbeSlotOrReturn(kad)
-      raiseAssert "probeSem released without acquire"
 
   # Candidate list is a snapshot; by the time a slot is free the peer may have
   # been refreshed (markUseful) or removed, and stop may have begun.

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -11,11 +11,11 @@ import
     routing_table, peer_registry, protobuf, types, find, get, put, keyspace, provider,
     ping,
   ]
-import ./kademlia/kademlia_metrics
+import ./kademlia/[kademlia_metrics, netsize]
 
 export
   chronicles, routing_table, peer_registry, protobuf, types, find, get, put, keyspace,
-  provider, ping, kademlia_metrics
+  provider, ping, kademlia_metrics, netsize
 
 logScope:
   topics = "kad-dht"
@@ -255,7 +255,6 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
     await sleepAsync(kad.config.livenessIdleInterval)
 
     let grace = kad.config.livenessGracePeriod
-    var saturated = false
 
     for rtable in kad.maintainableTables():
       if kad.stopping:

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -30,7 +30,7 @@ proc peersPastGracePeriod(
   var peers: seq[PeerId]
   for bucket in rtable.buckets:
     for nodeId in bucket.peers:
-      if not rtable.isReplaceable(nodeId, gracePeriod, now):
+      if not rtable.registry.isReplaceable(nodeId, rtable.selfId, gracePeriod, now):
         continue
       nodeId.toPeerId().withValue(pid):
         peers.add(pid)
@@ -115,7 +115,7 @@ proc checkAndEvictPeer(
 
   # Probe can race with unrelated traffic that markUseful'd the peer mid-flight.
   var evicted = 0
-  for rtable in kad.maintainableTables():
+  for rtable in dueTables:
     if not rtable.isReplaceable(peerId, grace, Moment.now()):
       continue
     discard rtable.removePeer(peerId, reason = "liveness")

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -84,6 +84,12 @@ proc checkAndEvictPeer(
     debug "Liveness probe skipped: peer no longer replaceable", peer = peerId.shortLog()
     return
 
+proc checkAndEvictPeer(
+    kad: KadDHT, rtable: RoutingTable, peerId: PeerId
+) {.async: (raises: []).} =
+  withProbeSlotOrReturn(kad)
+      raiseAssert "probeSem released without acquire"
+
   # Candidate list is a snapshot; by the time a slot is free the peer may have
   # been refreshed (markUseful) or removed, and stop may have begun.
   if kad.stopping:

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -27,7 +27,7 @@ proc peersInGracePeriod(
   var peers: seq[PeerId]
   for bucket in rtable.buckets:
     for entry in bucket.peers:
-      if not entry.isReplaceable(gracePeriod, now):
+      if not entry.needsLivenessCheck(gracePeriod, now):
         continue
       entry.nodeId.toPeerId().withValue(pid):
         peers.add(pid)

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -22,7 +22,7 @@ logScope:
 
 const KadCodec* = "/ipfs/kad/1.0.0"
 
-proc peersInGracePeriod(
+proc peersPastGracePeriod(
     rtable: RoutingTable, gracePeriod: Duration
 ): seq[PeerId] {.raises: [].} =
   ## Peers past the liveness grace period that should be probed.
@@ -30,7 +30,7 @@ proc peersInGracePeriod(
   var peers: seq[PeerId]
   for bucket in rtable.buckets:
     for nodeId in bucket.peers:
-      if not rtable.registry.isReplaceable(nodeId, gracePeriod, now):
+      if not rtable.isReplaceable(nodeId, gracePeriod, now):
         continue
       nodeId.toPeerId().withValue(pid):
         peers.add(pid)
@@ -183,7 +183,7 @@ proc probeAndEvictPeers*(
   if kad.stopping:
     return
 
-  let peers = rtable.peersInGracePeriod(kad.config.livenessGracePeriod)
+  let peers = rtable.peersPastGracePeriod(kad.config.livenessGracePeriod)
   if peers.len == 0:
     return
 
@@ -221,7 +221,7 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
     for rtable in kad.maintainableTables():
       if kad.stopping:
         return
-      let peers = rtable.peersInGracePeriod(grace)
+      let peers = rtable.peersPastGracePeriod(grace)
       if peers.len > 0:
         debug "Liveness scan found replaceable peers", peers = peers.len
       for peerId in peers:

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -33,28 +33,26 @@ proc peersInGracePeriod(
         peers.add(pid)
   peers
 
-method maintainableTables*(
-    kad: KadDHT
-): seq[RoutingTable] {.base, gcsafe, raises: [].} =
+method maintainableTables*(kad: KadDHT): seq[RoutingTable] {.base, gcsafe, raises: [].} =
   ## Routing tables the liveness loop should keep healthy. Service discovery
   ## overrides this to include per-service tables.
   @[kad.rtable]
 
 proc trackLivenessProbe(
-    kad: KadDHT, peerId: PeerId, probe: Future[void]
+    kad: KadDHT, probeKey: ProbeKey, probe: Future[void]
 ) {.raises: [].} =
   ## ``probe`` may already be done — a dial can fail without ever suspending.
   if probe.finished():
     return
-  kad.livenessProbes[peerId] = probe
+  kad.livenessProbes[probeKey] = probe
   probe.addCallback(
     proc(udata: pointer) {.gcsafe, raises: [].} =
-      if kad.livenessProbes.getOrDefault(peerId) == probe:
-        kad.livenessProbes.del(peerId)
+      if kad.livenessProbes.getOrDefault(probeKey) == probe:
+        kad.livenessProbes.del(probeKey)
   )
 
 proc checkAndEvictPeer(
-    kad: KadDHT, peerId: PeerId
+    kad: KadDHT, rtable: RoutingTable, peerId: PeerId
 ) {.async: (raises: [CancelledError]).} =
   ## Probes a peer once and applies the result to every maintainable table
   ## where that peer is past the liveness grace period. Returns immediately
@@ -90,8 +88,8 @@ proc checkAndEvictPeer(
     except AsyncSemaphoreError:
       raiseAssert "livenessSem released without acquire"
 
-  # Candidate list is a snapshot; the peer may have been refreshed (markUseful)
-  # or removed since it was selected.
+  # Candidate list is a snapshot; by the time a slot is free the peer may have
+  # been refreshed (markUseful) or removed, and stop may have begun.
   if kad.stopping:
     return
   let grace = kad.config.livenessGracePeriod
@@ -160,15 +158,22 @@ proc checkAndEvictPeer(
     peer = peerId.shortLog(), tables = evicted
   kad_routing_table_liveness_probes.inc(labelValues = ["fail"])
 
-proc launchLivenessProbe(kad: KadDHT, peerId: PeerId) {.raises: [].} =
-  ## Starts a liveness probe unless one is already in flight for this peer.
-  if kad.livenessProbes.hasKey(peerId):
-    debug "Liveness probe already in flight", peer = peerId.shortLog()
-    return
+proc tryLaunchLivenessProbe(
+    kad: KadDHT, rtable: RoutingTable, peerId: PeerId
+): bool {.raises: [].} =
+  ## Non-blocking launch of a liveness probe. Returns true when a probe was
+  ## started (or was already in flight). False when the shared probe semaphore
+  ## has no free slot — the caller should wait and retry.
+  let probeKey: ProbeKey = (rtable.selfId, peerId)
+  if kad.livenessProbes.hasKey(probeKey):
+    return true
   if kad.stopping:
-    return
-  debug "Launching liveness probe", peer = peerId.shortLog()
-  kad.trackLivenessProbe(peerId, kad.checkAndEvictPeer(peerId))
+    return true
+  if not kad.probeSem.tryAcquire():
+    kad_routing_table_liveness_probes.inc(labelValues = ["skipped"])
+    return false
+  kad.trackLivenessProbe(probeKey, kad.checkAndEvictPeer(rtable, peerId))
+  true
 
 proc probeAndEvictPeers*(
     kad: KadDHT, rtable: RoutingTable
@@ -176,8 +181,6 @@ proc probeAndEvictPeers*(
   ## One-shot batch: probes routing-table peers past the liveness grace period
   ## and removes those that fail to answer a FIND_NODE. Used by tests and any
   ## explicit maintenance call; production traffic uses ``maintainLiveness``.
-  ## Peers already being probed (e.g. from another table) are awaited, not
-  ## re-probed.
   if kad.stopping:
     return
 
@@ -185,15 +188,17 @@ proc probeAndEvictPeers*(
   if peers.len == 0:
     return
 
-  debug "Liveness batch starting", peers = peers.len
-  var futs = newSeqOfCap[Future[void]](peers.len)
-  for peerId in peers:
-    kad.livenessProbes.withValue(peerId, existing):
-      debug "Liveness batch reusing in-flight probe", peer = peerId.shortLog()
+  var futs = newSeqOfCap[Future[void]](candidates.len)
+  for peerId in candidates:
+    let probeKey: ProbeKey = (rtable.selfId, peerId)
+    kad.livenessProbes.withValue(probeKey, existing):
       futs.add(existing[])
       continue
-    let fut = kad.checkAndEvictPeer(peerId)
-    kad.trackLivenessProbe(peerId, fut)
+    if not kad.probeSem.tryAcquire():
+      kad_routing_table_liveness_probes.inc(labelValues = ["skipped"])
+      continue
+    let fut = kad.checkAndEvictPeer(rtable, peerId)
+    kad.trackLivenessProbe(probeKey, fut)
     futs.add(fut)
 
   if futs.len > 0:
@@ -274,6 +279,40 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
       except CancelledError as exc:
         await noCancel inFlight.cancelAndWait()
         raise exc
+
+proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
+  ## Continuous background task: drain replaceable peers via liveness probes
+  ## as soon as they become due, bounded by ``probeSem``. Independent of
+  ## bucket refresh so dead peers are not held until the next refresh tick.
+  # Yield once so start() can finish bootstrap before the first scan.
+  await sleepAsync(kad.config.livenessIdleInterval)
+
+  while not kad.stopping:
+    let grace = kad.config.livenessGracePeriod
+    var saturated = false
+
+    for rtable in kad.maintainableTables():
+      if kad.stopping:
+        return
+      for peerId in rtable.livenessCandidates(grace):
+        if not kad.tryLaunchLivenessProbe(rtable, peerId):
+          saturated = true
+          break
+      if saturated:
+        break
+
+    if kad.livenessProbes.len > 0:
+      let inFlight = kad.livenessProbes.values.toSeq()
+      try:
+        discard await one(inFlight)
+      except ValueError:
+        # All futures already finished between the snapshot and the wait.
+        discard
+      except CancelledError as exc:
+        await noCancel inFlight.cancelAndWait()
+        raise exc
+    else:
+      await sleepAsync(kad.config.livenessIdleInterval)
 
 proc refreshTable*(
     kad: KadDHT, rtable: RoutingTable, forceRefresh = false

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -251,8 +251,9 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
   ## At most one probe is in flight per peer across all maintainable tables.
 
   while not kad.stopping:
-    # Initial idle: let start() finish bootstrap before the first scan.
-    await sleepAsync(kad.config.livenessIdleInterval)
+    if idle:
+      # Initial idle: let start() finish bootstrap before the first scan.
+      await sleepAsync(kad.config.livenessIdleInterval)
 
     let grace = kad.config.livenessGracePeriod
 
@@ -276,6 +277,9 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
       except CancelledError as exc:
         await noCancel inFlight.cancelAndWait()
         raise exc
+      idle = false
+    else:
+      idle = true
 
 proc refreshTable*(
     kad: KadDHT, rtable: RoutingTable, forceRefresh = false

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -7,12 +7,15 @@ import ../utils/[heartbeat, future]
 import ../[peerid, switch, multihash]
 import ./protocol
 import
-  ./kademlia/[routing_table, protobuf, types, find, get, put, keyspace, provider, ping]
-import ./kademlia/[kademlia_metrics, netsize]
+  ./kademlia/[
+    routing_table, peer_registry, protobuf, types, find, get, put, keyspace, provider,
+    ping,
+  ]
+import ./kademlia/kademlia_metrics
 
 export
-  chronicles, routing_table, protobuf, types, find, get, put, keyspace, provider, ping,
-  kademlia_metrics, netsize
+  chronicles, routing_table, peer_registry, protobuf, types, find, get, put, keyspace,
+  provider, ping, kademlia_metrics
 
 logScope:
   topics = "kad-dht"
@@ -26,14 +29,16 @@ proc peersInGracePeriod(
   let now = Moment.now()
   var peers: seq[PeerId]
   for bucket in rtable.buckets:
-    for entry in bucket.peers:
-      if not entry.isReplaceable(gracePeriod, now):
+    for nodeId in bucket.peers:
+      if not rtable.registry.isReplaceable(nodeId, gracePeriod, now):
         continue
-      entry.nodeId.toPeerId().withValue(pid):
+      nodeId.toPeerId().withValue(pid):
         peers.add(pid)
   peers
 
-method maintainableTables*(kad: KadDHT): seq[RoutingTable] {.base, gcsafe, raises: [].} =
+method maintainableTables*(
+    kad: KadDHT
+): seq[RoutingTable] {.base, gcsafe, raises: [].} =
   ## Routing tables the liveness loop should keep healthy. Service discovery
   ## overrides this to include per-service tables.
   @[kad.rtable]
@@ -98,8 +103,7 @@ proc checkAndEvictPeer(
     if rtable.isReplaceable(peerId, grace, Moment.now()):
       dueTables.add(rtable)
   if dueTables.len == 0:
-    debug "Liveness probe skipped: peer no longer replaceable",
-      peer = peerId.shortLog()
+    debug "Liveness probe skipped: peer no longer replaceable", peer = peerId.shortLog()
     return
 
   # Candidate list is a snapshot; the peer may have been refreshed (markUseful)
@@ -134,13 +138,11 @@ proc checkAndEvictPeer(
         peer = peerId.shortLog()
     return
 
-  debug "Probing peer for liveness",
-    peer = peerId.shortLog(), tables = dueTables.len
+  debug "Probing peer for liveness", peer = peerId.shortLog(), tables = dueTables.len
   if (await kad.lookupCheck(peerId, addrs)):
     debug "Liveness probe succeeded", peer = peerId.shortLog()
-    # Peer is reachable: refresh usefulness on every table that holds it.
-    for rtable in kad.maintainableTables():
-      rtable.markUseful(peerId)
+    # Peer is reachable: one registry write refreshes usefulness for every index.
+    kad.rtable.markUseful(peerId)
     kad_routing_table_liveness_probes.inc(labelValues = ["ok"])
     return
 
@@ -265,8 +267,7 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
         kad.launchLivenessProbe(peerId)
 
     if kad.livenessProbes.len > 0:
-      debug "Waiting for in-flight liveness probes",
-        inFlight = kad.livenessProbes.len
+      debug "Waiting for in-flight liveness probes", inFlight = kad.livenessProbes.len
       let inFlight = kad.livenessProbes.values.toSeq()
       try:
         discard await one(inFlight)
@@ -294,7 +295,7 @@ proc refreshTable*(
       continue
 
     # skip if refresh conditions not met (forceRefresh OR stale bucket)
-    if not (forceRefresh or bucket.isStale(rtable.config.bucketStaleTime)):
+    if not (forceRefresh or rtable.isStale(i)):
       continue
 
     let target = rtable.refreshTarget(i, kad.rng).valueOr:

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -68,25 +68,6 @@ proc checkAndEvictPeer(
     debug "Liveness probe skipped: no free slot", peer = peerId.shortLog()
     kad_routing_table_liveness_probes.inc(labelValues = ["skipped"])
     return
-  kad.livenessProbes[probeKey] = probe
-  probe.addCallback(
-    proc(udata: pointer) {.gcsafe, raises: [].} =
-      if kad.livenessProbes.getOrDefault(peerId) == probe:
-        kad.livenessProbes.del(peerId)
-  )
-
-proc checkAndEvictPeer(
-    kad: KadDHT, peerId: PeerId
-) {.async: (raises: [CancelledError]).} =
-  ## Probes a peer once and applies the result to every maintainable table
-  ## where that peer is past the liveness grace period. Returns immediately
-  ## when all liveness probe slots are occupied.
-  if kad.stopping:
-    return
-  if not kad.livenessSem.tryAcquire():
-    debug "Liveness probe skipped: no free slot", peer = peerId.shortLog()
-    kad_routing_table_liveness_probes.inc(labelValues = ["skipped"])
-    return
   defer:
     try:
       kad.livenessSem.release()
@@ -104,20 +85,6 @@ proc checkAndEvictPeer(
       dueTables.add(rtable)
   if dueTables.len == 0:
     debug "Liveness probe skipped: peer no longer replaceable", peer = peerId.shortLog()
-    return
-
-  # Candidate list is a snapshot; the peer may have been refreshed (markUseful)
-  # or removed since it was selected.
-  if kad.stopping:
-    return
-  let grace = kad.config.livenessGracePeriod
-  var dueTables: seq[RoutingTable]
-  for rtable in kad.maintainableTables():
-    if rtable.isReplaceable(peerId, grace, Moment.now()):
-      dueTables.add(rtable)
-  if dueTables.len == 0:
-    debug "Liveness probe skipped: peer no longer replaceable",
-      peer = peerId.shortLog()
     return
 
   let addrs = kad.switch.peerStore[AddressBook][peerId]
@@ -212,39 +179,7 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
   ## bucket refresh so dead peers are not held until the next refresh tick.
   ## At most one probe is in flight per peer across all maintainable tables.
 
-  while not kad.stopping:
-    # Initial idle: let start() finish bootstrap before the first scan.
-    await sleepAsync(kad.config.livenessIdleInterval)
-
-    let grace = kad.config.livenessGracePeriod
-
-    for rtable in kad.maintainableTables():
-      if kad.stopping:
-        return
-      let peers = rtable.peersPastGracePeriod(grace)
-      if peers.len > 0:
-        debug "Liveness scan found replaceable peers", peers = peers.len
-      for peerId in peers:
-        kad.launchLivenessProbe(peerId)
-
-    if kad.livenessProbes.len > 0:
-      debug "Waiting for in-flight liveness probes", inFlight = kad.livenessProbes.len
-      let inFlight = kad.livenessProbes.values.toSeq()
-      try:
-        discard await one(inFlight)
-      except ValueError:
-        # All futures already finished between the snapshot and the wait.
-        discard
-      except CancelledError as exc:
-        await noCancel inFlight.cancelAndWait()
-        raise exc
-
-proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
-  ## Continuous background task: drain replaceable peers via liveness probes
-  ## as soon as they become due, bounded by ``livenessSem``. Independent of
-  ## bucket refresh so dead peers are not held until the next refresh tick.
-  ## At most one probe is in flight per peer across all maintainable tables.
-
+  var idle = true
   while not kad.stopping:
     if idle:
       # Initial idle: let start() finish bootstrap before the first scan.
@@ -255,7 +190,7 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
     for rtable in kad.maintainableTables():
       if kad.stopping:
         return
-      let peers = rtable.peersInGracePeriod(grace)
+      let peers = rtable.peersPastGracePeriod(grace)
       if peers.len > 0:
         debug "Liveness scan found replaceable peers", peers = peers.len
       for peerId in peers:

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -39,20 +39,20 @@ method maintainableTables*(kad: KadDHT): seq[RoutingTable] {.base, gcsafe, raise
   @[kad.rtable]
 
 proc trackLivenessProbe(
-    kad: KadDHT, probeKey: ProbeKey, probe: Future[void]
+    kad: KadDHT, peerId: PeerId, probe: Future[void]
 ) {.raises: [].} =
   ## ``probe`` may already be done — a dial can fail without ever suspending.
   if probe.finished():
     return
-  kad.livenessProbes[probeKey] = probe
+  kad.livenessProbes[peerId] = probe
   probe.addCallback(
     proc(udata: pointer) {.gcsafe, raises: [].} =
-      if kad.livenessProbes.getOrDefault(probeKey) == probe:
-        kad.livenessProbes.del(probeKey)
+      if kad.livenessProbes.getOrDefault(peerId) == probe:
+        kad.livenessProbes.del(peerId)
   )
 
 proc checkAndEvictPeer(
-    kad: KadDHT, rtable: RoutingTable, peerId: PeerId
+    kad: KadDHT, peerId: PeerId
 ) {.async: (raises: [CancelledError]).} =
   ## Probes a peer once and applies the result to every maintainable table
   ## where that peer is past the liveness grace period. Returns immediately
@@ -98,7 +98,8 @@ proc checkAndEvictPeer(
     if rtable.isReplaceable(peerId, grace, Moment.now()):
       dueTables.add(rtable)
   if dueTables.len == 0:
-    debug "Liveness probe skipped: peer no longer replaceable", peer = peerId.shortLog()
+    debug "Liveness probe skipped: peer no longer replaceable",
+      peer = peerId.shortLog()
     return
 
   # Candidate list is a snapshot; the peer may have been refreshed (markUseful)
@@ -133,7 +134,8 @@ proc checkAndEvictPeer(
         peer = peerId.shortLog()
     return
 
-  debug "Probing peer for liveness", peer = peerId.shortLog(), tables = dueTables.len
+  debug "Probing peer for liveness",
+    peer = peerId.shortLog(), tables = dueTables.len
   if (await kad.lookupCheck(peerId, addrs)):
     debug "Liveness probe succeeded", peer = peerId.shortLog()
     # Peer is reachable: refresh usefulness on every table that holds it.
@@ -158,22 +160,15 @@ proc checkAndEvictPeer(
     peer = peerId.shortLog(), tables = evicted
   kad_routing_table_liveness_probes.inc(labelValues = ["fail"])
 
-proc tryLaunchLivenessProbe(
-    kad: KadDHT, rtable: RoutingTable, peerId: PeerId
-): bool {.raises: [].} =
-  ## Non-blocking launch of a liveness probe. Returns true when a probe was
-  ## started (or was already in flight). False when the shared probe semaphore
-  ## has no free slot — the caller should wait and retry.
-  let probeKey: ProbeKey = (rtable.selfId, peerId)
-  if kad.livenessProbes.hasKey(probeKey):
-    return true
+proc launchLivenessProbe(kad: KadDHT, peerId: PeerId) {.raises: [].} =
+  ## Starts a liveness probe unless one is already in flight for this peer.
+  if kad.livenessProbes.hasKey(peerId):
+    debug "Liveness probe already in flight", peer = peerId.shortLog()
+    return
   if kad.stopping:
-    return true
-  if not kad.probeSem.tryAcquire():
-    kad_routing_table_liveness_probes.inc(labelValues = ["skipped"])
-    return false
-  kad.trackLivenessProbe(probeKey, kad.checkAndEvictPeer(rtable, peerId))
-  true
+    return
+  debug "Launching liveness probe", peer = peerId.shortLog()
+  kad.trackLivenessProbe(peerId, kad.checkAndEvictPeer(peerId))
 
 proc probeAndEvictPeers*(
     kad: KadDHT, rtable: RoutingTable
@@ -181,6 +176,8 @@ proc probeAndEvictPeers*(
   ## One-shot batch: probes routing-table peers past the liveness grace period
   ## and removes those that fail to answer a FIND_NODE. Used by tests and any
   ## explicit maintenance call; production traffic uses ``maintainLiveness``.
+  ## Peers already being probed (e.g. from another table) are awaited, not
+  ## re-probed.
   if kad.stopping:
     return
 
@@ -188,17 +185,15 @@ proc probeAndEvictPeers*(
   if peers.len == 0:
     return
 
-  var futs = newSeqOfCap[Future[void]](candidates.len)
-  for peerId in candidates:
-    let probeKey: ProbeKey = (rtable.selfId, peerId)
-    kad.livenessProbes.withValue(probeKey, existing):
+  debug "Liveness batch starting", peers = peers.len
+  var futs = newSeqOfCap[Future[void]](peers.len)
+  for peerId in peers:
+    kad.livenessProbes.withValue(peerId, existing):
+      debug "Liveness batch reusing in-flight probe", peer = peerId.shortLog()
       futs.add(existing[])
       continue
-    if not kad.probeSem.tryAcquire():
-      kad_routing_table_liveness_probes.inc(labelValues = ["skipped"])
-      continue
-    let fut = kad.checkAndEvictPeer(rtable, peerId)
-    kad.trackLivenessProbe(probeKey, fut)
+    let fut = kad.checkAndEvictPeer(peerId)
+    kad.trackLivenessProbe(peerId, fut)
     futs.add(fut)
 
   if futs.len > 0:
@@ -258,6 +253,7 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
     await sleepAsync(kad.config.livenessIdleInterval)
 
     let grace = kad.config.livenessGracePeriod
+    var saturated = false
 
     for rtable in kad.maintainableTables():
       if kad.stopping:
@@ -269,7 +265,8 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
         kad.launchLivenessProbe(peerId)
 
     if kad.livenessProbes.len > 0:
-      debug "Waiting for in-flight liveness probes", inFlight = kad.livenessProbes.len
+      debug "Waiting for in-flight liveness probes",
+        inFlight = kad.livenessProbes.len
       let inFlight = kad.livenessProbes.values.toSeq()
       try:
         discard await one(inFlight)
@@ -279,40 +276,6 @@ proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
       except CancelledError as exc:
         await noCancel inFlight.cancelAndWait()
         raise exc
-
-proc maintainLiveness(kad: KadDHT) {.async: (raises: [CancelledError]).} =
-  ## Continuous background task: drain replaceable peers via liveness probes
-  ## as soon as they become due, bounded by ``probeSem``. Independent of
-  ## bucket refresh so dead peers are not held until the next refresh tick.
-  # Yield once so start() can finish bootstrap before the first scan.
-  await sleepAsync(kad.config.livenessIdleInterval)
-
-  while not kad.stopping:
-    let grace = kad.config.livenessGracePeriod
-    var saturated = false
-
-    for rtable in kad.maintainableTables():
-      if kad.stopping:
-        return
-      for peerId in rtable.livenessCandidates(grace):
-        if not kad.tryLaunchLivenessProbe(rtable, peerId):
-          saturated = true
-          break
-      if saturated:
-        break
-
-    if kad.livenessProbes.len > 0:
-      let inFlight = kad.livenessProbes.values.toSeq()
-      try:
-        discard await one(inFlight)
-      except ValueError:
-        # All futures already finished between the snapshot and the wait.
-        discard
-      except CancelledError as exc:
-        await noCancel inFlight.cancelAndWait()
-        raise exc
-    else:
-      await sleepAsync(kad.config.livenessIdleInterval)
 
 proc refreshTable*(
     kad: KadDHT, rtable: RoutingTable, forceRefresh = false

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -27,7 +27,7 @@ proc peersInGracePeriod(
   var peers: seq[PeerId]
   for bucket in rtable.buckets:
     for entry in bucket.peers:
-      if not entry.needsLivenessCheck(gracePeriod, now):
+      if not entry.isReplaceable(gracePeriod, now):
         continue
       entry.nodeId.toPeerId().withValue(pid):
         peers.add(pid)
@@ -82,6 +82,14 @@ proc checkAndEvictPeer(
       dueTables.add(rtable)
   if dueTables.len == 0:
     debug "Liveness probe skipped: peer no longer replaceable", peer = peerId.shortLog()
+    return
+
+  # Candidate list is a snapshot; by the time a slot is free the peer may have
+  # been refreshed (markUseful) or removed, and stop may have begun.
+  if kad.stopping:
+    return
+  let grace = kad.config.livenessGracePeriod
+  if not rtable.isReplaceable(peerId, grace, Moment.now()):
     return
 
   let addrs = kad.switch.peerStore[AddressBook][peerId]

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -408,6 +408,10 @@ proc admitPeer(
   if not reachable:
     trace "Kad admission probe failed, not inserting peer", peer = peerId.shortLog()
     return
+  # Table may have been detachAll'd (e.g. service uninterest) while the probe ran.
+  if rtable.detached:
+    trace "Kad admission probe abandoned: table detached", peer = peerId.shortLog()
+    return
   if rtable.insert(peerId) and not onAdmit.isNil():
     onAdmit(peerId)
 

--- a/libp2p/protocols/kademlia/peer_registry.nim
+++ b/libp2p/protocols/kademlia/peer_registry.nim
@@ -110,10 +110,10 @@ proc dropPeer*(registry: PeerRegistry, nodeId: Key) =
   registry.tablesByPeer.del(nodeId)
 
 func tableIds*(registry: PeerRegistry, nodeId: Key): HashSet[Key] =
-  result = initHashSet[Key]()
+  var ids = initHashSet[Key]()
   registry.tablesByPeer.withValue(nodeId, tables):
     for tableId in tables[].keys:
-      result.incl(tableId)
+      ids.incl(tableId)
 
 func isReplaceable*(
     registry: PeerRegistry,

--- a/libp2p/protocols/kademlia/peer_registry.nim
+++ b/libp2p/protocols/kademlia/peer_registry.nim
@@ -115,6 +115,8 @@ func tableIds*(registry: PeerRegistry, nodeId: Key): HashSet[Key] =
     for tableId in tables[].keys:
       ids.incl(tableId)
 
+  return ids
+
 func isReplaceable*(
     registry: PeerRegistry,
     nodeId: Key,

--- a/libp2p/protocols/kademlia/peer_registry.nim
+++ b/libp2p/protocols/kademlia/peer_registry.nim
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## Shared DHT peer row store. Routing tables are indexes over this registry:
+## they hold ``Key`` references only; liveness/usefulness state lives here once.
+
+import std/[tables, sets]
+import chronos, results
+import ./types
+import ../../peerid
+
+{.push raises: [].}
+
+proc new*(T: typedesc[PeerRegistry]): PeerRegistry =
+  PeerRegistry(
+    peers: initTable[Key, PeerRecord](), tablesByPeer: initTable[Key, HashSet[Key]]()
+  )
+
+func contains*(registry: PeerRegistry, nodeId: Key): bool =
+  nodeId in registry.peers
+
+func get*(registry: PeerRegistry, nodeId: Key): Opt[PeerRecord] =
+  registry.peers.withValue(nodeId, record):
+    return Opt.some(record[])
+  Opt.none(PeerRecord)
+
+func len*(registry: PeerRegistry): int =
+  registry.peers.len
+
+func lastActivity*(record: PeerRecord): Moment =
+  ## Most recent time the peer answered a DHT query, or when it was first recorded.
+  record.lastUsefulAt.get(record.addedAt)
+
+func isReplaceable*(record: PeerRecord, gracePeriod: Duration, now: Moment): bool =
+  ## Replaceable once past ``gracePeriod`` without proving useful. Grace is global
+  ## (from first registry sighting), not per routing-table membership.
+  now - record.lastActivity() > gracePeriod
+
+proc ensure*(registry: PeerRegistry, nodeId: Key, now = Moment.now()): PeerRecord =
+  ## Return existing record or create a fresh one. Does not add table membership.
+  registry.peers.withValue(nodeId, existing):
+    return existing[]
+  let record = PeerRecord(
+    nodeId: nodeId, lastSeen: now, addedAt: now, lastUsefulAt: Opt.none(Moment)
+  )
+  registry.peers[nodeId] = record
+  record
+
+proc touch*(registry: PeerRegistry, nodeId: Key, now = Moment.now()) =
+  ## Bump ``lastSeen`` when the peer is observed again. No-op if missing.
+  registry.peers.withValue(nodeId, record):
+    record[].lastSeen = now
+
+proc markUseful*(registry: PeerRegistry, nodeId: Key, now = Moment.now()) =
+  ## Peer answered a query: refresh usefulness so it survives eviction.
+  registry.peers.withValue(nodeId, record):
+    record[].lastUsefulAt = Opt.some(now)
+    record[].lastSeen = now
+
+proc markUseful*(registry: PeerRegistry, peerId: PeerId, now = Moment.now()) =
+  registry.markUseful(peerId.toKey(), now)
+
+proc addMembership*(registry: PeerRegistry, nodeId: Key, tableId: Key) =
+  ## Record that ``tableId`` indexes ``nodeId``.
+  registry.tablesByPeer.mgetOrPut(nodeId, initHashSet[Key]()).incl(tableId)
+
+proc removeMembership*(registry: PeerRegistry, nodeId: Key, tableId: Key): bool =
+  ## Drop one table's reference. When no tables remain, delete the peer row.
+  ## Returns true if the peer was removed from the registry entirely.
+  registry.tablesByPeer.withValue(nodeId, tables):
+    tables[].excl(tableId)
+    if tables[].len > 0:
+      return false
+    registry.tablesByPeer.del(nodeId)
+    registry.peers.del(nodeId)
+    return true
+  # Membership missing but a row may still exist (failed insert path).
+  if nodeId in registry.peers and nodeId notin registry.tablesByPeer:
+    registry.peers.del(nodeId)
+    return true
+  false
+
+proc dropPeer*(registry: PeerRegistry, nodeId: Key) =
+  ## Remove the peer row and all membership tracking. Callers must also drop
+  ## the key from every routing-table bucket that still holds it.
+  registry.peers.del(nodeId)
+  registry.tablesByPeer.del(nodeId)
+
+func tableIds*(registry: PeerRegistry, nodeId: Key): HashSet[Key] =
+  registry.tablesByPeer.getOrDefault(nodeId)
+
+func isReplaceable*(
+    registry: PeerRegistry, nodeId: Key, gracePeriod: Duration, now: Moment
+): bool =
+  let record = registry.get(nodeId).valueOr:
+    return false
+  record.isReplaceable(gracePeriod, now)
+
+func isReplaceable*(
+    registry: PeerRegistry, peerId: PeerId, gracePeriod: Duration, now: Moment
+): bool =
+  registry.isReplaceable(peerId.toKey(), gracePeriod, now)

--- a/libp2p/protocols/kademlia/peer_registry.nim
+++ b/libp2p/protocols/kademlia/peer_registry.nim
@@ -3,6 +3,7 @@
 
 ## Shared DHT peer row store. Routing tables are indexes over this registry:
 ## they hold ``Key`` references only; liveness/usefulness state lives here once.
+## Usefulness grace is membership-local via ``Membership.addedAt``.
 
 import std/[tables, sets]
 import chronos, results
@@ -13,7 +14,8 @@ import ../../peerid
 
 proc new*(T: typedesc[PeerRegistry]): PeerRegistry =
   PeerRegistry(
-    peers: initTable[Key, PeerRecord](), tablesByPeer: initTable[Key, HashSet[Key]]()
+    peers: initTable[Key, PeerRecord](),
+    tablesByPeer: initTable[Key, Table[Key, Membership]](),
   )
 
 func contains*(registry: PeerRegistry, nodeId: Key): bool =
@@ -27,32 +29,36 @@ func get*(registry: PeerRegistry, nodeId: Key): Opt[PeerRecord] =
 func len*(registry: PeerRegistry): int =
   registry.peers.len
 
-func lastActivity*(record: PeerRecord): Moment =
-  ## Most recent time the peer answered a DHT query, or when it was first recorded.
-  record.lastUsefulAt.get(record.addedAt)
+func membership*(registry: PeerRegistry, nodeId: Key, tableId: Key): Opt[Membership] =
+  registry.tablesByPeer.withValue(nodeId, tables):
+    tables[].withValue(tableId, m):
+      return Opt.some(m[])
+  Opt.none(Membership)
 
-func isReplaceable*(record: PeerRecord, gracePeriod: Duration, now: Moment): bool =
-  ## Replaceable once past ``gracePeriod`` without proving useful. Grace is global
-  ## (from first registry sighting), not per routing-table membership.
-  now - record.lastActivity() > gracePeriod
+func lastActivity*(record: PeerRecord, membership: Membership): Moment =
+  ## Most recent useful answer, else when this table first indexed the peer.
+  record.lastUsefulAt.get(membership.addedAt)
 
-proc ensure*(registry: PeerRegistry, nodeId: Key, now = Moment.now()): PeerRecord =
-  ## Return existing record or create a fresh one. Does not add table membership.
+func isReplaceable*(
+    record: PeerRecord, membership: Membership, gracePeriod: Duration, now: Moment
+): bool =
+  ## Replaceable once past ``gracePeriod`` without proving useful. Grace starts
+  ## at membership ``addedAt`` (per table), not at first global sighting.
+  now - record.lastActivity(membership) > gracePeriod
+
+proc upsert*(registry: PeerRegistry, nodeId: Key, now = Moment.now()): PeerRecord =
+  ## Insert a new peer row, or refresh ``lastSeen`` if one already exists.
+  ## Does not add table membership.
   registry.peers.withValue(nodeId, existing):
+    existing[].lastSeen = now
     return existing[]
-  let record = PeerRecord(
-    nodeId: nodeId, lastSeen: now, addedAt: now, lastUsefulAt: Opt.none(Moment)
-  )
+  let record = PeerRecord(nodeId: nodeId, lastSeen: now, lastUsefulAt: Opt.none(Moment))
   registry.peers[nodeId] = record
   record
 
-proc touch*(registry: PeerRegistry, nodeId: Key, now = Moment.now()) =
-  ## Bump ``lastSeen`` when the peer is observed again. No-op if missing.
-  registry.peers.withValue(nodeId, record):
-    record[].lastSeen = now
-
 proc markUseful*(registry: PeerRegistry, nodeId: Key, now = Moment.now()) =
-  ## Peer answered a query: refresh usefulness so it survives eviction.
+  ## Peer answered a query: refresh usefulness so it survives eviction in every
+  ## table that indexes it.
   registry.peers.withValue(nodeId, record):
     record[].lastUsefulAt = Opt.some(now)
     record[].lastSeen = now
@@ -60,25 +66,42 @@ proc markUseful*(registry: PeerRegistry, nodeId: Key, now = Moment.now()) =
 proc markUseful*(registry: PeerRegistry, peerId: PeerId, now = Moment.now()) =
   registry.markUseful(peerId.toKey(), now)
 
-proc addMembership*(registry: PeerRegistry, nodeId: Key, tableId: Key) =
-  ## Record that ``tableId`` indexes ``nodeId``.
-  registry.tablesByPeer.mgetOrPut(nodeId, initHashSet[Key]()).incl(tableId)
-
-proc removeMembership*(registry: PeerRegistry, nodeId: Key, tableId: Key): bool =
-  ## Drop one table's reference. When no tables remain, delete the peer row.
-  ## Returns true if the peer was removed from the registry entirely.
+proc addMembership*(
+    registry: PeerRegistry, nodeId: Key, tableId: Key, now = Moment.now()
+) =
+  ## Record that ``tableId`` indexes ``nodeId``. Fresh membership starts grace.
+  ## No-op when the peer is already a member of this table.
+  if nodeId notin registry.tablesByPeer:
+    registry.tablesByPeer[nodeId] = initTable[Key, Membership]()
   registry.tablesByPeer.withValue(nodeId, tables):
-    tables[].excl(tableId)
+    if tableId in tables[]:
+      return
+    tables[][tableId] = Membership(addedAt: now)
+
+proc removeMembership*(registry: PeerRegistry, nodeId: Key, tableId: Key) =
+  ## Drop one table's reference. When no tables remain, delete the peer row.
+  registry.tablesByPeer.withValue(nodeId, tables):
+    tables[].del(tableId)
     if tables[].len > 0:
-      return false
+      return
     registry.tablesByPeer.del(nodeId)
     registry.peers.del(nodeId)
-    return true
+    return
   # Membership missing but a row may still exist (failed insert path).
   if nodeId in registry.peers and nodeId notin registry.tablesByPeer:
     registry.peers.del(nodeId)
-    return true
-  false
+
+proc dropTable*(registry: PeerRegistry, tableId: Key) =
+  ## Remove every membership for ``tableId``. Deletes peer rows that lose their
+  ## last table reference. Call when a routing table is destroyed.
+  var emptyPeers: seq[Key]
+  for nodeId, tables in registry.tablesByPeer.mpairs:
+    tables.del(tableId)
+    if tables.len == 0:
+      emptyPeers.add(nodeId)
+  for nodeId in emptyPeers:
+    registry.tablesByPeer.del(nodeId)
+    registry.peers.del(nodeId)
 
 proc dropPeer*(registry: PeerRegistry, nodeId: Key) =
   ## Remove the peer row and all membership tracking. Callers must also drop
@@ -87,16 +110,31 @@ proc dropPeer*(registry: PeerRegistry, nodeId: Key) =
   registry.tablesByPeer.del(nodeId)
 
 func tableIds*(registry: PeerRegistry, nodeId: Key): HashSet[Key] =
-  registry.tablesByPeer.getOrDefault(nodeId)
+  result = initHashSet[Key]()
+  registry.tablesByPeer.withValue(nodeId, tables):
+    for tableId in tables[].keys:
+      result.incl(tableId)
 
 func isReplaceable*(
-    registry: PeerRegistry, nodeId: Key, gracePeriod: Duration, now: Moment
+    registry: PeerRegistry,
+    nodeId: Key,
+    tableId: Key,
+    gracePeriod: Duration,
+    now: Moment,
 ): bool =
+  ## True when the peer is past grace for ``tableId``. Missing row or membership
+  ## (orphan index entry) is treated as replaceable so eviction can clean it up.
+  let membership = registry.membership(nodeId, tableId).valueOr:
+    return true
   let record = registry.get(nodeId).valueOr:
-    return false
-  record.isReplaceable(gracePeriod, now)
+    return true
+  record.isReplaceable(membership, gracePeriod, now)
 
 func isReplaceable*(
-    registry: PeerRegistry, peerId: PeerId, gracePeriod: Duration, now: Moment
+    registry: PeerRegistry,
+    peerId: PeerId,
+    tableId: Key,
+    gracePeriod: Duration,
+    now: Moment,
 ): bool =
-  registry.isReplaceable(peerId.toKey(), gracePeriod, now)
+  registry.isReplaceable(peerId.toKey(), tableId, gracePeriod, now)

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -99,10 +99,17 @@ func isReplaceable*(entry: NodeEntry, gracePeriod: Duration, now: Moment): bool 
   ## select peers for liveness probes by the background liveness loop.
   now - entry.lastActivity() > gracePeriod
 
-func needsLivenessCheck*(entry: NodeEntry, gracePeriod: Duration, now: Moment): bool =
-  ## True when the peer has had no successful DHT activity within `gracePeriod`
-  ## and should be probed (and possibly removed) during maintenance.
-  now - entry.lastActivity() > gracePeriod
+proc isReplaceable*(
+    rtable: RoutingTable, peerId: PeerId, gracePeriod: Duration, now: Moment
+): bool =
+  ## Live-table check: false when the peer is missing or still within grace.
+  let nodeId = peerId.toKey()
+  let idx = rtable.bucketIndex(nodeId)
+  if idx >= rtable.buckets.len:
+    return false
+  let pos = peerIndexInBucket(rtable.buckets[idx], nodeId).valueOr:
+    return false
+  rtable.buckets[idx].peers[pos].isReplaceable(gracePeriod, now)
 
 proc replaceableCandidate(bucket: Bucket, gracePeriod: Duration): Opt[int] =
   ## Least-recently-seen peer past the grace period, i.e. the best eviction

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -87,26 +87,27 @@ func nPeersForCpl*(rtable: RoutingTable, cpl: int): int =
   count
 
 proc peerIndexInBucket(bucket: Bucket, nodeId: Key): Opt[int] =
-  for i, p in bucket.peers:
-    if p == nodeId:
-      return Opt.some(i)
-  return Opt.none(int)
+  let i = bucket.peers.find(nodeId)
+  if i < 0:
+    return Opt.none(int)
+  Opt.some(i)
 
 proc oldestPeer*(bucket: Bucket, registry: PeerRegistry): (Key, int) =
   ## Least-recently-seen peer key in the bucket (by registry ``lastSeen``).
+  ## Orphan keys (no registry row) sort as oldest so they are preferred for eviction.
   var oldestIdx = 0
   var oldestKey = bucket.peers[0]
-  var oldestSeen = Moment.now()
-  registry.get(oldestKey).withValue(record):
-    oldestSeen = record.lastSeen
+  var oldestSeen = Moment.low
+  var found = false
   for i, p in bucket.peers:
-    var seen = Moment.now()
+    var seen = Moment.low
     registry.get(p).withValue(record):
       seen = record.lastSeen
-    if seen < oldestSeen:
+    if not found or seen < oldestSeen:
       oldestKey = p
       oldestIdx = i
       oldestSeen = seen
+      found = true
   (oldestKey, oldestIdx)
 
 proc oldestPeer*(rtable: RoutingTable, bucketIndex: int): (Key, int) =
@@ -115,32 +116,44 @@ proc oldestPeer*(rtable: RoutingTable, bucketIndex: int): (Key, int) =
 proc isReplaceable*(
     rtable: RoutingTable, peerId: PeerId, gracePeriod: Duration, now: Moment
 ): bool =
-  ## Live-index check: false when the peer is missing from this table or still
-  ## within the global usefulness grace period on its registry row.
+  ## Live-index check: false when the peer is missing from this table; true when
+  ## past this table's usefulness grace (membership ``addedAt``) or an orphan.
   let nodeId = peerId.toKey()
   let idx = rtable.bucketIndex(nodeId)
   if idx >= rtable.buckets.len:
     return false
   if peerIndexInBucket(rtable.buckets[idx], nodeId).isNone():
     return false
-  rtable.registry.isReplaceable(nodeId, gracePeriod, now)
+  rtable.registry.isReplaceable(nodeId, rtable.selfId, gracePeriod, now)
+
+proc isReplaceable*(
+    rtable: RoutingTable, nodeId: Key, gracePeriod: Duration, now: Moment
+): bool =
+  let idx = rtable.bucketIndex(nodeId)
+  if idx >= rtable.buckets.len:
+    return false
+  if peerIndexInBucket(rtable.buckets[idx], nodeId).isNone():
+    return false
+  rtable.registry.isReplaceable(nodeId, rtable.selfId, gracePeriod, now)
 
 proc replaceableCandidate(
-    bucket: Bucket, registry: PeerRegistry, gracePeriod: Duration
+    rtable: RoutingTable, bucket: Bucket, gracePeriod: Duration
 ): Opt[int] =
-  ## Least-recently-seen peer past the grace period. ``Opt.none`` when every
-  ## peer is still useful/fresh.
+  ## Least-recently-seen peer past the grace period for this table. Orphan keys
+  ## (missing registry row/membership) are always eligible. ``Opt.none`` when
+  ## every peer is still useful/fresh.
   let now = Moment.now()
   var candidateIdx = -1
   var oldestSeen: Moment
   for i, nodeId in bucket.peers:
-    let record = registry.get(nodeId).valueOr:
+    if not rtable.registry.isReplaceable(nodeId, rtable.selfId, gracePeriod, now):
       continue
-    if not record.isReplaceable(gracePeriod, now):
-      continue
-    if candidateIdx == -1 or record.lastSeen < oldestSeen:
+    var seen = Moment.low
+    rtable.registry.get(nodeId).withValue(record):
+      seen = record.lastSeen
+    if candidateIdx == -1 or seen < oldestSeen:
       candidateIdx = i
-      oldestSeen = record.lastSeen
+      oldestSeen = seen
   if candidateIdx == -1:
     return Opt.none(int)
   Opt.some(candidateIdx)
@@ -152,16 +165,14 @@ proc tryReplaceStalePeer(
     trace "Skipping replace: bucket is not full", newNodeId = newNodeId
     return false
 
-  let idx = bucket.replaceableCandidate(
-    rtable.registry, rtable.config.usefulnessGracePeriod
-  ).valueOr:
+  let idx = rtable.replaceableCandidate(bucket, rtable.config.usefulnessGracePeriod).valueOr:
     trace "Skipping replace: no peer past usefulness grace period",
       newNodeId = newNodeId
     return false
 
   let oldId = bucket.peers[idx]
   bucket.peers[idx] = newNodeId
-  discard rtable.registry.removeMembership(oldId, rtable.selfId)
+  rtable.registry.removeMembership(oldId, rtable.selfId)
   true
 
 proc updateRoutingTableMetrics*(rtable: RoutingTable) =
@@ -176,6 +187,9 @@ proc updateRoutingTableMetrics*(rtable: RoutingTable) =
   kad_routing_table_buckets.set(rtable.buckets.len.float64)
 
 proc insert*(rtable: RoutingTable, nodeId: Key): bool =
+  if rtable.detached:
+    debug "Cannot insert into detached routing table", nodeId = nodeId
+    return false
   if nodeId == rtable.selfId or nodeId == rtable.localNodeId:
     debug "Cannot insert self in routing table", nodeId = nodeId
     return false # No self insertion
@@ -189,10 +203,10 @@ proc insert*(rtable: RoutingTable, nodeId: Key): bool =
   var bucket = rtable.buckets[idx]
   let keyx = peerIndexInBucket(bucket, nodeId)
   if keyx.isSome:
-    rtable.registry.touch(nodeId)
+    discard rtable.registry.upsert(nodeId)
     return true
   elif bucket.peers.len < rtable.config.replication:
-    discard rtable.registry.ensure(nodeId)
+    discard rtable.registry.upsert(nodeId)
     bucket.peers.add(nodeId)
     rtable.registry.addMembership(nodeId, rtable.selfId)
     kad_routing_table_insertions.inc()
@@ -203,7 +217,7 @@ proc insert*(rtable: RoutingTable, nodeId: Key): bool =
       debug "Cannot insert, no replaceable peer in bucket",
         bucket = idx, nodeId = nodeId
       return false
-    discard rtable.registry.ensure(nodeId)
+    discard rtable.registry.upsert(nodeId)
     rtable.registry.addMembership(nodeId, rtable.selfId)
     kad_routing_table_replacements.inc()
 
@@ -230,13 +244,21 @@ proc removePeer*(rtable: RoutingTable, nodeId: Key, reason = "remove"): bool =
     return false
 
   rtable.buckets[idx].peers.delete(pos)
-  discard rtable.registry.removeMembership(nodeId, rtable.selfId)
+  rtable.registry.removeMembership(nodeId, rtable.selfId)
   kad_routing_table_evictions.inc(labelValues = [reason])
   updateRoutingTableMetrics(rtable)
   true
 
 proc removePeer*(rtable: RoutingTable, peerId: PeerId, reason = "remove"): bool =
   removePeer(rtable, peerId.toKey(), reason)
+
+proc detachAll*(rtable: RoutingTable) =
+  ## Drop this table's memberships from the shared registry and empty buckets.
+  ## Call when the table is destroyed (e.g. service uninterest).
+  rtable.detached = true
+  rtable.registry.dropTable(rtable.selfId)
+  rtable.buckets = @[]
+  updateRoutingTableMetrics(rtable)
 
 proc contains*(rtable: RoutingTable, nodeId: Key): bool =
   ## Scans only the node's bucket, not the whole table.
@@ -280,10 +302,7 @@ proc findClosest*(rtable: RoutingTable, targetId: Key, count: int): seq[Key] =
   return allNodes[0 ..< min(count, allNodes.len)]
 
 proc findClosestPeerIds*(rtable: RoutingTable, targetId: Key, count: int): seq[PeerId] =
-  return findClosest(rtable, targetId, count)
-    .mapIt(it.toPeerId())
-    .filterIt(it.isOk)
-    .mapIt(it.value())
+  findClosest(rtable, targetId, count).toPeerIds()
 
 proc randomPeersClosestFirst*(
     rtable: RoutingTable, rng: Rng, count: int, maxPerBucket = high(int)
@@ -318,10 +337,7 @@ proc randomPeersClosestFirst*(
 proc randomPeersClosestFirstPeerIds*(
     rtable: RoutingTable, rng: Rng, count: int, maxPerBucket = high(int)
 ): seq[PeerId] =
-  randomPeersClosestFirst(rtable, rng, count, maxPerBucket)
-    .mapIt(it.toPeerId())
-    .filterIt(it.isOk)
-    .mapIt(it.value())
+  randomPeersClosestFirst(rtable, rng, count, maxPerBucket).toPeerIds()
 
 proc isStale*(
     bucket: Bucket, registry: PeerRegistry, staleTime: Duration = DefaultBucketStaleTime

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -268,12 +268,12 @@ proc contains*(rtable: RoutingTable, nodeId: Key): bool =
   peerIndexInBucket(rtable.buckets[idx], nodeId).isSome()
 
 proc markUseful*(rtable: RoutingTable, nodeId: Key) =
-    ## Records that ``nodeId`` answered a query. Updates the shared registry row
-    ## so every index that references the peer sees the new usefulness. No-op when
-    ## the table is detached or the peer has no registry row (not in any table).
-    if rtable.detached:
-      return
-    rtable.registry.markUseful(nodeId)
+  ## Records that ``nodeId`` answered a query. Updates the shared registry row
+  ## so every index that references the peer sees the new usefulness. No-op when
+  ## the table is detached or the peer has no registry row (not in any table).
+  if rtable.detached:
+    return
+  rtable.registry.markUseful(nodeId)
 
 proc markUseful*(rtable: RoutingTable, peerId: PeerId) =
   rtable.markUseful(peerId.toKey())

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -83,7 +83,7 @@ func nPeersForCpl*(rtable: RoutingTable, cpl: int): int =
   ## Fullness of the bucket holding the peers that share `cpl` bits with self.
   var count = 0
   for bucket in rtable.buckets:
-    count += bucket.peers.countIt(rtable.commonPrefixLen(it.nodeId) == cpl)
+    count += bucket.peers.countIt(rtable.commonPrefixLen(it) == cpl)
   count
 
 proc peerIndexInBucket(bucket: Bucket, nodeId: Key): Opt[int] =

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -99,17 +99,10 @@ func isReplaceable*(entry: NodeEntry, gracePeriod: Duration, now: Moment): bool 
   ## select peers for liveness probes by the background liveness loop.
   now - entry.lastActivity() > gracePeriod
 
-proc isReplaceable*(
-    rtable: RoutingTable, peerId: PeerId, gracePeriod: Duration, now: Moment
-): bool =
-  ## Live-table check: false when the peer is missing or still within grace.
-  let nodeId = peerId.toKey()
-  let idx = rtable.bucketIndex(nodeId)
-  if idx >= rtable.buckets.len:
-    return false
-  let pos = peerIndexInBucket(rtable.buckets[idx], nodeId).valueOr:
-    return false
-  rtable.buckets[idx].peers[pos].isReplaceable(gracePeriod, now)
+func needsLivenessCheck*(entry: NodeEntry, gracePeriod: Duration, now: Moment): bool =
+  ## True when the peer has had no successful DHT activity within `gracePeriod`
+  ## and should be probed (and possibly removed) during maintenance.
+  now - entry.lastActivity() > gracePeriod
 
 proc replaceableCandidate(bucket: Bucket, gracePeriod: Duration): Opt[int] =
   ## Least-recently-seen peer past the grace period, i.e. the best eviction

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -1,9 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
+## Routing tables are virtual indexes over a shared ``PeerRegistry``.
+## Buckets hold peer ``Key`` references only; liveness state lives on the
+## registry row. Multiple tables (main Kad + per-service) share one registry.
+
 import algorithm, sequtils
 import chronos, chronicles, results
 import ./types
+import ./peer_registry
 import ./kademlia_metrics
 import ../../peerid
 import ../../crypto/crypto
@@ -41,9 +46,16 @@ proc new*(
     selfId: Key,
     config: RoutingTableConfig = RoutingTableConfig.new(),
     localNodeId: Opt[Key] = Opt.none(Key),
+    registry: PeerRegistry = PeerRegistry.new(),
 ): T =
+  ## ``registry`` is shared across tables on the same node. Unit tests may omit
+  ## it and get a private registry for a single-table setup.
   RoutingTable(
-    selfId: selfId, localNodeId: localNodeId.get(selfId), buckets: @[], config: config
+    selfId: selfId,
+    localNodeId: localNodeId.get(selfId),
+    buckets: @[],
+    config: config,
+    registry: registry,
   )
 
 func bucketCount(maxBuckets: int): int =
@@ -76,71 +88,80 @@ func nPeersForCpl*(rtable: RoutingTable, cpl: int): int =
 
 proc peerIndexInBucket(bucket: Bucket, nodeId: Key): Opt[int] =
   for i, p in bucket.peers:
-    if p.nodeId == nodeId:
+    if p == nodeId:
       return Opt.some(i)
   return Opt.none(int)
 
-proc oldestPeer*(bucket: Bucket): (NodeEntry, int) =
+proc oldestPeer*(bucket: Bucket, registry: PeerRegistry): (Key, int) =
+  ## Least-recently-seen peer key in the bucket (by registry ``lastSeen``).
   var oldestIdx = 0
-  var oldest = bucket.peers[0]
+  var oldestKey = bucket.peers[0]
+  var oldestSeen = Moment.now()
+  registry.get(oldestKey).withValue(record):
+    oldestSeen = record.lastSeen
   for i, p in bucket.peers:
-    if p.lastSeen < oldest.lastSeen:
-      oldest = p
+    var seen = Moment.now()
+    registry.get(p).withValue(record):
+      seen = record.lastSeen
+    if seen < oldestSeen:
+      oldestKey = p
       oldestIdx = i
-  (oldest, oldestIdx)
+      oldestSeen = seen
+  (oldestKey, oldestIdx)
 
-func lastActivity*(entry: NodeEntry): Moment =
-  ## Most recent time the peer answered a DHT query, or when it was admitted.
-  entry.lastUsefulAt.get(entry.addedAt)
-
-func isReplaceable*(entry: NodeEntry, gracePeriod: Duration, now: Moment): bool =
-  ## Replaceable once past `gracePeriod` in the table without proving useful; a
-  ## peer that answered recently or was just added is retained. Also used to
-  ## select peers for liveness probes by the background liveness loop.
-  now - entry.lastActivity() > gracePeriod
+proc oldestPeer*(rtable: RoutingTable, bucketIndex: int): (Key, int) =
+  rtable.buckets[bucketIndex].oldestPeer(rtable.registry)
 
 proc isReplaceable*(
     rtable: RoutingTable, peerId: PeerId, gracePeriod: Duration, now: Moment
 ): bool =
-  ## Live-table check: false when the peer is missing or still within grace.
+  ## Live-index check: false when the peer is missing from this table or still
+  ## within the global usefulness grace period on its registry row.
   let nodeId = peerId.toKey()
   let idx = rtable.bucketIndex(nodeId)
   if idx >= rtable.buckets.len:
     return false
-  let pos = peerIndexInBucket(rtable.buckets[idx], nodeId).valueOr:
+  if peerIndexInBucket(rtable.buckets[idx], nodeId).isNone():
     return false
-  rtable.buckets[idx].peers[pos].isReplaceable(gracePeriod, now)
+  rtable.registry.isReplaceable(nodeId, gracePeriod, now)
 
-proc replaceableCandidate(bucket: Bucket, gracePeriod: Duration): Opt[int] =
-  ## Least-recently-seen peer past the grace period, i.e. the best eviction
-  ## candidate. `Opt.none` when every peer is still useful/fresh.
+proc replaceableCandidate(
+    bucket: Bucket, registry: PeerRegistry, gracePeriod: Duration
+): Opt[int] =
+  ## Least-recently-seen peer past the grace period. ``Opt.none`` when every
+  ## peer is still useful/fresh.
   let now = Moment.now()
   var candidateIdx = -1
   var oldestSeen: Moment
-  for i, p in bucket.peers:
-    if not p.isReplaceable(gracePeriod, now):
+  for i, nodeId in bucket.peers:
+    let record = registry.get(nodeId).valueOr:
       continue
-    if candidateIdx == -1 or p.lastSeen < oldestSeen:
+    if not record.isReplaceable(gracePeriod, now):
+      continue
+    if candidateIdx == -1 or record.lastSeen < oldestSeen:
       candidateIdx = i
-      oldestSeen = p.lastSeen
+      oldestSeen = record.lastSeen
   if candidateIdx == -1:
     return Opt.none(int)
   Opt.some(candidateIdx)
 
 proc tryReplaceStalePeer(
-    bucket: var Bucket, newNodeId: Key, config: RoutingTableConfig
+    rtable: RoutingTable, bucket: var Bucket, newNodeId: Key
 ): bool =
-  if bucket.peers.len < config.replication:
+  if bucket.peers.len < rtable.config.replication:
     trace "Skipping replace: bucket is not full", newNodeId = newNodeId
     return false
 
-  let idx = bucket.replaceableCandidate(config.usefulnessGracePeriod).valueOr:
+  let idx = bucket.replaceableCandidate(
+    rtable.registry, rtable.config.usefulnessGracePeriod
+  ).valueOr:
     trace "Skipping replace: no peer past usefulness grace period",
       newNodeId = newNodeId
     return false
 
-  let now = Moment.now()
-  bucket.peers[idx] = NodeEntry(nodeId: newNodeId, lastSeen: now, addedAt: now)
+  let oldId = bucket.peers[idx]
+  bucket.peers[idx] = newNodeId
+  discard rtable.registry.removeMembership(oldId, rtable.selfId)
   true
 
 proc updateRoutingTableMetrics*(rtable: RoutingTable) =
@@ -168,17 +189,22 @@ proc insert*(rtable: RoutingTable, nodeId: Key): bool =
   var bucket = rtable.buckets[idx]
   let keyx = peerIndexInBucket(bucket, nodeId)
   if keyx.isSome:
-    bucket.peers[keyx.unsafeValue].lastSeen = Moment.now()
+    rtable.registry.touch(nodeId)
+    return true
   elif bucket.peers.len < rtable.config.replication:
-    let now = Moment.now()
-    bucket.peers.add(NodeEntry(nodeId: nodeId, lastSeen: now, addedAt: now))
+    discard rtable.registry.ensure(nodeId)
+    bucket.peers.add(nodeId)
+    rtable.registry.addMembership(nodeId, rtable.selfId)
     kad_routing_table_insertions.inc()
   else:
     # Full bucket with no replaceable peer: reject rather than evict a useful one.
-    if not bucket.tryReplaceStalePeer(nodeId, rtable.config):
+    # Leave any pre-existing registry row alone; do not create a row without membership.
+    if not rtable.tryReplaceStalePeer(bucket, nodeId):
       debug "Cannot insert, no replaceable peer in bucket",
         bucket = idx, nodeId = nodeId
       return false
+    discard rtable.registry.ensure(nodeId)
+    rtable.registry.addMembership(nodeId, rtable.selfId)
     kad_routing_table_replacements.inc()
 
   rtable.buckets[idx] = bucket
@@ -189,7 +215,8 @@ proc insert*(rtable: RoutingTable, peerId: PeerId): bool =
   insert(rtable, peerId.toKey())
 
 proc removePeer*(rtable: RoutingTable, nodeId: Key, reason = "remove"): bool =
-  ## Removes `nodeId` from the routing table. Returns true if it was present.
+  ## Removes ``nodeId`` from this index. Returns true if it was present.
+  ## Drops the registry row when no other table still references the peer.
   ## ``reason`` labels the ``kad_routing_table_evictions`` metric
   ## (e.g. ``"liveness"``, ``"remove"``).
   if nodeId == rtable.selfId or nodeId == rtable.localNodeId:
@@ -203,6 +230,7 @@ proc removePeer*(rtable: RoutingTable, nodeId: Key, reason = "remove"): bool =
     return false
 
   rtable.buckets[idx].peers.delete(pos)
+  discard rtable.registry.removeMembership(nodeId, rtable.selfId)
   kad_routing_table_evictions.inc(labelValues = [reason])
   updateRoutingTableMetrics(rtable)
   true
@@ -218,16 +246,10 @@ proc contains*(rtable: RoutingTable, nodeId: Key): bool =
   peerIndexInBucket(rtable.buckets[idx], nodeId).isSome()
 
 proc markUseful*(rtable: RoutingTable, nodeId: Key) =
-  ## Records that `nodeId` answered a query, refreshing its usefulness so it
-  ## survives eviction. No-op when the peer is not in the table.
-  let idx = rtable.bucketIndex(nodeId)
-  if idx >= rtable.buckets.len:
-    return
-  let pos = peerIndexInBucket(rtable.buckets[idx], nodeId).valueOr:
-    return
-  let now = Moment.now()
-  rtable.buckets[idx].peers[pos].lastUsefulAt = Opt.some(now)
-  rtable.buckets[idx].peers[pos].lastSeen = now
+  ## Records that ``nodeId`` answered a query. Updates the shared registry row
+  ## so every index that references the peer sees the new usefulness.
+  ## No-op when the peer has no registry row (not in any table).
+  rtable.registry.markUseful(nodeId)
 
 proc markUseful*(rtable: RoutingTable, peerId: PeerId) =
   rtable.markUseful(peerId.toKey())
@@ -238,7 +260,7 @@ proc findClosest*(rtable: RoutingTable, targetId: Key, count: int): seq[Key] =
 
   for bucket in rtable.buckets:
     for p in bucket.peers:
-      allNodes.add(p.nodeId)
+      allNodes.add(p)
 
   let hasher = rtable.config.hasher
   let targetHash =
@@ -285,8 +307,8 @@ proc randomPeersClosestFirst*(
 
     let take = min(remaining, min(maxPerBucket, bucket.peers.len))
     let picked = rng.pick(bucket.peers, take).valueOr(@[])
-    for entry in picked:
-      selected.add(entry.nodeId)
+    for nodeId in picked:
+      selected.add(nodeId)
       remaining.dec
       if remaining <= 0:
         break
@@ -301,21 +323,25 @@ proc randomPeersClosestFirstPeerIds*(
     .filterIt(it.isOk)
     .mapIt(it.value())
 
-proc isStale*(bucket: Bucket, staleTime: Duration = DefaultBucketStaleTime): bool =
+proc isStale*(
+    bucket: Bucket, registry: PeerRegistry, staleTime: Duration = DefaultBucketStaleTime
+): bool =
   ## True when the bucket is empty or any peer has not been seen for longer than
-  ## `staleTime`. Used only to decide whether to refresh the bucket, not to
+  ## ``staleTime``. Used only to decide whether to refresh the bucket, not to
   ## remove peers.
   if bucket.peers.len == 0:
     return true
-  for p in bucket.peers:
-    if Moment.now() - p.lastSeen > staleTime:
+  for nodeId in bucket.peers:
+    let record = registry.get(nodeId).valueOr:
+      return true
+    if Moment.now() - record.lastSeen > staleTime:
       return true
   return false
 
 proc isStale*(rtable: RoutingTable, bucketIndex: int): bool =
   if bucketIndex notin 0 ..< rtable.buckets.len:
     return true
-  rtable.buckets[bucketIndex].isStale(rtable.config.bucketStaleTime)
+  rtable.buckets[bucketIndex].isStale(rtable.registry, rtable.config.bucketStaleTime)
 
 proc randomKeyInBucket*(rtable: RoutingTable, bucketIndex: int, rng: Rng): Opt[Key] =
   let lz = clamp(bucketIndex, 0, bucketCount(rtable.config.maxBuckets) - 1)
@@ -335,16 +361,13 @@ proc randomKeyInBucket*(rtable: RoutingTable, bucketIndex: int, rng: Rng): Opt[K
   Opt.none(Key)
 
 proc allKeys*(bucket: Bucket): seq[Key] =
-  return bucket.peers.mapIt(it.nodeId)
+  return bucket.peers
 
 proc allKeys*(rtable: RoutingTable): seq[Key] =
   rtable.buckets.mapIt(it.allKeys()).concat()
 
 proc randomKey*(bucket: Bucket, rng: Rng): Opt[Key] =
-  rng.pickOne(bucket.peers).map(
-    proc(e: NodeEntry): Key =
-      e.nodeId
-  )
+  rng.pickOne(bucket.peers)
 
 proc refreshTarget*(rtable: RoutingTable, bucketIndex: int, rng: Rng): Opt[Key] =
   ## Key to run a findNode against in order to refresh `bucketIndex`.

--- a/libp2p/protocols/kademlia/routing_table.nim
+++ b/libp2p/protocols/kademlia/routing_table.nim
@@ -268,10 +268,12 @@ proc contains*(rtable: RoutingTable, nodeId: Key): bool =
   peerIndexInBucket(rtable.buckets[idx], nodeId).isSome()
 
 proc markUseful*(rtable: RoutingTable, nodeId: Key) =
-  ## Records that ``nodeId`` answered a query. Updates the shared registry row
-  ## so every index that references the peer sees the new usefulness.
-  ## No-op when the peer has no registry row (not in any table).
-  rtable.registry.markUseful(nodeId)
+    ## Records that ``nodeId`` answered a query. Updates the shared registry row
+    ## so every index that references the peer sees the new usefulness. No-op when
+    ## the table is detached or the peer has no registry row (not in any table).
+    if rtable.detached:
+      return
+    rtable.registry.markUseful(nodeId)
 
 proc markUseful*(rtable: RoutingTable, peerId: PeerId) =
   rtable.markUseful(peerId.toKey())

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -406,7 +406,8 @@ type KadDHTLimits* = object
   maxConcurrentRpcs*: int
     ## Maximum number of in-flight outbound RPCs (find/get/put/provider)
     ## across the whole node. Excess calls wait on a shared semaphore.
-  maxConcurrentProbes*: int ## Maximum number of concurrent FIND_NODE admission probes.
+  maxConcurrentProbes*: int
+    ## Maximum number of concurrent FIND_NODE admission probes.
   maxConcurrentLivenessProbes*: int
     ## Maximum number of concurrent liveness/eviction probes. Independent of
     ## ``maxConcurrentProbes`` so admission is never starved by eviction.
@@ -592,13 +593,17 @@ type KadDHT* = ref object of LPProtocol
     ## Reuses one outbound stream per peer across every RPC sent to it.
   rpcSem*: AsyncSemaphore
     ## Bounds in-flight outbound RPCs to ``config.limits.maxConcurrentRpcs``.
-  probeSem*: AsyncSemaphore
-    ## Bounds concurrent admission and liveness probes to
-    ## ``config.limits.maxConcurrentProbes``.
+  admissionSem*: AsyncSemaphore
+    ## Bounds concurrent admission probes to ``config.limits.maxConcurrentProbes``.
+  livenessSem*: AsyncSemaphore
+    ## Bounds concurrent liveness/eviction probes to
+    ## ``config.limits.maxConcurrentLivenessProbes``. Independent of
+    ## ``admissionSem`` so eviction never starves routing-table admission.
   admissionProbes*: Table[ProbeKey, Future[void]]
     ## In-flight admission probes, keyed by target table and candidate peer.
-  livenessProbes*: Table[ProbeKey, Future[void]]
-    ## In-flight routing-table liveness probes, keyed by target table and peer.
+  livenessProbes*: Table[PeerId, Future[void]]
+    ## In-flight liveness probes, keyed by peer only. A peer shared across
+    ## multiple routing tables (main Kad + service tables) is probed once.
   stopping*: bool
     ## Set once ``stop`` begins so racing handlers stop launching new probes,
     ## letting the shutdown drain terminate. Distinct from ``started``, which is

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -286,6 +286,18 @@ proc new*(
 
   return pm
 
+type
+  NetSizeMeasurement* = object
+    distance*: float64 ## normalized XOR distance to a lookup target, in ``[0, 1]``
+    weight*: float64
+    timestamp*: Moment
+
+  NetworkSizeEstimator* = ref object
+    ## Network size from the distances of the closest peers seen across lookups.
+    ## See ``netsize.nim`` for the math.
+    bucketSize*: int
+    measurements*: seq[seq[NetSizeMeasurement]] ## one bucket per closest-peer index
+
 proc toPeerIds*(keys: seq[Key]): seq[PeerId] =
   var peerIds = newSeqOfCap[PeerId](keys.len)
   for k in keys:

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -217,22 +217,27 @@ proc xorDistance*(a, b: PeerId, hasher: Opt[XorDHasher]): XorDistance =
   xorDistance(a.toKey(), b.toKey(), hasher)
 
 type
+  ## Per-table index membership. ``addedAt`` is when *this* table indexed the
+  ## peer and starts that table's usefulness grace window.
+  Membership* = object
+    addedAt*: Moment
+
   ## DHT peer row: liveness/usefulness state lives once, independent of which
   ## routing tables index the peer. Tables only store ``Key`` references.
   PeerRecord* = object
     nodeId*: Key
     lastSeen*: Moment
-    addedAt*: Moment
     lastUsefulAt*: Opt[Moment]
-      ## Set when the peer answers a query; `Opt.none` until then, which makes it
-      ## replaceable once past the grace period since it was first recorded.
+      ## Set when the peer answers a query. Global: one successful answer
+      ## refreshes usefulness for every table that indexes the peer.
+      ## ``Opt.none`` until then; grace then uses membership ``addedAt``.
 
   ## Shared store of peer rows plus reverse membership (which table selfIds
   ## index each peer). Owned by ``KadDHT``; every ``RoutingTable`` shares it.
   PeerRegistry* = ref object
     peers*: Table[Key, PeerRecord]
-    tablesByPeer*: Table[Key, HashSet[Key]]
-      ## peer key → set of routing-table ``selfId``s that reference the peer.
+    tablesByPeer*: Table[Key, Table[Key, Membership]]
+      ## peer key → table selfId → membership (with per-table addedAt).
 
   ## A k-bucket is an index partition: keys only, ordered for eviction by
   ## looking up ``PeerRecord`` timestamps in the shared registry.
@@ -255,6 +260,9 @@ type
     buckets*: seq[Bucket]
     config*: RoutingTableConfig
     registry*: PeerRegistry
+    detached*: bool
+      ## Set by ``detachAll`` when the table is destroyed. Blocks further inserts
+      ## so late admission probes cannot resurrect memberships.
 
   Provider* = Peer
 
@@ -275,6 +283,29 @@ type
     providerRecords*: ProviderRecords
     providedKeys*: ProvidedKeys
     knownKeys*: Table[Key, HashSet[Provider]]
+
+func len*(bucket: Bucket): int =
+  bucket.peers.len
+
+func contains*(bucket: Bucket, nodeId: Key): bool =
+  nodeId in bucket.peers
+
+iterator items*(bucket: Bucket): Key =
+  for nodeId in bucket.peers:
+    yield nodeId
+
+iterator items*(registry: PeerRegistry): PeerRecord =
+  for record in registry.peers.values:
+    yield record
+
+iterator pairs*(registry: PeerRegistry): (Key, PeerRecord) =
+  for nodeId, record in registry.peers:
+    yield (nodeId, record)
+
+template withRecord*(registry: PeerRegistry, nodeId: Key, record, body: untyped) =
+  ## Mutable access to one row. ``record`` is a ``ptr PeerRecord``; body uses ``record[]``.
+  registry.peers.withValue(nodeId, record):
+    body
 
 proc new*(
     T: typedesc[ProviderManager], providerRecordCapacity: int, providedKeyCapacity: int
@@ -552,6 +583,7 @@ proc new*(
     "maxShortlistSize must be >= replication so the shortlist can hold the target k-bucket"
   doAssert actualLimits.maxReceivedSize >= quorum,
     "maxReceivedSize must be >= quorum so getValue can ever satisfy quorum"
+  doAssert livenessIdleInterval > 0.nanoseconds, "livenessIdleInterval must be > 0"
   KadDHTConfig(
     validator: validator,
     selector: selector,

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -592,17 +592,13 @@ type KadDHT* = ref object of LPProtocol
     ## Reuses one outbound stream per peer across every RPC sent to it.
   rpcSem*: AsyncSemaphore
     ## Bounds in-flight outbound RPCs to ``config.limits.maxConcurrentRpcs``.
-  admissionSem*: AsyncSemaphore
-    ## Bounds concurrent admission probes to ``config.limits.maxConcurrentProbes``.
-  livenessSem*: AsyncSemaphore
-    ## Bounds concurrent liveness/eviction probes to
-    ## ``config.limits.maxConcurrentLivenessProbes``. Independent of
-    ## ``admissionSem`` so eviction never starves routing-table admission.
+  probeSem*: AsyncSemaphore
+    ## Bounds concurrent admission and liveness probes to
+    ## ``config.limits.maxConcurrentProbes``.
   admissionProbes*: Table[ProbeKey, Future[void]]
     ## In-flight admission probes, keyed by target table and candidate peer.
-  livenessProbes*: Table[PeerId, Future[void]]
-    ## In-flight liveness probes, keyed by peer only. A peer shared across
-    ## multiple routing tables (main Kad + service tables) is probed once.
+  livenessProbes*: Table[ProbeKey, Future[void]]
+    ## In-flight routing-table liveness probes, keyed by target table and peer.
   stopping*: bool
     ## Set once ``stop`` begins so racing handlers stop launching new probes,
     ## letting the shutdown drain terminate. Distinct from ``started``, which is

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -217,16 +217,27 @@ proc xorDistance*(a, b: PeerId, hasher: Opt[XorDHasher]): XorDistance =
   xorDistance(a.toKey(), b.toKey(), hasher)
 
 type
-  NodeEntry* = object
+  ## DHT peer row: liveness/usefulness state lives once, independent of which
+  ## routing tables index the peer. Tables only store ``Key`` references.
+  PeerRecord* = object
     nodeId*: Key
     lastSeen*: Moment
     addedAt*: Moment
     lastUsefulAt*: Opt[Moment]
       ## Set when the peer answers a query; `Opt.none` until then, which makes it
-      ## replaceable once past the grace period since it was added.
+      ## replaceable once past the grace period since it was first recorded.
 
+  ## Shared store of peer rows plus reverse membership (which table selfIds
+  ## index each peer). Owned by ``KadDHT``; every ``RoutingTable`` shares it.
+  PeerRegistry* = ref object
+    peers*: Table[Key, PeerRecord]
+    tablesByPeer*: Table[Key, HashSet[Key]]
+      ## peer key → set of routing-table ``selfId``s that reference the peer.
+
+  ## A k-bucket is an index partition: keys only, ordered for eviction by
+  ## looking up ``PeerRecord`` timestamps in the shared registry.
   Bucket* = object
-    peers*: seq[NodeEntry]
+    peers*: seq[Key]
 
   RoutingTableConfig* = ref object
     replication*: int
@@ -236,11 +247,14 @@ type
     usefulnessGracePeriod*: Duration
     bucketStaleTime*: Duration
 
+  ## Virtual routing table: k-bucket index over a shared ``PeerRegistry``.
+  ## Peers are not owned by the table; membership is a reference into the registry.
   RoutingTable* = ref object
     selfId*: Key
     localNodeId*: Key
     buckets*: seq[Bucket]
     config*: RoutingTableConfig
+    registry*: PeerRegistry
 
   Provider* = Peer
 
@@ -272,22 +286,10 @@ proc new*(
 
   return pm
 
-type
-  NetSizeMeasurement* = object
-    distance*: float64 ## normalized XOR distance to a lookup target, in ``[0, 1]``
-    weight*: float64
-    timestamp*: Moment
-
-  NetworkSizeEstimator* = ref object
-    ## Network size from the distances of the closest peers seen across lookups.
-    ## See ``netsize.nim`` for the math.
-    bucketSize*: int
-    measurements*: seq[seq[NetSizeMeasurement]] ## one bucket per closest-peer index
-
-proc toPeerIds*(entries: seq[NodeEntry]): seq[PeerId] =
-  var peerIds = newSeqOfCap[PeerId](entries.len)
-  for e in entries:
-    let peerId = e.nodeId.toPeerId().valueOr:
+proc toPeerIds*(keys: seq[Key]): seq[PeerId] =
+  var peerIds = newSeqOfCap[PeerId](keys.len)
+  for k in keys:
+    let peerId = k.toPeerId().valueOr:
       error "cannot convert key to peer id", error
       continue
     peerIds.add(peerId)
@@ -406,8 +408,7 @@ type KadDHTLimits* = object
   maxConcurrentRpcs*: int
     ## Maximum number of in-flight outbound RPCs (find/get/put/provider)
     ## across the whole node. Excess calls wait on a shared semaphore.
-  maxConcurrentProbes*: int
-    ## Maximum number of concurrent FIND_NODE admission probes.
+  maxConcurrentProbes*: int ## Maximum number of concurrent FIND_NODE admission probes.
   maxConcurrentLivenessProbes*: int
     ## Maximum number of concurrent liveness/eviction probes. Independent of
     ## ``maxConcurrentProbes`` so admission is never starved by eviction.

--- a/libp2p/protocols/service_discovery/advertiser.nim
+++ b/libp2p/protocols/service_discovery/advertiser.nim
@@ -152,7 +152,7 @@ proc maintainRegistrations*(
       for t in disco.advertiser.running:
         if t.serviceId == sid and t.bucketIdx == bucketIdx and not t.fut.finished:
           let regKey = t.registrar.toKey()
-          if not bucket.peers.anyIt(it.nodeId == regKey):
+          if regKey notin bucket.peers:
             stale.add(t)
       for t in stale:
         t.fut.cancelSoon()
@@ -166,8 +166,8 @@ proc maintainRegistrations*(
         continue
 
       var candidates: seq[PeerId]
-      for p in bucket.peers:
-        let pid = p.nodeId.toPeerId().valueOr:
+      for nodeId in bucket.peers:
+        let pid = nodeId.toPeerId().valueOr:
           continue
         if pid notin active and pid != selfPeer:
           candidates.add(pid)

--- a/libp2p/protocols/service_discovery/advertiser.nim
+++ b/libp2p/protocols/service_discovery/advertiser.nim
@@ -349,7 +349,7 @@ proc scheduleRegistrations(
       continue
 
     for peer in peers:
-      let registrar = peer.nodeId.toPeerId().valueOr:
+      let registrar = peer.toPeerId().valueOr:
         error "cannot convert key to peer id", error
         continue
 

--- a/libp2p/protocols/service_discovery/routing_table_manager.nim
+++ b/libp2p/protocols/service_discovery/routing_table_manager.nim
@@ -167,8 +167,7 @@ proc serviceIds*(manager: ServiceRoutingTableManager): seq[ServiceId] =
   return manager.tables.keys.toSeq()
 
 proc clear*(manager: ServiceRoutingTableManager) =
-  for table in manager.tables.values:
-    table.detachAll()
+  manager.tables.values.allIt(it.detachAll())
   manager.tables.clear()
   manager.serviceStatus.clear()
   manager.updateServiceTablesMetrics()

--- a/libp2p/protocols/service_discovery/routing_table_manager.nim
+++ b/libp2p/protocols/service_discovery/routing_table_manager.nim
@@ -45,19 +45,19 @@ proc addService*(
     manager.updateServiceTablesMetrics()
     return true
 
-  # Create new routing table
+  # Create new routing table as an index over the same peer registry.
   var rtable = RoutingTable.new(
     serviceId,
     config = RoutingTableConfig.new(
       replication = replication, maxBuckets = bucketsCount, selfIdPreHashed = true
     ),
     localNodeId = Opt.some(mainRoutingTable.localNodeId),
+    registry = mainRoutingTable.registry,
   )
 
-  # Seed from main table
-  for bucket in mainRoutingTable.buckets:
-    for peer in bucket.peers:
-      discard rtable.insert(peer.nodeId)
+  # Seed by referencing peers already in the main index (no peer-row copies).
+  for nodeId in mainRoutingTable.allKeys():
+    discard rtable.insert(nodeId)
 
   manager.tables[serviceId] = rtable
   manager.serviceStatus[serviceId] = status

--- a/libp2p/protocols/service_discovery/routing_table_manager.nim
+++ b/libp2p/protocols/service_discovery/routing_table_manager.nim
@@ -74,6 +74,9 @@ proc removeService*(
 ) =
   manager.serviceStatus.withValue(serviceId, currentStatus):
     if currentStatus[] == status:
+      manager.tables.withValue(serviceId, table):
+        # Drop reverse memberships so the shared registry does not leak rows.
+        table[].detachAll()
       manager.tables.del(serviceId)
       manager.serviceStatus.del(serviceId)
       manager.updateServiceTablesMetrics()
@@ -164,6 +167,8 @@ proc serviceIds*(manager: ServiceRoutingTableManager): seq[ServiceId] =
   return manager.tables.keys.toSeq()
 
 proc clear*(manager: ServiceRoutingTableManager) =
+  for table in manager.tables.values:
+    table.detachAll()
   manager.tables.clear()
   manager.serviceStatus.clear()
   manager.updateServiceTablesMetrics()

--- a/libp2p/protocols/service_discovery/routing_table_manager.nim
+++ b/libp2p/protocols/service_discovery/routing_table_manager.nim
@@ -167,7 +167,8 @@ proc serviceIds*(manager: ServiceRoutingTableManager): seq[ServiceId] =
   return manager.tables.keys.toSeq()
 
 proc clear*(manager: ServiceRoutingTableManager) =
-  manager.tables.values.allIt(it.detachAll())
+  for table in manager.tables.values:
+    table.detachAll()
   manager.tables.clear()
   manager.serviceStatus.clear()
   manager.updateServiceTablesMetrics()

--- a/tests/libp2p/kademlia/test_bootstrap.nim
+++ b/tests/libp2p/kademlia/test_bootstrap.nim
@@ -297,7 +297,7 @@ suite "KadDHT Bootstrap Component":
 
   asyncTest "liveness probe is de-duplicated while in flight":
     ## An in-flight entry must be awaited by a concurrent batch instead of
-    ## launching a second probe (and acquiring another probeSem slot).
+    ## launching a second probe (and acquiring another livenessSem slot).
     let kad = setupMockKad()
     startAndDeferStop(@[kad])
 
@@ -306,11 +306,10 @@ suite "KadDHT Bootstrap Component":
     agePeerPastLivenessGrace(kad.rtable, peer.toKey())
 
     let hang = newFuture[void]()
-    let probeKey = (kad.rtable.selfId, peer)
-    kad.livenessProbes[probeKey] = hang
+    kad.livenessProbes[peer] = hang
 
     let batch = kad.probeAndEvictPeers(kad.rtable)
-    await sleepAsync(chronos.milliseconds(20))
+
     check:
       not batch.finished()
       kad.livenessProbes.len == 1
@@ -319,7 +318,7 @@ suite "KadDHT Bootstrap Component":
     await batch
     # Hang stood in for the real probe body, so the peer was not removed.
     # Manual inject has no track callback; drop the finished entry ourselves.
-    kad.livenessProbes.del(probeKey)
+    kad.livenessProbes.del(peer)
     check:
       kad.hasKey(peer.toKey())
       kad.livenessProbes.len == 0

--- a/tests/libp2p/kademlia/test_bootstrap.nim
+++ b/tests/libp2p/kademlia/test_bootstrap.nim
@@ -52,7 +52,7 @@ suite "KadDHT Bootstrap":
     check bucketIndices.len >= 2
 
     for index in bucketIndices:
-      makeBucketStale(kad.rtable.buckets[index])
+      makeBucketStale(kad.rtable, index)
 
     kad.findNodeCalls = @[]
     await kad.bootstrap()
@@ -72,12 +72,12 @@ suite "KadDHT Bootstrap":
 
     # Make only the first bucket stale
     let staleBucketIndex = bucketIndices[0]
-    makeBucketStale(kad.rtable.buckets[staleBucketIndex])
-    check kad.rtable.buckets[staleBucketIndex].isStale()
+    makeBucketStale(kad.rtable, staleBucketIndex)
+    check kad.rtable.isStale(staleBucketIndex)
 
     # Verify that the rest of non-empty buckets is fresh
     for i in 1 ..< bucketIndices.len:
-      check not kad.rtable.buckets[bucketIndices[i]].isStale()
+      check not kad.rtable.isStale(bucketIndices[i])
 
     kad.findNodeCalls = @[]
     await kad.bootstrap()
@@ -277,9 +277,8 @@ suite "KadDHT Bootstrap Component":
       )
     )
     let leaf = setupKad(
-      config = testKadConfig(
-        timeout = chronos.milliseconds(200), disableBootstrapping = true
-      )
+      config =
+        testKadConfig(timeout = chronos.milliseconds(200), disableBootstrapping = true)
     )
     startAndDeferStop(@[hub, leaf])
     await connect(hub, leaf)

--- a/tests/libp2p/kademlia/test_bootstrap.nim
+++ b/tests/libp2p/kademlia/test_bootstrap.nim
@@ -147,7 +147,7 @@ suite "KadDHT Bootstrap Component":
       kad.hasKey(fakePeerId.toKey()) # fake peer should be in routing table
       kad.started # node should be operational
 
-  asyncTest "probeAndEvictPeers removes peers past liveness grace that fail probe":
+  asyncTest "pingAndEvictPeers removes peers past liveness grace that fail probe":
     let hub = setupKad()
     let leaf = setupKad(config = testKadConfig(timeout = chronos.milliseconds(200)))
     startAndDeferStop(@[hub, leaf])
@@ -160,13 +160,19 @@ suite "KadDHT Bootstrap Component":
     await leaf.stop()
     await leaf.switch.stop()
 
-    agePeerPastLivenessGrace(hub.rtable, leafId.toKey())
+    let past = Moment.now() - (DefaultLivenessGracePeriod + 1.minutes)
+    for b in hub.rtable.buckets.mitems:
+      for p in b.peers.mitems:
+        if p.nodeId == leafId.toKey():
+          p.addedAt = past
+          p.lastUsefulAt = Opt.none(Moment)
+          p.lastSeen = past
 
-    await hub.probeAndEvictPeers(hub.rtable)
+    await hub.pingAndEvictPeers(hub.rtable)
 
     check not hub.hasKey(leafId.toKey())
 
-  asyncTest "probeAndEvictPeers retains peers that answer the probe":
+  asyncTest "pingAndEvictPeers retains peers that answer the probe":
     let hub = setupKad()
     let leaf = setupKad()
     startAndDeferStop(@[hub, leaf])
@@ -176,15 +182,26 @@ suite "KadDHT Bootstrap Component":
     check hub.hasKey(leafId.toKey())
 
     # Age past grace so a probe is required; leaf is still alive.
-    agePeerPastLivenessGrace(hub.rtable, leafId.toKey())
+    let past = Moment.now() - (DefaultLivenessGracePeriod + 1.minutes)
+    for b in hub.rtable.buckets.mitems:
+      for p in b.peers.mitems:
+        if p.nodeId == leafId.toKey():
+          p.addedAt = past
+          p.lastUsefulAt = Opt.none(Moment)
+          p.lastSeen = past
 
-    await hub.probeAndEvictPeers(hub.rtable)
+    await hub.pingAndEvictPeers(hub.rtable)
 
     check hub.hasKey(leafId.toKey())
     # Successful probe marks the peer useful again.
-    check hub.isPeerUseful(leafId.toKey())
+    var useful = false
+    for b in hub.rtable.buckets:
+      for p in b.peers:
+        if p.nodeId == leafId.toKey():
+          useful = p.lastUsefulAt.isSome()
+    check useful
 
-  asyncTest "probeAndEvictPeers skips peers still within liveness grace":
+  asyncTest "pingAndEvictPeers skips peers still within liveness grace":
     let hub = setupKad()
     let leaf = setupKad(config = testKadConfig(timeout = chronos.milliseconds(200)))
     startAndDeferStop(@[hub, leaf])
@@ -195,20 +212,25 @@ suite "KadDHT Bootstrap Component":
     await leaf.switch.stop()
 
     # Fresh insert times: within grace, so no probe and no eviction.
-    await hub.probeAndEvictPeers(hub.rtable)
+    await hub.pingAndEvictPeers(hub.rtable)
     check hub.hasKey(leafId.toKey())
 
-  asyncTest "probeAndEvictPeers removes peers with no known addresses":
+  asyncTest "pingAndEvictPeers removes peers with no known addresses":
     let kad = setupMockKad()
     startAndDeferStop(@[kad])
 
     let orphan = randomPeerId()
-    check kad.rtable.insert(orphan)
+    discard kad.rtable.insert(orphan)
     # No AddressBook entry.
 
-    agePeerPastLivenessGrace(kad.rtable, orphan.toKey())
+    let past = Moment.now() - (DefaultLivenessGracePeriod + 1.minutes)
+    for b in kad.rtable.buckets.mitems:
+      for p in b.peers.mitems:
+        if p.nodeId == orphan.toKey():
+          p.addedAt = past
+          p.lastUsefulAt = Opt.none(Moment)
 
-    await kad.probeAndEvictPeers(kad.rtable)
+    await kad.pingAndEvictPeers(kad.rtable)
     check not kad.hasKey(orphan.toKey())
 
   asyncTest "probeAndEvictPeers keeps useful peer even with no addresses":

--- a/tests/libp2p/kademlia/test_bootstrap.nim
+++ b/tests/libp2p/kademlia/test_bootstrap.nim
@@ -277,8 +277,9 @@ suite "KadDHT Bootstrap Component":
       )
     )
     let leaf = setupKad(
-      config =
-        testKadConfig(timeout = chronos.milliseconds(200), disableBootstrapping = true)
+      config = testKadConfig(
+        timeout = chronos.milliseconds(200), disableBootstrapping = true
+      )
     )
     startAndDeferStop(@[hub, leaf])
     await connect(hub, leaf)
@@ -296,7 +297,7 @@ suite "KadDHT Bootstrap Component":
 
   asyncTest "liveness probe is de-duplicated while in flight":
     ## An in-flight entry must be awaited by a concurrent batch instead of
-    ## launching a second probe (and acquiring another livenessSem slot).
+    ## launching a second probe (and acquiring another probeSem slot).
     let kad = setupMockKad()
     startAndDeferStop(@[kad])
 
@@ -305,10 +306,11 @@ suite "KadDHT Bootstrap Component":
     agePeerPastLivenessGrace(kad.rtable, peer.toKey())
 
     let hang = newFuture[void]()
-    kad.livenessProbes[peer] = hang
+    let probeKey = (kad.rtable.selfId, peer)
+    kad.livenessProbes[probeKey] = hang
 
     let batch = kad.probeAndEvictPeers(kad.rtable)
-
+    await sleepAsync(chronos.milliseconds(20))
     check:
       not batch.finished()
       kad.livenessProbes.len == 1
@@ -317,7 +319,7 @@ suite "KadDHT Bootstrap Component":
     await batch
     # Hang stood in for the real probe body, so the peer was not removed.
     # Manual inject has no track callback; drop the finished entry ourselves.
-    kad.livenessProbes.del(peer)
+    kad.livenessProbes.del(probeKey)
     check:
       kad.hasKey(peer.toKey())
       kad.livenessProbes.len == 0

--- a/tests/libp2p/kademlia/test_bootstrap.nim
+++ b/tests/libp2p/kademlia/test_bootstrap.nim
@@ -304,7 +304,7 @@ suite "KadDHT Bootstrap Component":
     check kad.rtable.insert(peer)
     agePeerPastLivenessGrace(kad.rtable, peer.toKey())
 
-    let hang = newFuture[void]()
+    let hang = newFuture[void]("liveness-probe-dedup-hang")
     kad.livenessProbes[peer] = hang
 
     let batch = kad.probeAndEvictPeers(kad.rtable)

--- a/tests/libp2p/kademlia/test_bootstrap.nim
+++ b/tests/libp2p/kademlia/test_bootstrap.nim
@@ -160,13 +160,7 @@ suite "KadDHT Bootstrap Component":
     await leaf.stop()
     await leaf.switch.stop()
 
-    let past = Moment.now() - (DefaultLivenessGracePeriod + 1.minutes)
-    for b in hub.rtable.buckets.mitems:
-      for p in b.peers.mitems:
-        if p.nodeId == leafId.toKey():
-          p.addedAt = past
-          p.lastUsefulAt = Opt.none(Moment)
-          p.lastSeen = past
+    agePeerPastLivenessGrace(hub.rtable, leafId.toKey())
 
     await hub.pingAndEvictPeers(hub.rtable)
 
@@ -182,24 +176,13 @@ suite "KadDHT Bootstrap Component":
     check hub.hasKey(leafId.toKey())
 
     # Age past grace so a probe is required; leaf is still alive.
-    let past = Moment.now() - (DefaultLivenessGracePeriod + 1.minutes)
-    for b in hub.rtable.buckets.mitems:
-      for p in b.peers.mitems:
-        if p.nodeId == leafId.toKey():
-          p.addedAt = past
-          p.lastUsefulAt = Opt.none(Moment)
-          p.lastSeen = past
+    agePeerPastLivenessGrace(hub.rtable, leafId.toKey())
 
     await hub.pingAndEvictPeers(hub.rtable)
 
     check hub.hasKey(leafId.toKey())
     # Successful probe marks the peer useful again.
-    var useful = false
-    for b in hub.rtable.buckets:
-      for p in b.peers:
-        if p.nodeId == leafId.toKey():
-          useful = p.lastUsefulAt.isSome()
-    check useful
+    check hub.isPeerUseful(leafId.toKey())
 
   asyncTest "pingAndEvictPeers skips peers still within liveness grace":
     let hub = setupKad()
@@ -220,15 +203,10 @@ suite "KadDHT Bootstrap Component":
     startAndDeferStop(@[kad])
 
     let orphan = randomPeerId()
-    discard kad.rtable.insert(orphan)
+    check kad.rtable.insert(orphan)
     # No AddressBook entry.
 
-    let past = Moment.now() - (DefaultLivenessGracePeriod + 1.minutes)
-    for b in kad.rtable.buckets.mitems:
-      for p in b.peers.mitems:
-        if p.nodeId == orphan.toKey():
-          p.addedAt = past
-          p.lastUsefulAt = Opt.none(Moment)
+    agePeerPastLivenessGrace(kad.rtable, orphan.toKey())
 
     await kad.pingAndEvictPeers(kad.rtable)
     check not kad.hasKey(orphan.toKey())

--- a/tests/libp2p/kademlia/test_bootstrap.nim
+++ b/tests/libp2p/kademlia/test_bootstrap.nim
@@ -147,7 +147,7 @@ suite "KadDHT Bootstrap Component":
       kad.hasKey(fakePeerId.toKey()) # fake peer should be in routing table
       kad.started # node should be operational
 
-  asyncTest "pingAndEvictPeers removes peers past liveness grace that fail probe":
+  asyncTest "probeAndEvictPeers removes peers past liveness grace that fail probe":
     let hub = setupKad()
     let leaf = setupKad(config = testKadConfig(timeout = chronos.milliseconds(200)))
     startAndDeferStop(@[hub, leaf])
@@ -162,11 +162,11 @@ suite "KadDHT Bootstrap Component":
 
     agePeerPastLivenessGrace(hub.rtable, leafId.toKey())
 
-    await hub.pingAndEvictPeers(hub.rtable)
+    await hub.probeAndEvictPeers(hub.rtable)
 
     check not hub.hasKey(leafId.toKey())
 
-  asyncTest "pingAndEvictPeers retains peers that answer the probe":
+  asyncTest "probeAndEvictPeers retains peers that answer the probe":
     let hub = setupKad()
     let leaf = setupKad()
     startAndDeferStop(@[hub, leaf])
@@ -178,13 +178,13 @@ suite "KadDHT Bootstrap Component":
     # Age past grace so a probe is required; leaf is still alive.
     agePeerPastLivenessGrace(hub.rtable, leafId.toKey())
 
-    await hub.pingAndEvictPeers(hub.rtable)
+    await hub.probeAndEvictPeers(hub.rtable)
 
     check hub.hasKey(leafId.toKey())
     # Successful probe marks the peer useful again.
     check hub.isPeerUseful(leafId.toKey())
 
-  asyncTest "pingAndEvictPeers skips peers still within liveness grace":
+  asyncTest "probeAndEvictPeers skips peers still within liveness grace":
     let hub = setupKad()
     let leaf = setupKad(config = testKadConfig(timeout = chronos.milliseconds(200)))
     startAndDeferStop(@[hub, leaf])
@@ -195,10 +195,10 @@ suite "KadDHT Bootstrap Component":
     await leaf.switch.stop()
 
     # Fresh insert times: within grace, so no probe and no eviction.
-    await hub.pingAndEvictPeers(hub.rtable)
+    await hub.probeAndEvictPeers(hub.rtable)
     check hub.hasKey(leafId.toKey())
 
-  asyncTest "pingAndEvictPeers removes peers with no known addresses":
+  asyncTest "probeAndEvictPeers removes peers with no known addresses":
     let kad = setupMockKad()
     startAndDeferStop(@[kad])
 
@@ -208,7 +208,7 @@ suite "KadDHT Bootstrap Component":
 
     agePeerPastLivenessGrace(kad.rtable, orphan.toKey())
 
-    await kad.pingAndEvictPeers(kad.rtable)
+    await kad.probeAndEvictPeers(kad.rtable)
     check not kad.hasKey(orphan.toKey())
 
   asyncTest "probeAndEvictPeers keeps useful peer even with no addresses":

--- a/tests/libp2p/kademlia/test_find.nim
+++ b/tests/libp2p/kademlia/test_find.nim
@@ -227,9 +227,9 @@ suite "KadDHT Find":
 
     # Make kads[1]'s bucket stale to trigger refresh
     let bucketIdx = kads[0].rtable.bucketIndex(kads[1].rtable.selfId)
-    makeBucketStale(kads[0].rtable.buckets[bucketIdx])
+    makeBucketStale(kads[0].rtable, bucketIdx)
 
-    check kads[0].rtable.buckets[bucketIdx].isStale()
+    check kads[0].rtable.isStale(bucketIdx)
     check not kads[0].hasKey(kads[2].rtable.selfId)
 
     await kads[0].bootstrap()

--- a/tests/libp2p/kademlia/test_peer_registry.nim
+++ b/tests/libp2p/kademlia/test_peer_registry.nim
@@ -1,0 +1,394 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import std/sets
+import chronos, results
+import ../../../libp2p/[peerid, protocols/kademlia, crypto/crypto]
+import ../../tools/[unittest, crypto]
+
+proc testKey*(x: byte): Key =
+  var buf: array[IdLength, byte]
+  buf[31] = x
+  return @buf
+
+suite "KadDHT PeerRegistry":
+  test "new registry is empty":
+    let registry = PeerRegistry.new()
+    check:
+      registry.len == 0
+      testKey(1) notin registry
+      registry.get(testKey(1)).isNone()
+      registry.membership(testKey(1), testKey(0)).isNone()
+      registry.tableIds(testKey(1)).len == 0
+
+  test "upsert inserts a new peer row":
+    let registry = PeerRegistry.new()
+    let now = Moment.now()
+    let nodeId = testKey(1)
+
+    let record = registry.upsert(nodeId, now)
+    check:
+      registry.len == 1
+      nodeId in registry
+      record.nodeId == nodeId
+      record.lastSeen == now
+      record.lastUsefulAt.isNone()
+      registry.get(nodeId).get().lastSeen == now
+      # Upsert alone does not create table membership.
+      registry.membership(nodeId, testKey(0)).isNone()
+      registry.tableIds(nodeId).len == 0
+
+  test "upsert refreshes lastSeen on existing peer":
+    let registry = PeerRegistry.new()
+    let nodeId = testKey(1)
+    let first = Moment.now() - 1.hours
+    let second = Moment.now()
+
+    discard registry.upsert(nodeId, first)
+    let refreshed = registry.upsert(nodeId, second)
+
+    check:
+      registry.len == 1
+      refreshed.lastSeen == second
+      registry.get(nodeId).get().lastSeen == second
+      refreshed.lastUsefulAt.isNone()
+
+  test "markUseful sets lastUsefulAt and refreshes lastSeen":
+    let registry = PeerRegistry.new()
+    let nodeId = testKey(1)
+    let seenAt = Moment.now() - 1.hours
+    let usefulAt = Moment.now()
+
+    discard registry.upsert(nodeId, seenAt)
+    registry.markUseful(nodeId, usefulAt)
+
+    let record = registry.get(nodeId).get()
+    check:
+      record.lastUsefulAt.get() == usefulAt
+      record.lastSeen == usefulAt
+
+  test "markUseful is a no-op for unknown peers":
+    let registry = PeerRegistry.new()
+    registry.markUseful(testKey(1), Moment.now())
+    check:
+      registry.len == 0
+      testKey(1) notin registry
+
+  test "markUseful accepts PeerId":
+    let registry = PeerRegistry.new()
+    let peerId = PeerId.init(KeyPair.random(ECDSA, rng()).get().pubkey).get()
+    let nodeId = peerId.toKey()
+    let usefulAt = Moment.now()
+
+    discard registry.upsert(nodeId, usefulAt - 1.hours)
+    registry.markUseful(peerId, usefulAt)
+
+    let record = registry.get(nodeId).get()
+    check:
+      record.lastUsefulAt.get() == usefulAt
+      record.lastSeen == usefulAt
+
+  test "addMembership records per-table membership":
+    let registry = PeerRegistry.new()
+    let nodeId = testKey(1)
+    let tableA = testKey(10)
+    let tableB = testKey(20)
+    let now = Moment.now()
+
+    discard registry.upsert(nodeId, now)
+    registry.addMembership(nodeId, tableA, now)
+    registry.addMembership(nodeId, tableB, now + 1.seconds)
+
+    check:
+      registry.membership(nodeId, tableA).get().addedAt == now
+      registry.membership(nodeId, tableB).get().addedAt == now + 1.seconds
+      registry.tableIds(nodeId) == [tableA, tableB].toHashSet()
+
+  test "addMembership is a no-op when membership already exists":
+    let registry = PeerRegistry.new()
+    let nodeId = testKey(1)
+    let tableId = testKey(10)
+    let first = Moment.now() - 1.hours
+    let second = Moment.now()
+
+    discard registry.upsert(nodeId, first)
+    registry.addMembership(nodeId, tableId, first)
+    registry.addMembership(nodeId, tableId, second)
+
+    check:
+      registry.membership(nodeId, tableId).get().addedAt == first
+      registry.tableIds(nodeId).len == 1
+
+  test "removeMembership drops one table reference and keeps the peer row":
+    let registry = PeerRegistry.new()
+    let nodeId = testKey(1)
+    let tableA = testKey(10)
+    let tableB = testKey(20)
+    let now = Moment.now()
+
+    discard registry.upsert(nodeId, now)
+    registry.addMembership(nodeId, tableA, now)
+    registry.addMembership(nodeId, tableB, now)
+
+    registry.removeMembership(nodeId, tableA)
+    check:
+      nodeId in registry
+      registry.membership(nodeId, tableA).isNone()
+      registry.membership(nodeId, tableB).isSome()
+      registry.tableIds(nodeId) == [tableB].toHashSet()
+
+  test "removeMembership deletes peer row when last table reference is gone":
+    let registry = PeerRegistry.new()
+    let nodeId = testKey(1)
+    let tableId = testKey(10)
+    let now = Moment.now()
+
+    discard registry.upsert(nodeId, now)
+    registry.addMembership(nodeId, tableId, now)
+    registry.removeMembership(nodeId, tableId)
+
+    check:
+      nodeId notin registry
+      registry.len == 0
+      registry.get(nodeId).isNone()
+      registry.membership(nodeId, tableId).isNone()
+      registry.tableIds(nodeId).len == 0
+
+  test "removeMembership cleans orphan peer rows without membership map":
+    ## Membership missing but a peer row still exists (failed insert path).
+    let registry = PeerRegistry.new()
+    let nodeId = testKey(1)
+    discard registry.upsert(nodeId)
+
+    check nodeId notin registry.tablesByPeer
+    registry.removeMembership(nodeId, testKey(10))
+
+    check:
+      nodeId notin registry
+      registry.len == 0
+
+  test "removeMembership is a no-op for completely unknown peers":
+    let registry = PeerRegistry.new()
+    registry.removeMembership(testKey(1), testKey(10))
+    check registry.len == 0
+
+  test "dropTable removes memberships and orphaned peer rows":
+    let registry = PeerRegistry.new()
+    let peerA = testKey(1)
+    let peerB = testKey(2)
+    let peerC = testKey(3)
+    let tableA = testKey(10)
+    let tableB = testKey(20)
+    let now = Moment.now()
+
+    for peer in [peerA, peerB, peerC]:
+      discard registry.upsert(peer, now)
+
+    # peerA only in tableA → should be deleted
+    registry.addMembership(peerA, tableA, now)
+    # peerB in tableA and tableB → should keep tableB membership
+    registry.addMembership(peerB, tableA, now)
+    registry.addMembership(peerB, tableB, now)
+    # peerC only in tableB → untouched
+    registry.addMembership(peerC, tableB, now)
+
+    registry.dropTable(tableA)
+
+    check:
+      peerA notin registry
+      peerB in registry
+      peerC in registry
+      registry.len == 2
+      registry.membership(peerB, tableA).isNone()
+      registry.membership(peerB, tableB).isSome()
+      registry.membership(peerC, tableB).isSome()
+      registry.tableIds(peerB) == [tableB].toHashSet()
+      registry.tableIds(peerC) == [tableB].toHashSet()
+
+  test "dropTable is a no-op for unknown table ids":
+    let registry = PeerRegistry.new()
+    let nodeId = testKey(1)
+    let tableId = testKey(10)
+    discard registry.upsert(nodeId)
+    registry.addMembership(nodeId, tableId)
+
+    registry.dropTable(testKey(99))
+    check:
+      nodeId in registry
+      registry.membership(nodeId, tableId).isSome()
+
+  test "dropPeer removes row and all membership tracking":
+    let registry = PeerRegistry.new()
+    let nodeId = testKey(1)
+    let tableA = testKey(10)
+    let tableB = testKey(20)
+    let now = Moment.now()
+
+    discard registry.upsert(nodeId, now)
+    registry.addMembership(nodeId, tableA, now)
+    registry.addMembership(nodeId, tableB, now)
+
+    registry.dropPeer(nodeId)
+    check:
+      nodeId notin registry
+      registry.len == 0
+      registry.tableIds(nodeId).len == 0
+      registry.membership(nodeId, tableA).isNone()
+      registry.membership(nodeId, tableB).isNone()
+
+  test "dropPeer is a no-op for unknown peers":
+    let registry = PeerRegistry.new()
+    registry.dropPeer(testKey(1))
+    check registry.len == 0
+
+  test "lastActivity prefers lastUsefulAt over membership addedAt":
+    let now = Moment.now()
+    let membership = Membership(addedAt: now - 2.hours)
+    let withoutUseful =
+      PeerRecord(nodeId: testKey(1), lastSeen: now, lastUsefulAt: Opt.none(Moment))
+    let withUseful = PeerRecord(
+      nodeId: testKey(1), lastSeen: now, lastUsefulAt: Opt.some(now - 30.minutes)
+    )
+
+    check:
+      withoutUseful.lastActivity(membership) == membership.addedAt
+      withUseful.lastActivity(membership) == now - 30.minutes
+
+  test "isReplaceable uses membership grace, not first global sighting":
+    let registry = PeerRegistry.new()
+    let nodeId = testKey(1)
+    let tableA = testKey(10)
+    let tableB = testKey(20)
+    let now = Moment.now()
+    let grace = 1.hours
+
+    # Peer was first seen long ago and is past grace in tableA.
+    discard registry.upsert(nodeId, now - 3.hours)
+    registry.addMembership(nodeId, tableA, now - 2.hours)
+    # Fresh membership in tableB still has grace remaining.
+    registry.addMembership(nodeId, tableB, now - 10.minutes)
+
+    check:
+      registry.isReplaceable(nodeId, tableA, grace, now)
+      not registry.isReplaceable(nodeId, tableB, grace, now)
+
+  test "isReplaceable becomes false after markUseful":
+    let registry = PeerRegistry.new()
+    let nodeId = testKey(1)
+    let tableId = testKey(10)
+    let now = Moment.now()
+    let grace = 1.hours
+
+    discard registry.upsert(nodeId, now - 2.hours)
+    registry.addMembership(nodeId, tableId, now - 2.hours)
+    check registry.isReplaceable(nodeId, tableId, grace, now)
+
+    registry.markUseful(nodeId, now - 10.minutes)
+    check not registry.isReplaceable(nodeId, tableId, grace, now)
+
+  test "isReplaceable is true for missing membership or peer row":
+    let registry = PeerRegistry.new()
+    let nodeId = testKey(1)
+    let tableId = testKey(10)
+    let now = Moment.now()
+    let grace = 1.hours
+
+    # Completely unknown peer.
+    check registry.isReplaceable(nodeId, tableId, grace, now)
+
+    # Row exists but no membership for this table (orphan index entry).
+    discard registry.upsert(nodeId, now)
+    check registry.isReplaceable(nodeId, tableId, grace, now)
+
+  test "isReplaceable accepts PeerId":
+    let registry = PeerRegistry.new()
+    let peerId = PeerId.init(KeyPair.random(ECDSA, rng()).get().pubkey).get()
+    let nodeId = peerId.toKey()
+    let tableId = testKey(10)
+    let now = Moment.now()
+    let grace = 1.hours
+
+    discard registry.upsert(nodeId, now - 2.hours)
+    registry.addMembership(nodeId, tableId, now - 2.hours)
+
+    check registry.isReplaceable(peerId, tableId, grace, now)
+
+  test "record-level isReplaceable matches lastActivity grace rule":
+    let now = Moment.now()
+    let membership = Membership(addedAt: now - 2.hours)
+    let stale =
+      PeerRecord(nodeId: testKey(1), lastSeen: now, lastUsefulAt: Opt.none(Moment))
+    let useful = PeerRecord(
+      nodeId: testKey(1), lastSeen: now, lastUsefulAt: Opt.some(now - 30.minutes)
+    )
+
+    check:
+      stale.isReplaceable(membership, 1.hours, now)
+      not useful.isReplaceable(membership, 1.hours, now)
+      not stale.isReplaceable(membership, 3.hours, now)
+
+  test "items and pairs iterate all peer rows":
+    let registry = PeerRegistry.new()
+    let a = testKey(1)
+    let b = testKey(2)
+    let now = Moment.now()
+
+    discard registry.upsert(a, now)
+    discard registry.upsert(b, now)
+
+    var fromItems = initHashSet[Key]()
+    for record in registry.items:
+      fromItems.incl(record.nodeId)
+
+    var fromPairs = initHashSet[Key]()
+    for nodeId, record in registry.pairs:
+      check nodeId == record.nodeId
+      fromPairs.incl(nodeId)
+
+    check:
+      fromItems == [a, b].toHashSet()
+      fromPairs == [a, b].toHashSet()
+
+  test "withRecord mutates the stored peer row":
+    let registry = PeerRegistry.new()
+    let nodeId = testKey(1)
+    let now = Moment.now()
+    discard registry.upsert(nodeId, now)
+
+    registry.withRecord(nodeId, record):
+      record[].lastUsefulAt = Opt.some(now)
+      record[].lastSeen = now + 1.seconds
+
+    let stored = registry.get(nodeId).get()
+    check:
+      stored.lastUsefulAt.get() == now
+      stored.lastSeen == now + 1.seconds
+
+  test "shared row: usefulness is global across table memberships":
+    ## One successful answer refreshes usefulness for every table that indexes
+    ## the peer, even though each table keeps its own membership addedAt.
+    let registry = PeerRegistry.new()
+    let nodeId = testKey(1)
+    let tableA = testKey(10)
+    let tableB = testKey(20)
+    let now = Moment.now()
+    let grace = 1.hours
+
+    discard registry.upsert(nodeId, now - 3.hours)
+    registry.addMembership(nodeId, tableA, now - 2.hours)
+    registry.addMembership(nodeId, tableB, now - 90.minutes)
+
+    check:
+      registry.isReplaceable(nodeId, tableA, grace, now)
+      registry.isReplaceable(nodeId, tableB, grace, now)
+
+    registry.markUseful(nodeId, now - 5.minutes)
+
+    check:
+      not registry.isReplaceable(nodeId, tableA, grace, now)
+      not registry.isReplaceable(nodeId, tableB, grace, now)
+      registry.membership(nodeId, tableA).get().addedAt == now - 2.hours
+      registry.membership(nodeId, tableB).get().addedAt == now - 90.minutes
+      registry.len == 1

--- a/tests/libp2p/kademlia/test_routing_table.nim
+++ b/tests/libp2p/kademlia/test_routing_table.nim
@@ -239,7 +239,7 @@ suite "KadDHT Routing Table":
       not rt.removePeer(selfId)
       not rt.removePeer(localNodeId)
 
-  test "needsLivenessCheck follows grace period from last activity":
+  test "isReplaceable follows grace period from last activity":
     let now = Moment.now()
     var entry = NodeEntry(
       nodeId: testKey(1),
@@ -247,7 +247,7 @@ suite "KadDHT Routing Table":
       addedAt: now - 2.hours,
       lastUsefulAt: Opt.none(Moment),
     )
-    check entry.needsLivenessCheck(1.hours, now)
+    check entry.isReplaceable(1.hours, now)
 
     entry = NodeEntry(
       nodeId: testKey(1),
@@ -255,7 +255,7 @@ suite "KadDHT Routing Table":
       addedAt: now - 2.hours,
       lastUsefulAt: Opt.some(now - 30.minutes),
     )
-    check not entry.needsLivenessCheck(1.hours, now)
+    check not entry.isReplaceable(1.hours, now)
 
   test "randomKeyInBucket returns id at correct distance":
     let selfId = testKey(0)

--- a/tests/libp2p/kademlia/test_routing_table.nim
+++ b/tests/libp2p/kademlia/test_routing_table.nim
@@ -221,14 +221,10 @@ suite "KadDHT Routing Table":
       selfId, config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     )
     let key = rt.keyInBucket(TargetBucket)
-    check:
-      rt.insert(key)
-      key in rt
-
-    check:
-      rt.removePeer(key)
-      key notin rt
-
+    check rt.insert(key)
+    check key in rt
+    check rt.removePeer(key)
+    check key notin rt
     check not rt.removePeer(key) # already gone
 
   test "removePeer rejects self and localNodeId":
@@ -239,7 +235,7 @@ suite "KadDHT Routing Table":
       not rt.removePeer(selfId)
       not rt.removePeer(localNodeId)
 
-  test "isReplaceable follows grace period from last activity":
+  test "needsLivenessCheck follows grace period from last activity":
     let now = Moment.now()
     var entry = NodeEntry(
       nodeId: testKey(1),
@@ -247,15 +243,9 @@ suite "KadDHT Routing Table":
       addedAt: now - 2.hours,
       lastUsefulAt: Opt.none(Moment),
     )
-    check entry.isReplaceable(1.hours, now)
-
-    entry = NodeEntry(
-      nodeId: testKey(1),
-      lastSeen: now,
-      addedAt: now - 2.hours,
-      lastUsefulAt: Opt.some(now - 30.minutes),
-    )
-    check not entry.isReplaceable(1.hours, now)
+    check entry.needsLivenessCheck(1.hours, now)
+    entry.lastUsefulAt = Opt.some(now - 30.minutes)
+    check not entry.needsLivenessCheck(1.hours, now)
 
   test "randomKeyInBucket returns id at correct distance":
     let selfId = testKey(0)

--- a/tests/libp2p/kademlia/test_routing_table.nim
+++ b/tests/libp2p/kademlia/test_routing_table.nim
@@ -31,6 +31,15 @@ suite "KadDHT Routing Table":
   proc keyInBucket(rt: RoutingTable, bucket: int): Key =
     randomKeyInBucket(rt, bucket, rng()).expect("bucket is reachable")
 
+  proc agePastGrace(rt: RoutingTable, bucketIdx: int) =
+    ## Push every peer past the usefulness grace period so eviction can act.
+    let past = Moment.now() - 2.hours
+    for nodeId in rt.buckets[bucketIdx].peers:
+      rt.registry.peers.withValue(nodeId, record):
+        record[].addedAt = past
+        record[].lastUsefulAt = Opt.none(Moment)
+        record[].lastSeen = past
+
   test "inserts single key in correct bucket":
     let selfId = testKey(0)
     var rt = RoutingTable.new(selfId)
@@ -41,7 +50,8 @@ suite "KadDHT Routing Table":
     check:
       rt.buckets.len > idx
       rt.buckets[idx].peers.len == 1
-      rt.buckets[idx].peers[0].nodeId == other
+      rt.buckets[idx].peers[0] == other
+      other in rt.registry
 
   test "does not insert self":
     let selfId = testKey(0)
@@ -61,13 +71,6 @@ suite "KadDHT Routing Table":
     let bucket = rt.buckets[TargetBucket]
     check bucket.peers.len <= config.replication
 
-  proc agePastGrace(rt: RoutingTable, bucketIdx: int) =
-    ## Push every peer past the usefulness grace period so eviction can act.
-    var bucket = rt.buckets[bucketIdx]
-    for i in 0 ..< bucket.peers.len:
-      bucket.peers[i].addedAt = Moment.now() - 2.hours
-    rt.buckets[bucketIdx] = bucket
-
   test "evicts oldest replaceable key at max capacity":
     let selfId = testKey(0)
     let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
@@ -81,13 +84,13 @@ suite "KadDHT Routing Table":
     # Age fresh peers past the grace period so they become evictable.
     rt.agePastGrace(TargetBucket)
 
-    let (oldest, _) = rt.buckets[TargetBucket].oldestPeer()
+    let (oldest, _) = rt.oldestPeer(TargetBucket)
 
     check rt.insert(rt.keyInBucket(TargetBucket))
 
     check:
       rt.buckets[TargetBucket].peers.len == config.replication
-      not rt.buckets[TargetBucket].allKeys().contains(oldest.nodeId)
+      not rt.buckets[TargetBucket].allKeys().contains(oldest)
 
   test "retains peers still within the usefulness grace period":
     let selfId = testKey(0)
@@ -115,11 +118,11 @@ suite "KadDHT Routing Table":
     rt.agePastGrace(TargetBucket)
 
     # Marking the oldest-seen peer useful spares it and evicts a different one.
-    let (oldest, _) = rt.buckets[TargetBucket].oldestPeer()
-    rt.markUseful(oldest.nodeId)
+    let (oldest, _) = rt.oldestPeer(TargetBucket)
+    rt.markUseful(oldest)
 
     check rt.insert(rt.keyInBucket(TargetBucket))
-    check rt.buckets[TargetBucket].allKeys().contains(oldest.nodeId)
+    check rt.buckets[TargetBucket].allKeys().contains(oldest)
 
   test "re-insert existing key updates lastSeen":
     let selfId = testKey(0)
@@ -134,16 +137,16 @@ suite "KadDHT Routing Table":
     discard rt.insert(key2)
     discard rt.insert(key3)
 
-    check rt.buckets[TargetBucket].peers[0].nodeId == key1
+    check rt.buckets[TargetBucket].peers[0] == key1
 
-    let previousLastSeen = rt.buckets[TargetBucket].peers[0].lastSeen
+    let previousLastSeen = rt.registry.get(key1).get().lastSeen
 
     discard rt.insert(key1)
 
-    # Re-inserting existing key updates lastSeen timestamp without changing bucket position
+    # Re-inserting existing key updates lastSeen without changing bucket position
     check:
-      rt.buckets[TargetBucket].peers[0].nodeId == key1
-      rt.buckets[TargetBucket].peers[0].lastSeen > previousLastSeen
+      rt.buckets[TargetBucket].peers[0] == key1
+      rt.registry.get(key1).get().lastSeen > previousLastSeen
 
   test "findClosest returns sorted keys":
     let selfId = testKey(0)
@@ -206,14 +209,21 @@ suite "KadDHT Routing Table":
     check res == expected
 
   test "isStale returns true for empty or old keys":
+    let registry = PeerRegistry.new()
     var bucket: Bucket
-    check isStale(bucket) == true
+    check isStale(bucket, registry) == true
 
-    bucket.peers = @[NodeEntry(nodeId: testKey(1), lastSeen: Moment.now() - 40.minutes)]
-    check isStale(bucket) == true
+    let oldKey = testKey(1)
+    discard registry.ensure(oldKey)
+    registry.peers.withValue(oldKey, record):
+      record[].lastSeen = Moment.now() - 40.minutes
+    bucket.peers = @[oldKey]
+    check isStale(bucket, registry) == true
 
-    bucket.peers = @[NodeEntry(nodeId: testKey(1), lastSeen: Moment.now())]
-    check isStale(bucket) == false
+    let freshKey = testKey(2)
+    discard registry.ensure(freshKey)
+    bucket.peers = @[freshKey]
+    check isStale(bucket, registry) == false
 
   test "removePeer removes an existing entry":
     let selfId = testKey(0)
@@ -224,10 +234,12 @@ suite "KadDHT Routing Table":
     check:
       rt.insert(key)
       key in rt
+      key in rt.registry
 
     check:
       rt.removePeer(key)
       key notin rt
+      key notin rt.registry
 
     check not rt.removePeer(key) # already gone
 
@@ -241,21 +253,59 @@ suite "KadDHT Routing Table":
 
   test "isReplaceable follows grace period from last activity":
     let now = Moment.now()
-    var entry = NodeEntry(
+    var record = PeerRecord(
       nodeId: testKey(1),
       lastSeen: now,
       addedAt: now - 2.hours,
       lastUsefulAt: Opt.none(Moment),
     )
-    check entry.isReplaceable(1.hours, now)
+    check record.isReplaceable(1.hours, now)
 
-    entry = NodeEntry(
+    record = PeerRecord(
       nodeId: testKey(1),
       lastSeen: now,
       addedAt: now - 2.hours,
       lastUsefulAt: Opt.some(now - 30.minutes),
     )
-    check not entry.isReplaceable(1.hours, now)
+    check not record.isReplaceable(1.hours, now)
+
+  test "shared registry: one peer row across two tables":
+    let registry = PeerRegistry.new()
+    let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
+    var mainRt = RoutingTable.new(testKey(0), config, registry = registry)
+    var serviceRt = RoutingTable.new(
+      testKey(0xFF),
+      RoutingTableConfig.new(
+        hasher = Opt.some(noOpHasher), maxBuckets = 16, selfIdPreHashed = true
+      ),
+      localNodeId = Opt.some(mainRt.localNodeId),
+      registry = registry,
+    )
+
+    let peer = testKey(1)
+    check mainRt.insert(peer)
+    check serviceRt.insert(peer)
+
+    check:
+      registry.len == 1
+      peer in mainRt
+      peer in serviceRt
+      registry.tableIds(peer).len == 2
+
+    mainRt.markUseful(peer)
+    check registry.get(peer).get().lastUsefulAt.isSome()
+
+    check serviceRt.removePeer(peer)
+    check:
+      peer in mainRt
+      peer notin serviceRt
+      peer in registry
+      registry.tableIds(peer).len == 1
+
+    check mainRt.removePeer(peer)
+    check:
+      peer notin registry
+      registry.len == 0
 
   test "randomKeyInBucket returns id at correct distance":
     let selfId = testKey(0)

--- a/tests/libp2p/kademlia/test_routing_table.nim
+++ b/tests/libp2p/kademlia/test_routing_table.nim
@@ -35,10 +35,12 @@ suite "KadDHT Routing Table":
     ## Push every peer past the usefulness grace period so eviction can act.
     let past = Moment.now() - 2.hours
     for nodeId in rt.buckets[bucketIdx].peers:
-      rt.registry.peers.withValue(nodeId, record):
-        record[].addedAt = past
+      rt.registry.withRecord(nodeId, record):
         record[].lastUsefulAt = Opt.none(Moment)
         record[].lastSeen = past
+      rt.registry.tablesByPeer.withValue(nodeId, tables):
+        tables[].withValue(rt.selfId, m):
+          m[].addedAt = past
 
   test "inserts single key in correct bucket":
     let selfId = testKey(0)
@@ -214,14 +216,14 @@ suite "KadDHT Routing Table":
     check isStale(bucket, registry) == true
 
     let oldKey = testKey(1)
-    discard registry.ensure(oldKey)
+    discard registry.upsert(oldKey)
     registry.peers.withValue(oldKey, record):
       record[].lastSeen = Moment.now() - 40.minutes
     bucket.peers = @[oldKey]
     check isStale(bucket, registry) == true
 
     let freshKey = testKey(2)
-    discard registry.ensure(freshKey)
+    discard registry.upsert(freshKey)
     bucket.peers = @[freshKey]
     check isStale(bucket, registry) == false
 
@@ -251,23 +253,17 @@ suite "KadDHT Routing Table":
       not rt.removePeer(selfId)
       not rt.removePeer(localNodeId)
 
-  test "isReplaceable follows grace period from last activity":
+  test "isReplaceable follows grace period from membership addedAt":
     let now = Moment.now()
-    var record = PeerRecord(
-      nodeId: testKey(1),
-      lastSeen: now,
-      addedAt: now - 2.hours,
-      lastUsefulAt: Opt.none(Moment),
-    )
-    check record.isReplaceable(1.hours, now)
+    let record =
+      PeerRecord(nodeId: testKey(1), lastSeen: now, lastUsefulAt: Opt.none(Moment))
+    let oldMembership = Membership(addedAt: now - 2.hours)
+    check record.isReplaceable(oldMembership, 1.hours, now)
 
-    record = PeerRecord(
-      nodeId: testKey(1),
-      lastSeen: now,
-      addedAt: now - 2.hours,
-      lastUsefulAt: Opt.some(now - 30.minutes),
+    let useful = PeerRecord(
+      nodeId: testKey(1), lastSeen: now, lastUsefulAt: Opt.some(now - 30.minutes)
     )
-    check not record.isReplaceable(1.hours, now)
+    check not useful.isReplaceable(oldMembership, 1.hours, now)
 
   test "shared registry: one peer row across two tables":
     let registry = PeerRegistry.new()
@@ -306,6 +302,75 @@ suite "KadDHT Routing Table":
     check:
       peer notin registry
       registry.len == 0
+
+  test "seeded service membership gets fresh grace window":
+    ## An aged main-table peer must not be immediately replaceable in a new
+    ## service table that just indexed it.
+    let registry = PeerRegistry.new()
+    let config = RoutingTableConfig.new(
+      hasher = Opt.some(noOpHasher), usefulnessGracePeriod = 1.hours
+    )
+    var mainRt = RoutingTable.new(testKey(0), config, registry = registry)
+    let peer = testKey(1)
+    check mainRt.insert(peer)
+
+    let past = Moment.now() - 2.hours
+    registry.withRecord(peer, record):
+      record[].lastUsefulAt = Opt.none(Moment)
+      record[].lastSeen = past
+    registry.tablesByPeer.withValue(peer, tables):
+      tables[].withValue(mainRt.selfId, m):
+        m[].addedAt = past
+
+    check mainRt.isReplaceable(peer, 1.hours, Moment.now())
+
+    var serviceRt = RoutingTable.new(
+      testKey(0xFF),
+      RoutingTableConfig.new(
+        hasher = Opt.some(noOpHasher),
+        maxBuckets = 16,
+        selfIdPreHashed = true,
+        usefulnessGracePeriod = 1.hours,
+      ),
+      localNodeId = Opt.some(mainRt.localNodeId),
+      registry = registry,
+    )
+    check serviceRt.insert(peer)
+    check not serviceRt.isReplaceable(peer, 1.hours, Moment.now())
+
+  test "orphan bucket key is replaceable and preferred for eviction":
+    let selfId = testKey(0)
+    let config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
+    var rt = RoutingTable.new(selfId, config)
+    for _ in 0 ..< config.replication:
+      discard rt.insert(rt.keyInBucket(TargetBucket))
+
+    # Corrupt: leave a key in the bucket but drop its registry row.
+    let orphan = rt.buckets[TargetBucket].peers[0]
+    rt.registry.dropPeer(orphan)
+    check rt.registry.isReplaceable(
+      orphan, rt.selfId, config.usefulnessGracePeriod, Moment.now()
+    )
+
+    let newcomer = rt.keyInBucket(TargetBucket)
+    check rt.insert(newcomer)
+    check:
+      newcomer in rt.buckets[TargetBucket].peers
+      orphan notin rt.buckets[TargetBucket].peers
+
+  test "detachAll drops memberships and blocks further inserts":
+    let registry = PeerRegistry.new()
+    var rt = RoutingTable.new(testKey(0), registry = registry)
+    let peer = testKey(1)
+    check rt.insert(peer)
+    check peer in registry
+
+    rt.detachAll()
+    check:
+      rt.detached
+      peer notin registry
+      rt.buckets.len == 0
+      not rt.insert(testKey(2))
 
   test "randomKeyInBucket returns id at correct distance":
     let selfId = testKey(0)

--- a/tests/libp2p/kademlia/test_routing_table.nim
+++ b/tests/libp2p/kademlia/test_routing_table.nim
@@ -221,10 +221,14 @@ suite "KadDHT Routing Table":
       selfId, config = RoutingTableConfig.new(hasher = Opt.some(noOpHasher))
     )
     let key = rt.keyInBucket(TargetBucket)
-    check rt.insert(key)
-    check key in rt
-    check rt.removePeer(key)
-    check key notin rt
+    check:
+      rt.insert(key)
+      key in rt
+
+    check:
+      rt.removePeer(key)
+      key notin rt
+
     check not rt.removePeer(key) # already gone
 
   test "removePeer rejects self and localNodeId":
@@ -244,7 +248,13 @@ suite "KadDHT Routing Table":
       lastUsefulAt: Opt.none(Moment),
     )
     check entry.needsLivenessCheck(1.hours, now)
-    entry.lastUsefulAt = Opt.some(now - 30.minutes)
+
+    entry = NodeEntry(
+      nodeId: testKey(1),
+      lastSeen: now,
+      addedAt: now - 2.hours,
+      lastUsefulAt: Opt.some(now - 30.minutes),
+    )
     check not entry.needsLivenessCheck(1.hours, now)
 
   test "randomKeyInBucket returns id at correct distance":

--- a/tests/libp2p/kademlia/utils.nim
+++ b/tests/libp2p/kademlia/utils.nim
@@ -163,11 +163,7 @@ proc connect*(kad1, kad2: KadDHT) {.async.} =
     kad1.switch.peerInfo.addrs
 
 proc hasKey*(kad: KadDHT, key: Key): bool =
-  for b in kad.rtable.buckets:
-    for ent in b.peers:
-      if ent.nodeId == key:
-        return true
-  return false
+  key in kad.rtable
 
 proc hasKeys*(kad: KadDHT, keys: seq[Key]): bool =
   keys.allIt(kad.hasKey(it))
@@ -178,8 +174,8 @@ proc hasNoKeys*(kad: KadDHT, keys: seq[Key]): bool =
 proc countBucketEntries*(buckets: seq[Bucket], key: Key): uint32 =
   var res: uint32 = 0
   for b in buckets:
-    for ent in b.peers:
-      if ent.nodeId == key:
+    for nodeId in b.peers:
+      if nodeId == key:
         res += 1
   return res
 
@@ -247,8 +243,8 @@ proc addPeersWithAddrs*(kad: KadDHT, count: int) =
 proc getPeersFromRoutingTable*(kad: KadDHT): seq[PeerId] =
   var peersInTable: seq[PeerId]
   for bucket in kad.rtable.buckets:
-    for entry in bucket.peers:
-      peersInTable.add(entry.nodeId.toPeerId().get())
+    for nodeId in bucket.peers:
+      peersInTable.add(nodeId.toPeerId().get())
   peersInTable
 
 proc nonEmptyBuckets*(kad: KadDHT): seq[int] =
@@ -258,9 +254,11 @@ proc nonEmptyBuckets*(kad: KadDHT): seq[int] =
       bucketIndices.add(i)
   bucketIndices
 
-proc makeBucketStale*(bucket: var Bucket) =
-  for peer in bucket.peers.mitems:
-    peer.lastSeen = Moment.now() - (DefaultBucketStaleTime + 1.minutes)
+proc makeBucketStale*(rtable: RoutingTable, bucketIdx: int) =
+  let past = Moment.now() - (DefaultBucketStaleTime + 1.minutes)
+  for nodeId in rtable.buckets[bucketIdx].peers:
+    rtable.registry.peers.withValue(nodeId, record):
+      record[].lastSeen = past
 
 proc agePeerPastLivenessGrace*(
     rtable: var RoutingTable,
@@ -270,19 +268,15 @@ proc agePeerPastLivenessGrace*(
   ## Age a routing-table entry past the liveness grace so the next
   ## liveness pass / continuous loop will probe it.
   let past = Moment.now() - (gracePeriod + 1.minutes)
-  for b in rtable.buckets.mitems:
-    for p in b.peers.mitems:
-      if p.nodeId == key:
-        p.addedAt = past
-        p.lastUsefulAt = Opt.none(Moment)
-        p.lastSeen = past
+  rtable.registry.peers.withValue(key, record):
+    record[].addedAt = past
+    record[].lastUsefulAt = Opt.none(Moment)
+    record[].lastSeen = past
 
 proc isPeerUseful*(kad: KadDHT, key: Key): bool =
-  for b in kad.rtable.buckets:
-    for p in b.peers:
-      if p.nodeId == key:
-        return p.lastUsefulAt.isSome()
-  false
+  let record = kad.rtable.registry.get(key).valueOr:
+    return false
+  record.lastUsefulAt.isSome()
 
 proc sortPeers*(
     peers: seq[PeerId], targetKey: Key, hasher: Opt[XorDHasher]

--- a/tests/libp2p/kademlia/utils.nim
+++ b/tests/libp2p/kademlia/utils.nim
@@ -257,21 +257,21 @@ proc nonEmptyBuckets*(kad: KadDHT): seq[int] =
 proc makeBucketStale*(rtable: RoutingTable, bucketIdx: int) =
   let past = Moment.now() - (DefaultBucketStaleTime + 1.minutes)
   for nodeId in rtable.buckets[bucketIdx].peers:
-    rtable.registry.peers.withValue(nodeId, record):
+    rtable.registry.withRecord(nodeId, record):
       record[].lastSeen = past
 
 proc agePeerPastLivenessGrace*(
-    rtable: var RoutingTable,
-    key: Key,
-    gracePeriod: Duration = DefaultLivenessGracePeriod,
+    rtable: RoutingTable, key: Key, gracePeriod: Duration = DefaultLivenessGracePeriod
 ) =
-  ## Age a routing-table entry past the liveness grace so the next
+  ## Age a routing-table membership past the liveness grace so the next
   ## liveness pass / continuous loop will probe it.
   let past = Moment.now() - (gracePeriod + 1.minutes)
-  rtable.registry.peers.withValue(key, record):
-    record[].addedAt = past
+  rtable.registry.withRecord(key, record):
     record[].lastUsefulAt = Opt.none(Moment)
     record[].lastSeen = past
+  rtable.registry.tablesByPeer.withValue(key, tables):
+    tables[].withValue(rtable.selfId, m):
+      m[].addedAt = past
 
 proc isPeerUseful*(kad: KadDHT, key: Key): bool =
   let record = kad.rtable.registry.get(key).valueOr:

--- a/tests/libp2p/service_discovery/component/test_advertise_discover.nim
+++ b/tests/libp2p/service_discovery/component/test_advertise_discover.nim
@@ -65,8 +65,8 @@ suite "Service Discovery Component - Advertise Discover":
     let peerBKey = peerB.switch.peerInfo.peerId.toKey()
 
     check:
-      discovererNode.rtable.buckets.anyIt(it.peers.anyIt(it.nodeId == peerAKey))
-      discovererNode.rtable.buckets.anyIt(it.peers.anyIt(it.nodeId == peerBKey))
+      hasPeer(discovererNode.rtable, peerAKey)
+      hasPeer(discovererNode.rtable, peerBKey)
       not discovererNode.rtManager.hasService(serviceHash)
 
     check discovererNode.rtManager.getTable(serviceHash).isNone()
@@ -76,8 +76,8 @@ suite "Service Discovery Component - Advertise Discover":
     let table = discovererNode.rtManager.getTable(serviceHash)
     check:
       table.isSome()
-      table.get().buckets.anyIt(it.peers.anyIt(it.nodeId == peerAKey))
-      table.get().buckets.anyIt(it.peers.anyIt(it.nodeId == peerBKey))
+      hasPeer(table.get(), peerAKey)
+      hasPeer(table.get(), peerBKey)
 
     discovererNode.unregisterInterest(serviceId)
     check not discovererNode.rtManager.hasService(serviceHash)

--- a/tests/libp2p/service_discovery/test_routing_table_manager.nim
+++ b/tests/libp2p/service_discovery/test_routing_table_manager.nim
@@ -149,6 +149,29 @@ suite "ServiceRoutingTableManager":
       peer1 in peers
       peer2 in peers
 
+  test "addService shares registry with main table (no peer-row copies)":
+    let selfId = makeKey(0)
+    let peer1 = makeKey(1)
+    let peer2 = makeKey(2)
+    let mainRt = makeMainTable(selfId, @[peer1, peer2])
+    let registryLenBefore = mainRt.registry.len
+
+    let manager = ServiceRoutingTableManager.new()
+    let serviceId = makeServiceId(3)
+    check manager.addService(
+      serviceId, mainRt, DefaultReplication, DefaultMaxBuckets, Interest
+    )
+
+    let serviceTable = manager.getTable(serviceId).get()
+    check:
+      serviceTable.registry == mainRt.registry
+      mainRt.registry.len == registryLenBefore
+      mainRt.registry.tableIds(peer1).len == 2
+      mainRt.registry.tableIds(peer2).len == 2
+
+    mainRt.markUseful(peer1)
+    check serviceTable.registry.get(peer1).get().lastUsefulAt.isSome()
+
   test "removeService removes entry when status matches":
     let manager = ServiceRoutingTableManager.new()
     let serviceId = makeServiceId(1)
@@ -441,7 +464,7 @@ suite "ServiceRoutingTableManager - service id hashing":
     check:
       preHashBucket != doubleHashBucket
       serviceTable.buckets[preHashBucket].peers.len == 1
-      serviceTable.buckets[preHashBucket].peers[0].nodeId == peer
+      serviceTable.buckets[preHashBucket].peers[0] == peer
 
   test "service table with small bucketsCount uses scaled bucket mapping":
     let
@@ -462,7 +485,7 @@ suite "ServiceRoutingTableManager - service id hashing":
 
     var actual = -1
     for i, b in table.buckets:
-      if b.peers.anyIt(it.nodeId == peer):
+      if peer in b.peers:
         actual = i
         break
     check actual == expectedScaled

--- a/tests/libp2p/service_discovery/test_routing_table_manager.nim
+++ b/tests/libp2p/service_discovery/test_routing_table_manager.nim
@@ -3,10 +3,11 @@
 
 {.used.}
 
-import chronos, results, sets, tables
+import chronos, results, sets, tables, sequtils
 import
-  ../../../libp2p/[peerinfo],
+  ../../../libp2p/[peerinfo, peerid],
   ../../../libp2p/protocols/kademlia,
+  ../../../libp2p/protocols/service_discovery,
   ../../../libp2p/protocols/service_discovery/[types, routing_table_manager]
 import ../../tools/[lifecycle, unittest]
 import ../kademlia/[mock_kademlia, utils]
@@ -171,6 +172,40 @@ suite "ServiceRoutingTableManager":
 
     mainRt.markUseful(peer1)
     check serviceTable.registry.get(peer1).get().lastUsefulAt.isSome()
+
+  test "removeService detaches table memberships from shared registry":
+    let selfId = makeKey(0)
+    let peer1 = makeKey(1)
+    let mainRt = makeMainTable(selfId, @[peer1])
+    let manager = ServiceRoutingTableManager.new()
+    let serviceId = makeServiceId(3)
+    check manager.addService(
+      serviceId, mainRt, DefaultReplication, DefaultMaxBuckets, Interest
+    )
+    check mainRt.registry.tableIds(peer1).len == 2
+
+    manager.removeService(serviceId, Interest)
+    check:
+      not manager.hasService(serviceId)
+      peer1 in mainRt
+      peer1 in mainRt.registry
+      mainRt.registry.tableIds(peer1).len == 1
+      serviceId notin mainRt.registry.tableIds(peer1)
+
+  test "clear detaches all service tables from shared registry":
+    let selfId = makeKey(0)
+    let peer1 = makeKey(1)
+    let mainRt = makeMainTable(selfId, @[peer1])
+    let manager = ServiceRoutingTableManager.new()
+    let serviceId = makeServiceId(3)
+    check manager.addService(
+      serviceId, mainRt, DefaultReplication, DefaultMaxBuckets, Interest
+    )
+    manager.clear()
+    check:
+      manager.count() == 0
+      peer1 in mainRt.registry
+      mainRt.registry.tableIds(peer1).len == 1
 
   test "removeService removes entry when status matches":
     let manager = ServiceRoutingTableManager.new()
@@ -489,3 +524,51 @@ suite "ServiceRoutingTableManager - service id hashing":
         actual = i
         break
     check actual == expectedScaled
+
+suite "ServiceDiscovery liveness over service tables":
+  asyncTest "maintainableTables includes service tables":
+    let disco = setupServiceDiscoveryNode()
+    startAndDeferStop(@[disco])
+
+    let serviceId = makeServiceId(1)
+    check disco.rtManager.addService(
+      serviceId, disco.rtable, disco.config.replication, disco.discoConfig.bucketsCount,
+      Interest,
+    )
+
+    let tables = disco.maintainableTables()
+    check:
+      tables.len == 2
+      tables.anyIt(it.selfId == disco.rtable.selfId)
+      tables.anyIt(it.selfId == serviceId)
+
+  asyncTest "probeAndEvictPeers removes aged peer from service table":
+    ## Dynamic dispatch through maintainableTables must cover per-service indexes.
+    let grace = 50.milliseconds
+    let disco = setupServiceDiscoveryNode(
+      kadConfig = KadDHTConfig.new(
+        ExtEntryValidator(),
+        ExtEntrySelector(),
+        timeout = 200.milliseconds,
+        livenessGracePeriod = grace,
+        livenessIdleInterval = 1.hours,
+        disableBootstrapping = true,
+      )
+    )
+    startAndDeferStop(@[disco])
+
+    let serviceId = makeServiceId(7)
+    check disco.rtManager.addService(
+      serviceId, disco.rtable, disco.config.replication, disco.discoConfig.bucketsCount,
+      Interest,
+    )
+    let serviceTable = disco.rtManager.getTable(serviceId).get()
+
+    let peer = randomPeerId()
+    check serviceTable.insert(peer)
+    # No addresses → liveness path evicts without dialling.
+    agePeerPastLivenessGrace(serviceTable, peer.toKey(), grace)
+
+    check peer.toKey() in serviceTable
+    await disco.probeAndEvictPeers(serviceTable)
+    check peer.toKey() notin serviceTable

--- a/tests/libp2p/service_discovery/test_routing_table_manager.nim
+++ b/tests/libp2p/service_discovery/test_routing_table_manager.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import chronos, results, sets, tables, sequtils
+import chronos, results, sets, tables
 import
   ../../../libp2p/[peerinfo],
   ../../../libp2p/protocols/kademlia,

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -179,7 +179,7 @@ proc connect*(disco1, disco2: ServiceDiscovery) {.async.} =
     disco1.switch.peerInfo.addrs
 
 proc hasPeer*(rtable: RoutingTable, peerKey: Key): bool =
-  rtable.buckets.anyIt(it.peers.anyIt(it.nodeId == peerKey))
+  peerKey in rtable
 
 proc populateRoutingTable*(disco: ServiceDiscovery, count: int) =
   for i in 0 ..< count:


### PR DESCRIPTION
Instead of each table owning peers, a new registry own peer information and tables are just referencing this.

This avoid copying peers to multiple tables and simplify peer state management.