### PR TITLE
feat(addr-mgr): the switch owns the ObservedAddrManager

### DIFF
--- a/interop/hole-punching-v2/hole_punching.nim
+++ b/interop/hole-punching-v2/hole_punching.nim
@@ -25,7 +25,7 @@ proc createSwitch(
     config: BaseConfig, relayClient: Relay = nil, hpService: Service = nil
 ): Switch =
   var s = buildBaseSwitch(config, tcpFlags = {ServerFlags.TcpNoDelay})
-    .withObservedAddrManager(ObservedAddrManager.new(maxSize = 1, minCount = 1))
+    .withObservedAddrManager(ObservedAddrManagerConfig(maxSize: 1, minCount: 1))
     .withAutonat()
     .withCircuitRelay(relayClient)
     .build()

--- a/interop/hole-punching/hole_punching.nim
+++ b/interop/hole-punching/hole_punching.nim
@@ -132,7 +132,7 @@ proc createSwitch(
     config: BaseConfig, relayClient: Relay = nil, hpService: Service = nil
 ): Switch =
   var s = buildBaseSwitch(config, tcpFlags = {ServerFlags.TcpNoDelay})
-    .withObservedAddrManager(ObservedAddrManager.new(maxSize = 1, minCount = 1))
+    .withObservedAddrManager(ObservedAddrManagerConfig(maxSize: 1, minCount: 1))
     .withAutonat()
     .withCircuitRelay(relayClient)
     .build()

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -420,6 +420,7 @@ proc withObservedAddrManager*(
     b: SwitchBuilder, config: ObservedAddrManagerConfig
 ): SwitchBuilder =
   ## Set the thresholds of the observed address manager.
+  b.observedAddrManager = nil
   b.observedAddrConfig = Opt.some(config)
   b
 
@@ -428,6 +429,7 @@ proc withObservedAddrManager*(
 ): SwitchBuilder {.
     deprecated: "the switch owns the manager; pass an ObservedAddrManagerConfig"
 .} =
+  b.observedAddrConfig = Opt.none(ObservedAddrManagerConfig)
   b.observedAddrManager = observedAddrManager
   b
 
@@ -451,9 +453,6 @@ proc buildObservedAddrManager(b: SwitchBuilder): ObservedAddrManager =
   if b.observedAddrManager.isNil():
     return
       ObservedAddrManager.new(b.observedAddrConfig.get(ObservedAddrManagerConfig()))
-
-  if b.observedAddrConfig.isSome():
-    warn "the deprecated withObservedAddrManager(instance) drops the given config"
   b.observedAddrManager
 
 proc buildSwitch(b: SwitchBuilder): Switch {.raises: [LPError].} =

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -98,6 +98,7 @@ type
     kad: Opt[KadInfo]
     identifyPusherEnabled: bool
     observedAddrManager: ObservedAddrManager
+    observedAddrConfig: Opt[ObservedAddrManagerConfig]
     enableWildcardResolver: bool
     addressPolicy: PeerAddressPolicy
 
@@ -124,6 +125,7 @@ proc new*(T: type[SwitchBuilder]): T =
     enableWildcardResolver: true,
     addressPolicy: defaultAddressPolicy,
     addressTtls: AddressConfidenceTtls(),
+    observedAddrConfig: Opt.none(ObservedAddrManagerConfig),
   )
 
 proc withPrivateKey*(
@@ -415,8 +417,17 @@ proc withIdentifyPusher*(b: SwitchBuilder, enabled: bool = true): SwitchBuilder 
   b
 
 proc withObservedAddrManager*(
-    b: SwitchBuilder, observedAddrManager: ObservedAddrManager
+    b: SwitchBuilder, config: ObservedAddrManagerConfig
 ): SwitchBuilder =
+  ## Set the thresholds of the observed address manager.
+  b.observedAddrConfig = Opt.some(config)
+  b
+
+proc withObservedAddrManager*(
+    b: SwitchBuilder, observedAddrManager: ObservedAddrManager
+): SwitchBuilder {.
+    deprecated: "the switch owns the manager; pass an ObservedAddrManagerConfig"
+.} =
   b.observedAddrManager = observedAddrManager
   b
 
@@ -435,6 +446,15 @@ proc withPrivateAddressFilter*(b: SwitchBuilder): SwitchBuilder =
   ## - Private addresses received from other peers are discarded
   ## Circuit relay and DNS addresses are never filtered.
   b.withAddressPolicy(publicRoutableAddressPolicy)
+
+proc buildObservedAddrManager(b: SwitchBuilder): ObservedAddrManager =
+  if b.observedAddrManager.isNil():
+    return
+      ObservedAddrManager.new(b.observedAddrConfig.get(ObservedAddrManagerConfig()))
+
+  if b.observedAddrConfig.isSome():
+    warn "the deprecated withObservedAddrManager(instance) drops the given config"
+  b.observedAddrManager
 
 proc buildSwitch(b: SwitchBuilder): Switch {.raises: [LPError].} =
   if isNil(b.rng):
@@ -463,11 +483,8 @@ proc buildSwitch(b: SwitchBuilder): Switch {.raises: [LPError].} =
     announcedAddrs = b.announcedAddrs,
   )
 
-  let identify =
-    if b.observedAddrManager != nil:
-      Identify.new(peerInfo, b.sendSignedPeerRecord, b.observedAddrManager)
-    else:
-      Identify.new(peerInfo, b.sendSignedPeerRecord)
+  let observedAddrManager = b.buildObservedAddrManager()
+  let identify = Identify.new(peerInfo, b.sendSignedPeerRecord, observedAddrManager)
 
   var peerStore = block:
     b.peerStoreCapacity.withValue(capacity):
@@ -522,6 +539,7 @@ proc buildSwitch(b: SwitchBuilder): Switch {.raises: [LPError].} =
     rng: b.rng,
     muxedUpgrade: muxedUpgrade,
     services: services,
+    observedAddrManager: observedAddrManager,
   )
 
   return switch

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -1138,6 +1138,14 @@ proc matchPartial*(pat: MaPattern, address: MultiAddress): bool =
   let res = matchPart(pat, protos)
   res.flag
 
+proc hasIp*(ma: MultiAddress): bool =
+  ## Returns ``true`` if ``ma`` starts with an IP4 or IP6 component.
+  IP.matchPartial(ma)
+
+proc hasTransport*(ma: MultiAddress): bool =
+  ## Returns ``true`` if ``ma`` carries a transport, as in ``/ip4/1.2.3.4/tcp/1``.
+  Reliable.matchPartial(ma) or Unreliable.matchPartial(ma)
+
 proc `$`*(pat: MaPattern): string =
   ## Return pattern ``pat`` as string.
   var sub = newSeq[string]()

--- a/libp2p/observedaddrmanager.nim
+++ b/libp2p/observedaddrmanager.nim
@@ -7,19 +7,46 @@ import std/[sequtils, tables, sugar]
 import chronos
 import multiaddress, multicodec
 
+const
+  DefaultObservedAddrMaxSize* = 10
+  DefaultObservedAddrMinCount* = 3
+
 type
-  ## Manages observed MultiAddresses by reomte peers. It keeps track of the most observed IP and IP/Port.
+  ObservedAddrManagerConfig* = object
+    maxSize*: int = DefaultObservedAddrMaxSize
+    minCount*: int = DefaultObservedAddrMinCount
+
+  ObservedAddrManagerState = enum
+    Fresh ## accepts observations: a manager seeded before the start is valid
+    Started
+    Stopped
+
   ObservedAddrManager* = ref object of RootObj
     observedIPsAndPorts: seq[MultiAddress]
     maxSize: int
     minCount: int
+    state: ObservedAddrManagerState
+
+func namesDialableAddr(observedAddr: MultiAddress): bool =
+  # a remote peer picks what it reports, and the window holds maxSize entries,
+  # so an address which no getter can return would only evict a useful one
+  let code = (observedAddr[0].flatMap(protoCode)).valueOr:
+    return false
+  if code != multiCodec("ip4") and code != multiCodec("ip6"):
+    return false
+  observedAddr.len().get(0) > 1
 
 proc addObservation*(self: ObservedAddrManager, observedAddr: MultiAddress): bool =
   ## Adds a new observed MultiAddress. If the number of observations exceeds maxSize, the oldest one is removed.
+  ## Returns false when the manager is stopped, or when the address names no dialable address.
+  if self.state == Stopped:
+    return false
+  if not observedAddr.namesDialableAddr():
+    return false
   if self.observedIPsAndPorts.len >= self.maxSize:
     self.observedIPsAndPorts.del(0)
   self.observedIPsAndPorts.add(observedAddr)
-  return true
+  true
 
 proc getProtocol(
     self: ObservedAddrManager, observations: seq[MultiAddress], multiCodec: MultiCodec
@@ -76,11 +103,32 @@ proc guessDialableAddr*(self: ObservedAddrManager, ma: MultiAddress): MultiAddre
   return concat(observedIP, maRest).valueOr:
     ma
 
+func isStarted*(self: ObservedAddrManager): bool =
+  self.state == Started
+
+proc start*(self: ObservedAddrManager) {.async: (raises: [CancelledError]).} =
+  if self.state == Started:
+    return
+  self.state = Started
+
+proc stop*(self: ObservedAddrManager) {.async: (raises: [CancelledError]).} =
+  if self.state != Started:
+    return
+  self.state = Stopped
+  self.observedIPsAndPorts.setLen(0)
+
 proc `$`*(self: ObservedAddrManager): string =
   ## Returns a string representation of the ObservedAddrManager.
   return "IPs and Ports: " & $self.observedIPsAndPorts
 
-proc new*(T: typedesc[ObservedAddrManager], maxSize = 10, minCount = 3): T =
-  ## Creates a new ObservedAddrManager.
+proc new*(
+    T: typedesc[ObservedAddrManager],
+    maxSize = DefaultObservedAddrMaxSize,
+    minCount = DefaultObservedAddrMinCount,
+): T =
   return
     T(observedIPsAndPorts: newSeq[MultiAddress](), maxSize: maxSize, minCount: minCount)
+
+proc new*(T: typedesc[ObservedAddrManager], config: ObservedAddrManagerConfig): T =
+  ## Creates a new ObservedAddrManager from a switch-level config.
+  T.new(maxSize = config.maxSize, minCount = config.minCount)

--- a/libp2p/observedaddrmanager.nim
+++ b/libp2p/observedaddrmanager.nim
@@ -93,8 +93,9 @@ proc guessDialableAddr*(self: ObservedAddrManager, ma: MultiAddress): MultiAddre
   return concat(observedIP, maRest).valueOr:
     ma
 
-func isStarted*(self: ObservedAddrManager): bool =
-  self.started
+when defined(libp2p_testing):
+  func isStarted*(self: ObservedAddrManager): bool =
+    self.started
 
 proc start*(self: ObservedAddrManager) =
   self.started = true

--- a/libp2p/observedaddrmanager.nim
+++ b/libp2p/observedaddrmanager.nim
@@ -16,33 +16,23 @@ type
     maxSize*: int = DefaultObservedAddrMaxSize
     minCount*: int = DefaultObservedAddrMinCount
 
-  ObservedAddrManagerState = enum
-    Fresh ## accepts observations: a manager seeded before the start is valid
-    Started
-    Stopped
-
   ObservedAddrManager* = ref object of RootObj
     observedIPsAndPorts: seq[MultiAddress]
     maxSize: int
     minCount: int
-    state: ObservedAddrManagerState
-
-func namesDialableAddr(observedAddr: MultiAddress): bool =
-  # a remote peer picks what it reports, and the window holds maxSize entries,
-  # so an address which no getter can return would only evict a useful one
-  let code = (observedAddr[0].flatMap(protoCode)).valueOr:
-    return false
-  if code != multiCodec("ip4") and code != multiCodec("ip6"):
-    return false
-  observedAddr.len().get(0) > 1
+    started: bool
 
 proc addObservation*(self: ObservedAddrManager, observedAddr: MultiAddress): bool =
   ## Adds a new observed MultiAddress. If the number of observations exceeds maxSize, the oldest one is removed.
-  ## Returns false when the manager is stopped, or when the address names no dialable address.
-  if self.state == Stopped:
+  ## Returns false when the manager is not started, or when the address is not a direct IP address with a transport.
+  if not self.started:
     return false
-  if not observedAddr.namesDialableAddr():
+
+  # a remote peer picks what it reports: junk would only evict a useful entry
+  if not (observedAddr.hasIp() and observedAddr.hasTransport()) or
+      observedAddr.contains(multiCodec("p2p-circuit")).get(false):
     return false
+
   if self.observedIPsAndPorts.len >= self.maxSize:
     self.observedIPsAndPorts.del(0)
   self.observedIPsAndPorts.add(observedAddr)
@@ -104,17 +94,13 @@ proc guessDialableAddr*(self: ObservedAddrManager, ma: MultiAddress): MultiAddre
     ma
 
 func isStarted*(self: ObservedAddrManager): bool =
-  self.state == Started
+  self.started
 
-proc start*(self: ObservedAddrManager) {.async: (raises: [CancelledError]).} =
-  if self.state == Started:
-    return
-  self.state = Started
+proc start*(self: ObservedAddrManager) =
+  self.started = true
 
-proc stop*(self: ObservedAddrManager) {.async: (raises: [CancelledError]).} =
-  if self.state != Started:
-    return
-  self.state = Stopped
+proc stop*(self: ObservedAddrManager) =
+  self.started = false
   self.observedIPsAndPorts.setLen(0)
 
 proc `$`*(self: ObservedAddrManager): string =
@@ -123,12 +109,9 @@ proc `$`*(self: ObservedAddrManager): string =
 
 proc new*(
     T: typedesc[ObservedAddrManager],
-    maxSize = DefaultObservedAddrMaxSize,
-    minCount = DefaultObservedAddrMinCount,
+    config: ObservedAddrManagerConfig = ObservedAddrManagerConfig(),
 ): T =
-  return
-    T(observedIPsAndPorts: newSeq[MultiAddress](), maxSize: maxSize, minCount: minCount)
-
-proc new*(T: typedesc[ObservedAddrManager], config: ObservedAddrManagerConfig): T =
-  ## Creates a new ObservedAddrManager from a switch-level config.
-  T.new(maxSize = config.maxSize, minCount = config.minCount)
+  ## Creates a new ObservedAddrManager. A threshold below one is raised to one:
+  ## an empty window has nothing to evict, and a minCount of zero would let a
+  ## single peer decide the external address.
+  T(maxSize: max(config.maxSize, 1), minCount: max(config.minCount, 1))

--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -570,10 +570,14 @@ proc identify*(
     else:
       await noCancel stream.reset()
 
-proc getMostObservedProtosAndPorts*(self: PeerStore): seq[MultiAddress] =
+proc getMostObservedProtosAndPorts*(
+    self: PeerStore
+): seq[MultiAddress] {.deprecated: "use switch.observedAddrManager".} =
   return self.identify.observedAddrManager.getMostObservedProtosAndPorts()
 
-proc guessDialableAddr*(self: PeerStore, ma: MultiAddress): MultiAddress =
+proc guessDialableAddr*(
+    self: PeerStore, ma: MultiAddress
+): MultiAddress {.deprecated: "use switch.observedAddrManager".} =
   return self.identify.observedAddrManager.guessDialableAddr(ma)
 
 proc extend*[T](self: SeqPeerBook[T], key: PeerId, new: seq[T]) =

--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -180,7 +180,9 @@ proc schedule(
     await service.askConnectedPeers(switch)
 
 proc addressMapper(
-    self: AutonatService, peerStore: PeerStore, listenAddrs: seq[MultiAddress]
+    self: AutonatService,
+    observedAddrManager: ObservedAddrManager,
+    listenAddrs: seq[MultiAddress],
 ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
   if self.networkReachability != NetworkReachability.Reachable:
     return listenAddrs
@@ -191,7 +193,7 @@ proc addressMapper(
     try:
       if not listenAddr.isPublicMA() and
           self.networkReachability == NetworkReachability.Reachable:
-        processedMA = peerStore.guessDialableAddr(listenAddr)
+        processedMA = observedAddrManager.guessDialableAddr(listenAddr)
           # handle manual port forwarding
     except CatchableError as exc:
       debug "Error while handling address mapper", description = exc.msg
@@ -204,7 +206,7 @@ method setup*(self: AutonatService, switch: Switch) {.raises: [].} =
   self.addressMapper = proc(
       listenAddrs: seq[MultiAddress]
   ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
-    return await addressMapper(self, switch.peerStore, listenAddrs)
+    return await addressMapper(self, switch.observedAddrManager, listenAddrs)
 
   if self.askNewConnectedPeers:
     self.newConnectedPeerHandler = proc(

--- a/libp2p/protocols/connectivity/autonatv2/service.nim
+++ b/libp2p/protocols/connectivity/autonatv2/service.nim
@@ -160,10 +160,10 @@ proc askPeer(
     # the chicken-and-egg.
     var observedCandidates: seq[MultiAddress]
     for listenAddr in switch.peerInfo.listenAddrs:
-      let guessed = switch.peerStore.guessDialableAddr(listenAddr)
+      let guessed = switch.observedAddrManager.guessDialableAddr(listenAddr)
       if guessed != listenAddr:
         observedCandidates.add(guessed)
-    observedCandidates &= switch.peerStore.getMostObservedProtosAndPorts()
+    observedCandidates &= switch.observedAddrManager.getMostObservedProtosAndPorts()
 
     reqAddrs = deduplicate(observedCandidates & reqAddrs).filterIt(
         switch.peerInfo.addressPolicy(it)
@@ -223,7 +223,9 @@ proc schedule(
     await service.askConnectedPeers(switch)
 
 proc addressMapper(
-    self: AutonatV2Service, peerStore: PeerStore, listenAddrs: seq[MultiAddress]
+    self: AutonatV2Service,
+    observedAddrManager: ObservedAddrManager,
+    listenAddrs: seq[MultiAddress],
 ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
   if not self.networkReachability.isReachable():
     return listenAddrs
@@ -233,7 +235,7 @@ proc addressMapper(
     if listenAddr.isPublicMA() or not self.networkReachability.isReachable():
       addrs.add(listenAddr)
     else:
-      addrs.add(peerStore.guessDialableAddr(listenAddr))
+      addrs.add(observedAddrManager.guessDialableAddr(listenAddr))
   return addrs
 
 method setup*(self: AutonatV2Service, switch: Switch) {.raises: [].} =
@@ -242,7 +244,7 @@ method setup*(self: AutonatV2Service, switch: Switch) {.raises: [].} =
   self.addressMapper = proc(
       listenAddrs: seq[MultiAddress]
   ): Future[seq[MultiAddress]] {.async: (raises: [CancelledError]).} =
-    return await addressMapper(self, switch.peerStore, listenAddrs)
+    return await addressMapper(self, switch.observedAddrManager, listenAddrs)
 
   if self.config.askNewConnectedPeers:
     self.newConnectedPeerHandler = proc(

--- a/libp2p/protocols/connectivity/dcutr/server.nim
+++ b/libp2p/protocols/connectivity/dcutr/server.nim
@@ -34,7 +34,7 @@ proc new*(
 
       debug "Dcutr receiver received a Connect message.", connectMsg
 
-      var ourAddrs = switch.peerStore.getMostObservedProtosAndPorts()
+      var ourAddrs = switch.observedAddrManager.getMostObservedProtosAndPorts()
         # likely empty when the peer is reachable
       if ourAddrs.len == 0:
         # this list should be the same as the peer's public addrs when it is reachable;
@@ -44,7 +44,9 @@ proc new*(
           if switch.peerInfo.addrs.len > 0:
             switch.peerInfo.addrs
           else:
-            switch.peerInfo.listenAddrs.mapIt(switch.peerStore.guessDialableAddr(it))
+            switch.peerInfo.listenAddrs.mapIt(
+              switch.observedAddrManager.guessDialableAddr(it)
+            )
       var ourDialableAddrs = getHolePunchableAddrs(ourAddrs)
       if ourDialableAddrs.len == 0:
         debug "Dcutr receiver has no supported dialable addresses. Aborting Dcutr.",

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -15,7 +15,6 @@ import
   ../peerid,
   ../crypto/crypto,
   ../multiaddress,
-  ../multicodec,
   ../protocols/protocol,
   ../utils/[opt, protobuf],
   ../errors,
@@ -185,12 +184,7 @@ proc identify*(
     peer = remotePeerId
 
   identifyMsg.observedAddr.withValue(observed):
-    # Currently, we use the ObservedAddrManager only to find our dialable external NAT address. Therefore, addresses
-    # like "...\p2p-circuit\p2p\..." and "\p2p\..." are not useful to us.
-    if observed.contains(multiCodec("p2p-circuit")).get(false) or
-        P2PPattern.matchPartial(observed):
-      trace "Not adding address to ObservedAddrManager.", observed
-    elif not self.observedAddrManager.addObservation(observed):
+    if not self.observedAddrManager.addObservation(observed):
       trace "Observed address is not valid.", observedAddr = observed
 
   return makeIdentifyInfo(peer, identifyMsg)

--- a/libp2p/services/hpservice.nim
+++ b/libp2p/services/hpservice.nim
@@ -80,7 +80,7 @@ proc newConnectedPeerHandler(
       return
 
     let dcutrClient = DcutrClient.new()
-    var natAddrs = switch.peerStore.getMostObservedProtosAndPorts()
+    var natAddrs = switch.observedAddrManager.getMostObservedProtosAndPorts()
     if natAddrs.len == 0:
       # Prefer the explicit/expanded announce set when nothing has been
       # observed yet — it honors withAnnouncedAddresses and any address
@@ -89,7 +89,9 @@ proc newConnectedPeerHandler(
         if switch.peerInfo.addrs.len > 0:
           switch.peerInfo.addrs
         else:
-          switch.peerInfo.listenAddrs.mapIt(switch.peerStore.guessDialableAddr(it))
+          switch.peerInfo.listenAddrs.mapIt(
+            switch.observedAddrManager.guessDialableAddr(it)
+          )
     await dcutrClient.startSync(switch, peerId, natAddrs)
     await closeRelayConn(relayedConn)
   except CancelledError as err:

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -27,10 +27,11 @@ import
   errors,
   results,
   dialer,
+  observedaddrmanager,
   utils/future,
   crypto/rng
 
-export connmanager, upgrade, dialer, peerstore
+export connmanager, upgrade, dialer, peerstore, observedaddrmanager
 
 logScope:
   topics = "libp2p switch"
@@ -56,6 +57,7 @@ type
     dialer*: Dialer
     peerStore*: PeerStore
     nameResolver*: NameResolver
+    observedAddrManager*: ObservedAddrManager
     started: bool
     services*: seq[Service]
     rng*: Rng
@@ -354,6 +356,10 @@ proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
 
   await s.ms.stop()
 
+  # stopped last, after every component which can still observe an address
+  if not s.observedAddrManager.isNil():
+    await s.observedAddrManager.stop()
+
   s.peerStore.close()
 
   trace "Switch stopped"
@@ -365,6 +371,12 @@ proc start*(s: Switch) {.async: (raises: [CancelledError, LPError]).} =
     return
 
   debug "starting switch for peer", peerInfo = s.peerInfo
+
+  if s.observedAddrManager.isNil():
+    s.observedAddrManager = ObservedAddrManager.new()
+
+  # started first, so that identify can feed it as soon as a peer connects
+  await s.observedAddrManager.start()
 
   # start services and transports without await to prevent any
   # issues when one needs another to start first.

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -45,6 +45,9 @@ logScope:
 const ConcurrentUpgrades* = 32
 const UpgradeTimeout* = 30.seconds
 
+# a Switch built field by field, as TorSwitch and SwitchStub do, must copy it
+const MissingObservedAddrManager = "switch has no ObservedAddrManager"
+
 type
   Switch* = ref object of Dial
     peerInfo*: PeerInfo
@@ -357,8 +360,8 @@ proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
   await s.ms.stop()
 
   # stopped last, after every component which can still observe an address
-  if not s.observedAddrManager.isNil():
-    await s.observedAddrManager.stop()
+  doAssert not s.observedAddrManager.isNil(), MissingObservedAddrManager
+  s.observedAddrManager.stop()
 
   s.peerStore.close()
 
@@ -372,11 +375,9 @@ proc start*(s: Switch) {.async: (raises: [CancelledError, LPError]).} =
 
   debug "starting switch for peer", peerInfo = s.peerInfo
 
-  if s.observedAddrManager.isNil():
-    s.observedAddrManager = ObservedAddrManager.new()
-
   # started first, so that identify can feed it as soon as a peer connects
-  await s.observedAddrManager.start()
+  doAssert not s.observedAddrManager.isNil(), MissingObservedAddrManager
+  s.observedAddrManager.start()
 
   # start services and transports without await to prevent any
   # issues when one needs another to start first.

--- a/libp2p/transports/tortransport.nim
+++ b/libp2p/transports/tortransport.nim
@@ -316,6 +316,7 @@ proc new*(
       switch.ms, nil,
     ),
     nameResolver: nil,
+    observedAddrManager: switch.observedAddrManager,
   )
 
   torSwitch.connManager.peerStore = switch.peerStore

--- a/tests/libp2p/protocols/test_autonat_service.nim
+++ b/tests/libp2p/protocols/test_autonat_service.nim
@@ -181,7 +181,7 @@ suite "Autonat Service":
     check reachabilityConfidence(NetworkReachability.Reachable) == 0.3
 
     check switch1.peerInfo.addrs ==
-      switch1.peerInfo.addrs.mapIt(switch1.peerStore.guessDialableAddr(it))
+      switch1.peerInfo.addrs.mapIt(switch1.observedAddrManager.guessDialableAddr(it))
 
     await allFuturesRaising(
       switch1.stop(), switch2.stop(), switch3.stop(), switch4.stop()

--- a/tests/libp2p/protocols/test_autonat_v2_service.nim
+++ b/tests/libp2p/protocols/test_autonat_v2_service.nim
@@ -642,13 +642,19 @@ suite "AutonatV2 Service":
       switch = createSwitch(Opt.some(service))
       switches = @[createSwitch()]
 
+    await switch.start()
+
     # Simulate identify reports from other peers: the same public address
-    # must be observed at least quorum times to become a candidate.
+    # must be observed at least quorum times to become a candidate. The manager
+    # takes observations only while it runs, so the switch starts first.
     let observedAddr = MultiAddress.init("/ip4/8.8.8.8/tcp/4040").tryGet()
     for _ in 0 ..< ObservedAddrQuorum:
-      discard switch.peerStore.identify.observedAddrManager.addObservation(observedAddr)
+      check switch.observedAddrManager.addObservation(observedAddr)
 
-    await switch.startAndConnect(switches)
+    await switches.startAll()
+    for peer in switches:
+      await switch.connect(peer.peerInfo.peerId, peer.peerInfo.addrs)
+
     await client.finished
 
     let tcpPart = switch.peerInfo.listenAddrs[0][1].tryGet()

--- a/tests/libp2p/protocols/test_noise.nim
+++ b/tests/libp2p/protocols/test_noise.nim
@@ -82,6 +82,7 @@ proc makeSwitch(ma: MultiAddress, outgoing: bool, plaintext: bool = false): Swit
     peerStore: peerStore,
     dialer: dialer,
     rng: rng(),
+    observedAddrManager: identify.observedAddrManager,
   )
 
 suite "Noise":

--- a/tests/libp2p/test_observed_addr_manager.nim
+++ b/tests/libp2p/test_observed_addr_manager.nim
@@ -7,12 +7,26 @@ import chronos
 import ../../libp2p/[multiaddress, multicodec, observedaddrmanager, switch]
 import ../tools/[unittest, switch_builder, multiaddress]
 
+proc newManager(
+    maxSize = DefaultObservedAddrMaxSize, minCount = DefaultObservedAddrMinCount
+): ObservedAddrManager =
+  ObservedAddrManager.new(
+    ObservedAddrManagerConfig(maxSize: maxSize, minCount: minCount)
+  )
+
+proc newStartedManager(
+    maxSize = DefaultObservedAddrMaxSize, minCount = DefaultObservedAddrMinCount
+): ObservedAddrManager =
+  let observedAddrManager = newManager(maxSize, minCount)
+  observedAddrManager.start()
+  observedAddrManager
+
 suite "ObservedAddrManager":
   teardown:
     checkTrackers()
 
   asyncTest "Calculate the most oberserved IP correctly":
-    let observedAddrManager = ObservedAddrManager.new(minCount = 3)
+    let observedAddrManager = newStartedManager(minCount = 3)
 
     # Calculate the most oberserved IP4 correctly
     let mostObservedIP4AndPort = MultiAddress.init("/ip4/1.2.3.0/tcp/1").get()
@@ -58,7 +72,7 @@ suite "ObservedAddrManager":
         @[mostObservedIP4AndPort, mostObservedIP6AndPort]
 
   asyncTest "replace first proto value by most observed when there is only one protocol":
-    let observedAddrManager = ObservedAddrManager.new(minCount = 3)
+    let observedAddrManager = newStartedManager(minCount = 3)
     let mostObservedIP4AndPort = MultiAddress.init("/ip4/1.2.3.4/tcp/1").get()
 
     check:
@@ -69,95 +83,91 @@ suite "ObservedAddrManager":
       observedAddrManager.guessDialableAddr(MultiAddress.init("/ip4/0.0.0.0").get()) ==
         MultiAddress.init("/ip4/1.2.3.4").get()
 
-  asyncTest "an address which names no dialable address is rejected":
+  asyncTest "an address which is not a direct IP address with a transport is rejected":
     let
-      observedAddrManager = ObservedAddrManager.new(maxSize = 2, minCount = 1)
+      observedAddrManager = newStartedManager(maxSize = 2, minCount = 1)
       observed = ma("/ip4/1.2.3.4/tcp/1")
 
     check observedAddrManager.addObservation(observed)
 
-    # a peer reports what it wants, and the window is small: junk must neither
-    # be counted nor evict the useful observation
+    # the window is small: junk must neither be counted nor evict the good entry
     for _ in 0 ..< 4:
       check:
         not observedAddrManager.addObservation(ma("/dns4/example.com/tcp/1"))
         not observedAddrManager.addObservation(ma("/ip4/1.2.3.4"))
+        not observedAddrManager.addObservation(ma("/ip4/1.2.3.4/tcp/1/p2p-circuit"))
 
     check observedAddrManager.getMostObservedProtosAndPorts() == @[observed]
 
+  asyncTest "a threshold below one is raised to one":
+    let
+      observedAddrManager = newStartedManager(maxSize = 0, minCount = 0)
+      firstObserved = ma("/ip4/1.2.3.4/tcp/1")
+      lastObserved = ma("/ip4/5.6.7.8/tcp/1")
+
+    check:
+      observedAddrManager.addObservation(firstObserved)
+      observedAddrManager.addObservation(lastObserved)
+      observedAddrManager.getMostObservedProtosAndPorts() == @[lastObserved]
+
   asyncTest "a stopped manager rejects observations until it starts again":
     let
-      observedAddrManager = ObservedAddrManager.new(minCount = 1)
+      observedAddrManager = newManager(minCount = 1)
       observed = ma("/ip4/1.2.3.4/tcp/1")
 
-    await observedAddrManager.start()
+    observedAddrManager.start()
     check observedAddrManager.addObservation(observed)
 
-    await observedAddrManager.stop()
+    observedAddrManager.stop()
     check:
       not observedAddrManager.addObservation(observed)
       observedAddrManager.getMostObservedProtosAndPorts().len == 0
 
-    await observedAddrManager.start()
+    observedAddrManager.start()
     check:
       observedAddrManager.addObservation(observed)
       observedAddrManager.getMostObservedProtosAndPorts() == @[observed]
 
-    await observedAddrManager.stop()
+    observedAddrManager.stop()
 
   asyncTest "start and stop are idempotent":
     let
-      observedAddrManager = ObservedAddrManager.new(minCount = 1)
+      observedAddrManager = newManager(minCount = 1)
       observed = ma("/ip4/1.2.3.4/tcp/1")
 
-    await observedAddrManager.stop()
+    observedAddrManager.stop()
     check not observedAddrManager.isStarted()
 
-    await observedAddrManager.start()
-    await observedAddrManager.start()
+    observedAddrManager.start()
+    observedAddrManager.start()
 
     check:
       observedAddrManager.isStarted()
       observedAddrManager.addObservation(observed)
       observedAddrManager.getMostObservedProtosAndPorts() == @[observed]
 
-    await observedAddrManager.stop()
-    await observedAddrManager.stop()
+    observedAddrManager.stop()
+    observedAddrManager.stop()
 
     check:
       not observedAddrManager.isStarted()
       observedAddrManager.getMostObservedProtosAndPorts().len == 0
 
-  asyncTest "starting keeps the observations made before the start":
+  asyncTest "a manager which never started rejects observations":
     let
-      observedAddrManager = ObservedAddrManager.new(minCount = 1)
+      observedAddrManager = newManager(minCount = 1)
       observed = ma("/ip4/1.2.3.4/tcp/1")
 
+    check:
+      not observedAddrManager.isStarted()
+      not observedAddrManager.addObservation(observed)
+      observedAddrManager.getMostObservedProtosAndPorts().len == 0
+
+    observedAddrManager.start()
+
     check observedAddrManager.addObservation(observed)
-    await observedAddrManager.start()
 
-    check observedAddrManager.getMostObservedProtosAndPorts() == @[observed]
-
-    await observedAddrManager.stop()
-
-type LifecycleProbe = ref object of Service
-  ## Records the state of the manager at the moment the switch starts and stops
-  ## the services.
-  managerStartedOnServiceStart: bool
-  managerStartedOnServiceStop: bool
-
-method setup(self: LifecycleProbe, switch: Switch) {.raises: [].} =
-  discard
-
-method start(
-    self: LifecycleProbe, switch: Switch
-) {.async: (raises: [CancelledError]).} =
-  self.managerStartedOnServiceStart = switch.observedAddrManager.isStarted()
-
-method stop(
-    self: LifecycleProbe, switch: Switch
-) {.async: (raises: [CancelledError]).} =
-  self.managerStartedOnServiceStop = switch.observedAddrManager.isStarted()
+    observedAddrManager.stop()
 
 suite "Switch-owned ObservedAddrManager":
   teardown:
@@ -197,6 +207,10 @@ suite "Switch-owned ObservedAddrManager":
       firstObserved = ma("/ip4/1.2.3.4/tcp/1")
       lastObserved = ma("/ip4/5.6.7.8/tcp/1")
 
+    await switch.start()
+    defer:
+      await switch.stop()
+
     # minCount is 1, so a single observation is enough
     check:
       switch.observedAddrManager.addObservation(firstObserved)
@@ -209,7 +223,7 @@ suite "Switch-owned ObservedAddrManager":
       switch.observedAddrManager.getMostObservedProtosAndPorts() == @[lastObserved]
 
   asyncTest "the deprecated builder hook still wires the given manager":
-    let observedAddrManager = ObservedAddrManager.new(maxSize = 1, minCount = 1)
+    let observedAddrManager = newManager(maxSize = 1, minCount = 1)
 
     {.push warning[Deprecated]: off.}
     let switch = makeStandardSwitchBuilder(ma("/memorytransport/*"))
@@ -221,21 +235,16 @@ suite "Switch-owned ObservedAddrManager":
       switch.observedAddrManager == observedAddrManager
       switch.peerStore.identify.observedAddrManager == observedAddrManager
 
-  asyncTest "the manager starts before the services and stops after them":
-    let
-      switch = makeStandardSwitch(ma("/memorytransport/*"))
-      probe = LifecycleProbe()
-    switch.services.add(probe)
+  asyncTest "the switch starts and stops the manager":
+    let switch = makeStandardSwitch(ma("/memorytransport/*"))
+
+    check not switch.observedAddrManager.isStarted()
 
     await switch.start()
     check switch.observedAddrManager.isStarted()
 
     await switch.stop()
-
-    check:
-      probe.managerStartedOnServiceStart
-      probe.managerStartedOnServiceStop
-      not switch.observedAddrManager.isStarted()
+    check not switch.observedAddrManager.isStarted()
 
   asyncTest "stopping the switch drops the observations":
     let

--- a/tests/libp2p/test_observed_addr_manager.nim
+++ b/tests/libp2p/test_observed_addr_manager.nim
@@ -4,8 +4,8 @@
 {.used.}
 
 import chronos
-import ../../libp2p/[multiaddress, observedaddrmanager]
-import ../tools/[unittest]
+import ../../libp2p/[multiaddress, multicodec, observedaddrmanager, switch]
+import ../tools/[unittest, switch_builder, multiaddress]
 
 suite "ObservedAddrManager":
   teardown:
@@ -68,3 +68,193 @@ suite "ObservedAddrManager":
 
       observedAddrManager.guessDialableAddr(MultiAddress.init("/ip4/0.0.0.0").get()) ==
         MultiAddress.init("/ip4/1.2.3.4").get()
+
+  asyncTest "an address which names no dialable address is rejected":
+    let
+      observedAddrManager = ObservedAddrManager.new(maxSize = 2, minCount = 1)
+      observed = ma("/ip4/1.2.3.4/tcp/1")
+
+    check observedAddrManager.addObservation(observed)
+
+    # a peer reports what it wants, and the window is small: junk must neither
+    # be counted nor evict the useful observation
+    for _ in 0 ..< 4:
+      check:
+        not observedAddrManager.addObservation(ma("/dns4/example.com/tcp/1"))
+        not observedAddrManager.addObservation(ma("/ip4/1.2.3.4"))
+
+    check observedAddrManager.getMostObservedProtosAndPorts() == @[observed]
+
+  asyncTest "a stopped manager rejects observations until it starts again":
+    let
+      observedAddrManager = ObservedAddrManager.new(minCount = 1)
+      observed = ma("/ip4/1.2.3.4/tcp/1")
+
+    await observedAddrManager.start()
+    check observedAddrManager.addObservation(observed)
+
+    await observedAddrManager.stop()
+    check:
+      not observedAddrManager.addObservation(observed)
+      observedAddrManager.getMostObservedProtosAndPorts().len == 0
+
+    await observedAddrManager.start()
+    check:
+      observedAddrManager.addObservation(observed)
+      observedAddrManager.getMostObservedProtosAndPorts() == @[observed]
+
+    await observedAddrManager.stop()
+
+  asyncTest "start and stop are idempotent":
+    let
+      observedAddrManager = ObservedAddrManager.new(minCount = 1)
+      observed = ma("/ip4/1.2.3.4/tcp/1")
+
+    await observedAddrManager.stop()
+    check not observedAddrManager.isStarted()
+
+    await observedAddrManager.start()
+    await observedAddrManager.start()
+
+    check:
+      observedAddrManager.isStarted()
+      observedAddrManager.addObservation(observed)
+      observedAddrManager.getMostObservedProtosAndPorts() == @[observed]
+
+    await observedAddrManager.stop()
+    await observedAddrManager.stop()
+
+    check:
+      not observedAddrManager.isStarted()
+      observedAddrManager.getMostObservedProtosAndPorts().len == 0
+
+  asyncTest "starting keeps the observations made before the start":
+    let
+      observedAddrManager = ObservedAddrManager.new(minCount = 1)
+      observed = ma("/ip4/1.2.3.4/tcp/1")
+
+    check observedAddrManager.addObservation(observed)
+    await observedAddrManager.start()
+
+    check observedAddrManager.getMostObservedProtosAndPorts() == @[observed]
+
+    await observedAddrManager.stop()
+
+type LifecycleProbe = ref object of Service
+  ## Records the state of the manager at the moment the switch starts and stops
+  ## the services.
+  managerStartedOnServiceStart: bool
+  managerStartedOnServiceStop: bool
+
+method setup(self: LifecycleProbe, switch: Switch) {.raises: [].} =
+  discard
+
+method start(
+    self: LifecycleProbe, switch: Switch
+) {.async: (raises: [CancelledError]).} =
+  self.managerStartedOnServiceStart = switch.observedAddrManager.isStarted()
+
+method stop(
+    self: LifecycleProbe, switch: Switch
+) {.async: (raises: [CancelledError]).} =
+  self.managerStartedOnServiceStop = switch.observedAddrManager.isStarted()
+
+suite "Switch-owned ObservedAddrManager":
+  teardown:
+    checkTrackers()
+
+  asyncTest "the switch owns the manager and identify holds the same instance":
+    let switch = makeStandardSwitch(ma("/memorytransport/*"))
+
+    check:
+      not switch.observedAddrManager.isNil()
+      switch.peerStore.identify.observedAddrManager == switch.observedAddrManager
+
+  asyncTest "identify feeds the manager which the switch owns":
+    let
+      dialer = makeStandardSwitchBuilder(TcpAutoAddress)
+        .withObservedAddrManager(ObservedAddrManagerConfig(minCount: 1))
+        .build()
+      listener = makeStandardSwitch(TcpAutoAddress)
+
+    await allFutures(dialer.start(), listener.start())
+    defer:
+      await allFutures(dialer.stop(), listener.stop())
+
+    # the dialer identifies the listener, which reports back the address it sees
+    await dialer.connect(listener.peerInfo.peerId, listener.peerInfo.addrs)
+
+    let observed = dialer.observedAddrManager.getMostObservedProtosAndPorts()
+    check:
+      observed.len == 1
+      observed[0].contains(multiCodec("ip4")).get(false)
+
+  asyncTest "the builder config sets the thresholds":
+    let
+      switch = makeStandardSwitchBuilder(ma("/memorytransport/*"))
+        .withObservedAddrManager(ObservedAddrManagerConfig(maxSize: 2, minCount: 1))
+        .build()
+      firstObserved = ma("/ip4/1.2.3.4/tcp/1")
+      lastObserved = ma("/ip4/5.6.7.8/tcp/1")
+
+    # minCount is 1, so a single observation is enough
+    check:
+      switch.observedAddrManager.addObservation(firstObserved)
+      switch.observedAddrManager.getMostObservedProtosAndPorts() == @[firstObserved]
+
+    # maxSize is 2, so the third observation drops the first one
+    check:
+      switch.observedAddrManager.addObservation(lastObserved)
+      switch.observedAddrManager.addObservation(lastObserved)
+      switch.observedAddrManager.getMostObservedProtosAndPorts() == @[lastObserved]
+
+  asyncTest "the deprecated builder hook still wires the given manager":
+    let observedAddrManager = ObservedAddrManager.new(maxSize = 1, minCount = 1)
+
+    {.push warning[Deprecated]: off.}
+    let switch = makeStandardSwitchBuilder(ma("/memorytransport/*"))
+      .withObservedAddrManager(observedAddrManager)
+      .build()
+    {.pop.}
+
+    check:
+      switch.observedAddrManager == observedAddrManager
+      switch.peerStore.identify.observedAddrManager == observedAddrManager
+
+  asyncTest "the manager starts before the services and stops after them":
+    let
+      switch = makeStandardSwitch(ma("/memorytransport/*"))
+      probe = LifecycleProbe()
+    switch.services.add(probe)
+
+    await switch.start()
+    check switch.observedAddrManager.isStarted()
+
+    await switch.stop()
+
+    check:
+      probe.managerStartedOnServiceStart
+      probe.managerStartedOnServiceStop
+      not switch.observedAddrManager.isStarted()
+
+  asyncTest "stopping the switch drops the observations":
+    let
+      switch = makeStandardSwitch(ma("/memorytransport/*"))
+      observed = ma("/ip4/1.2.3.4/tcp/1")
+      listenAddr = ma("/ip4/0.0.0.0/tcp/80")
+
+    await switch.start()
+
+    for _ in 0 ..< 3:
+      check switch.observedAddrManager.addObservation(observed)
+
+    check:
+      switch.observedAddrManager.getMostObservedProtosAndPorts() == @[observed]
+      switch.observedAddrManager.guessDialableAddr(listenAddr) ==
+        ma("/ip4/1.2.3.4/tcp/80")
+
+    await switch.stop()
+
+    check:
+      switch.observedAddrManager.getMostObservedProtosAndPorts().len == 0
+      switch.observedAddrManager.guessDialableAddr(listenAddr) == listenAddr

--- a/tests/libp2p/transports/stream_tests.nim
+++ b/tests/libp2p/transports/stream_tests.nim
@@ -206,14 +206,13 @@ template streamTransportTest*(
     )
 
   asyncTest "Connection.reset aborts the initiator stream":
-    var serverResetDone = newFuture[void]()
+    let serverResetDone = newFuture[void]()
 
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
-      noExceptionWithStreamClose(stream):
+      noExceptionWithStreamClose(stream, serverResetDone):
         let msg = await stream.readLp(100)
         check msg == fromHex("1234")
         await stream.reset()
-        serverResetDone.complete()
 
     proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
@@ -235,10 +234,10 @@ template streamTransportTest*(
     )
 
   asyncTest "EOF handling - first readOnce at EOF + repeated reads":
-    var serverHandlerDone = newFuture[void]()
+    let serverHandlerDone = newFuture[void]()
 
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
-      noExceptionWithStreamClose(stream):
+      noExceptionWithStreamClose(stream, serverHandlerDone):
         check (await stream.readExactlyAsStr(serverMessage.len)) == serverMessage
 
         var buffer: array[1, byte]
@@ -253,8 +252,6 @@ template streamTransportTest*(
         # # Attempting readExactly at EOF
         expect LPStreamRemoteClosedError:
           await stream.readExactly(addr buffer, 1)
-
-        serverHandlerDone.complete()
 
     proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
@@ -335,10 +332,10 @@ template streamTransportTest*(
     await server.stop()
 
   asyncTest "incomplete read":
-    var serverHandlerDone = newFuture[void]()
+    let serverHandlerDone = newFuture[void]()
 
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
-      noExceptionWithStreamClose(stream):
+      noExceptionWithStreamClose(stream, serverHandlerDone):
         var buffer: array[2 * serverMessage.len, byte]
 
         expect LPStreamIncompleteError:
@@ -346,8 +343,6 @@ template streamTransportTest*(
 
         # Verify that partial data was read before EOF
         check string.fromBytes(buffer[0 ..< serverMessage.len]) == serverMessage
-
-        serverHandlerDone.complete()
 
     proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
@@ -399,16 +394,14 @@ template streamTransportTest*(
     )
 
   asyncTest "multiple empty writes before closeWrite":
-    var serverHandlerDone = newFuture[void]()
+    let serverHandlerDone = newFuture[void]()
 
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
-      noExceptionWithStreamClose(stream):
+      noExceptionWithStreamClose(stream, serverHandlerDone):
         # Even with multiple empty writes, reading should eventually get EOF
         var buffer: array[1, byte]
         let bytesRead = await stream.readOnce(addr buffer[0], 1)
         check bytesRead == 0 # Should get EOF
-
-        serverHandlerDone.complete()
 
     proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
@@ -428,16 +421,14 @@ template streamTransportTest*(
     )
 
   asyncTest "closeWrite immediately after newStream":
-    var serverHandlerDone = newFuture[void]()
+    let serverHandlerDone = newFuture[void]()
 
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
-      noExceptionWithStreamClose(stream):
+      noExceptionWithStreamClose(stream, serverHandlerDone):
         # Should get EOF immediately
         var buffer: array[1, byte]
         let bytesRead = await stream.readOnce(addr buffer[0], 1)
         check bytesRead == 0
-
-        serverHandlerDone.complete()
 
     proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
@@ -507,14 +498,13 @@ template streamTransportTest*(
     const messageSize = 2048
     const chunkSize = 256
     let message = newData(messageSize)
-    var serverHandlerDone = newFuture[void]()
+    let serverHandlerDone = newFuture[void]()
 
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
-      noExceptionWithStreamClose(stream):
+      noExceptionWithStreamClose(stream, serverHandlerDone):
         let receivedData =
           await readStreamByChunkTillEOF(stream, chunkSize, messageSize)
         check receivedData == message
-        serverHandlerDone.complete()
 
     proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
@@ -533,10 +523,10 @@ template streamTransportTest*(
     const messageSize = 2 * 1024 * 1024
     const chunkSize = 256 * 1024
     const parallelWrites = 10
-    var serverHandlerDone = newFuture[void]()
+    let serverHandlerDone = newFuture[void]()
 
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
-      noExceptionWithStreamClose(stream):
+      noExceptionWithStreamClose(stream, serverHandlerDone):
         const expectedSize = messageSize * parallelWrites
         let receivedData =
           await readStreamByChunkTillEOF(stream, chunkSize, expectedSize)
@@ -553,8 +543,6 @@ template streamTransportTest*(
             check receivedData[offset + j] == expectedValue
             if receivedData[offset + j] != expectedValue:
               break # stop on first mismatch (not to pollute stdout)
-
-        serverHandlerDone.complete()
 
     proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):

--- a/tests/libp2p/transports/stream_tests.nim
+++ b/tests/libp2p/transports/stream_tests.nim
@@ -399,12 +399,16 @@ template streamTransportTest*(
     )
 
   asyncTest "multiple empty writes before closeWrite":
+    var serverHandlerDone = newFuture[void]()
+
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         # Even with multiple empty writes, reading should eventually get EOF
         var buffer: array[1, byte]
         let bytesRead = await stream.readOnce(addr buffer[0], 1)
         check bytesRead == 0 # Should get EOF
+
+        serverHandlerDone.complete()
 
     proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
@@ -413,6 +417,7 @@ template streamTransportTest*(
         await stream.write(@[])
         await stream.write(@[])
         await stream.closeWrite()
+        await serverHandlerDone
 
     await runSingleStreamScenario(
       @[addressIP4],
@@ -423,6 +428,8 @@ template streamTransportTest*(
     )
 
   asyncTest "closeWrite immediately after newStream":
+    var serverHandlerDone = newFuture[void]()
+
     proc serverStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         # Should get EOF immediately
@@ -430,10 +437,13 @@ template streamTransportTest*(
         let bytesRead = await stream.readOnce(addr buffer[0], 1)
         check bytesRead == 0
 
+        serverHandlerDone.complete()
+
     proc clientStreamHandler(stream: MuxedStream) {.async: (raises: []).} =
       noExceptionWithStreamClose(stream):
         # Close write immediately without any data
         await stream.closeWrite()
+        await serverHandlerDone
 
     await runSingleStreamScenario(
       @[addressIP4],

--- a/tests/libp2p/transports/utils.nim
+++ b/tests/libp2p/transports/utils.nim
@@ -136,6 +136,17 @@ template noExceptionWithStreamClose*(stream: Stream, body) =
   finally:
     await noCancel stream.close()
 
+template noExceptionWithStreamClose*(stream: Stream, handlerDone: Future[void], body) =
+  ## Variant for a handler whose peer must wait for it. The scenarios tear the
+  ## connection down as soon as the client handler returns, which cancels a
+  ## server handler that still runs, so the peer awaits `handlerDone` before it
+  ## returns. The signal fires on every exit path, also on a failed check, so
+  ## the peer cannot hang and turn a failure into a timeout.
+  try:
+    noExceptionWithStreamClose(stream, body)
+  finally:
+    handlerDone.complete()
+
 proc serverHandlerSingleStream*(
     server: Transport, streamProvider: StreamProvider, handler: StreamHandler
 ) {.async: (raises: []).} =

--- a/tests/stubs/switchstub.nim
+++ b/tests/stubs/switchstub.nim
@@ -48,5 +48,6 @@ proc new*(
     dialer: switch.dialer,
     nameResolver: switch.nameResolver,
     services: switch.services,
+    observedAddrManager: switch.observedAddrManager,
     connectStub: connectStub,
   )


### PR DESCRIPTION
## Summary

First task of the [2026Q3 address manager roadmap](https://roadmap.vac.dev/p2p/ift/2026q3-nimlibp2p-addr-manager): decouple the `ObservedAddrManager`.

The manager belonged to Identify, and each consumer reached it through `switch.peerStore`. The switch now owns it as `switch.observedAddrManager`. Identify keeps a reference, and it only feeds the manager. The manager gets `start`, `stop` and `isStarted`. The switch starts it first and stops it last.

The manager also owns every rule about what a valid observation is. It takes an address which starts with ip4 or ip6, which carries a transport, and which is not relayed. Identify no longer holds a copy of that rule.

## Affected Areas

- [x] Peer Management / Discovery
  Observed addresses move from `identify.nim` and `peerstore.nim` to `switch.nim`.

- [x] Protocol Logic
  `hpservice`, the dcutr server, and both autonat services read the manager from the switch. `identify.nim` drops its own relay filter, because `addObservation` applies it.

- [x] Other
  `withObservedAddrManager` takes an `ObservedAddrManagerConfig`. `TorSwitch` copies the new field. `multiaddress.nim` gets two helpers, `hasIp` and `hasTransport`, which the manager uses to validate an observation.

## Compatibility & Downstream Validation

No downstream branch is necessary. Each old route stays as a deprecated shim. Nimbus, Waku and Codex: N/A.

## Impact on Library Users

Deprecated, but still functional: `withObservedAddrManager(instance)`, `PeerStore.guessDialableAddr` and `PeerStore.getMostObservedProtosAndPorts`.

Three behavior changes. `switch.stop()` drops the observations. `addObservation` rejects an address which does not start with ip4 or ip6, which has no transport part, or which is relayed. The manager takes an observation only while it runs, so a manager which never started, or which stopped, rejects every address.

A `Switch` built field by field must set `observedAddrManager`, and it must call `switch.start()` before the manager takes anything.

`ObservedAddrManagerConfig` raises a `maxSize` or a `minCount` below one to one. A `maxSize` of zero used to evict from an empty window on the first observation.

## Risk Assessment

The getters keep the same algorithm and the same defaults. The validation drops only an address which the getters can never return, so the announced addresses stay the same. The relay rule moves from Identify to the manager without a change of outcome, and the manager now also rejects a relayed address which carries an IP prefix.

## References

- https://roadmap.vac.dev/p2p/ift/2026q3-nimlibp2p-addr-manager (`obsaddr-decouple`)

## Additional Notes

`tests/libp2p/test_observed_addr_manager.nim` covers an end-to-end case over TCP, the start and stop order, the rejection rules, the threshold clamp, and the builder hooks.

`tests/libp2p/transports/stream_tests.nim` carries an unrelated fix for two flaky cases: `runSingleStreamScenario` stops the server as soon as the client handler returns, which cancels the server read before it can see the EOF that the test asserts. The client now waits for the server handler.
