### PR TITLE
feat(cbind): expose the GossipSub ingress limits in Libp2pConfig

### DIFF
--- a/cbind/examples/gossipsub.c
+++ b/cbind/examples/gossipsub.c
@@ -43,15 +43,15 @@ static LibP2PCtx *gossipsubNode(const char *listenAddr, const char *label) {
   NimFfiStr addrSlot = nimffi_str(listenAddr);
   Libp2pConfig cfg;
   memset(&cfg, 0, sizeof(cfg));
-  cfg.mountGossipsub = true;
-  cfg.gossipsubTriggerSelf = true;
+  cfg.gossipsub.mount = true;
+  cfg.gossipsub.triggerSelf = true;
   // Bound the inbound side: one message is at most 1 MiB, and a peer gets
   // 64 KiB of protocol overhead per second. The budget only counts overhead
-  // until gossipsubDisconnectPeerAboveRateLimit enforces it, which this demo
-  // leaves off so a slow CI runner cannot drop its own peer.
-  cfg.gossipsubMaxMessageSize = 1024 * 1024;
-  cfg.gossipsubOverheadRateLimitBytes = 64 * 1024;
-  cfg.gossipsubOverheadRateLimitIntervalMs = 1000;
+  // until disconnectPeerAboveRateLimit enforces it, which this demo leaves off
+  // so a slow CI runner cannot drop its own peer.
+  cfg.gossipsub.maxMessageSize = 1024 * 1024;
+  cfg.gossipsub.overheadRateLimit.bytes = 64 * 1024;
+  cfg.gossipsub.overheadRateLimit.intervalMs = 1000;
   cfg.addrs.data = &addrSlot;
   cfg.addrs.len = 1;
   cfg.muxer = MUXER_TYPE_MPLEX;

--- a/cbind/examples/gossipsub.c
+++ b/cbind/examples/gossipsub.c
@@ -45,6 +45,13 @@ static LibP2PCtx *gossipsubNode(const char *listenAddr, const char *label) {
   memset(&cfg, 0, sizeof(cfg));
   cfg.mountGossipsub = true;
   cfg.gossipsubTriggerSelf = true;
+  // Bound the inbound side: one message is at most 1 MiB, and a peer gets
+  // 64 KiB of protocol overhead per second. The budget only counts overhead
+  // until gossipsubDisconnectPeerAboveRateLimit enforces it, which this demo
+  // leaves off so a slow CI runner cannot drop its own peer.
+  cfg.gossipsubMaxMessageSize = 1024 * 1024;
+  cfg.gossipsubOverheadRateLimitBytes = 64 * 1024;
+  cfg.gossipsubOverheadRateLimitIntervalMs = 1000;
   cfg.addrs.data = &addrSlot;
   cfg.addrs.len = 1;
   cfg.muxer = MUXER_TYPE_MPLEX;

--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -252,8 +252,18 @@ const MaxReadBytes {.ffiConst.} = 64 * 1024 * 1024
   ## Caps the buffer an untrusted peer can make us pre-allocate before any byte
   ## arrives; well above libp2p's largest framed messages.
 
-proc mountGossipsub(lib: LibP2P, triggerSelf: bool): Result[void, string] =
-  let gs = GossipSub.init(switch = lib.switch, triggerSelf = triggerSelf, rng = lib.rng)
+proc mountGossipsub(lib: LibP2P, cfg: ParsedGossipsub): Result[void, string] =
+  # `init` marks the set explicit, so every parameter left out keeps its default.
+  let gs = GossipSub.init(
+    switch = lib.switch,
+    triggerSelf = cfg.triggerSelf,
+    maxMessageSize = cfg.maxMessageSize,
+    rng = lib.rng,
+    parameters = GossipSubParams.init(
+      overheadRateLimit = cfg.overheadRateLimit,
+      disconnectPeerAboveRateLimit = cfg.disconnectPeerAboveRateLimit,
+    ),
+  )
   try:
     lib.switch.mount(gs)
   except LPError as e:
@@ -302,7 +312,7 @@ proc mountServiceDiscovery(
 
 proc mountProtocols(lib: LibP2P, cfg: ParsedConfig): Result[void, string] =
   if cfg.mountGossipsub:
-    ?mountGossipsub(lib, cfg.gossipsubTriggerSelf)
+    ?mountGossipsub(lib, cfg.gossipsub)
 
   if cfg.mountServiceDiscovery:
     ?mountServiceDiscovery(lib, cfg.bootstrapNodes)
@@ -441,6 +451,10 @@ type CLibp2pConfig {.exportc: "libp2p_config", bycopy.} = object
   logLevel: cint
   mountGossipsub: cint
   gossipsubTriggerSelf: cint
+  gossipsubMaxMessageSize: cint
+  gossipsubOverheadRateLimitBytes: cint
+  gossipsubOverheadRateLimitIntervalMs: int64
+  gossipsubDisconnectPeerAboveRateLimit: cint
   mountKad: cint
   mountServiceDiscovery: cint
   dnsResolver: cstring

--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -311,7 +311,7 @@ proc mountServiceDiscovery(
   ok()
 
 proc mountProtocols(lib: LibP2P, cfg: ParsedConfig): Result[void, string] =
-  if cfg.mountGossipsub:
+  if cfg.gossipsub.mount:
     ?mountGossipsub(lib, cfg.gossipsub)
 
   if cfg.mountServiceDiscovery:
@@ -447,14 +447,20 @@ proc libp2pDestroy*(lib: LibP2P): Future[void] {.ffiDtor.} =
 # config without the generated header. Not layout-compatible with the generated
 # `Libp2pConfig` (strings and enums differ); `muxer`/`transport` carry the
 # `MuxerType`/`TransportType` ordinals. Keep the field list in sync.
+type CRateLimitConfig {.exportc: "libp2p_rate_limit_config", bycopy.} = object
+  bytes: cint
+  intervalMs: int64
+
+type CGossipsubConfig {.exportc: "libp2p_gossipsub_config", bycopy.} = object
+  mount: cint
+  triggerSelf: cint
+  maxMessageSize: cint
+  overheadRateLimit: CRateLimitConfig
+  disconnectPeerAboveRateLimit: cint
+
 type CLibp2pConfig {.exportc: "libp2p_config", bycopy.} = object
   logLevel: cint
-  mountGossipsub: cint
-  gossipsubTriggerSelf: cint
-  gossipsubMaxMessageSize: cint
-  gossipsubOverheadRateLimitBytes: cint
-  gossipsubOverheadRateLimitIntervalMs: int64
-  gossipsubDisconnectPeerAboveRateLimit: cint
+  gossipsub: CGossipsubConfig
   mountKad: cint
   mountServiceDiscovery: cint
   dnsResolver: cstring

--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -255,16 +255,21 @@ const MaxReadBytes {.ffiConst.} = 64 * 1024 * 1024
 
 proc mountGossipsub(lib: LibP2P, cfg: ParsedGossipsub): Result[void, string] =
   # `init` marks the set explicit, so every parameter left out keeps its default.
-  let gs = GossipSub.init(
-    switch = lib.switch,
-    triggerSelf = cfg.triggerSelf,
-    maxMessageSize = cfg.maxMessageSize,
-    rng = lib.rng,
-    parameters = GossipSubParams.init(
-      overheadRateLimit = cfg.overheadRateLimit,
-      disconnectPeerAboveRateLimit = cfg.disconnectPeerAboveRateLimit,
-    ),
-  )
+  # It also runs `validateParameters`, which rejects an inconsistent rate limit.
+  let gs =
+    try:
+      GossipSub.init(
+        switch = lib.switch,
+        triggerSelf = cfg.triggerSelf,
+        maxMessageSize = cfg.maxMessageSize,
+        rng = lib.rng,
+        parameters = GossipSubParams.init(
+          overheadRateLimit = cfg.overheadRateLimit,
+          disconnectPeerAboveRateLimit = cfg.disconnectPeerAboveRateLimit,
+        ),
+      )
+    except InitializationError as e:
+      return err(e.msg)
   try:
     lib.switch.mount(gs)
   except LPError as e:

--- a/cbind/libp2p/config.nim
+++ b/cbind/libp2p/config.nim
@@ -172,7 +172,7 @@ const
     ## unbounded interval overflows `Duration` and raises a Defect no caller
     ## catches. An hour is already a quota rather than a rate limit.
 
-func requireGossipsubForLimits(config: Libp2pConfig): Result[void, string] =
+func requireGossipsubMount(config: Libp2pConfig): Result[void, string] =
   if config.mountGossipsub:
     return ok()
   if config.gossipsubMaxMessageSize != 0 or config.gossipsubOverheadRateLimitBytes != 0 or
@@ -181,7 +181,7 @@ func requireGossipsubForLimits(config: Libp2pConfig): Result[void, string] =
     return err("gossipsub limits require mountGossipsub")
   ok()
 
-func parseGossipsubMaxMessageSize(config: Libp2pConfig): Result[int, string] =
+func parseMaxMessageSize(config: Libp2pConfig): Result[int, string] =
   if config.gossipsubMaxMessageSize < 0:
     return err("gossipsubMaxMessageSize must be 0 or greater")
   if config.gossipsubMaxMessageSize == 0:
@@ -192,7 +192,7 @@ func parseGossipsubMaxMessageSize(config: Libp2pConfig): Result[int, string] =
     )
   ok(config.gossipsubMaxMessageSize)
 
-func validateOverheadRateLimitRange(config: Libp2pConfig): Result[void, string] =
+func checkRateLimitRange(config: Libp2pConfig): Result[void, string] =
   if config.gossipsubOverheadRateLimitBytes < 0:
     return err("gossipsubOverheadRateLimitBytes must be 0 or greater")
   if config.gossipsubOverheadRateLimitIntervalMs < 0:
@@ -204,12 +204,12 @@ func validateOverheadRateLimitRange(config: Libp2pConfig): Result[void, string] 
     )
   ok()
 
-func parseGossipsubOverheadRateLimit(
+func parseOverheadRateLimit(
     config: Libp2pConfig
 ): Result[Opt[OverheadRateLimit], string] =
   ## The per-peer token bucket bounding protocol overhead an untrusted peer can
   ## push at us: `bytes` per `interval`. Both halves are needed, or neither.
-  ?validateOverheadRateLimitRange(config)
+  ?checkRateLimitRange(config)
   if config.gossipsubOverheadRateLimitBytes == 0:
     if config.gossipsubOverheadRateLimitIntervalMs > 0:
       return err(
@@ -233,13 +233,13 @@ func parseGossipsubOverheadRateLimit(
     )
   )
 
-func parseGossipsubConfig(config: Libp2pConfig): Result[ParsedGossipsub, string] =
-  ?requireGossipsubForLimits(config)
+func parseGossipsub(config: Libp2pConfig): Result[ParsedGossipsub, string] =
+  ?requireGossipsubMount(config)
   ok(
     ParsedGossipsub(
       triggerSelf: config.gossipsubTriggerSelf,
-      maxMessageSize: ?parseGossipsubMaxMessageSize(config),
-      overheadRateLimit: ?parseGossipsubOverheadRateLimit(config),
+      maxMessageSize: ?parseMaxMessageSize(config),
+      overheadRateLimit: ?parseOverheadRateLimit(config),
       disconnectPeerAboveRateLimit: config.gossipsubDisconnectPeerAboveRateLimit,
     )
   )
@@ -422,7 +422,7 @@ proc parse(config: Libp2pConfig): Result[ParsedConfig, string] =
       nat: ?parseNATConfig(config),
       autonatV2Server: config.autonatV2Server,
       mountGossipsub: config.mountGossipsub,
-      gossipsub: ?parseGossipsubConfig(config),
+      gossipsub: ?parseGossipsub(config),
       mountKad: config.mountKad,
       mountServiceDiscovery: config.mountServiceDiscovery,
     )

--- a/cbind/libp2p/config.nim
+++ b/cbind/libp2p/config.nim
@@ -28,25 +28,22 @@ type BootstrapNode {.ffi.} = object
   peerId: string
   multiaddrs: seq[string]
 
+type RateLimitConfig {.ffi.} = object
+  ## Token bucket. Set both fields or neither; all zero disables the limit.
+  bytes: int
+  intervalMs: int64
+
+type GossipsubConfig {.ffi.} = object
+  mount: bool
+  triggerSelf: bool ## Deliver locally published messages to self.
+  maxMessageSize: int ## 0 uses the core default; capped at `MAX_GOSSIPSUB_MESSAGE_SIZE`.
+  overheadRateLimit: RateLimitConfig ## Per-peer protocol-overhead budget, on ingress.
+  disconnectPeerAboveRateLimit: bool
+    ## False leaves the budget as a metric; nothing enforces it.
+
 type Libp2pConfig {.ffi.} = object
   logLevel: int ## Chronicles runtime log level to apply before node construction.
-  mountGossipsub: bool
-    ## Mount GossipSub for publishing and receiving messages via pubsub.
-  gossipsubTriggerSelf: bool ## Deliver locally published GossipSub messages to self.
-  gossipsubMaxMessageSize: int
-    ## Largest GossipSub message accepted or sent, in bytes. 0 uses the core
-    ## default; the ceiling is `MAX_GOSSIPSUB_MESSAGE_SIZE`. A limit fails
-    ## closed here, so a negative value is an error rather than a default.
-  gossipsubOverheadRateLimitBytes: int
-    ## Per-peer budget of protocol-overhead bytes per interval. 0 disables the
-    ## ingress rate limit; a negative value is an error.
-  gossipsubOverheadRateLimitIntervalMs: int64
-    ## Refill interval of the per-peer overhead budget, up to
-    ## `MAX_OVERHEAD_RATE_LIMIT_INTERVAL_MS`. Needed with the bytes above.
-  gossipsubDisconnectPeerAboveRateLimit: bool
-    ## Disconnect a peer that spends its overhead budget. Needs the two fields
-    ## above. Leave it false and the budget only feeds the
-    ## `libp2p_gossipsub_peers_rate_limit_hits` metric: nothing enforces it.
+  gossipsub: GossipsubConfig ## Mounting and ingress limits for GossipSub.
   mountKad: bool ## Mount the Kademlia DHT service.
   mountServiceDiscovery: bool ## Mount random-find based service discovery.
   dnsResolver: string ## DNS server address; empty uses the core defaults.
@@ -86,15 +83,11 @@ type Libp2pConfig {.ffi.} = object
   natHolePunchingScheduleIntervalMs: int64
     ## Hole-punch reachability probe interval; <= 0 disables scheduling override.
 
-type OverheadRateLimit = tuple[bytes: int, interval: Duration]
-  ## GossipSub's per-peer overhead budget: `bytes` of protocol overhead per `interval`.
-
 type ParsedGossipsub = object
-  ## GossipSub's slice of the config: how to mount it, and the ingress limits
-  ## that bound what an untrusted peer can push at the node.
+  mount: bool
   triggerSelf: bool
   maxMessageSize: int
-  overheadRateLimit: Opt[OverheadRateLimit]
+  overheadRateLimit: Opt[RateLimit]
   disconnectPeerAboveRateLimit: bool
 
 type ParsedTransport = object
@@ -124,7 +117,6 @@ type ParsedConfig = object
   autonat: bool
   nat: Opt[NATConfig]
   autonatV2Server: bool
-  mountGossipsub: bool
   gossipsub: ParsedGossipsub
   mountKad: bool
   mountServiceDiscovery: bool
@@ -165,82 +157,64 @@ proc parsePrivateKey(raw: seq[byte]): Result[Opt[PrivateKey], string] =
 
 const
   MaxGossipsubMessageSize {.ffiConst.} = 64 * 1024 * 1024
-    ## A peer can make us preallocate one message of this size before a single
-    ## byte is validated, so cap what a host can ask for.
+    ## A peer can make us preallocate this much before a byte is validated.
   MaxOverheadRateLimitIntervalMs {.ffiConst.} = 60 * 60 * 1000
-    ## `chronos.milliseconds` multiplies by a million without checking, so an
-    ## unbounded interval overflows `Duration` and raises a Defect no caller
-    ## catches. An hour is already a quota rather than a rate limit.
+    ## Above an hour `chronos.milliseconds` overflows `Duration` and raises a Defect.
 
-func requireGossipsubMount(config: Libp2pConfig): Result[void, string] =
-  if config.mountGossipsub:
+func requireMount(cfg: GossipsubConfig): Result[void, string] =
+  if cfg.mount:
     return ok()
-  if config.gossipsubMaxMessageSize != 0 or config.gossipsubOverheadRateLimitBytes != 0 or
-      config.gossipsubOverheadRateLimitIntervalMs != 0 or
-      config.gossipsubDisconnectPeerAboveRateLimit:
-    return err("gossipsub limits require mountGossipsub")
+  if cfg.maxMessageSize != 0 or cfg.overheadRateLimit.bytes != 0 or
+      cfg.overheadRateLimit.intervalMs != 0 or cfg.disconnectPeerAboveRateLimit:
+    return err("gossipsub limits require gossipsub.mount")
   ok()
 
-func parseMaxMessageSize(config: Libp2pConfig): Result[int, string] =
-  if config.gossipsubMaxMessageSize < 0:
-    return err("gossipsubMaxMessageSize must be 0 or greater")
-  if config.gossipsubMaxMessageSize == 0:
+func parseMaxMessageSize(size: int): Result[int, string] =
+  if size < 0:
+    return err("maxMessageSize must be 0 or greater")
+  if size == 0:
     return ok(DefaultPubSubMaxMessageSize)
-  if config.gossipsubMaxMessageSize > MaxGossipsubMessageSize:
-    return err(
-      "gossipsubMaxMessageSize must be at most " & $MaxGossipsubMessageSize & " bytes"
-    )
-  ok(config.gossipsubMaxMessageSize)
+  if size > MaxGossipsubMessageSize:
+    return err("maxMessageSize must be at most " & $MaxGossipsubMessageSize & " bytes")
+  ok(size)
 
-func checkRateLimitRange(config: Libp2pConfig): Result[void, string] =
-  if config.gossipsubOverheadRateLimitBytes < 0:
-    return err("gossipsubOverheadRateLimitBytes must be 0 or greater")
-  if config.gossipsubOverheadRateLimitIntervalMs < 0:
-    return err("gossipsubOverheadRateLimitIntervalMs must be 0 or greater")
-  if config.gossipsubOverheadRateLimitIntervalMs > MaxOverheadRateLimitIntervalMs:
+func checkRange(limit: RateLimitConfig): Result[void, string] =
+  if limit.bytes < 0:
+    return err("overheadRateLimit.bytes must be 0 or greater")
+  if limit.intervalMs < 0:
+    return err("overheadRateLimit.intervalMs must be 0 or greater")
+  if limit.intervalMs > MaxOverheadRateLimitIntervalMs:
     return err(
-      "gossipsubOverheadRateLimitIntervalMs must be at most " &
-        $MaxOverheadRateLimitIntervalMs & " ms"
+      "overheadRateLimit.intervalMs must be at most " & $MaxOverheadRateLimitIntervalMs
     )
   ok()
 
-func parseOverheadRateLimit(
-    config: Libp2pConfig
-): Result[Opt[OverheadRateLimit], string] =
-  ## The per-peer token bucket bounding protocol overhead an untrusted peer can
-  ## push at us: `bytes` per `interval`. Both halves are needed, or neither.
-  ?checkRateLimitRange(config)
-  if config.gossipsubOverheadRateLimitBytes == 0:
-    if config.gossipsubOverheadRateLimitIntervalMs > 0:
-      return err(
-        "gossipsubOverheadRateLimitIntervalMs requires gossipsubOverheadRateLimitBytes"
-      )
-    if config.gossipsubDisconnectPeerAboveRateLimit:
-      return err(
-        "gossipsubDisconnectPeerAboveRateLimit requires gossipsubOverheadRateLimitBytes"
-      )
-    return ok(Opt.none(OverheadRateLimit))
-  if config.gossipsubOverheadRateLimitIntervalMs == 0:
-    return err(
-      "gossipsubOverheadRateLimitBytes requires gossipsubOverheadRateLimitIntervalMs"
-    )
+func parseRateLimit(cfg: GossipsubConfig): Result[Opt[RateLimit], string] =
+  let limit = cfg.overheadRateLimit
+  ?checkRange(limit)
+  if limit.bytes == 0:
+    if limit.intervalMs > 0:
+      return err("overheadRateLimit.intervalMs requires overheadRateLimit.bytes")
+    if cfg.disconnectPeerAboveRateLimit:
+      return err("disconnectPeerAboveRateLimit requires overheadRateLimit.bytes")
+    return ok(Opt.none(RateLimit))
+  if limit.intervalMs == 0:
+    return err("overheadRateLimit.bytes requires overheadRateLimit.intervalMs")
   ok(
     Opt.some(
-      (
-        bytes: config.gossipsubOverheadRateLimitBytes,
-        interval: chronos.milliseconds(config.gossipsubOverheadRateLimitIntervalMs),
-      )
+      RateLimit(bytes: limit.bytes, interval: chronos.milliseconds(limit.intervalMs))
     )
   )
 
-func parseGossipsub(config: Libp2pConfig): Result[ParsedGossipsub, string] =
-  ?requireGossipsubMount(config)
+func parseGossipsub(cfg: GossipsubConfig): Result[ParsedGossipsub, string] =
+  ?requireMount(cfg)
   ok(
     ParsedGossipsub(
-      triggerSelf: config.gossipsubTriggerSelf,
-      maxMessageSize: ?parseMaxMessageSize(config),
-      overheadRateLimit: ?parseOverheadRateLimit(config),
-      disconnectPeerAboveRateLimit: config.gossipsubDisconnectPeerAboveRateLimit,
+      mount: cfg.mount,
+      triggerSelf: cfg.triggerSelf,
+      maxMessageSize: ?parseMaxMessageSize(cfg.maxMessageSize),
+      overheadRateLimit: ?parseRateLimit(cfg),
+      disconnectPeerAboveRateLimit: cfg.disconnectPeerAboveRateLimit,
     )
   )
 
@@ -421,8 +395,7 @@ proc parse(config: Libp2pConfig): Result[ParsedConfig, string] =
       autonat: config.autonat,
       nat: ?parseNATConfig(config),
       autonatV2Server: config.autonatV2Server,
-      mountGossipsub: config.mountGossipsub,
-      gossipsub: ?parseGossipsub(config),
+      gossipsub: ?parseGossipsub(config.gossipsub),
       mountKad: config.mountKad,
       mountServiceDiscovery: config.mountServiceDiscovery,
     )

--- a/cbind/libp2p/config.nim
+++ b/cbind/libp2p/config.nim
@@ -178,7 +178,8 @@ func parseMaxMessageSize(size: int): Result[int, string] =
     return err("maxMessageSize must be at most " & $MaxGossipsubMessageSize & " bytes")
   ok(size)
 
-func checkRange(limit: RateLimitConfig): Result[void, string] =
+func validateLimit(cfg: GossipsubConfig): Result[void, string] =
+  let limit = cfg.overheadRateLimit
   if limit.bytes < 0:
     return err("overheadRateLimit.bytes must be 0 or greater")
   if limit.intervalMs < 0:
@@ -187,19 +188,21 @@ func checkRange(limit: RateLimitConfig): Result[void, string] =
     return err(
       "overheadRateLimit.intervalMs must be at most " & $MaxOverheadRateLimitIntervalMs
     )
-  ok()
-
-func parseRateLimit(cfg: GossipsubConfig): Result[Opt[RateLimit], string] =
-  let limit = cfg.overheadRateLimit
-  ?checkRange(limit)
   if limit.bytes == 0:
     if limit.intervalMs > 0:
       return err("overheadRateLimit.intervalMs requires overheadRateLimit.bytes")
     if cfg.disconnectPeerAboveRateLimit:
       return err("disconnectPeerAboveRateLimit requires overheadRateLimit.bytes")
-    return ok(Opt.none(RateLimit))
+    return ok()
   if limit.intervalMs == 0:
     return err("overheadRateLimit.bytes requires overheadRateLimit.intervalMs")
+  ok()
+
+func parseRateLimit(cfg: GossipsubConfig): Result[Opt[RateLimit], string] =
+  ?validateLimit(cfg)
+  let limit = cfg.overheadRateLimit
+  if limit.bytes == 0:
+    return ok(Opt.none(RateLimit))
   ok(
     Opt.some(
       RateLimit(bytes: limit.bytes, interval: chronos.milliseconds(limit.intervalMs))

--- a/cbind/libp2p/config.nim
+++ b/cbind/libp2p/config.nim
@@ -158,8 +158,8 @@ proc parsePrivateKey(raw: seq[byte]): Result[Opt[PrivateKey], string] =
 const
   MaxGossipsubMessageSize {.ffiConst.} = 64 * 1024 * 1024
     ## A peer can make us preallocate this much before a byte is validated.
-  MaxOverheadRateLimitIntervalMs {.ffiConst.} = 60 * 60 * 1000
-    ## Above an hour `chronos.milliseconds` overflows `Duration` and raises a Defect.
+  MaxOverheadRateLimitIntervalMs {.ffiConst.} = high(int64) div 1_000_000
+    ## `chronos.milliseconds` scales to the nanoseconds a `Duration` holds.
 
 func requireMount(cfg: GossipsubConfig): Result[void, string] =
   if cfg.mount:
@@ -178,29 +178,21 @@ func parseMaxMessageSize(size: int): Result[int, string] =
     return err("maxMessageSize must be at most " & $MaxGossipsubMessageSize & " bytes")
   ok(size)
 
-func validateLimit(cfg: GossipsubConfig): Result[void, string] =
-  let limit = cfg.overheadRateLimit
-  if limit.bytes < 0:
-    return err("overheadRateLimit.bytes must be 0 or greater")
-  if limit.intervalMs < 0:
-    return err("overheadRateLimit.intervalMs must be 0 or greater")
+func validateLimit(limit: RateLimitConfig): Result[void, string] =
+  ## Rules of the wire shape only; `GossipSubParams.validateParameters` checks
+  ## the limit itself.
   if limit.intervalMs > MaxOverheadRateLimitIntervalMs:
     return err(
       "overheadRateLimit.intervalMs must be at most " & $MaxOverheadRateLimitIntervalMs
     )
-  if limit.bytes == 0:
-    if limit.intervalMs > 0:
-      return err("overheadRateLimit.intervalMs requires overheadRateLimit.bytes")
-    if cfg.disconnectPeerAboveRateLimit:
-      return err("disconnectPeerAboveRateLimit requires overheadRateLimit.bytes")
-    return ok()
-  if limit.intervalMs == 0:
+  if limit.bytes == 0 and limit.intervalMs != 0:
+    return err("overheadRateLimit.intervalMs requires overheadRateLimit.bytes")
+  if limit.bytes != 0 and limit.intervalMs == 0:
     return err("overheadRateLimit.bytes requires overheadRateLimit.intervalMs")
   ok()
 
-func parseRateLimit(cfg: GossipsubConfig): Result[Opt[RateLimit], string] =
-  ?validateLimit(cfg)
-  let limit = cfg.overheadRateLimit
+func parseRateLimit(limit: RateLimitConfig): Result[Opt[RateLimit], string] =
+  ?validateLimit(limit)
   if limit.bytes == 0:
     return ok(Opt.none(RateLimit))
   ok(
@@ -216,7 +208,7 @@ func parseGossipsub(cfg: GossipsubConfig): Result[ParsedGossipsub, string] =
       mount: cfg.mount,
       triggerSelf: cfg.triggerSelf,
       maxMessageSize: ?parseMaxMessageSize(cfg.maxMessageSize),
-      overheadRateLimit: ?parseRateLimit(cfg),
+      overheadRateLimit: ?parseRateLimit(cfg.overheadRateLimit),
       disconnectPeerAboveRateLimit: cfg.disconnectPeerAboveRateLimit,
     )
   )

--- a/cbind/libp2p/config.nim
+++ b/cbind/libp2p/config.nim
@@ -33,6 +33,20 @@ type Libp2pConfig {.ffi.} = object
   mountGossipsub: bool
     ## Mount GossipSub for publishing and receiving messages via pubsub.
   gossipsubTriggerSelf: bool ## Deliver locally published GossipSub messages to self.
+  gossipsubMaxMessageSize: int
+    ## Largest GossipSub message accepted or sent, in bytes. 0 uses the core
+    ## default; the ceiling is `MAX_GOSSIPSUB_MESSAGE_SIZE`. A limit fails
+    ## closed here, so a negative value is an error rather than a default.
+  gossipsubOverheadRateLimitBytes: int
+    ## Per-peer budget of protocol-overhead bytes per interval. 0 disables the
+    ## ingress rate limit; a negative value is an error.
+  gossipsubOverheadRateLimitIntervalMs: int64
+    ## Refill interval of the per-peer overhead budget, up to
+    ## `MAX_OVERHEAD_RATE_LIMIT_INTERVAL_MS`. Needed with the bytes above.
+  gossipsubDisconnectPeerAboveRateLimit: bool
+    ## Disconnect a peer that spends its overhead budget. Needs the two fields
+    ## above. Leave it false and the budget only feeds the
+    ## `libp2p_gossipsub_peers_rate_limit_hits` metric: nothing enforces it.
   mountKad: bool ## Mount the Kademlia DHT service.
   mountServiceDiscovery: bool ## Mount random-find based service discovery.
   dnsResolver: string ## DNS server address; empty uses the core defaults.
@@ -72,6 +86,17 @@ type Libp2pConfig {.ffi.} = object
   natHolePunchingScheduleIntervalMs: int64
     ## Hole-punch reachability probe interval; <= 0 disables scheduling override.
 
+type OverheadRateLimit = tuple[bytes: int, interval: Duration]
+  ## GossipSub's per-peer overhead budget: `bytes` of protocol overhead per `interval`.
+
+type ParsedGossipsub = object
+  ## GossipSub's slice of the config: how to mount it, and the ingress limits
+  ## that bound what an untrusted peer can push at the node.
+  triggerSelf: bool
+  maxMessageSize: int
+  overheadRateLimit: Opt[OverheadRateLimit]
+  disconnectPeerAboveRateLimit: bool
+
 type ParsedTransport = object
   ## The transport to build, plus the muxer it needs. A muxer is only used with
   ## TCP, so the variant makes "no muxer for QUIC" unrepresentable rather than
@@ -100,7 +125,7 @@ type ParsedConfig = object
   nat: Opt[NATConfig]
   autonatV2Server: bool
   mountGossipsub: bool
-  gossipsubTriggerSelf: bool
+  gossipsub: ParsedGossipsub
   mountKad: bool
   mountServiceDiscovery: bool
 
@@ -137,6 +162,87 @@ proc parsePrivateKey(raw: seq[byte]): Result[Opt[PrivateKey], string] =
   let key = PrivateKey.init(raw).valueOr:
     return err("invalid private key: " & $error)
   ok(Opt.some(key))
+
+const
+  MaxGossipsubMessageSize {.ffiConst.} = 64 * 1024 * 1024
+    ## A peer can make us preallocate one message of this size before a single
+    ## byte is validated, so cap what a host can ask for.
+  MaxOverheadRateLimitIntervalMs {.ffiConst.} = 60 * 60 * 1000
+    ## `chronos.milliseconds` multiplies by a million without checking, so an
+    ## unbounded interval overflows `Duration` and raises a Defect no caller
+    ## catches. An hour is already a quota rather than a rate limit.
+
+func requireGossipsubForLimits(config: Libp2pConfig): Result[void, string] =
+  if config.mountGossipsub:
+    return ok()
+  if config.gossipsubMaxMessageSize != 0 or config.gossipsubOverheadRateLimitBytes != 0 or
+      config.gossipsubOverheadRateLimitIntervalMs != 0 or
+      config.gossipsubDisconnectPeerAboveRateLimit:
+    return err("gossipsub limits require mountGossipsub")
+  ok()
+
+func parseGossipsubMaxMessageSize(config: Libp2pConfig): Result[int, string] =
+  if config.gossipsubMaxMessageSize < 0:
+    return err("gossipsubMaxMessageSize must be 0 or greater")
+  if config.gossipsubMaxMessageSize == 0:
+    return ok(DefaultPubSubMaxMessageSize)
+  if config.gossipsubMaxMessageSize > MaxGossipsubMessageSize:
+    return err(
+      "gossipsubMaxMessageSize must be at most " & $MaxGossipsubMessageSize & " bytes"
+    )
+  ok(config.gossipsubMaxMessageSize)
+
+func validateOverheadRateLimitRange(config: Libp2pConfig): Result[void, string] =
+  if config.gossipsubOverheadRateLimitBytes < 0:
+    return err("gossipsubOverheadRateLimitBytes must be 0 or greater")
+  if config.gossipsubOverheadRateLimitIntervalMs < 0:
+    return err("gossipsubOverheadRateLimitIntervalMs must be 0 or greater")
+  if config.gossipsubOverheadRateLimitIntervalMs > MaxOverheadRateLimitIntervalMs:
+    return err(
+      "gossipsubOverheadRateLimitIntervalMs must be at most " &
+        $MaxOverheadRateLimitIntervalMs & " ms"
+    )
+  ok()
+
+func parseGossipsubOverheadRateLimit(
+    config: Libp2pConfig
+): Result[Opt[OverheadRateLimit], string] =
+  ## The per-peer token bucket bounding protocol overhead an untrusted peer can
+  ## push at us: `bytes` per `interval`. Both halves are needed, or neither.
+  ?validateOverheadRateLimitRange(config)
+  if config.gossipsubOverheadRateLimitBytes == 0:
+    if config.gossipsubOverheadRateLimitIntervalMs > 0:
+      return err(
+        "gossipsubOverheadRateLimitIntervalMs requires gossipsubOverheadRateLimitBytes"
+      )
+    if config.gossipsubDisconnectPeerAboveRateLimit:
+      return err(
+        "gossipsubDisconnectPeerAboveRateLimit requires gossipsubOverheadRateLimitBytes"
+      )
+    return ok(Opt.none(OverheadRateLimit))
+  if config.gossipsubOverheadRateLimitIntervalMs == 0:
+    return err(
+      "gossipsubOverheadRateLimitBytes requires gossipsubOverheadRateLimitIntervalMs"
+    )
+  ok(
+    Opt.some(
+      (
+        bytes: config.gossipsubOverheadRateLimitBytes,
+        interval: chronos.milliseconds(config.gossipsubOverheadRateLimitIntervalMs),
+      )
+    )
+  )
+
+func parseGossipsubConfig(config: Libp2pConfig): Result[ParsedGossipsub, string] =
+  ?requireGossipsubForLimits(config)
+  ok(
+    ParsedGossipsub(
+      triggerSelf: config.gossipsubTriggerSelf,
+      maxMessageSize: ?parseGossipsubMaxMessageSize(config),
+      overheadRateLimit: ?parseGossipsubOverheadRateLimit(config),
+      disconnectPeerAboveRateLimit: config.gossipsubDisconnectPeerAboveRateLimit,
+    )
+  )
 
 func parseTransportConfig(config: Libp2pConfig): ParsedTransport =
   # A muxer is only used with TCP, so a QUIC config's `muxer` is ignored.
@@ -316,7 +422,7 @@ proc parse(config: Libp2pConfig): Result[ParsedConfig, string] =
       nat: ?parseNATConfig(config),
       autonatV2Server: config.autonatV2Server,
       mountGossipsub: config.mountGossipsub,
-      gossipsubTriggerSelf: config.gossipsubTriggerSelf,
+      gossipsub: ?parseGossipsubConfig(config),
       mountKad: config.mountKad,
       mountServiceDiscovery: config.mountServiceDiscovery,
     )

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -162,6 +162,19 @@ proc init*(
     pingpongExtensionConfig: pingpongExtensionConfig,
   )
 
+func validateOverheadRateLimit(parameters: GossipSubParams): Result[void, cstring] =
+  let limit = parameters.overheadRateLimit.valueOr:
+    if parameters.disconnectPeerAboveRateLimit:
+      return err(
+        "gossipsub: disconnectPeerAboveRateLimit parameter error, Requires overheadRateLimit"
+      )
+    return ok()
+  if limit.bytes <= 0:
+    return err("gossipsub: overheadRateLimit.bytes parameter error, Must be > 0")
+  if limit.interval <= ZeroDuration:
+    return err("gossipsub: overheadRateLimit.interval parameter error, Must be > 0")
+  ok()
+
 proc validateParameters*(parameters: GossipSubParams): Result[void, cstring] =
   if (parameters.dOut >= parameters.dLow) or (parameters.dOut > (parameters.d div 2)):
     err(
@@ -210,7 +223,7 @@ proc validateParameters*(parameters: GossipSubParams): Result[void, cstring] =
   elif parameters.maxLowPriorityQueueLen <= 0:
     err("gossipsub: maxLowPriorityQueueLen parameter error, Must be > 0")
   else:
-    ok()
+    validateOverheadRateLimit(parameters)
 
 proc validateParameters*(parameters: TopicParams): Result[void, cstring] =
   if parameters.timeInMeshWeight <= 0.0 or parameters.timeInMeshWeight > 1.0:

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -105,7 +105,7 @@ proc init*(
     disconnectBadPeers = false,
     enablePX = false,
     bandwidthEstimatebps = 100_000_000, # 100 Mbps or 12.5 MBps
-    overheadRateLimit = Opt.none(tuple[bytes: int, interval: Duration]),
+    overheadRateLimit = Opt.none(RateLimit),
     disconnectPeerAboveRateLimit = false,
     maxHighPriorityQueueLen = DefaultMaxHighPriorityQueueLen,
     maxMediumPriorityQueueLen = DefaultMaxMediumPriorityQueueLen,

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -101,6 +101,10 @@ type
     slowPeerPenalty*: float64 # penalty from repeated medium/low queue overflow drops
     behaviourPenalty*: float64 # the eventual penalty score
 
+  RateLimit* = object
+    bytes*: int
+    interval*: Duration
+
   GossipSubParams* = object
     # explicit is used to check if the GossipSubParams instance was created by the user either passing params to GossipSubParams(...)
     # or GossipSubParams.init(...). In the first case explicit should be set to true when calling the Nim constructor.
@@ -153,7 +157,7 @@ type
     bandwidthEstimatebps*: int
       # This is currently used only for limting flood publishing. 0 disables flood-limiting completely
 
-    overheadRateLimit*: Opt[tuple[bytes: int, interval: Duration]]
+    overheadRateLimit*: Opt[RateLimit]
     disconnectPeerAboveRateLimit*: bool
 
     # Max number of high-priority sends. When this limit has been reached, the peer will be disconnected.

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -42,6 +42,7 @@ const
   KnownLibP2PTopics* {.strdefine.} = ""
   KnownLibP2PTopicsSeq* = KnownLibP2PTopics.toLowerAscii().split(",")
   DefaultTopicsHigh* = 1024 ## max topics a single peer may subscribe to
+  DefaultPubSubMaxMessageSize* = 1024 * 1024 ## max size of a single pubsub message
 
 declareGauge(libp2p_pubsub_peers, "pubsub peer instances")
 declareGauge(libp2p_pubsub_topics, "pubsub subscribed topics")
@@ -718,7 +719,7 @@ proc init*[PubParams: object | bool](
     sign: bool = true,
     msgIdProvider: MsgIdProvider = defaultMsgIdProvider,
     subscriptionValidator: SubscriptionValidator = nil,
-    maxMessageSize: int = 1024 * 1024,
+    maxMessageSize: int = DefaultPubSubMaxMessageSize,
     rng: Rng,
     parameters: PubParams = false,
     customStreamCallbacks: Opt[CustomStreamCallbacks] = Opt.none(CustomStreamCallbacks),

--- a/tests/libp2p/kademlia/utils.nim
+++ b/tests/libp2p/kademlia/utils.nim
@@ -293,21 +293,12 @@ proc seedRoutingTable*(kad: KadDHT, count: int, target: Key): seq[PeerId] =
 proc seedRoutingTableBelow*(
     kad: KadDHT, count: int, target: Key
 ): tuple[closest: PeerId, seeded: seq[PeerId]] =
-  ## Seeds the routing table as `seedRoutingTable` does, and draws one more peer
-  ## that is closer to `target` than all of them. That peer is left out of the
-  ## routing table, so only a reply can bring it into a lookup.
-  const maxDraws = 1000
-  let peers = kad.seedRoutingTable(count, target)
-  let hasher = kad.rtable.config.hasher
-  let closestSeeded = xorDistance(peers[0], target, hasher)
-
-  for _ in 0 ..< maxDraws:
-    let candidate = randomPeerId()
-    if xorDistance(candidate, target, hasher) < closestSeeded:
-      return (candidate, peers)
-
-  raiseAssert "no peer closer than the " & $count & " seeded ones in " & $maxDraws &
-    " draws"
+  ## Seeds `count` peers plus a closer one that only a reply can bring into a
+  ## lookup, since it is held out of the routing table.
+  let drawn = kad.seedRoutingTable(count + 1, target)
+  doAssert kad.rtable.removePeer(drawn[0]),
+    "the closest drawn peer is missing from the routing table"
+  (drawn[0], drawn[1 .. ^1])
 
 proc addRandomPeers*(
     state: LookupState, count: int, target: Key, hasher: Opt[XorDHasher]

--- a/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
@@ -55,7 +55,7 @@ suite "GossipSub Component - Scoring":
     let nodes = generateNodes(
         2,
         gossip = true,
-        overheadRateLimit = Opt.some((20, 1.millis)),
+        overheadRateLimit = Opt.some(RateLimit(bytes: 20, interval: 1.millis)),
         verifySignature = false,
           # Avoid being disconnected by failing signature verification
       )
@@ -95,7 +95,7 @@ suite "GossipSub Component - Scoring":
     let nodes = generateNodes(
         2,
         gossip = true,
-        overheadRateLimit = Opt.some((20, 1.millis)),
+        overheadRateLimit = Opt.some(RateLimit(bytes: 20, interval: 1.millis)),
         verifySignature = false,
           # Avoid being disconnected by failing signature verification
       )
@@ -132,7 +132,7 @@ suite "GossipSub Component - Scoring":
     let nodes = generateNodes(
         2,
         gossip = true,
-        overheadRateLimit = Opt.some((40, 1.millis)),
+        overheadRateLimit = Opt.some(RateLimit(bytes: 40, interval: 1.millis)),
         verifySignature = false,
           # Avoid being disconnected by failing signature verification
       )
@@ -182,7 +182,7 @@ suite "GossipSub Component - Scoring":
     let nodes = generateNodes(
         2,
         gossip = true,
-        overheadRateLimit = Opt.some((30, 1.millis)),
+        overheadRateLimit = Opt.some(RateLimit(bytes: 30, interval: 1.millis)),
         verifySignature = false,
           # Avoid being disconnected by failing signature verification
       )

--- a/tests/libp2p/pubsub/test_gossipsub.nim
+++ b/tests/libp2p/pubsub/test_gossipsub.nim
@@ -524,7 +524,7 @@ suite "GossipSub":
     const
       bytes = 1
       interval = 1.millis
-      overheadRateLimit = Opt.some((bytes, interval))
+      overheadRateLimit = Opt.some(RateLimit(bytes: bytes, interval: interval))
 
     gossipSub.parameters.overheadRateLimit = overheadRateLimit
     peer.overheadRateLimitOpt = Opt.some(TokenBucket.new(bytes, interval))
@@ -557,7 +557,7 @@ suite "GossipSub":
     const
       bytes = 1
       interval = 1.millis
-      overheadRateLimit = Opt.some((bytes, interval))
+      overheadRateLimit = Opt.some(RateLimit(bytes: bytes, interval: interval))
 
     gossipSub.parameters.overheadRateLimit = overheadRateLimit
     peer.overheadRateLimitOpt = Opt.some(TokenBucket.new(bytes, interval))
@@ -586,7 +586,7 @@ suite "GossipSub":
     const
       bytes = 1
       interval = 1.millis
-      overheadRateLimit = Opt.some((bytes, interval))
+      overheadRateLimit = Opt.some(RateLimit(bytes: bytes, interval: interval))
 
     gossipSub.parameters.overheadRateLimit = overheadRateLimit
     peer.overheadRateLimitOpt = Opt.some(TokenBucket.new(bytes, interval))

--- a/tests/libp2p/pubsub/test_gossipsub_params.nim
+++ b/tests/libp2p/pubsub/test_gossipsub_params.nim
@@ -378,6 +378,44 @@ suite "GossipSubParams validation":
     params.maxLowPriorityQueueLen = 1
     check params.validateParameters().isOk()
 
+  test "overheadRateLimit.bytes fails when zero":
+    const errorMessage =
+      "gossipsub: overheadRateLimit.bytes parameter error, Must be > 0"
+    var params = newDefaultValidParams()
+    params.overheadRateLimit = Opt.some(RateLimit(bytes: 0, interval: 1.seconds))
+    let res = params.validateParameters()
+    check res.isErr()
+    check res.error == errorMessage
+
+  test "overheadRateLimit.interval fails when zero":
+    const errorMessage =
+      "gossipsub: overheadRateLimit.interval parameter error, Must be > 0"
+    var params = newDefaultValidParams()
+    params.overheadRateLimit = Opt.some(RateLimit(bytes: 1, interval: ZeroDuration))
+    let res = params.validateParameters()
+    check res.isErr()
+    check res.error == errorMessage
+
+  test "overheadRateLimit succeeds when both fields are positive":
+    var params = newDefaultValidParams()
+    params.overheadRateLimit = Opt.some(RateLimit(bytes: 1, interval: 1.seconds))
+    check params.validateParameters().isOk()
+
+  test "disconnectPeerAboveRateLimit fails without overheadRateLimit":
+    const errorMessage =
+      "gossipsub: disconnectPeerAboveRateLimit parameter error, Requires overheadRateLimit"
+    var params = newDefaultValidParams()
+    params.disconnectPeerAboveRateLimit = true
+    let res = params.validateParameters()
+    check res.isErr()
+    check res.error == errorMessage
+
+  test "disconnectPeerAboveRateLimit succeeds with overheadRateLimit":
+    var params = newDefaultValidParams()
+    params.overheadRateLimit = Opt.some(RateLimit(bytes: 1, interval: 1.seconds))
+    params.disconnectPeerAboveRateLimit = true
+    check params.validateParameters().isOk()
+
 suite "TopicParams validation":
   proc newDefaultValidTopicParams(): TopicParams =
     TopicParams.init()

--- a/tests/libp2p/pubsub/utils.nim
+++ b/tests/libp2p/pubsub/utils.nim
@@ -203,8 +203,7 @@ proc generateNodes*(
     fanoutTTL = 1.minutes,
     maxMessageSize: int = 1024 * 1024,
     enablePX: bool = false,
-    overheadRateLimit: Opt[tuple[bytes: int, interval: Duration]] =
-      Opt.none(tuple[bytes: int, interval: Duration]),
+    overheadRateLimit: Opt[RateLimit] = Opt.none(RateLimit),
     codecs: seq[string] = @[],
     sendIDontWantOnPublish: bool = false,
     heartbeatInterval: Duration = TEST_GOSSIPSUB_HEARTBEAT_INTERVAL,


### PR DESCRIPTION
## Summary

`cbind` mounted GossipSub with the defaults, so a C host could not bound what an untrusted peer sends to it. `overheadRateLimit` stayed `Opt.none`, `disconnectPeerAboveRateLimit` stayed `false`, and `maxMessageSize` stayed at the 1 MiB pubsub default.

Part 1 bounds the per-topic queue of the module. This PR is Part 2. It bounds the ingress rate on the same path.

`Libp2pConfig` now holds one `gossipsub` sub-object instead of flat `gossipsub*` fields.

| field | meaning |
| --- | --- |
| `gossipsub.mount` | Mount GossipSub. Was `mountGossipsub`. |
| `gossipsub.triggerSelf` | Deliver locally published messages to self. Was `gossipsubTriggerSelf`. |
| `gossipsub.maxMessageSize` | Largest message accepted or sent, in bytes. 0 uses the core default. The ceiling is `MAX_GOSSIPSUB_MESSAGE_SIZE` (64 MiB). |
| `gossipsub.overheadRateLimit.bytes` | Per-peer budget of protocol-overhead bytes per interval. 0 disables the limit. |
| `gossipsub.overheadRateLimit.intervalMs` | Refill interval of that budget, up to `MAX_OVERHEAD_RATE_LIMIT_INTERVAL_MS` (1 hour). |
| `gossipsub.disconnectPeerAboveRateLimit` | Disconnect a peer that spends its budget. |

Read the last row with care. An empty bucket only increments `libp2p_gossipsub_peers_rate_limit_hits` and logs at `debug` (`gossipsub.nim:617-627`, `scoring.nim:346-357`). It does not lower the score of the peer. The budget stays a measurement until `disconnectPeerAboveRateLimit` makes it an enforcement. The field docs say so.

`maxMessageSize` needs no such caveat. It bounds `readLp` on the receive path (`pubsubpeer.nim:315`) and the send path (`pubsubpeer.nim:585`).

`parse` validates every value once, and a limit fails closed.

- A negative value on any numeric field is an error, not a silent default. A host with an arithmetic underflow must not ship a node with the defense off. This differs from the `maxConnections` convention nearby, on purpose.
- The bytes and the interval go together, or neither.
- `disconnectPeerAboveRateLimit` without a budget is an error, because it never fires.
- Any limit without `gossipsub.mount` is an error, because nothing applies it.
- The interval stops at one hour. `chronos.milliseconds` multiplies by a million with no overflow guard (`chronos/timer.nim:273-275`), and `buildffi` compiles with overflow checks on. An unbounded interval raises an `OverflowDefect` that the `except LPError` of `libp2pNew` cannot catch.
- Both ceilings are `{.ffiConst.}`. A host reads `MAX_GOSSIPSUB_MESSAGE_SIZE` and `MAX_OVERHEAD_RATE_LIMIT_INTERVAL_MS` from `libp2p.h` instead of an error string.

## Affected Areas

- [x] Gossipsub
  `GossipSubParams.overheadRateLimit` changes from `Opt[tuple[bytes: int, interval: Duration]]` to `Opt[RateLimit]`, where `RateLimit` is a new exported object with the same two fields. The named type stops a silent field swap. No scoring, validation or peer-handling logic changes. `pubsub.nim` gains one exported const, `DefaultPubSubMaxMessageSize`, which replaces the `1024 * 1024` literal in `PubSub.init` so cbind stops the copy.

- [ ] Transports

- [ ] Peer Management / Discovery

- [ ] Protocol Logic

- [ ] Build / Tooling

- [x] Other
  C bindings (`cbind/`): the new `GossipsubConfig` and `RateLimitConfig` FFI types, the `ParsedGossipsub` parse result, the hand-maintained `libp2p_config` C mirror, and the `gossipsub.c` example.

## Compatibility & Downstream Validation

Reference PRs / branches / commits demonstrating successful integration:

- **Nimbus:** check needed. The project breaks only if it sets `overheadRateLimit`.
- **Waku:** check needed. Same condition.
- **Codex:** check needed. Same condition.

The `cbind/` changes reach none of these projects.

## Impact on Library Users

Nim API, breaking: a caller that writes `overheadRateLimit = Opt.some((bytes, interval))` must write `overheadRateLimit = Opt.some(RateLimit(bytes: bytes, interval: interval))`. Field access and behaviour stay the same. `DefaultPubSubMaxMessageSize` is new and exported. No default moves.

C hosts, breaking: the layout of `Libp2pConfig` changes, and `mountGossipsub` and `gossipsubTriggerSelf` move to `gossipsub.mount` and `gossipsub.triggerSelf`. A host must regenerate `c_bindings/libp2p.h` and rebuild. A zero-filled config still behaves as it does today, with no rate limit and 1 MiB messages.

## Risk Assessment

Backward compatibility: two breaking renames, one in the Nim API and one in the C config layout. Both fail at compile time, so neither fails silently.

Network behaviour: unchanged until a host opts in. With `disconnectPeerAboveRateLimit` set, the node disconnects a peer over budget, so a budget that is too tight drops honest peers. That flag needs an explicit budget, which keeps the choice deliberate.

Performance: one token bucket per peer, and only when the host sets a budget.

Security: a host can now bound the size of a single inbound message, and it can measure or enforce the per-peer protocol overhead. Two judgment calls are mine and need your review. The 64 MiB message ceiling matches the `MaxReadBytes` cap on stream reads. The one-hour interval ceiling keeps `chronos.milliseconds` from an overflow.

## References

Part 1 of this work bounds the per-topic queue of the module.

## Additional Notes

Verification: `nimble genbindings_c` and `genbindings_cddl` compile the whole binding surface and carry the nested types and the two constants. `nimble examples` built and ran all six examples, and `gossipsub` delivered its message with the limits active. A throwaway C probe confirmed nine cases: six rejected combinations return their intended error, and two valid configs start. `test_gossipsub` (31 tests) and `test_gossipsub_scoring` (11 tests) pass with the `RateLimit` object.

Known gap: no automated test covers the validation rules, because `cbind/` has no test target. `cbindings.yml` builds and runs the examples only. A probe outside the repo covers the six error paths. A cbind test target is worth the work, and it stays out of this PR on purpose.

The `gossipsub.c` example sets a 1 MiB message cap and 64 KiB of overhead per second per peer. It leaves enforcement off so a slow CI runner cannot drop its own peer.
