### PR TITLE
chore(nat): bump libplum to v0.6.2

### DIFF
--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -14,7 +14,7 @@ requires "nim >= 2.2.4",
   "serialization >= 0.5.0", "json_serialization >= 0.4.4", "lsquic >= 0.8.1",
   "protobuf_serialization >= 0.6.0",
   "https://github.com/status-im/nim-websock >= 0.4.0",
-  "https://github.com/logos-storage/nim-libplum#acefbe424cf9d1f05f2d93533790c9ac4e034df8"
+  "https://github.com/logos-storage/nim-libplum >= 0.6.2"
 
 import os
 

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -82,8 +82,8 @@
 
   libplum = pkgs.fetchgit {
     url = "https://github.com/logos-storage/nim-libplum";
-    rev = "acefbe424cf9d1f05f2d93533790c9ac4e034df8";
-    sha256 = "0j6rc96cznsh90pvs27i1qgpby3ib04a2xqihps3jwlnlng2nrkb";
+    rev = "611bb3ed06b5f1e43aea02500761693af1d53d03";
+    sha256 = "0j3xl78c1vrifnk1yw203qrwax0zcf7bcs203fdhj0b5bqdbrj7q";
     fetchSubmodules = true;
   };
 

--- a/nix/libp2p.lock
+++ b/nix/libp2p.lock
@@ -151,8 +151,8 @@
       }
     },
     "libplum": {
-      "version": "0.6.0",
-      "vcsRevision": "acefbe424cf9d1f05f2d93533790c9ac4e034df8",
+      "version": "0.6.2",
+      "vcsRevision": "611bb3ed06b5f1e43aea02500761693af1d53d03",
       "url": "https://github.com/logos-storage/nim-libplum",
       "downloadMethod": "git",
       "dependencies": [
@@ -162,7 +162,7 @@
         "unittest2"
       ],
       "checksums": {
-        "sha1": "d644699c7edbd11fd4e1b204acf3c2a4f5959db4"
+        "sha1": "d3e4d461b0d31fce0587d12c65105cbf415b96cd"
       }
     },
     "faststreams": {


### PR DESCRIPTION
## Summary

Bump `libplum` to v0.6.2.

v0.6.1 fixes a memory bug ([nim-libplum#20](https://github.com/logos-storage/nim-libplum/pull/20)): the old code pinned the mapping handle with `GC_ref` on the chronos thread and unpinned it with `GC_unref` on the libplum thread, and each thread has its own GC. The new code deallocates only after both threads release the handle. This matters under `--mm:refc`.

v0.6.1 also repoints the vendored C submodule from the fork `2-towns/libplum` to upstream `paullouisageneau/libplum` ([nim-libplum#19](https://github.com/logos-storage/nim-libplum/pull/19)).

v0.6.2 adds the two fixes that v0.6.1 needs to build here ([nim-libplum#18](https://github.com/logos-storage/nim-libplum/pull/18)): `libplum.nimble` installs `libplum_units.c` again, and `plum.nim` re-raises the typed `CancelledError` instead of a bare `raise`. Both failures blocked every build job on v0.6.1.

`libp2p.nimble` now takes the version, `>= 0.6.2`, instead of a commit. The lock and `nix/deps.nix` record the tag rev `611bb3e`.

## Affected Areas

- [x] Build / Tooling

- [x] Other — NAT port mapping through libplum

## Impact on Library Users

No API change. A node that runs the libplum NAT service gets the memory fix and the upstream C sources.

## References

- [nim-libplum#20](https://github.com/logos-storage/nim-libplum/pull/20) — refc memory fix
- [nim-libplum#19](https://github.com/logos-storage/nim-libplum/pull/19) — repoint on paullouisageneau
- [nim-libplum#18](https://github.com/logos-storage/nim-libplum/pull/18) — install `libplum_units.c`, typed re-raise
