### PR TITLE
fix(service-disco): initialise the network size estimator

### DIFF
--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -150,6 +150,28 @@ proc maintainBuckets(kad: KadDHT) {.async: (raises: [CancelledError]).} =
       kad.config.bucketRefreshTime
     )
 
+proc initKadBase*(
+    kad: KadDHT, switch: Switch, config: KadDHTConfig, rng: Rng, isServer: bool
+) {.raises: [].} =
+  ## Set the shared fields in one place, so a new base field cannot miss a constructor.
+  kad.rng = rng
+  kad.switch = switch
+  kad.rtable = RoutingTable.new(
+    switch.peerInfo.peerId.toKey(),
+    config = RoutingTableConfig.new(
+      replication = config.replication,
+      usefulnessGracePeriod = config.usefulnessGracePeriod,
+      bucketStaleTime = config.bucketStaleTime,
+    ),
+  )
+  kad.config = config
+  kad.providerManager =
+    ProviderManager.new(config.providerRecordCapacity, config.providedKeyCapacity)
+  kad.nsEstimator = NetworkSizeEstimator.new(config.replication)
+  kad.rpcSem = newAsyncSemaphore(config.limits.maxConcurrentRpcs)
+  kad.probeSem = newAsyncSemaphore(config.limits.maxConcurrentProbes)
+  kad.isServer = isServer
+
 # K instead of T to avoid clashing with the T type param in withValue[T] when
 # called inside a withValue block, which causes a compiler error under --lineDir:on
 proc new*(
@@ -161,26 +183,8 @@ proc new*(
     isServer: bool = true,
     codec: string = KadCodec,
 ): K {.raises: [].} =
-  var rtable = RoutingTable.new(
-    switch.peerInfo.peerId.toKey(),
-    config = RoutingTableConfig.new(
-      replication = config.replication,
-      usefulnessGracePeriod = config.usefulnessGracePeriod,
-      bucketStaleTime = config.bucketStaleTime,
-    ),
-  )
-  let kad = K(
-    rng: rng,
-    switch: switch,
-    rtable: rtable,
-    config: config,
-    providerManager:
-      ProviderManager.new(config.providerRecordCapacity, config.providedKeyCapacity),
-    nsEstimator: NetworkSizeEstimator.new(config.replication),
-    rpcSem: newAsyncSemaphore(config.limits.maxConcurrentRpcs),
-    probeSem: newAsyncSemaphore(config.limits.maxConcurrentProbes),
-    isServer: isServer,
-  )
+  let kad = K()
+  kad.initKadBase(switch, config, rng, isServer)
 
   # Fill up buckets with initial bootstrap nodes
   kad.updatePeers(bootstrapNodes)

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -75,32 +75,15 @@ proc new*(
     discoConfig: ServiceDiscoveryConfig = ServiceDiscoveryConfig.new(),
     xprPublishing: bool = true,
 ): T {.raises: [].} =
-  var rtable = RoutingTable.new(
-    switch.peerInfo.peerId.toKey(),
-    config = RoutingTableConfig.new(
-      replication = config.replication,
-      usefulnessGracePeriod = config.usefulnessGracePeriod,
-      bucketStaleTime = config.bucketStaleTime,
-    ),
-  )
-
   let disco = ServiceDiscovery(
-    rng: rng,
-    switch: switch,
-    rtable: rtable,
-    config: config,
-    providerManager:
-      ProviderManager.new(config.providerRecordCapacity, config.providedKeyCapacity),
-    rpcSem: newAsyncSemaphore(config.limits.maxConcurrentRpcs),
-    probeSem: newAsyncSemaphore(config.limits.maxConcurrentProbes),
     rtManager: ServiceRoutingTableManager.new(),
-    isServer: not client,
     advertiser: Advertiser.new(),
     registrar: Registrar.new(discoConfig.advertCacheCap),
     services: toHashSet(services),
     discoConfig: discoConfig,
     xprPublishing: xprPublishing,
   )
+  disco.initKadBase(switch, config, rng, isServer = not client)
 
   # Fill up buckets with initial bootstrap nodes
   disco.updatePeers(bootstrapNodes)

--- a/tests/libp2p/service_discovery/component/test_add_provider.nim
+++ b/tests/libp2p/service_discovery/component/test_add_provider.nim
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+{.used.}
+
+import chronos
+import ../../../../libp2p/protocols/kademlia
+import ../../../tools/[lifecycle, unittest]
+import ../utils
+
+suite "Service Discovery Component - Add Provider":
+  teardown:
+    checkTrackers()
+
+  asyncTest "provide a key from a service discovery node":
+    let nodes = setupServiceDiscoveryNodes(2)
+    startAndDeferStop(nodes)
+    await connect(nodes[0], nodes[1])
+
+    await nodes[0].startProviding(nodes[1].rtable.selfId.toCid())
+
+    checkUntilTimeout:
+      nodes[1].providerManager.providerRecords.len == 1
+      nodes[0].providerManager.providedKeys.len == 1


### PR DESCRIPTION
## Summary

`ServiceDiscovery.new` built the `KadDHT` base object field by field and missed `nsEstimator`. `KadDHT.new` set that field, so only a node that mounts service discovery carried a nil estimator.

Every provider path reads the estimator, so a provide on such a node segfaults:

- `addProvider` calls `kad.nsEstimator.networkSize()` at `libp2p/protocols/kademlia/provider.nim:314`.
- `maybeTrackNetsize` calls `kad.nsEstimator.track()` at `libp2p/protocols/kademlia/provider.nim:252`.

The crash happens with `optimisticProvide` on and off, because `maybeTrackNetsize` runs on both branches. This is the downstream trace, from the logos-libp2p-module tutorial job, which calls `startProviding` through the C bindings on a node that mounts service discovery:

```
cbind/libp2p.nim(852) libp2pKadStartProviding
libp2p/protocols/kademlia/provider.nim(339) startProviding
libp2p/protocols/kademlia/provider.nim(314) addProvider
libp2p/protocols/kademlia/netsize.nim(89) networkSize
SIGSEGV: Illegal storage access. (Attempt to read from nil?)
```

Two constructors that build the same base object are the reason one field went missing, so the fix removes the duplication instead of patching one line. `initKadBase` in `libp2p/protocols/kademlia.nim` now sets every shared field, including the routing table both constructors built from the same three config values. `KadDHT.new` and `ServiceDiscovery.new` both call it, and `ServiceDiscovery.new` keeps only its own fields. The next base field reaches both protocols on its own.

## Affected Areas

- [x] Peer Management / Discovery
- [x] Protocol Logic

`KadDHT` and `ServiceDiscovery` construction, and the Kademlia provider paths a service discovery node reaches.

## Compatibility & Downstream Validation

The signatures of `KadDHT.new` and `ServiceDiscovery.new` do not change, and `initKadBase` sets the same fields to the same values the two constructors set before, so no downstream project needs an adaptation.

- **Nimbus:** not run. The diff changes no `KadDHT.new` behaviour, so a Nimbus node observes no difference.
- **Waku:** not run. Same reason.
- **Codex:** not run. Same reason.
- **logos-libp2p-module:** the consumer that hit the crash. Its tutorial job segfaults on the current `master` pin. See https://github.com/logos-co/logos-libp2p-module/pull/99.

## Impact on Library Users

No API change. A `ServiceDiscovery` node now provides keys instead of crashing. A user who avoided `startProviding` and `addProvider` on a service discovery node to dodge the crash can drop that workaround.

## Risk Assessment

Low. `initKadBase` assigns the fields the two constructors assigned inline, with the same expressions. The estimator starts empty, so `networkSize` returns "not enough data" until enough lookups converge, which is the state a plain `KadDHT` node already starts in. The new indirection runs one time per node, at construction.

The refactor touches `KadDHT.new`, which every Kademlia user reaches, so the field-by-field diff is worth a close read.

## References

- https://github.com/logos-co/logos-libp2p-module/pull/99 — the PR that hits the crash.
- #2911 — added the estimator and the optimistic provide path.

## Additional Notes

`tests/libp2p/service_discovery/component/test_add_provider.nim` provides a key between two service discovery nodes, which is the shortest path to the same crash. It reproduces the SIGSEGV on `master` and passes with the fix.