### PR TITLE
fix(service-disco): validate advert length and re-check client mode

### DIFF
--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -919,6 +919,8 @@ proc libp2pServiceDiscoStartAdvertising*(
   ## node's record. A non-empty `advertisement` is a signed extended peer record,
   ## published verbatim instead of this node's own record; it fails when that
   ## record does not decode, is oversized, or does not list `serviceId`.
+  ## A service that is already advertised fails here: stop it first, then start
+  ## it again with the new advertisement.
   let disco = resolveServiceDiscovery(lib).valueOr:
     return err(error)
 

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import chronos, chronicles, results, sets
+import chronos, chronicles, results, sets, tables, sequtils
 import ../utils/[heartbeat, future]
 import ../[peerid, switch, multihash, peerinfo, extended_peer_record]
 import ./kademlia
@@ -92,7 +92,12 @@ proc new*(
     if disco.config.disableBootstrapping:
       return
 
-    disco.serviceBootstrapFuts.trackFut(disco.bootstrapServiceTable(serviceId))
+    disco.serviceBootstrapFuts[serviceId] = disco.bootstrapServiceTable(serviceId)
+
+  disco.rtManager.onServiceTableRemoved = proc(serviceId: ServiceId) =
+    disco.serviceBootstrapFuts.withValue(serviceId, fut):
+      fut[].cancelSoon()
+    disco.serviceBootstrapFuts.del(serviceId)
 
   disco.codec = codec
 
@@ -178,7 +183,7 @@ method stop*(disco: ServiceDiscovery) {.async: (raises: []).} =
   await disco.advertiser.clear()
 
   let serviceBootstrapFuts = move disco.serviceBootstrapFuts
-  await noCancel serviceBootstrapFuts.cancelAndWait()
+  await noCancel serviceBootstrapFuts.values.toSeq().cancelAndWait()
 
   if not disco.selfSignedPeerRecordLoop.isNil:
     await disco.selfSignedPeerRecordLoop.cancelAndWait()

--- a/libp2p/protocols/service_discovery/advertiser.nim
+++ b/libp2p/protocols/service_discovery/advertiser.nim
@@ -49,6 +49,13 @@ proc getAdvertBytes(disco: ServiceDiscovery, explicit: Opt[seq[byte]]): Opt[seq[
     return Opt.none(seq[byte])
   Opt.some(extRecord.encode())
 
+proc advertFor(disco: ServiceDiscovery, serviceId: ServiceId): seq[byte] =
+  ## The caller's own bytes when it supplied them, this node's record otherwise.
+  if serviceId in disco.advertiser.providedAdverts:
+    return disco.advertiser.providedAdverts.getOrDefault(serviceId)
+
+  disco.getAdvertBytes(Opt.none(seq[byte])).get(@[])
+
 proc advertiseToRegistrar*(
   disco: ServiceDiscovery,
   serviceId: ServiceId,
@@ -60,6 +67,10 @@ proc advertiseToRegistrar*(
 proc startLocalRegistration(disco: ServiceDiscovery) =
   ## Starts (or restarts) the single long-lived local self-registration task.
 
+  if not disco.isServer:
+    trace "not registering locally while in client mode"
+    return
+
   if not disco.localRegistrationLoop.isNil and not disco.localRegistrationLoop.finished:
     return
   if disco.services.len == 0:
@@ -68,12 +79,7 @@ proc startLocalRegistration(disco: ServiceDiscovery) =
   let someService = disco.services.toSeq()[0]
   let sid = someService.id.hashServiceId()
 
-  let advertBytes = (
-    if sid in disco.advertiser.providedAdverts:
-      disco.advertiser.providedAdverts.getOrDefault(sid)
-    else:
-      disco.getAdvertBytes(Opt.none(seq[byte])).get(@[])
-  )
+  let advertBytes = disco.advertFor(sid)
   if advertBytes.len == 0:
     return
 
@@ -101,6 +107,10 @@ proc maintainRegistrations*(
   ## maintenance loop can rotate the slot to another peer in the bucket.
 
   cleanupFinishedTasks(disco.advertiser)
+
+  if not disco.isServer:
+    trace "no registration maintenance while in client mode"
+    return
 
   let selfPeer = disco.switch.peerInfo.peerId
 
@@ -146,12 +156,7 @@ proc maintainRegistrations*(
         if pid notin active and pid != selfPeer:
           candidates.add(pid)
 
-      let advertBytes = (
-        if sid in disco.advertiser.providedAdverts:
-          disco.advertiser.providedAdverts.getOrDefault(sid)
-        else:
-          disco.getAdvertBytes(Opt.none(seq[byte])).get(@[])
-      )
+      let advertBytes = disco.advertFor(sid)
       if advertBytes.len == 0:
         continue
 
@@ -233,10 +238,6 @@ proc advertiseToRegistrar*(
     ticket: Opt[Ticket],
     advert: seq[byte],
 ) {.async: (raises: [CancelledError]).} =
-  if not disco.isServer:
-    debug "not advertising while in client mode", serviceId, registrar
-    return
-
   if not disco.rtManager.hasService(serviceId):
     error "no service routing table found", serviceId
     return
@@ -248,7 +249,12 @@ proc advertiseToRegistrar*(
 
   debug "registering advert", serviceId, registrar, isSelf
 
+  # `changeMode` can flip the mode at any point, so every iteration re-reads it
   while true:
+    if not disco.isServer:
+      trace "not advertising while in client mode", serviceId, registrar
+      return
+
     let response = (
       await disco.sendRegister(registrar, serviceId, advert, currentTicket)
     ).valueOr:
@@ -297,6 +303,14 @@ proc advertiseToRegistrar*(
 proc validateAdvert(advert: seq[byte], service: ServiceInfo): Result[void, string] =
   ## Applies the checks a registrar applies in `isValidAdvertisement`, so a bad
   ## record fails here instead of being republished on every rotation.
+
+  # measured before the decode, which skips (and so hides) unknown fields
+  if advert.len > MaxXPRSize:
+    return err(
+      "oversized advertisement: the encoded record must stay under " & $MaxXPRSize &
+        " bytes"
+    )
+
   let ad = Advertisement.decode(advert).valueOr:
     return err("cannot decode advertisement: " & $error)
 
@@ -310,6 +324,33 @@ proc validateAdvert(advert: seq[byte], service: ServiceInfo): Result[void, strin
     return err("advertisement does not advertise service '" & service.id & "'")
 
   ok()
+
+proc scheduleRegistrations(
+    disco: ServiceDiscovery,
+    serviceId: ServiceId,
+    table: RoutingTable,
+    advertBytes: seq[byte],
+) =
+  ## Spawns up to kRegister registration tasks per populated bucket.
+  for bucketIdx, bucket in table.buckets.pairs:
+    if bucket.peers.len == 0:
+      continue
+
+    let peers = disco.rng.pick(bucket.peers, disco.discoConfig.kRegister).valueOr:
+      continue
+
+    for peer in peers:
+      let registrar = peer.nodeId.toPeerId().valueOr:
+        error "cannot convert key to peer id", error
+        continue
+
+      let fut =
+        disco.advertiseToRegistrar(serviceId, registrar, Opt.none(Ticket), advertBytes)
+      let task = AdvertiseTask(
+        fut: fut, serviceId: serviceId, registrar: registrar, bucketIdx: bucketIdx
+      )
+      disco.advertiser.running.incl(task)
+      cd_advertiser_pending_actions.inc()
 
 proc addProvidedService*(
     disco: ServiceDiscovery,
@@ -331,7 +372,7 @@ proc addProvidedService*(
     serviceId, disco.rtable, disco.config.replication, disco.discoConfig.bucketsCount,
     Provided,
   ):
-    return ok()
+    return err("service '" & service.id & "' is already advertised, stop it first")
 
   debug "added provided service", service = service.id, serviceId
 
@@ -349,25 +390,7 @@ proc addProvidedService*(
   let advertBytes = disco.getAdvertBytes(advert).valueOr:
     return err("cannot build the extended peer record to advertise")
 
-  for bucketIdx, bucket in advTable.buckets.pairs:
-    if bucket.peers.len == 0:
-      continue
-
-    let peers = disco.rng.pick(bucket.peers, disco.discoConfig.kRegister).valueOr:
-      continue
-
-    for peer in peers:
-      let registrar = peer.nodeId.toPeerId().valueOr:
-        error "cannot convert key to peer id", error
-        continue
-
-      let fut =
-        disco.advertiseToRegistrar(serviceId, registrar, Opt.none(Ticket), advertBytes)
-      let task = AdvertiseTask(
-        fut: fut, serviceId: serviceId, registrar: registrar, bucketIdx: bucketIdx
-      )
-      disco.advertiser.running.incl(task)
-      cd_advertiser_pending_actions.inc()
+  disco.scheduleRegistrations(serviceId, advTable, advertBytes)
 
   # Ensure the single local registration loop is running.
   # We start it when we add the first provided service.

--- a/libp2p/protocols/service_discovery/advertiser.nim
+++ b/libp2p/protocols/service_discovery/advertiser.nim
@@ -51,8 +51,8 @@ proc getAdvertBytes(disco: ServiceDiscovery, explicit: Opt[seq[byte]]): Opt[seq[
 
 proc advertFor(disco: ServiceDiscovery, serviceId: ServiceId): seq[byte] =
   ## The caller's own bytes when it supplied them, this node's record otherwise.
-  if serviceId in disco.advertiser.providedAdverts:
-    return disco.advertiser.providedAdverts.getOrDefault(serviceId)
+  disco.advertiser.providedAdverts.withValue(serviceId, stored):
+    return stored[]
 
   disco.getAdvertBytes(Opt.none(seq[byte])).get(@[])
 
@@ -64,11 +64,27 @@ proc advertiseToRegistrar*(
   advert: seq[byte],
 ) {.async: (raises: [CancelledError]).}
 
+proc trackAdvertiseTask(
+    disco: ServiceDiscovery,
+    serviceId: ServiceId,
+    registrar: PeerId,
+    bucketIdx: int,
+    advertBytes: seq[byte],
+) =
+  let fut =
+    disco.advertiseToRegistrar(serviceId, registrar, Opt.none(Ticket), advertBytes)
+  disco.advertiser.running.incl(
+    AdvertiseTask(
+      fut: fut, serviceId: serviceId, registrar: registrar, bucketIdx: bucketIdx
+    )
+  )
+  cd_advertiser_pending_actions.inc()
+
 proc startLocalRegistration(disco: ServiceDiscovery) =
   ## Starts (or restarts) the single long-lived local self-registration task.
 
   if not disco.isServer:
-    trace "not registering locally while in client mode"
+    trace "not registering locally while in client mode", services = disco.services.len
     return
 
   if not disco.localRegistrationLoop.isNil and not disco.localRegistrationLoop.finished:
@@ -164,13 +180,7 @@ proc maintainRegistrations*(
         continue
 
       for registrar in toAdd:
-        let fut =
-          disco.advertiseToRegistrar(sid, registrar, Opt.none(Ticket), advertBytes)
-        let task = AdvertiseTask(
-          fut: fut, serviceId: sid, registrar: registrar, bucketIdx: bucketIdx
-        )
-        disco.advertiser.running.incl(task)
-        cd_advertiser_pending_actions.inc()
+        disco.trackAdvertiseTask(sid, registrar, bucketIdx, advertBytes)
 
   # Defensive restart of the local registration loop if it died unexpectedly
   # while we still provide services.
@@ -307,8 +317,7 @@ proc validateAdvert(advert: seq[byte], service: ServiceInfo): Result[void, strin
   # measured before the decode, which skips (and so hides) unknown fields
   if advert.len > MaxXPRSize:
     return err(
-      "oversized advertisement: the encoded record must stay under " & $MaxXPRSize &
-        " bytes"
+      "oversized advertisement: " & $advert.len & " bytes, the limit is " & $MaxXPRSize
     )
 
   let ad = Advertisement.decode(advert).valueOr:
@@ -316,8 +325,8 @@ proc validateAdvert(advert: seq[byte], service: ServiceInfo): Result[void, strin
 
   if not ad.isValid():
     return err(
-      "oversized advertisement: the record must stay under " & $MaxXPRSize &
-        " bytes and each service data under " & $MaxServiceDataSize & " bytes"
+      "invalid advertisement: the record must stay at most " & $MaxXPRSize &
+        " bytes and each service data at most " & $MaxServiceDataSize & " bytes"
     )
 
   if not ad.advertisesService(service.id.hashServiceId()):
@@ -344,13 +353,16 @@ proc scheduleRegistrations(
         error "cannot convert key to peer id", error
         continue
 
-      let fut =
-        disco.advertiseToRegistrar(serviceId, registrar, Opt.none(Ticket), advertBytes)
-      let task = AdvertiseTask(
-        fut: fut, serviceId: serviceId, registrar: registrar, bucketIdx: bucketIdx
-      )
-      disco.advertiser.running.incl(task)
-      cd_advertiser_pending_actions.inc()
+      disco.trackAdvertiseTask(serviceId, registrar, bucketIdx, advertBytes)
+
+proc undoProvidedService(
+    disco: ServiceDiscovery, service: ServiceInfo, serviceId: ServiceId
+) =
+  ## Undoes what `addProvidedService` changed before it failed, so the caller can
+  ## retry instead of meeting "already advertised" on the next attempt.
+  disco.advertiser.providedAdverts.del(serviceId)
+  disco.rtManager.removeService(serviceId, Provided)
+  disco.services.excl(service)
 
 proc addProvidedService*(
     disco: ServiceDiscovery,
@@ -374,12 +386,10 @@ proc addProvidedService*(
   ):
     return err("service '" & service.id & "' is already advertised, stop it first")
 
-  debug "added provided service", service = service.id, serviceId
-
   disco.services.incl(service)
-  cd_advertiser_services_added.inc()
 
   let advTable = disco.rtManager.getTable(serviceId).valueOr:
+    disco.undoProvidedService(service, serviceId)
     return err("routing table missing for service '" & service.id & "'")
 
   # When a caller supplied an explicit advert we store it so that future
@@ -388,7 +398,11 @@ proc addProvidedService*(
     disco.advertiser.providedAdverts[serviceId] = advert.get()
 
   let advertBytes = disco.getAdvertBytes(advert).valueOr:
+    disco.undoProvidedService(service, serviceId)
     return err("cannot build the extended peer record to advertise")
+
+  debug "added provided service", service = service.id, serviceId
+  cd_advertiser_services_added.inc()
 
   disco.scheduleRegistrations(serviceId, advTable, advertBytes)
 

--- a/libp2p/protocols/service_discovery/routing_table_manager.nim
+++ b/libp2p/protocols/service_discovery/routing_table_manager.nim
@@ -77,6 +77,8 @@ proc removeService*(
       manager.tables.del(serviceId)
       manager.serviceStatus.del(serviceId)
       manager.updateServiceTablesMetrics()
+      if not manager.onServiceTableRemoved.isNil():
+        manager.onServiceTableRemoved(serviceId)
       return
 
     if (currentStatus[], status) == (Both, Interest):

--- a/libp2p/protocols/service_discovery/types.nim
+++ b/libp2p/protocols/service_discovery/types.nim
@@ -46,6 +46,7 @@ type
     tables*: Table[ServiceId, RoutingTable]
     serviceStatus*: Table[ServiceId, ServiceStatus]
     onServiceTableCreated*: proc(serviceId: ServiceId) {.gcsafe, closure, raises: [].}
+    onServiceTableRemoved*: proc(serviceId: ServiceId) {.gcsafe, closure, raises: [].}
 
   Advertisement* = SignedExtendedPeerRecord
 
@@ -105,7 +106,7 @@ type
     refreshServiceTablesLoop*: Future[void]
     advertiserMaintenanceLoop*: Future[void]
     localRegistrationLoop*: Future[void]
-    serviceBootstrapFuts*: seq[Future[void]]
+    serviceBootstrapFuts*: Table[ServiceId, Future[void]]
 
 proc new*(
     T: typedesc[ServiceDiscoveryConfig],

--- a/tests/libp2p/service_discovery/component/test_client_mode.nim
+++ b/tests/libp2p/service_discovery/component/test_client_mode.nim
@@ -105,3 +105,25 @@ suite "Service Discovery Component - Client Mode":
     let other = makeServiceInfo("other-service")
     check advertiserNode.addProvidedService(other).isErr()
     check registrarNode.countAdsInCache(other.id.hashServiceId()) == 0
+
+  asyncTest "a downgrade to client mode ends the running registrations":
+    # a task already inside its loop stops at its next refresh
+    let conf = ServiceDiscoveryConfig.new(advertExpiry = 100.millis)
+    let advertiserNode = setupServiceDiscoveryNode(discoConfig = conf)
+    let registrarNode = setupServiceDiscoveryNode(discoConfig = conf)
+    startAndDeferStop(@[advertiserNode, registrarNode])
+    await connect(advertiserNode, registrarNode)
+
+    let service = makeServiceInfo("service")
+    let serviceId = service.id.hashServiceId()
+
+    check advertiserNode.addProvidedService(service).isOk()
+    check advertiserNode.advertiser.running.len() > 0
+    checkUntilTimeout:
+      advertiserNode.countAdsInCache(serviceId) == 1
+
+    check await advertiserNode.changeMode(isServer = false)
+
+    checkUntilTimeout:
+      advertiserNode.localRegistrationLoop.finished()
+      advertiserNode.advertiser.running.allIt(it.fut.finished())

--- a/tests/libp2p/service_discovery/test_advertiser.nim
+++ b/tests/libp2p/service_discovery/test_advertiser.nim
@@ -243,6 +243,27 @@ suite "Advertiser - removeProvidedService":
       disco.rtManager.hasService(sid2)
       disco.advertiser.running.len() == 1
 
+  asyncTest "cancels the service bootstrap future once the table is gone":
+    let disco = setupServiceDiscoveryNode()
+    let service = makeServiceInfo()
+    let sid = service.id.hashServiceId()
+
+    disco.populateRoutingTable(1)
+    check disco.addProvidedService(service).isOk()
+
+    let bootstrapFut = newFuture[void]("test service bootstrap")
+    disco.serviceBootstrapFuts[sid] = bootstrapFut
+
+    await disco.removeProvidedService(service.id)
+    check sid in disco.serviceBootstrapFuts # the local registrar still has interest
+
+    disco.unregisterInterest(service.id)
+    await sleepAsync(0.millis) # let the pending cancellation run
+
+    check:
+      sid notin disco.serviceBootstrapFuts
+      bootstrapFut.cancelled()
+
   asyncTest "removing non-existent service is a no-op":
     let disco = setupServiceDiscoveryNode()
     let service = makeServiceInfo()

--- a/tests/libp2p/service_discovery/test_advertiser.nim
+++ b/tests/libp2p/service_discovery/test_advertiser.nim
@@ -75,7 +75,7 @@ suite "Advertiser - addProvidedService":
 
     check disco.advertiser.running.len() == overpopulatedBuckets * kRegister
 
-  test "adding same service twice is idempotent":
+  asyncTest "adding the same service twice fails until it is removed":
     let disco = setupServiceDiscoveryNode()
     let service = makeServiceInfo()
     let serviceId = service.id.hashServiceId()
@@ -84,10 +84,13 @@ suite "Advertiser - addProvidedService":
     check disco.addProvidedService(service).isOk()
     let runningAfterFirst = disco.advertiser.running.len()
 
-    check disco.addProvidedService(service).isOk()
+    check disco.addProvidedService(service).isErr()
 
     check disco.rtManager.hasService(serviceId)
     check disco.advertiser.running.len() == runningAfterFirst
+
+    await disco.removeProvidedService(service.id)
+    check disco.addProvidedService(service).isOk()
 
   test "multiple distinct services each get their own routing table":
     let disco = setupServiceDiscoveryNode()
@@ -141,6 +144,63 @@ suite "Advertiser - caller-supplied advertisement":
 
     check disco.addProvidedService(service, Opt.some(advert)).isErr()
     check not disco.rtManager.hasService(service.id.hashServiceId())
+
+  test "rejects an advertisement padded past MaxXPRSize with unknown fields":
+    let disco = setupServiceDiscoveryNode()
+    let service = makeServiceInfo()
+    let advert = padAdvertisement(makeAdvertisement(service.id).encode(), MaxXPRSize)
+
+    # the decoder skips the padding, so only the incoming length rejects this
+    check advert.len > MaxXPRSize
+    check Advertisement.decode(advert).isOk()
+
+    check disco.addProvidedService(service, Opt.some(advert)).isErr()
+    check not disco.rtManager.hasService(service.id.hashServiceId())
+
+  asyncTest "a new advertisement needs a stop before a restart":
+    let disco = setupServiceDiscoveryNode()
+    let service = makeServiceInfo()
+    let serviceId = service.id.hashServiceId()
+    let first = makeAdvertisement(service.id).encode()
+    let second = makeAdvertisement(service.id).encode()
+
+    disco.populateRoutingTable(1)
+
+    check disco.startAdvertising(service, Opt.some(first)).isOk()
+    check disco.startAdvertising(service, Opt.some(second)).isErr()
+    check disco.advertiser.providedAdverts[serviceId] == first
+
+    await disco.stopAdvertising(service.id)
+
+    check disco.startAdvertising(service, Opt.some(second)).isOk()
+    check disco.advertiser.providedAdverts[serviceId] == second
+
+suite "Advertiser - maintainRegistrations":
+  teardown:
+    checkTrackers()
+
+  asyncTest "stops scheduling in client mode and resumes on an upgrade":
+    let disco = setupServiceDiscoveryNode()
+    let service = makeServiceInfo()
+
+    disco.populateAdvertisementTable(service.id.hashServiceId())
+    check disco.addProvidedService(service).isOk()
+
+    await disco.advertiser.clear()
+    await disco.localRegistrationLoop.cancelAndWait()
+    check await disco.changeMode(isServer = false)
+
+    await disco.maintainRegistrations()
+
+    check disco.advertiser.running.len() == 0
+    check disco.localRegistrationLoop.finished()
+
+    check await disco.changeMode(isServer = true)
+
+    await disco.maintainRegistrations()
+
+    check disco.advertiser.running.len() > 0
+    check not disco.localRegistrationLoop.finished()
 
 suite "Advertiser - removeProvidedService":
   teardown:

--- a/tests/libp2p/service_discovery/test_advertiser.nim
+++ b/tests/libp2p/service_discovery/test_advertiser.nim
@@ -92,6 +92,23 @@ suite "Advertiser - addProvidedService":
     await disco.removeProvidedService(service.id)
     check disco.addProvidedService(service).isOk()
 
+  test "a failed record build leaves no half-added service behind":
+    let disco = setupServiceDiscoveryNode()
+    let service = makeServiceInfo()
+    let serviceId = service.id.hashServiceId()
+
+    var addrs: seq[MultiAddress]
+    for _ in 1 .. 200: # enough that the record no longer fits MaxXPRSize
+      addrs.add(makeMultiAddress("10.0.0.1"))
+    disco.switch.peerInfo.addrs = addrs
+    check disco.record().isErr()
+
+    check disco.addProvidedService(service).isErr()
+    check not disco.rtManager.hasService(serviceId)
+
+    disco.switch.peerInfo.addrs = @[makeMultiAddress("10.0.0.1")]
+    check disco.addProvidedService(service).isOk()
+
   test "multiple distinct services each get their own routing table":
     let disco = setupServiceDiscoveryNode()
     let s1 = makeServiceInfo("svc-1")
@@ -163,6 +180,7 @@ suite "Advertiser - caller-supplied advertisement":
     let serviceId = service.id.hashServiceId()
     let first = makeAdvertisement(service.id).encode()
     let second = makeAdvertisement(service.id).encode()
+    check first != second # each helper call signs with a fresh key
 
     disco.populateRoutingTable(1)
 

--- a/tests/libp2p/service_discovery/test_advertiser.nim
+++ b/tests/libp2p/service_discovery/test_advertiser.nim
@@ -250,12 +250,13 @@ suite "Advertiser - removeProvidedService":
 
     disco.populateRoutingTable(1)
     check disco.addProvidedService(service).isOk()
+    check disco.registerInterest(service.id)
 
     let bootstrapFut = newFuture[void]("test service bootstrap")
     disco.serviceBootstrapFuts[sid] = bootstrapFut
 
     await disco.removeProvidedService(service.id)
-    check sid in disco.serviceBootstrapFuts # the local registrar still has interest
+    check sid in disco.serviceBootstrapFuts # interest keeps the table alive
 
     disco.unregisterInterest(service.id)
     await sleepAsync(0.millis) # let the pending cancellation run

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -12,6 +12,7 @@ import
     multiaddress,
     peerid,
     peerinfo,
+    protobuf/minprotobuf,
     protocols/kademlia,
     protocols/kademlia/protobuf,
     protocols/service_discovery,
@@ -100,6 +101,16 @@ proc makeOversizedAdvertisement*(
     services: @[ServiceInfo(id: serviceId, data: newSeq[byte](MaxServiceDataSize + 1))],
   )
   SignedExtendedPeerRecord.init(privateKey, extRecord).get()
+
+const UnknownEnvelopeField = 15 ## no `Envelope` field carries this number
+
+proc padAdvertisement*(advert: seq[byte], padding: int): seq[byte] =
+  ## Grows the encoded record with a field the decoder skips, so only its
+  ## incoming length reveals the padding.
+  var pb = initProtoBuffer()
+  pb.write(UnknownEnvelopeField, newSeq[byte](padding))
+  pb.finish()
+  advert & pb.buffer
 
 proc createSwitch*(
     privateKey: Opt[PrivateKey] = Opt.none(PrivateKey),

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -104,11 +104,11 @@ proc makeOversizedAdvertisement*(
 
 const UnknownEnvelopeField = 15 ## no `Envelope` field carries this number
 
-proc padAdvertisement*(advert: seq[byte], padding: int): seq[byte] =
+proc padAdvertisement*(advert: seq[byte], paddingBytes: int): seq[byte] =
   ## Grows the encoded record with a field the decoder skips, so only its
   ## incoming length reveals the padding.
   var pb = initProtoBuffer()
-  pb.write(UnknownEnvelopeField, newSeq[byte](padding))
+  pb.write(UnknownEnvelopeField, newSeq[byte](paddingBytes))
   pb.finish()
   advert & pb.buffer
 


### PR DESCRIPTION
## Summary

Applies the review comments left on https://github.com/vacp2p/nim-libp2p/pull/2917 after it merged.

`validateAdvert` decoded the caller's bytes before it measured them. The protobuf decoder skips unknown fields, and `isValid()` measures the record after a re-encode, which drops those fields again. A caller could therefore pass the FFI a valid signed record plus one large unknown padding field, clear validation, and have the node store it in `providedAdverts` and republish it to every registrar on every rotation. The length is now checked on the bytes as they arrive, before the decode, as `isValidAdvertisement` already does in `registrar.nim`.

`addProvidedService` returned `ok()` when the service was already provided, while `providedAdverts` kept the previous bytes. A caller that wanted to publish a fresh record silently kept advertising the old one. It now returns an error, so the caller stops the service and starts it again.

`advertiseToRegistrar` read `isServer` once, before its retry loop, so a task already inside the loop kept registering after `changeMode` downgraded the node. The mode is now read on every iteration. `maintainRegistrations` and `startLocalRegistration` get the same guard, and both resume when the node returns to server mode.

The last review comment, about partially changed state on an error return, does need a change after all. `addProvidedService` writes to `disco.services` and to the routing table manager, and the two error paths that follow those writes used to leave both in place. The new "already advertised" error turns that into a dead end, because the retry then fails for the wrong reason. `undoProvidedService` now reverts both writes on each of those paths, so a caller retries after it fixes the cause. `cd_advertiser_services_added` moved to the success path, so it counts only the services that the node really added.

Three cleanups came out of the same procs: `advertFor` replaces the "stored advert, else this node's record" expression that `startLocalRegistration` and `maintainRegistrations` each carried, `scheduleRegistrations` holds the per-bucket fan-out that `addProvidedService` inlined, and `trackAdvertiseTask` holds the future, the task record, the set insert and the metric that `scheduleRegistrations` and `maintainRegistrations` each repeated.

## Affected Areas

- [x] Peer Management / Discovery
  `validateAdvert`, `addProvidedService`, `advertiseToRegistrar`, `maintainRegistrations` and `startLocalRegistration` in `libp2p/protocols/service_discovery/advertiser.nim`, plus the four new private procs.

- [x] Build / Tooling
  A doc comment on `libp2pServiceDiscoStartAdvertising` in `cbind/libp2p.nim`. No generated header or CDDL schema carries this text, so nothing needs a regeneration.

## Compatibility & Downstream Validation

- **Nimbus:** N/A — does not consume service discovery.
- **Waku:** N/A — same reason.
- **Codex:** N/A — same reason.

## Impact on Library Users

`addProvidedService` and `startAdvertising` now fail on a service that is already advertised, where they used to report success. A caller that refreshes its record calls `stopAdvertising` first. C binding users meet the same rule through the error string of `libp2pServiceDiscoStartAdvertising`; the request type is unchanged.

An advertisement larger than `MaxXPRSize` on the wire is rejected where it used to be accepted. A record that fits the limit is unaffected, because the registrar applied the same bound on receipt already.

The rejection strings changed. An oversized advertisement now reports its own size next to the limit, and a record that fails `isValid()` after the decode reads "invalid advertisement" instead of the same "oversized" text. No caller matches on these strings in this repository.

## Risk Assessment

- Backward compatibility: the FFI surface is unchanged. The new "already advertised" error is the one behaviour change a caller observes.
- Network behaviour: a node that flips to client mode stops advertising within one `advertExpiry`, and resumes at the next maintenance tick after it flips back. Server-mode behaviour is unchanged.
- Security: the length check closes the path where one FFI call made the node rebroadcast unbounded caller-supplied bytes on every rotation.
- Error paths: a failed `addProvidedService` now leaves the node in the state it held before the call, so a retry behaves like a first call.
- Performance: one length compare per `startAdvertising`, and one boolean read per registration loop iteration.

## References

- Review comments: https://github.com/vacp2p/nim-libp2p/pull/2917#discussion_r3750728187, https://github.com/vacp2p/nim-libp2p/pull/2917#discussion_r3750773019, https://github.com/vacp2p/nim-libp2p/pull/2917#discussion_r3750798765, https://github.com/vacp2p/nim-libp2p/pull/2917#discussion_r3750806744
- Prior PR: https://github.com/vacp2p/nim-libp2p/pull/2917
- Issue: https://github.com/logos-co/logos-libp2p-module/issues/98

## Additional Notes

New tests: a record padded past `MaxXPRSize` with an unknown field, which still decodes, so it proves why the raw length check is needed; a second advertisement that needs a stop before a restart; a failed record build that leaves no half-added service behind; `maintainRegistrations` in both mode directions; and an end-to-end downgrade that ends the local loop and the running tasks.

The `MaxXPRSize` bound now sits in two validators, `registrar.isValidAdvertisement` and `advertiser.validateAdvert`. Merging them is worth doing, but the two run different follow-up checks, so a shared validator would change how strict the receive path is. That belongs in its own PR.

Neither validator checks that the advertised record belongs to this node. A caller can hand the FFI any validly signed extended peer record and the node registers it at every registrar, and the receive path accepts a record from a peer that does not own it. The rule has to be decided for both sides at once, so it is not in this PR.
