### PR TITLE
fix(autotls): checkDNSRecords retry loop

### DIFF
--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -57,18 +57,20 @@ proc checkDNSRecords*(
   let ip4Domain = api.Domain(dashedIpAddr & "." & baseDomain)
   debug "Waiting for DNS record to be set", ip = ip4Domain, acme = acmeChalDomain
 
-  var txt: seq[string]
-  var ip4: seq[TransportAddress]
-  for _ in 0 .. retries:
-    txt = await nameResolver.resolveTxt(acmeChalDomain)
+  for attempt in 0 .. retries:
+    if attempt > 0:
+      await sleepAsync(retryTime)
+
+    let txt = await nameResolver.resolveTxt(acmeChalDomain)
+    var ip4: seq[TransportAddress]
     try:
       ip4 = await nameResolver.resolveIp(ip4Domain, 0.Port)
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
       error "Failed to resolve IP", description = exc.msg # retry
-  if txt.len > 0 and txt[0] == keyAuth and ip4.len > 0:
-    return true
-  await sleepAsync(retryTime)
+
+    if txt.len > 0 and txt[0] == keyAuth and ip4.len > 0:
+      return true
 
   return false

--- a/tests/libp2p/autotls/test_utils.nim
+++ b/tests/libp2p/autotls/test_utils.nim
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import net, chronos
+import ../../../libp2p/[autotls/utils, autotls/acme/api, autotls/acme/client]
+import ../../tools/[unittest, resolver]
+
+suite "AutoTLS DNS records":
+  const
+    BaseDomain = api.Domain("k51qzi5uqu5dhkzk3z.libp2p.direct")
+    AcmeChallengeName = "_acme-challenge.k51qzi5uqu5dhkzk3z.libp2p.direct"
+    Ip4Name = "100-10-10-3.k51qzi5uqu5dhkzk3z.libp2p.direct"
+    KeyAuth = KeyAuthorization("expected-key-authorization")
+    OtherKeyAuth = KeyAuthorization("another-key-authorization")
+
+  let ipAddress = parseIpAddress("100.10.10.3")
+
+  var resolver {.threadvar.}: StubNameResolver
+
+  asyncTeardown:
+    checkTrackers()
+
+  asyncSetup:
+    resolver =
+      StubNameResolver.new(txtRecords = @[KeyAuth], ipAddresses = @["100.10.10.3"])
+
+  asyncTest "matching TXT and a published A record report the records as set":
+    let dnsSet = await checkDNSRecords(
+      resolver, ipAddress, BaseDomain, KeyAuth, retries = 0, retryTime = 0.seconds
+    )
+    check dnsSet == true
+
+  asyncTest "a TXT record holding another key authorization is not accepted":
+    resolver.txtScript = @[@[OtherKeyAuth]]
+
+    let dnsSet = await checkDNSRecords(
+      resolver, ipAddress, BaseDomain, KeyAuth, retries = 0, retryTime = 0.seconds
+    )
+    check dnsSet == false
+
+  asyncTest "a matching TXT record without an A record is not accepted":
+    resolver.ipAddresses = @[]
+
+    let dnsSet = await checkDNSRecords(
+      resolver, ipAddress, BaseDomain, KeyAuth, retries = 0, retryTime = 0.seconds
+    )
+    check dnsSet == false
+
+  asyncTest "an absent TXT record is not accepted":
+    resolver.txtScript = @[@[]]
+
+    let dnsSet = await checkDNSRecords(
+      resolver, ipAddress, BaseDomain, KeyAuth, retries = 0, retryTime = 0.seconds
+    )
+    check dnsSet == false
+
+  asyncTest "the challenge name and the dashed-IP name are the names queried":
+    discard await checkDNSRecords(
+      resolver, ipAddress, BaseDomain, KeyAuth, retries = 0, retryTime = 0.seconds
+    )
+
+    check:
+      resolver.txtQueries == @[AcmeChallengeName]
+      resolver.ipQueries == @[Ip4Name]
+
+  asyncTest "stops at the first attempt that sees both records":
+    let dnsSet = await checkDNSRecords(
+      resolver, ipAddress, BaseDomain, KeyAuth, retries = 10, retryTime = 0.seconds
+    )
+
+    check:
+      dnsSet == true
+      resolver.txtQueries.len == 1
+      resolver.ipQueries.len == 1
+
+  asyncTest "a TXT record that only appears on a later attempt is accepted":
+    resolver.txtScript = @[@[], @[KeyAuth]]
+
+    let dnsSet = await checkDNSRecords(
+      resolver, ipAddress, BaseDomain, KeyAuth, retries = 10, retryTime = 0.seconds
+    )
+
+    check:
+      dnsSet == true
+      resolver.txtQueries.len == 2
+
+  asyncTest "an A record resolved on an earlier attempt is not carried over":
+    resolver.txtScript = @[@[], @[KeyAuth]]
+    resolver.ipScript =
+      @[StubNameResolverIpOutcome.Resolve, StubNameResolverIpOutcome.RaiseAddressError]
+
+    let dnsSet = await checkDNSRecords(
+      resolver, ipAddress, BaseDomain, KeyAuth, retries = 10, retryTime = 0.seconds
+    )
+    check dnsSet == false
+
+  asyncTest "retries until both records are seen on the same attempt":
+    # Only the third attempt sees the two together.
+    resolver.txtScript = @[@[KeyAuth], @[], @[KeyAuth]]
+    resolver.ipScript = @[
+      StubNameResolverIpOutcome.RaiseAddressError, StubNameResolverIpOutcome.Resolve,
+      StubNameResolverIpOutcome.Resolve,
+    ]
+
+    let dnsSet = await checkDNSRecords(
+      resolver, ipAddress, BaseDomain, KeyAuth, retries = 10, retryTime = 0.seconds
+    )
+
+    check:
+      dnsSet == true
+      resolver.txtQueries.len == 3
+      resolver.ipQueries.len == 3
+
+  asyncTest "waits retryTime before each retry":
+    resolver.txtScript = @[@[]]
+
+    let start = Moment.now()
+    let dnsSet = await checkDNSRecords(
+      resolver,
+      ipAddress,
+      BaseDomain,
+      KeyAuth,
+      retries = 4,
+      retryTime = 200.milliseconds,
+    )
+    let elapsed = Moment.now() - start
+
+    # retries = 4 is 5 total attempts with a delay before each retry, so 4 x 200ms.
+    check:
+      dnsSet == false
+      elapsed >= 700.milliseconds
+
+  asyncTest "an A record that never resolves is not accepted":
+    resolver.ipScript = @[StubNameResolverIpOutcome.RaiseAddressError]
+
+    let dnsSet = await checkDNSRecords(
+      resolver, ipAddress, BaseDomain, KeyAuth, retries = 3, retryTime = 0.seconds
+    )
+    check dnsSet == false
+
+  asyncTest "cancellation while resolving the A record propagates":
+    resolver.ipScript = @[StubNameResolverIpOutcome.RaiseCancelled]
+
+    expect(CancelledError):
+      discard await checkDNSRecords(
+        resolver, ipAddress, BaseDomain, KeyAuth, retries = 3, retryTime = 0.seconds
+      )
+
+  # TODO: vacp2p/nim-libp2p#2711
+  asyncTest "an IPv6 address is queried in its colon form":
+    discard await checkDNSRecords(
+      resolver,
+      parseIpAddress("2001:db8::1"),
+      BaseDomain,
+      KeyAuth,
+      retries = 0,
+      retryTime = 0.seconds,
+    )
+
+    # Colons are not legal in a DNS label, should use an IPv6 form or reject the address.
+    check resolver.ipQueries == @["2001:db8::1.k51qzi5uqu5dhkzk3z.libp2p.direct"]

--- a/tests/tools/resolver.nim
+++ b/tests/tools/resolver.nim
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import ../../libp2p/nameresolving/mockresolver
+import sequtils, chronos
+import ../../libp2p/nameresolving/[nameresolver, mockresolver]
 
 export mockresolver
 
@@ -10,3 +11,55 @@ proc default*(T: typedesc[MockResolver]): T =
   resolver.ipResponses[("localhost", false)] = @["127.0.0.1"]
   resolver.ipResponses[("localhost", true)] = @["::1"]
   resolver
+
+type StubNameResolverIpOutcome* {.pure.} = enum
+  Resolve
+  RaiseAddressError
+  RaiseCancelled
+
+type StubNameResolver* = ref object of NameResolver
+  ## Answers consecutive lookups of one name, recording what was queried.
+  txtScript*: seq[seq[string]]
+  ipScript*: seq[StubNameResolverIpOutcome]
+  ipAddresses*: seq[string]
+  txtQueries*: seq[string]
+  ipQueries*: seq[string]
+
+proc responseForCall[T](script: seq[T], callIndex: int): T =
+  ## Entries answer consecutive calls, the last entry answers every call after it.
+  script[min(callIndex, script.high)]
+
+method resolveIp*(
+    self: StubNameResolver,
+    address: string,
+    port: Port,
+    domain: Domain = Domain.AF_UNSPEC,
+): Future[seq[TransportAddress]] {.
+    async: (raises: [CancelledError, TransportAddressError])
+.} =
+  self.ipQueries.add(address)
+
+  case self.ipScript.responseForCall(self.ipQueries.high)
+  of StubNameResolverIpOutcome.RaiseAddressError:
+    raise newException(TransportAddressError, "Could not resolve " & address)
+  of StubNameResolverIpOutcome.RaiseCancelled:
+    raise newException(CancelledError, "Cancelled while resolving " & address)
+  of StubNameResolverIpOutcome.Resolve:
+    self.ipAddresses.mapIt(initTAddress(it, port))
+
+method resolveTxt*(
+    self: StubNameResolver, address: string
+): Future[seq[string]] {.async: (raises: [CancelledError]).} =
+  self.txtQueries.add(address)
+  self.txtScript.responseForCall(self.txtQueries.high)
+
+proc new*(
+    T: typedesc[StubNameResolver],
+    txtRecords: seq[string] = @[],
+    ipAddresses: seq[string] = @[],
+): T =
+  T(
+    txtScript: @[txtRecords],
+    ipScript: @[StubNameResolverIpOutcome.Resolve],
+    ipAddresses: ipAddresses,
+  )


### PR DESCRIPTION
## Summary

The retry loop in `checkDNSRecords` never worked. The success check and the sleep both sit outside the loop, so it runs all its attempts, then checks once at the end.

Three things go wrong:

- It never stops early. Every issuance does 22 DNS queries, even when the first attempt already found both records.
- It never sleeps between attempts. The lookups fire back to back, so waiting for DNS to propagate does nothing.
- It can return true using an A record from an earlier attempt that has since stopped resolving.

The fix moves the check and the sleep inside the loop. `txt` and `ip4` are now declared inside it too, so a value from one attempt can't leak into the next. The sleep runs before each retry instead of after each attempt.

## Affected Areas

- [x] Other
  autotls ACME dns-01 challenge polling (`libp2p/autotls/utils.nim`).

## Impact on Library Users

No API change. Only affects users of `.withAutotls()`.

A normal issuance now does 2 DNS queries instead of 22. A poll that finds nothing takes 10s instead of 1s, because it now sleeps between attempts.

## Risk Assessment

The old check mixed the last attempt's TXT record with any attempt's A record, so I had to pick a rule to replace it. I went with requiring both records to show up in the same attempt.

If you would rather it remember each record once it has been seen, that is a small change.
