### PR TITLE
fix(autotls): renewal never fires and renewBufferTime is applied twice

### DIFF
--- a/libp2p/autotls/mockservice.nim
+++ b/libp2p/autotls/mockservice.nim
@@ -3,6 +3,7 @@
 
 import ./service, ./acme/client, ./broker
 import ../crypto/crypto, ../crypto/rsa, websock/websock
+from times import now
 
 type MockAutotlsService* = ref object of AutotlsService
   mockedCert*: TLSCertificate
@@ -27,7 +28,7 @@ proc new*(
 method getCertWhenReady*(
     self: MockAutotlsService
 ): Future[AutotlsCert] {.async: (raises: [AutoTLSError, CancelledError]).} =
-  AutotlsCert.new(self.mockedCert, self.mockedKey, Moment.now)
+  AutotlsCert.new(self.mockedCert, self.mockedKey, now())
 
 method setup*(self: MockAutotlsService) {.base, async.} =
   self.running.fire()

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -7,6 +7,7 @@ import sequtils
 import bearssl/pem
 import chronos, chronicles, net, results, uri
 import chronos/streams/tlsstream
+from times import DateTime, now, toTime, toUnix
 
 import
   ./acme/client,
@@ -40,7 +41,7 @@ const
 type AutotlsCert* = ref object
   cert*: TLSCertificate
   privkey*: TLSPrivateKey
-  expiry*: Moment
+  expiry*: DateTime
 
 type AutotlsConfig* = object
   acmeServerURL*: Uri
@@ -74,7 +75,7 @@ proc new*(
     T: typedesc[AutotlsCert],
     cert: TLSCertificate,
     privkey: TLSPrivateKey,
-    expiry: Moment,
+    expiry: DateTime,
 ): T =
   T(cert: cert, privkey: privkey, expiry: expiry)
 
@@ -204,7 +205,7 @@ method issueCertificate(
       AutotlsCert.new(
         TLSCertificate.init(certificate.rawCertificate),
         TLSPrivateKey.init(derPrivKey.pemEncode("PRIVATE KEY")),
-        asMoment(certificate.certificateExpiry),
+        certificate.certificateExpiry,
       )
     except TLSStreamProtocolError as exc:
       raise newException(
@@ -248,12 +249,11 @@ method start*(
         if self.cert.isNone():
           await self.tryIssueCertificate()
 
-        # AutotlsService will renew the cert 1h before it expires
         let cert = self.cert.valueOr:
           error "Could not issue certificate"
           return
-        let waitTime = cert.expiry - Moment.now - self.config.renewBufferTime
-        if waitTime <= self.config.renewBufferTime:
+        let timeUntilExpiry = seconds(cert.expiry.toTime.toUnix - now().toTime.toUnix)
+        if timeUntilExpiry <= self.config.renewBufferTime:
           await self.tryIssueCertificate()
     except CancelledError:
       trace "Autotls management cancelled"

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -4,7 +4,6 @@
 
 import chronos, chronicles, strutils
 import stew/base36
-from times import DateTime, toTime, toUnix
 import
   ../errors,
   ../peerid,
@@ -22,10 +21,6 @@ type AutoTLSError* = object of LPError
 const
   DefaultDnsRetries = 3
   DefaultDnsRetryTime = 1.seconds
-
-proc asMoment*(dt: DateTime): Moment =
-  let unixTime: int64 = dt.toTime.toUnix
-  return Moment.init(unixTime, Second)
 
 proc encodePeerId*(peerId: PeerId): string {.raises: [AutoTLSError].} =
   var mh: MultiHash

--- a/tests/integration/test_autotls_integration.nim
+++ b/tests/integration/test_autotls_integration.nim
@@ -5,6 +5,7 @@
 
 when defined(linux) and defined(amd64):
   import chronos, chronos/apps/http/httpclient
+  from times import now, initDuration, `-`, `<`
   import
     ../../libp2p/[
       stream/connection,
@@ -126,8 +127,9 @@ when defined(linux) and defined(amd64):
         raiseAssert "certificate not found"
 
       # invalidate certificate
-      let invalidCert =
-        AutotlsCert.new(certBefore.cert, certBefore.privkey, Moment.now - 2.hours)
+      let invalidCert = AutotlsCert.new(
+        certBefore.cert, certBefore.privkey, now() - initDuration(hours = 2)
+      )
       autotls.cert = Opt.some(invalidCert)
 
       # wait for cert to be renewed
@@ -140,4 +142,4 @@ when defined(linux) and defined(amd64):
       check certBefore.cert != certAfter.cert
 
       # cert is valid
-      check certAfter.expiry > Moment.now
+      check certAfter.expiry > now()

--- a/tests/libp2p/autotls/test_service.nim
+++ b/tests/libp2p/autotls/test_service.nim
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import chronos
+from times import now, initDuration, `+`
+import
+  ../../../libp2p/
+    [autotls/service, autotls/broker, autotls/acme/client, crypto/rsa, switch]
+import ../../tools/[unittest, crypto, multiaddress, switch_builder]
+import ../../stubs/[acme_api_stub, peer_id_auth_client_stub]
+
+suite "AutoTLS certificate renewal":
+  const
+    RenewCheckTime = 20.milliseconds
+    RenewBufferTime = 1.hours
+
+  # RSA generation dominates the runtime of every test here, so one key pair each.
+  let
+    accountKey = RsaPrivateKey.random(rng()).get()
+    (certKey, cert) = tlsCertGenerator()
+
+  var acmeApi {.threadvar.}: ACMEApiStub
+  var service {.threadvar.}: AutotlsService
+  var switch {.threadvar.}: Switch
+
+  proc newService(): AutotlsService =
+    AutotlsService(
+      acmeClient:
+        ACMEClient.new(rng(), api = ACMEApi(acmeApi), key = Opt.some(accountKey)),
+      broker: AutotlsBroker.new(rng(), DefaultBrokerURL, PeerIDAuthClientStub.new()),
+      cert: Opt.none(AutotlsCert),
+      certReady: newAsyncEvent(),
+      running: newAsyncEvent(),
+      config: AutotlsConfig.new(
+        renewCheckTime = RenewCheckTime, renewBufferTime = RenewBufferTime
+      ),
+      rng: rng(),
+    )
+
+  proc installCert(service: AutotlsService, expiresIn: times.Duration) =
+    service.cert = Opt.some(AutotlsCert.new(cert, certKey, now() + expiresIn))
+
+  asyncSetup:
+    acmeApi = ACMEApiStub.new()
+    switch = makeStandardSwitch(TcpAutoAddress)
+    await switch.start()
+
+  asyncTeardown:
+    await service.stop(switch)
+    await switch.stop()
+    checkTrackers()
+
+  asyncTest "a certificate expiring in 5 minutes is renewed":
+    service = newService()
+    service.installCert(initDuration(minutes = 5))
+    await service.start(switch)
+
+    # A renewal attempt fails on its first ACME request, which is enough to see it.
+    checkUntilTimeoutCustom(5.seconds, 10.milliseconds):
+      acmeApi.requestedUris.len > 0
+
+  asyncTest "a certificate expiring in 90 minutes is not renewed under a 1 hour buffer":
+    service = newService()
+    service.installCert(initDuration(minutes = 90))
+    await service.start(switch)
+
+    # Nothing signals a heartbeat that decided against renewing, so wait out several.
+    await sleepAsync(10 * RenewCheckTime)
+
+    check acmeApi.requestedUris.len == 0

--- a/tests/libp2p/autotls/test_service.nim
+++ b/tests/libp2p/autotls/test_service.nim
@@ -58,7 +58,7 @@ suite "AutoTLS certificate renewal":
     await service.start(switch)
 
     # A renewal attempt fails on its first ACME request, which is enough to see it.
-    checkUntilTimeoutCustom(5.seconds, 10.milliseconds):
+    checkUntilTimeout:
       acmeApi.requestedUris.len > 0
 
   asyncTest "a certificate expiring in 90 minutes is not renewed under a 1 hour buffer":

--- a/tests/stubs/acme_api_stub.nim
+++ b/tests/stubs/acme_api_stub.nim
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+{.push raises: [].}
+
+import uri
+import chronos, chronos/apps/http/httpclient
+import ../../libp2p/[autotls/acme/api, utils/opt]
+
+export api
+
+type ACMEApiStub* = ref object of ACMEApi
+  ## Refuses every ACME request, recording what was requested.
+  stalls*: bool
+  requestedUris*: seq[Uri]
+
+proc new*(T: typedesc[ACMEApiStub]): ACMEApiStub =
+  ACMEApiStub(
+    session: HttpSessionRef.new(),
+    directory: Opt.some(
+      ACMEDirectory(
+        newNonce: LetsEncryptURL & "/new-nonce",
+        newOrder: LetsEncryptURL & "/new-order",
+        newAccount: LetsEncryptURL & "/new-account",
+      )
+    ),
+    acmeServerURL: parseUri(LetsEncryptURL),
+  )
+
+method requestNonce*(
+    self: ACMEApiStub
+): Future[Nonce] {.async: (raises: [ACMEError, CancelledError]).} =
+  Nonce($self.acmeServerURL & "/acme/1234")
+
+proc stallUntilCancelled(self: ACMEApiStub) {.async: (raises: [CancelledError]).} =
+  ## A request that only ends when the caller gives up on it.
+  await Future[void].Raising([CancelledError]).init("ACMEApiStub.request")
+
+proc refuse(
+    self: ACMEApiStub, uri: Uri
+): Future[HTTPResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+  self.requestedUris.add(uri)
+  if self.stalls:
+    await self.stallUntilCancelled()
+  raise newException(ACMEError, "ACMEApiStub refused " & $uri)
+
+method post*(
+    self: ACMEApiStub, uri: Uri, payload: string
+): Future[HTTPResponse] {.async: (raises: [ACMEError, HttpError, CancelledError]).} =
+  await self.refuse(uri)
+
+method get*(
+    self: ACMEApiStub, uri: Uri
+): Future[HTTPResponse] {.async: (raises: [ACMEError, HttpError, CancelledError]).} =
+  await self.refuse(uri)

--- a/tests/stubs/acme_api_stub.nim
+++ b/tests/stubs/acme_api_stub.nim
@@ -7,43 +7,21 @@
 
 import uri
 import chronos, chronos/apps/http/httpclient
-import ../../libp2p/[autotls/acme/api, utils/opt]
+import ../../libp2p/autotls/acme/api
 
 export api
 
 type ACMEApiStub* = ref object of ACMEApi
   ## Refuses every ACME request, recording what was requested.
-  stalls*: bool
   requestedUris*: seq[Uri]
 
 proc new*(T: typedesc[ACMEApiStub]): ACMEApiStub =
-  ACMEApiStub(
-    session: HttpSessionRef.new(),
-    directory: Opt.some(
-      ACMEDirectory(
-        newNonce: LetsEncryptURL & "/new-nonce",
-        newOrder: LetsEncryptURL & "/new-order",
-        newAccount: LetsEncryptURL & "/new-account",
-      )
-    ),
-    acmeServerURL: parseUri(LetsEncryptURL),
-  )
-
-method requestNonce*(
-    self: ACMEApiStub
-): Future[Nonce] {.async: (raises: [ACMEError, CancelledError]).} =
-  Nonce($self.acmeServerURL & "/acme/1234")
-
-proc stallUntilCancelled(self: ACMEApiStub) {.async: (raises: [CancelledError]).} =
-  ## A request that only ends when the caller gives up on it.
-  await Future[void].Raising([CancelledError]).init("ACMEApiStub.request")
+  ACMEApiStub(session: HttpSessionRef.new(), acmeServerURL: parseUri(LetsEncryptURL))
 
 proc refuse(
     self: ACMEApiStub, uri: Uri
 ): Future[HTTPResponse] {.async: (raises: [ACMEError, CancelledError]).} =
   self.requestedUris.add(uri)
-  if self.stalls:
-    await self.stallUntilCancelled()
   raise newException(ACMEError, "ACMEApiStub refused " & $uri)
 
 method post*(


### PR DESCRIPTION
## Summary

Fixes two independent defects in AutoTLS certificate renewal. Neither had test coverage.

**Certificate expiry was compared against the wrong clock.** `asMoment` built a `Moment` out of Unix epoch seconds, but `Moment` is monotonic (chronos defaults to `asyncTimer = "mono"`, and its docs say a Moment's value has no direct meaning). So `cert.expiry - Moment.now` evaluated to the epoch value minus the machine's uptime, which is around 56 years on any real host. The renewal branch was never taken and certificates expired in place. `asMoment` is deleted. `ACMECertificateResponse.certificateExpiry` is already a `DateTime`, so the service now stores it unchanged and `manageCert` subtracts wall-clock now.

**`renewBufferTime` was applied twice.** The old code computed `waitTime = timeUntilExpiry - renewBufferTime` and then tested `waitTime <= renewBufferTime`, which reduces to `timeUntilExpiry <= 2 * renewBufferTime`. Renewal began two hours before expiry with the default one hour buffer, while the comment directly above promised one hour. The expression collapses to `if timeUntilExpiry <= self.config.renewBufferTime` and the comment goes, since the code now states it.

## Affected Areas

  - [x] Other
    AutoTLS certificate service (`libp2p/autotls/`). Certificate renewal scheduling only. No transport, muxer or protocol code is touched.

## Compatibility & Downstream Validation

No downstream validation was run. AutoTLS is opt-in through `.withAutotls()`, and `AutotlsCert` is not re-exported through `libp2p.nim`, so only projects that import `libp2p/autotls/service` directly can see the type change.

## Impact on Library Users

`AutotlsCert.expiry` is now a `times.DateTime` instead of a `chronos.Moment`, and `AutotlsCert.new` takes a `DateTime`. Five call sites exist in this repo and all are updated here.

Renewal behavior fires at all now, where before it never did, and it starts at `renewBufferTime` before expiry rather than at twice that.

## Risk Assessment

The renewal path has never run in production, so treat it as new code even though it is not. Nodes that previously served a certificate until it expired will now place real ACME orders against a rate-limited CA.

## Additional Notes

 Tests are in `tests/libp2p/autotls/test_service.nim`, with a new `tests/stubs/acme_api_stub.nim` that refuses every ACME request and records the URI. Each issuance attempt fails on its first request, so a recorded request is an attempted renewal.

The integration test's renewal half passed for the wrong reason. It overwrote `expiry` by hand before waiting, which stepped over the clock bug, and its follow-up `certAfter.expiry > Moment.now` was always true because the value was an epoch number. That assertion is meaningful now.