### PR TITLE
fix(dialer): bound outbound dials so one stuck peer cannot stall the node

### DIFF
--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -76,7 +76,7 @@ proc dialAndUpgrade*(
       let dialed =
         try:
           libp2p_total_dial_attempts.inc()
-          deadline.awaitWithDeadline(transport.dial(hostname, addrs, peerId, dir))
+          transport.dial(hostname, addrs, peerId, dir).awaitWithDeadline(deadline)
         except CancelledError as e:
           trace "Dialing canceled", description = e.msg, peerId
           raise e
@@ -98,7 +98,7 @@ proc dialAndUpgrade*(
           # The if below is more general and might handle other use cases in the future.
           if dialed.dir != dir:
             dialed.dir = dir
-          deadline.awaitWithDeadline(transport.upgrade(dialed, peerId))
+          transport.upgrade(dialed, peerId).awaitWithDeadline(deadline)
         except CancelledError as e:
           await dialed.close()
           raise e
@@ -131,7 +131,7 @@ proc dialAndUpgrade*(
   return nil
 
 proc expandDnsAddr(
-    self: Dialer, peerId: Opt[PeerId], address: MultiAddress
+    self: Dialer, peerId: Opt[PeerId], address: MultiAddress, deadline: Moment
 ): Future[seq[(MultiAddress, Opt[PeerId])]] {.
     async: (raises: [CancelledError, MaError, TransportAddressError, LPError])
 .} =
@@ -142,16 +142,22 @@ proc expandDnsAddr(
     return @[]
 
   trace "Start trying to resolve addresses"
-  let
-    toResolve =
-      if peerId.isSome:
-        try:
-          address & MultiAddress.init(multiCodec("p2p"), peerId.tryGet()).tryGet()
-        except ResultError[void]:
-          raiseAssert "checked with if"
-      else:
-        address
-    resolved = await self.nameResolver.resolveDnsAddr(toResolve)
+  let toResolve =
+    if peerId.isSome:
+      try:
+        address & MultiAddress.init(multiCodec("p2p"), peerId.tryGet()).tryGet()
+      except ResultError[void]:
+        raiseAssert "checked with if"
+    else:
+      address
+  # A dnsaddr record points at more dnsaddr records, and each lookup can take
+  # seconds, so the chain answers to the dial deadline like the dial itself.
+  let resolved =
+    try:
+      self.nameResolver.resolveDnsAddr(toResolve).awaitWithDeadline(deadline)
+    except AsyncTimeoutError:
+      debug "Out of time resolving dnsaddr", ma = toResolve
+      return @[]
 
   debug "resolved addresses",
     originalAddresses = toResolve, resolvedAddresses = resolved
@@ -171,6 +177,20 @@ proc expandDnsAddr(
     else:
       addrs.add((resolvedAddress, peerId))
   addrs
+
+proc resolveWithDeadline(
+    self: Dialer, address: MultiAddress, deadline: Moment
+): Future[seq[MultiAddress]] {.
+    async: (raises: [CancelledError, MaError, TransportAddressError])
+.} =
+  ## Empty when the resolver has no answer left in the dial's budget.
+  if isNil(self.nameResolver):
+    return @[address]
+  try:
+    self.nameResolver.resolveMAddress(address).awaitWithDeadline(deadline)
+  except AsyncTimeoutError:
+    debug "Out of time resolving address", ma = address
+    @[]
 
 proc normalizedDialAddrs(
     peerId: Opt[PeerId], addrs: seq[MultiAddress]
@@ -202,16 +222,12 @@ proc dialAndUpgrade*(
       debug "Out of time for the remaining addresses", peerId, addrs = dialAddrs
       return nil
     # resolve potential dnsaddr
-    let addresses = await self.expandDnsAddr(peerId, rawAddress)
+    let addresses = await self.expandDnsAddr(peerId, rawAddress, deadline)
     for (expandedAddress, addrPeerId) in addresses:
       # DNS resolution
       let
         hostname = expandedAddress.getHostname()
-        resolvedAddresses =
-          if isNil(self.nameResolver):
-            @[expandedAddress]
-          else:
-            await self.nameResolver.resolveMAddress(expandedAddress)
+        resolvedAddresses = await self.resolveWithDeadline(expandedAddress, deadline)
 
       debug "Expanded address and hostname",
         expandedAddress = expandedAddress,
@@ -233,12 +249,6 @@ proc tryReusingConnection(self: Dialer, peerId: PeerId): Opt[Muxer] =
   trace "Reusing existing connection", muxer, direction = $muxer.connection.dir
   return Opt.some(muxer)
 
-proc release(dialLock: DialLock) {.raises: [].} =
-  try:
-    dialLock.lock.release()
-  except AsyncLockError as e:
-    raiseAssert "dial lock released without acquire: " & e.msg
-
 proc dropUser(self: Dialer, peerId: PeerId, dialLock: DialLock) {.raises: [].} =
   ## Drop the entry once nobody holds or waits for it, so the table stays bounded
   ## by the number of concurrent dials instead of by every peer ever dialed.
@@ -246,19 +256,23 @@ proc dropUser(self: Dialer, peerId: PeerId, dialLock: DialLock) {.raises: [].} =
   if dialLock.users == 0 and self.dialLocks.getOrDefault(peerId) == dialLock:
     self.dialLocks.del(peerId)
 
+proc releaseDialLock(self: Dialer, peerId: PeerId, dialLock: DialLock) {.raises: [].} =
+  try:
+    dialLock.lock.release()
+  except AsyncLockError as e:
+    raiseAssert "dial lock released without acquire: " & e.msg
+  self.dropUser(peerId, dialLock)
+
 proc acquireDialLock(
     self: Dialer, peerId: PeerId
 ): Future[DialLock] {.async: (raises: [CancelledError]).} =
   let dialLock = self.dialLocks.mgetOrPut(peerId, DialLock(lock: newAsyncLock()))
   dialLock.users.inc()
-  # Cancellation can land at the instant chronos hands the lock over, which
-  # leaves it held with no owner and stalls every later dial to this peer.
-  let acquireFut = dialLock.lock.acquire()
   try:
-    await acquireFut
+    await dialLock.lock.acquire()
   except CancelledError as e:
-    if acquireFut.completed():
-      dialLock.release()
+    # The lock is not ours: chronos leaves the waiter in the queue and skips it
+    # on the next handover.
     self.dropUser(peerId, dialLock)
     raise e
   dialLock
@@ -353,8 +367,7 @@ proc internalConnect(
   # Ensure there's only one in-flight attempt per peer
   let dialLock = await self.acquireDialLock(pid)
   defer:
-    dialLock.release()
-    self.dropUser(pid, dialLock)
+    self.releaseDialLock(pid, dialLock)
 
   await self.establishConnection(peerId, addrs, forceDial, reuseConnection, dir)
 
@@ -537,7 +550,7 @@ proc new*(
     ms: MultistreamSelect,
     nameResolver: NameResolver = nil,
     dialTimeout = DefaultDialerTimeout,
-): Dialer =
+): Dialer {.raises: [].} =
   T(
     localPeerId: localPeerId,
     connManager: connManager,

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -19,6 +19,7 @@ import
   transports/transport,
   nameresolving/nameresolver,
   upgrademngrs/upgrade,
+  utils/future,
   errors
 
 export dial, errors, results
@@ -35,15 +36,27 @@ declarePublicHistogram libp2p_dial_duration_ms,
   buckets =
     [10.0, 25.0, 50.0, 100.0, 250.0, 500.0, 1000.0, 2500.0, 5000.0, 10000.0, 30000.0]
 
-type Dialer* = ref object of Dial
-  localPeerId*: PeerId
-  connManager: ConnManager
-  dialLock: Table[PeerId, AsyncLock]
-  transports: seq[Transport]
-  peerStore: PeerStore
-  nameResolver: NameResolver
-  ms: MultistreamSelect
-  ongoingReleaseOnClose: seq[Future[void].Raising([])]
+const DefaultDialerTimeout* = 30.seconds
+  ## Budget for reaching one peer. Every address it advertises shares it, and
+  ## identify gets the same budget again once a connection stands. The transport
+  ## dial and the upgrade have no bound of their own, so without this a remote
+  ## that goes quiet mid-handshake holds the peer's dial lock forever.
+
+type
+  DialLock = ref object
+    lock: AsyncLock
+    users: int ## dials holding or waiting for `lock`
+
+  Dialer* = ref object of Dial
+    localPeerId*: PeerId
+    connManager: ConnManager
+    dialLocks: Table[PeerId, DialLock]
+    dialTimeout: Duration
+    transports: seq[Transport]
+    peerStore: PeerStore
+    nameResolver: NameResolver
+    ms: MultistreamSelect
+    ongoingReleaseOnClose: seq[Future[void].Raising([])]
 
 proc dialAndUpgrade*(
     self: Dialer,
@@ -51,6 +64,7 @@ proc dialAndUpgrade*(
     hostname: string,
     addrs: MultiAddress,
     dir = Direction.Out,
+    deadline = Moment.now() + self.dialTimeout,
 ): Future[Muxer] {.async: (raises: [CancelledError]).} =
   ## Dial one resolved transport address and upgrade it to a muxer.
   ## Returns nil when no transport can establish an upgraded connection.
@@ -62,13 +76,13 @@ proc dialAndUpgrade*(
       let dialed =
         try:
           libp2p_total_dial_attempts.inc()
-          await transport.dial(hostname, addrs, peerId, dir)
-        except CancelledError as exc:
-          trace "Dialing canceled", description = exc.msg, peerId
-          raise exc
-        except CatchableError as exc:
+          await transport.dial(hostname, addrs, peerId, dir).wait(deadline.timeLeft())
+        except CancelledError as e:
+          trace "Dialing canceled", description = e.msg, peerId
+          raise e
+        except CatchableError as e:
           debug "Dialing failed",
-            description = exc.msg, peerId = peerId, address = addrs, hostname
+            description = e.msg, peerId = peerId, address = addrs, hostname
           libp2p_failed_dials.inc()
           libp2p_dial_duration_ms.observe(
             (Moment.now() - dialStarted).milliseconds, labelValues = ["failed"]
@@ -84,16 +98,16 @@ proc dialAndUpgrade*(
           # The if below is more general and might handle other use cases in the future.
           if dialed.dir != dir:
             dialed.dir = dir
-          await transport.upgrade(dialed, peerId)
-        except CancelledError as exc:
+          await transport.upgrade(dialed, peerId).wait(deadline.timeLeft())
+        except CancelledError as e:
           await dialed.close()
-          raise exc
-        except CatchableError as exc:
+          raise e
+        except CatchableError as e:
           # If we failed to establish the connection through one transport,
           # we won't succeeded through another - no use in trying again
           await dialed.close()
           debug "Connection upgrade failed",
-            description = exc.msg, peerId, address = addrs, hostname
+            description = e.msg, peerId, address = addrs, hostname
           if dialed.dir == Direction.Out:
             libp2p_failed_upgrades_outgoing.inc()
           else:
@@ -167,17 +181,26 @@ proc normalizedDialAddrs(
     addrs
 
 proc dialAndUpgrade*(
-    self: Dialer, peerId: Opt[PeerId], addrs: seq[MultiAddress], dir = Direction.Out
+    self: Dialer,
+    peerId: Opt[PeerId],
+    addrs: seq[MultiAddress],
+    dir = Direction.Out,
+    deadline = Moment.now() + self.dialTimeout,
 ): Future[Muxer] {.
     async: (raises: [CancelledError, MaError, TransportAddressError, LPError])
 .} =
   ## Dial address candidates, resolving DNS addresses when configured.
   ## Returns the first upgraded muxer, or nil when no address succeeds.
+  ## Every candidate shares `deadline`: a peer names as many addresses as it
+  ## likes, and each one it stalls on would otherwise cost a full timeout.
 
   let dialAddrs = normalizedDialAddrs(peerId, addrs)
   debug "Dialing peer", peerId = peerId, addrs = dialAddrs
 
   for rawAddress in dialAddrs:
+    if deadline.timeLeft().isZero():
+      debug "Out of time for the remaining addresses", peerId, addrs = dialAddrs
+      return nil
     # resolve potential dnsaddr
     let addresses = await self.expandDnsAddr(peerId, rawAddress)
     for (expandedAddress, addrPeerId) in addresses:
@@ -196,7 +219,9 @@ proc dialAndUpgrade*(
         resolvedAddresses = resolvedAddresses
 
       for resolvedAddress in resolvedAddresses:
-        let mux = await self.dialAndUpgrade(addrPeerId, hostname, resolvedAddress, dir)
+        let mux = await self.dialAndUpgrade(
+          addrPeerId, hostname, resolvedAddress, dir, deadline
+        )
         if not isNil(mux):
           return mux
 
@@ -207,6 +232,105 @@ proc tryReusingConnection(self: Dialer, peerId: PeerId): Opt[Muxer] =
 
   trace "Reusing existing connection", muxer, direction = $muxer.connection.dir
   return Opt.some(muxer)
+
+proc release(dialLock: DialLock) {.raises: [].} =
+  try:
+    dialLock.lock.release()
+  except AsyncLockError as e:
+    raiseAssert "dial lock released without acquire: " & e.msg
+
+proc dropUser(self: Dialer, peerId: PeerId, dialLock: DialLock) {.raises: [].} =
+  ## Drop the entry once nobody holds or waits for it, so the table stays bounded
+  ## by the number of concurrent dials instead of by every peer ever dialed.
+  dialLock.users.dec()
+  if dialLock.users == 0 and self.dialLocks.getOrDefault(peerId) == dialLock:
+    self.dialLocks.del(peerId)
+
+proc acquireDialLock(
+    self: Dialer, peerId: PeerId
+): Future[DialLock] {.async: (raises: [CancelledError]).} =
+  let dialLock = self.dialLocks.mgetOrPut(peerId, DialLock(lock: newAsyncLock()))
+  dialLock.users.inc()
+  # Cancellation can land at the instant chronos hands the lock over, which
+  # leaves it held with no owner and stalls every later dial to this peer.
+  let acquireFut = dialLock.lock.acquire()
+  try:
+    await acquireFut
+  except CancelledError as e:
+    if acquireFut.completed():
+      dialLock.release()
+    self.dropUser(peerId, dialLock)
+    raise e
+  dialLock
+
+proc finishUpgrade(
+    self: Dialer, muxed: Muxer, dir: Direction
+) {.async: (raises: [DialFailedError, CancelledError]).} =
+  ## Store the muxer, learn who is on the other end, and announce the peer.
+  try:
+    await self.connManager.storeMuxer(muxed)
+    # Its own budget, not the dial's leftovers: the connection stands at this
+    # point, and a remote that never answers identify would otherwise hold the
+    # peer's dial lock for as long as that connection lives.
+    await self.peerStore.identify(muxed, dir).wait(self.dialTimeout)
+    await self.connManager.triggerPeerEvents(
+      muxed.connection.peerId,
+      PeerEvent(kind: PeerEventKind.Identified, initiator: true),
+    )
+  except CancelledError as e:
+    await muxed.close()
+    raise e
+  except CatchableError as e:
+    trace "Failed to finish outgoing upgrade", description = e.msg
+    await muxed.close()
+    raise newException(
+      DialFailedError, "failed finishUpgrade in establishConnection: " & e.msg, e
+    )
+
+proc establishConnection(
+    self: Dialer,
+    peerId: Opt[PeerId],
+    addrs: seq[MultiAddress],
+    forceDial: bool,
+    reuseConnection: bool,
+    dir: Direction,
+): Future[Muxer] {.async: (raises: [DialFailedError, CancelledError]).} =
+  if reuseConnection:
+    peerId.withValue(peerId):
+      self.tryReusingConnection(peerId).withValue(mux):
+        return mux
+
+  let slot =
+    try:
+      self.connManager.getOutgoingSlot(forceDial)
+    except TooManyConnectionsError as e:
+      raise newException(
+        DialFailedError, "failed getOutgoingSlot in establishConnection: " & e.msg, e
+      )
+
+  let dialAddrs = normalizedDialAddrs(peerId, addrs)
+  let muxed =
+    try:
+      await self.dialAndUpgrade(peerId, dialAddrs, dir, Moment.now() + self.dialTimeout)
+    except CancelledError as e:
+      slot.release()
+      raise e
+    except CatchableError as e:
+      slot.release()
+      raise newException(
+        DialFailedError, "failed dialAndUpgrade in establishConnection: " & e.msg, e
+      )
+  if isNil(muxed): # None of the addresses connected
+    slot.release()
+    raise newException(
+      DialFailedError,
+      "Unable to establish outgoing link in establishConnection: peer_id=" &
+        shortLog(peerId) & " addrs=" & $dialAddrs,
+    )
+
+  slot.trackMuxer(muxed)
+  await self.finishUpgrade(muxed, dir)
+  muxed
 
 proc internalConnect(
     self: Dialer,
@@ -219,70 +343,20 @@ proc internalConnect(
   if Opt.some(self.localPeerId) == peerId:
     raise newException(DialFailedError, "internalConnect can't dial self!")
 
+  # A dial without a peer id has no connection to reuse and no identity to
+  # serialize on. Sharing one lock for all of them would make an unreachable
+  # address block every other address dial.
+  let pid = peerId.valueOr:
+    return
+      await self.establishConnection(peerId, addrs, forceDial, reuseConnection, dir)
+
   # Ensure there's only one in-flight attempt per peer
-  let lock = self.dialLock.mgetOrPut(peerId.get(default(PeerId)), newAsyncLock())
-  await lock.acquire()
+  let dialLock = await self.acquireDialLock(pid)
   defer:
-    try:
-      lock.release()
-    except AsyncLockError as e:
-      raiseAssert "lock must have been acquired in line above: " & e.msg
+    dialLock.release()
+    self.dropUser(pid, dialLock)
 
-  if reuseConnection:
-    peerId.withValue(peerId):
-      self.tryReusingConnection(peerId).withValue(mux):
-        return mux
-
-  let slot =
-    try:
-      self.connManager.getOutgoingSlot(forceDial)
-    except TooManyConnectionsError as exc:
-      raise newException(
-        DialFailedError, "failed getOutgoingSlot in internalConnect: " & exc.msg, exc
-      )
-
-  let dialAddrs = normalizedDialAddrs(peerId, addrs)
-  let muxed =
-    try:
-      await self.dialAndUpgrade(peerId, dialAddrs, dir)
-    except CancelledError as exc:
-      slot.release()
-      raise exc
-    except CatchableError as exc:
-      slot.release()
-      raise newException(
-        DialFailedError, "failed dialAndUpgrade in internalConnect: " & exc.msg, exc
-      )
-  if isNil(muxed): # None of the addresses connected
-    slot.release()
-    raise newException(
-      DialFailedError,
-      "Unable to establish outgoing link in internalConnect: peer_id=" & shortLog(
-        peerId
-      ) & " addrs=" & $dialAddrs,
-    )
-
-  slot.trackMuxer(muxed)
-
-  try:
-    await self.connManager.storeMuxer(muxed)
-    await self.peerStore.identify(muxed, dir)
-    await self.connManager.triggerPeerEvents(
-      muxed.connection.peerId,
-      PeerEvent(kind: PeerEventKind.Identified, initiator: true),
-    )
-    return muxed
-  except CancelledError as exc:
-    await muxed.close()
-    raise exc
-  except CatchableError as exc:
-    trace "Failed to finish outgoing upgrade", description = exc.msg
-    await muxed.close()
-    raise newException(
-      DialFailedError,
-      "Failed to finish outgoing upgrade in internalConnect: " & exc.msg,
-      exc,
-    )
+  await self.establishConnection(peerId, addrs, forceDial, reuseConnection, dir)
 
 method connect*(
     self: Dialer,
@@ -418,12 +492,10 @@ method dial*(
 
   let dialAddrs = normalizedDialAddrs(Opt.some(peerId), addrs)
 
+  # `conn` belongs to the connection manager and carries other protocols' streams.
   proc cleanup() {.async: (raises: []).} =
     if not (isNil(stream)):
-      await stream.closeWithEOF()
-
-    if not (isNil(conn)):
-      await conn.close()
+      await stream.reset()
 
   try:
     trace "Dialing (new)", peerId, protos
@@ -464,6 +536,7 @@ proc new*(
     transports: seq[Transport],
     ms: MultistreamSelect,
     nameResolver: NameResolver = nil,
+    dialTimeout = DefaultDialerTimeout,
 ): Dialer =
   T(
     localPeerId: localPeerId,
@@ -472,4 +545,5 @@ proc new*(
     peerStore: peerStore,
     nameResolver: nameResolver,
     ms: ms,
+    dialTimeout: dialTimeout,
   )

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -76,7 +76,7 @@ proc dialAndUpgrade*(
       let dialed =
         try:
           libp2p_total_dial_attempts.inc()
-          await transport.dial(hostname, addrs, peerId, dir).wait(deadline.timeLeft())
+          deadline.awaitWithDeadline(transport.dial(hostname, addrs, peerId, dir))
         except CancelledError as e:
           trace "Dialing canceled", description = e.msg, peerId
           raise e
@@ -98,7 +98,7 @@ proc dialAndUpgrade*(
           # The if below is more general and might handle other use cases in the future.
           if dialed.dir != dir:
             dialed.dir = dir
-          await transport.upgrade(dialed, peerId).wait(deadline.timeLeft())
+          deadline.awaitWithDeadline(transport.upgrade(dialed, peerId))
         except CancelledError as e:
           await dialed.close()
           raise e

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -251,9 +251,9 @@ proc bootstrap*(
 
 proc maintainBuckets(kad: KadDHT) {.async: (raises: [CancelledError]).} =
   heartbeat "Refreshing buckets", kad.config.bucketRefreshTime, sleepFirst = true:
-    discard await kad.refreshTable(kad.rtable, false).withTimeout(
-      kad.config.bucketRefreshTime
-    )
+    let refresh = kad.refreshTable(kad.rtable, false)
+    if not await refresh.withTimeout(kad.config.bucketRefreshTime):
+      await noCancel refresh.cancelAndWait()
 
 proc initKadBase*(
     kad: KadDHT,
@@ -383,8 +383,11 @@ method start*(kad: KadDHT) {.async: (raises: [CancelledError]).} =
   kad.msgSender.start()
 
   if not kad.config.disableBootstrapping:
-    discard
-      await kad.bootstrap(forceRefresh = true).withTimeout(kad.config.bucketRefreshTime)
+    # A timed-out bootstrap keeps running and keeps dispatching RPCs unless it is
+    # cancelled here: nothing else holds it.
+    let boot = kad.bootstrap(forceRefresh = true)
+    if not await boot.withTimeout(kad.config.bucketRefreshTime):
+      await noCancel boot.cancelAndWait()
 
   kad.maintenanceLoop = kad.maintainBuckets()
   kad.livenessLoop = kad.maintainLiveness()

--- a/libp2p/protocols/kademlia/message_sender.nim
+++ b/libp2p/protocols/kademlia/message_sender.nim
@@ -70,10 +70,6 @@ func init(
 func `$`*(e: SendError): string {.raises: [].} =
   $e.stage & ": " & e.msg
 
-proc timeLeft(deadline: Moment): Duration {.raises: [].} =
-  ## Zero once the deadline passed: chronos clamps a negative `Duration`.
-  deadline - Moment.now()
-
 proc discardStream(
     ps: PeerMessageSender, stream: Stream
 ) {.async: (raises: []), gcsafe.} =

--- a/libp2p/utils/future.nim
+++ b/libp2p/utils/future.nim
@@ -38,14 +38,18 @@ template timeLeft*(deadline: Moment): Duration =
   ## Zero once the deadline passed: chronos clamps a negative `Duration`.
   deadline - Moment.now()
 
-template awaitWithDeadline*(deadline: Moment, fut: untyped): untyped =
-  ## Await `fut` with what is left of `deadline`, and raise `AsyncTimeoutError`
-  ## when nothing is left. `wait(ZeroDuration)` raises that error too, but it
-  ## leaves `fut` running with nobody to cancel or reap it.
-  let remaining = deadline.timeLeft()
-  if remaining.isZero():
+template awaitWithDeadline*(fut: untyped, deadline: Moment): untyped =
+  ## Await `fut` with what is left of `deadline`. A future that already finished
+  ## still gives its result, whatever the clock says. Otherwise, with no time
+  ## left, cancel it and raise `AsyncTimeoutError`: `wait(ZeroDuration)` raises
+  ## that error too, but it leaves `fut` running with nobody to reap it.
+  let
+    f = fut
+    remaining = deadline.timeLeft()
+  if remaining.isZero() and not f.finished():
+    await f.cancelAndWait()
     raise newException(AsyncTimeoutError, "deadline exceeded")
-  await fut.wait(remaining)
+  await f.wait(remaining)
 
 template newFutureCompleted*[T](): auto =
   let fut = newFuture[T]()

--- a/libp2p/utils/future.nim
+++ b/libp2p/utils/future.nim
@@ -34,8 +34,9 @@ proc anyCompleted*[T](
     except CatchableError:
       continue
 
-func timeLeft*(deadline: Moment): Duration =
+proc timeLeft*(deadline: Moment): Duration =
   ## Zero once the deadline passed: chronos clamps a negative `Duration`.
+  ## Not a `func`, because `Moment.now()` reads the clock.
   deadline - Moment.now()
 
 template newFutureCompleted*[T](): auto =

--- a/libp2p/utils/future.nim
+++ b/libp2p/utils/future.nim
@@ -34,6 +34,10 @@ proc anyCompleted*[T](
     except CatchableError:
       continue
 
+func timeLeft*(deadline: Moment): Duration =
+  ## Zero once the deadline passed: chronos clamps a negative `Duration`.
+  deadline - Moment.now()
+
 template newFutureCompleted*[T](): auto =
   let fut = newFuture[T]()
   fut.complete()

--- a/libp2p/utils/future.nim
+++ b/libp2p/utils/future.nim
@@ -34,10 +34,18 @@ proc anyCompleted*[T](
     except CatchableError:
       continue
 
-proc timeLeft*(deadline: Moment): Duration =
+template timeLeft*(deadline: Moment): Duration =
   ## Zero once the deadline passed: chronos clamps a negative `Duration`.
-  ## Not a `func`, because `Moment.now()` reads the clock.
   deadline - Moment.now()
+
+template awaitWithDeadline*(deadline: Moment, fut: untyped): untyped =
+  ## Await `fut` with what is left of `deadline`, and raise `AsyncTimeoutError`
+  ## when nothing is left. `wait(ZeroDuration)` raises that error too, but it
+  ## leaves `fut` running with nobody to cancel or reap it.
+  let remaining = deadline.timeLeft()
+  if remaining.isZero():
+    raise newException(AsyncTimeoutError, "deadline exceeded")
+  await fut.wait(remaining)
 
 template newFutureCompleted*[T](): auto =
   let fut = newFuture[T]()

--- a/tests/libp2p/kademlia/mock_kademlia.nim
+++ b/tests/libp2p/kademlia/mock_kademlia.nim
@@ -14,17 +14,32 @@ type MockKadDHT* = ref object of KadDHT
   handleFindNodeDelay*: Duration
   handleFindNodeCalls*: int
   handleFindNodeMalformedResponse*: bool
+  findNodeStalls*: bool
+  findNodeCancels*: int
+
+proc stallUntilCancelled(kad: MockKadDHT) {.async: (raises: [CancelledError]).} =
+  ## A lookup that only ends when the caller gives up on it.
+  let stall = Future[void].Raising([CancelledError]).init("MockKadDHT.findNode")
+  try:
+    await stall
+  except CancelledError as e:
+    kad.findNodeCancels.inc()
+    raise e
 
 method findNode*(
     kad: MockKadDHT, target: Key, rtable: RoutingTable
 ): Future[seq[PeerId]] {.async: (raises: [CancelledError]).} =
   kad.findNodeCalls.add(target)
+  if kad.findNodeStalls:
+    await kad.stallUntilCancelled()
   rtable.findClosestPeerIds(target, kad.config.replication)
 
 method findNode*(
     kad: MockKadDHT, target: Key
 ): Future[seq[PeerId]] {.async: (raises: [CancelledError]).} =
   kad.findNodeCalls.add(target)
+  if kad.findNodeStalls:
+    await kad.stallUntilCancelled()
   kad.rtable.findClosestPeerIds(target, kad.config.replication)
 
 method handleGetValue*(

--- a/tests/libp2p/kademlia/test_bootstrap.nim
+++ b/tests/libp2p/kademlia/test_bootstrap.nim
@@ -102,6 +102,35 @@ suite "KadDHT Bootstrap":
     # Self lookup + one lookup per non-empty bucket
     check kad.findNodeCalls.len == nonEmptyBucketCount + 1
 
+  asyncTest "start cancels a bootstrap that runs out of time":
+    let kad = setupMockKad()
+    kad.config.bucketRefreshTime = 200.milliseconds
+    kad.findNodeStalls = true
+    defer:
+      await stopNodes(@[kad])
+
+    # The switch starts the kad it carries, and that bootstrap stalls in
+    # findNode. Unless start cancels it, the lookup outlives the timeout.
+    await startNodes(@[kad]).wait(5.seconds)
+
+    check:
+      kad.started
+      kad.findNodeCancels == 1
+
+  asyncTest "bucket maintenance cancels a refresh that runs out of time":
+    let kad = setupMockKad()
+    kad.config.bucketRefreshTime = 200.milliseconds
+    kad.findNodeStalls = true
+    defer:
+      await stopNodes(@[kad])
+
+    await startNodes(@[kad]).wait(5.seconds)
+    let afterBootstrap = kad.findNodeCancels
+
+    # Every round would otherwise leave a lookup behind, still sending RPCs.
+    checkUntilTimeout:
+      kad.findNodeCancels > afterBootstrap
+
 suite "KadDHT Bootstrap Component":
   teardown:
     checkTrackers()

--- a/tests/libp2p/test_dialer.nim
+++ b/tests/libp2p/test_dialer.nim
@@ -3,9 +3,38 @@
 
 {.used.}
 
-import chronos, sequtils
+import chronos, sequtils, results
 import ../../libp2p/[builders, switch]
-import ../tools/[unittest, futures, switch_builder]
+import ../tools/[unittest, futures, switch_builder, crypto, multiaddress]
+
+type StallServer = ref object
+  ## A remote that accepts the connection and then never speaks, so the dialer
+  ## blocks in the security handshake with nothing to read.
+  server: StreamServer
+  accepted: seq[StreamTransport]
+  address: MultiAddress
+
+proc startStallServer(): StallServer =
+  let stall = StallServer()
+
+  proc acceptAndStall(
+      server: StreamServer, client: StreamTransport
+  ) {.async: (raises: []).} =
+    stall.accepted.add(client)
+
+  stall.server =
+    createStreamServer(initTAddress("127.0.0.1:0"), acceptAndStall, {ReuseAddr})
+  stall.server.start()
+  # `local` carries the address the socket really bound, port 0 resolved.
+  stall.address = MultiAddress.init(stall.server.local).tryGet()
+  stall
+
+proc stop(stall: StallServer) {.async: (raises: []).} =
+  # `stop2` over `stop`: the raising variant would break `raises: []` here.
+  stall.server.stop2().isOkOr:
+    raiseAssert "stall server stop failed"
+  await stall.server.closeWait()
+  await noCancel allFutures(stall.accepted.mapIt(it.closeWait()))
 
 suite "Dialer":
   teardown:
@@ -52,3 +81,60 @@ suite "Dialer":
     )
 
     await allFuturesRaising(switches.mapIt(it.stop()))
+
+  asyncTest "A stalling remote gives up at the dial timeout":
+    let
+      stall = startStallServer()
+      src = makeStandardSwitch(TcpAutoAddress)
+    await src.start()
+    defer:
+      await src.stop()
+      await stall.stop()
+
+    let dialer = Dialer.new(
+      src.peerInfo.peerId,
+      src.connManager,
+      src.peerStore,
+      src.transports,
+      src.ms,
+      dialTimeout = 1.seconds,
+    )
+    let peerId = PeerId.random(rng()).tryGet()
+
+    # Twice: the second dial only gets its turn if the first freed the peer's
+    # dial lock, which a dial that hangs never does.
+    for _ in 0 .. 1:
+      expect DialFailedError:
+        await dialer.connect(peerId, @[stall.address]).wait(10.seconds)
+
+  asyncTest "A stalling address-only dial does not block another one":
+    let
+      stall = startStallServer()
+      src = makeStandardSwitch(TcpAutoAddress)
+      dst = makeStandardSwitch(TcpAutoAddress)
+    await src.start()
+    await dst.start()
+
+    let dialer = Dialer.new(
+      src.peerInfo.peerId,
+      src.connManager,
+      src.peerStore,
+      src.transports,
+      src.ms,
+      dialTimeout = 30.seconds,
+    )
+
+    # Dials with no peer id shared one lock keyed on `default(PeerId)`, so the
+    # stalling one held up every other address the node dialed.
+    let stalling = dialer.connect(stall.address, allowUnknownPeerId = true)
+    defer:
+      await noCancel stalling.cancelAndWait()
+      await allFutures(src.stop(), dst.stop())
+      await stall.stop()
+
+    await sleepAsync(100.milliseconds) # let the stalling dial take its lock
+
+    let dialed = await dialer
+      .connect(dst.peerInfo.addrs[0], allowUnknownPeerId = true)
+      .wait(5.seconds)
+    check dialed == dst.peerInfo.peerId

--- a/tests/libp2p/test_dialer.nim
+++ b/tests/libp2p/test_dialer.nim
@@ -29,12 +29,28 @@ proc startStallServer(): StallServer =
   stall.address = MultiAddress.init(stall.server.local).tryGet()
   stall
 
+proc waitAccepted(stall: StallServer) {.async: (raises: [CancelledError]).} =
+  ## A dial holds the peer's lock once the server accepted it. A fixed delay
+  ## proves nothing: on a slow runner the next dial can start first.
+  while stall.accepted.len == 0:
+    await sleepAsync(10.milliseconds)
+
 proc stop(stall: StallServer) {.async: (raises: []).} =
   # `stop2` over `stop`: the raising variant would break `raises: []` here.
   stall.server.stop2().isOkOr:
     raiseAssert "stall server stop failed"
   await stall.server.closeWait()
   await noCancel allFutures(stall.accepted.mapIt(it.closeWait()))
+
+proc stallIdentify(sw: Switch) =
+  ## Answer everything up to identify, then go quiet. The connection stands, so
+  ## only the identify budget can end a dial to this peer.
+  proc stall(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
+    await stream.join()
+
+  for holder in sw.ms.handlers:
+    if IdentifyCodec in holder.protos:
+      holder.protocol.handler = stall
 
 suite "Dialer":
   teardown:
@@ -132,9 +148,41 @@ suite "Dialer":
       await allFutures(src.stop(), dst.stop())
       await stall.stop()
 
-    await sleepAsync(100.milliseconds) # let the stalling dial take its lock
+    await stall.waitAccepted().wait(5.seconds)
 
     let dialed = await dialer
       .connect(dst.peerInfo.addrs[0], allowUnknownPeerId = true)
       .wait(5.seconds)
     check dialed == dst.peerInfo.peerId
+
+  asyncTest "A remote that never answers identify gives up at the dial timeout":
+    let
+      src = makeStandardSwitch(TcpAutoAddress)
+      dst = makeStandardSwitch(TcpAutoAddress)
+    await src.start()
+    await dst.start()
+    dst.stallIdentify()
+    defer:
+      await allFutures(src.stop(), dst.stop())
+
+    let dialer = Dialer.new(
+      src.peerInfo.peerId,
+      src.connManager,
+      src.peerStore,
+      src.transports,
+      src.ms,
+      dialTimeout = 1.seconds,
+    )
+
+    # Twice: the second dial only gets its turn if the first freed the peer's
+    # dial lock, which identify holds for as long as the connection lives.
+    for _ in 0 .. 1:
+      expect DialFailedError:
+        await dialer
+          .connect(
+            dst.peerInfo.peerId,
+            dst.peerInfo.addrs,
+            forceDial = true,
+            reuseConnection = false,
+          )
+          .wait(10.seconds)


### PR DESCRIPTION
## Summary

An outbound dial has no deadline. `Dialer.internalConnect` takes the per-peer dial lock. It then waits for `transport.dial`, for `transport.upgrade` and for `peerStore.identify`. None of the three has a bound. The inbound path caps the same work with `UpgradeTimeout` (`switch.nim:252`). A remote that completes the transport handshake and then goes quiet parks the dial forever, and holds the peer's dial lock for the same time.

A 1000-node run showed the effect. About 400 nodes never returned from `KadDHT.bootstrap(forceRefresh = true)`. There was no error, no timeout and no retry. `-d:chronosFutureTracking` showed the queue: dials parked in `internalConnect`, more dials waited at `AsyncLock.acquire`, and `cancelAndWait` never completed, because that build dialed under `noCancel`. `lookupCheck` waits for its probe, `iterativeLookup` waits for `lookupCheck`, `refreshTable` waits for the lookup, and `bootstrap` waits for `refreshTable`.

#2901 removed the `noCancel` dial from the Kademlia RPC path. This PR fixes the dialer.

Dialer:

- `DefaultDialerTimeout` (30s) bounds one attempt to reach a peer. All addresses of that peer share the deadline, because a per-address budget multiplies by a count that the remote picks.
- `identify` gets the same budget again after the connection stands. It runs under the same lock.
- A dial without a peer id takes no lock. Such dials shared one `default(PeerId)` entry, so one dead address blocked all of them.
- `acquireDialLock` handles a cancel at the instant that chronos hands the lock over. That race left the lock held with no owner.
- Dial lock entries count their users, and the dialer drops each entry when it goes idle. The table grew with every peer id.
- A failed protocol dial no longer closes `conn`. The connection manager owns that muxer, and other protocols hold streams on it. The dialer resets the stream instead.

Kademlia:

- `start` and `maintainBuckets` cancel the refresh future when `withTimeout` fires. Both used `discard await ...withTimeout(...)`, which left the lookup alive and kept it sending RPCs.

Tests:

- Two tests in `test_dialer.nim` dial a TCP server that accepts the connection and stays silent. The first test checks that the dial gives up at the timeout, twice, which proves that it frees the lock. The second test checks that a dial without a peer id does not block a second one.

`timeLeft(deadline)` moves from `message_sender.nim` to `utils/future.nim`, because the dialer needs it too.

## Affected Areas

- [x] Peer Management / Discovery
  <!-- Kademlia start and bucket refresh no longer leak a timed-out lookup -->

- [x] Protocol Logic
  <!-- Dialer: dial deadline, identify deadline, dial lock ownership and lifetime, stream dial cleanup -->

## Compatibility & Downstream Validation

Every downstream user shares this dial path. A dial that used to hang now fails with `DialFailedError` after 30 seconds.

- **Nimbus:** N/A
- **Waku:** N/A
- **Codex:** N/A

## Impact on Library Users

No API is removed. `Dialer.new` gains an optional `dialTimeout`. Both `dialAndUpgrade` overloads gain an optional `deadline`.

- One attempt to reach a peer costs at most `DefaultDialerTimeout` for all of its addresses, plus the same again for identify. Before, each address got an unbounded attempt.
- A failed or cancelled protocol dial keeps the connection open. Streams that other protocols hold on it stay alive.
- `TorTransport` users with slow circuit setup can need a larger `dialTimeout`. `TorSwitch` builds its own `Dialer` and can pass one.

## Risk Assessment

- Backward compatibility: no signature is removed, and every new parameter has a default.
- Network behaviour: the node can now drop a peer that is slow but alive at 30 seconds. `UpgradeTimeout` already applies that value to the inbound side of the same handshake.
- Performance: one more timer per dial attempt.
- Security: a remote that does not answer can no longer hold a dial slot, a dial lock or a bootstrap for an unbounded time. It also cannot extend the hold with more addresses.

## References

- #2901 removed the `noCancel` dial from the Kademlia RPC path, and added the per-RPC deadline in `message_sender`.

## Additional Notes

`kademlia/ping.nim:14` and `service_discovery/connection.nim:30` still dial under `noCancel`. They can no longer hang forever, but a cancel there waits up to `DefaultDialerTimeout`. Take care with the service-discovery one: the `catch:` around it swallows a `CancelledError`.
