### PR TITLE
fix(autotls): retry a failed issuance round and fix the issueRetries count

### DIFF
--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -219,7 +219,9 @@ proc hasTcpStarted(switch: Switch): bool =
   switch.transports.filterIt(it of TcpTransport and it.running).len == 0
 
 proc tryIssueCertificate(self: AutotlsService) {.async: (raises: [CancelledError]).} =
-  for _ in 0 ..< self.config.issueRetries:
+  for attempt in 0 .. self.config.issueRetries:
+    if attempt > 0:
+      await sleepAsync(self.config.issueRetryTime)
     try:
       await self.issueCertificate()
       return
@@ -227,7 +229,6 @@ proc tryIssueCertificate(self: AutotlsService) {.async: (raises: [CancelledError
       raise exc
     except CatchableError as exc:
       error "Failed to issue certificate", err = exc.msg
-    await sleepAsync(self.config.issueRetryTime)
   error "Failed to issue certificate"
 
 method start*(
@@ -249,12 +250,10 @@ method start*(
         if self.cert.isNone():
           await self.tryIssueCertificate()
 
-        let cert = self.cert.valueOr:
-          error "Could not issue certificate"
-          return
-        let timeUntilExpiry = seconds(cert.expiry.toTime.toUnix - now().toTime.toUnix)
-        if timeUntilExpiry <= self.config.renewBufferTime:
-          await self.tryIssueCertificate()
+        self.cert.withValue(cert):
+          let timeUntilExpiry = seconds(cert.expiry.toTime.toUnix - now().toTime.toUnix)
+          if timeUntilExpiry <= self.config.renewBufferTime:
+            await self.tryIssueCertificate()
     except CancelledError:
       trace "Autotls management cancelled"
 

--- a/tests/libp2p/autotls/test_service.nim
+++ b/tests/libp2p/autotls/test_service.nim
@@ -74,7 +74,7 @@ suite "AutoTLS certificate issuance and renewal":
     check acmeApi.requestedUris.len == 0
 
   asyncTest "issuance is retried issueRetries times":
-    # The default renew check time keeps the run to a single round.
+    # renewCheckTime is left at its 1 hour default, so a second round won't start
     service =
       newService(AutotlsConfig.new(issueRetries = 3, issueRetryTime = 0.seconds))
     await service.start(switch)

--- a/tests/libp2p/autotls/test_service.nim
+++ b/tests/libp2p/autotls/test_service.nim
@@ -79,34 +79,25 @@ suite "AutoTLS certificate issuance and renewal":
       newService(AutotlsConfig.new(issueRetries = 3, issueRetryTime = 0.seconds))
     await service.start(switch)
 
-    # Every attempt fails on its first ACME request, so a request is an attempt:
-    # the first one, then three retries.
+    # Every attempt fails on its first ACME request, so a request is an attempt.
     checkUntilTimeout:
       acmeApi.requestedUris.len == 4
 
   asyncTest "a failed round is retried on the next heartbeat":
     # No retries, so a round is one request.
-    service = newService(
-      AutotlsConfig.new(
-        issueRetries = 0, issueRetryTime = 0.seconds, renewCheckTime = 200.milliseconds
-      )
-    )
+    service =
+      newService(AutotlsConfig.new(issueRetries = 0, renewCheckTime = RenewCheckTime))
     await service.start(switch)
 
     checkUntilTimeout:
-      acmeApi.requestedUris.len == 2
+      acmeApi.requestedUris.len >= 2
 
   asyncTest "a service stopped during issuance makes no further attempt":
     acmeApi.stalls = true
-    service = newService(
-      AutotlsConfig.new(
-        issueRetries = 3, issueRetryTime = 0.seconds, renewCheckTime = RenewCheckTime
-      )
-    )
+    service = newService(AutotlsConfig.new(issueRetries = 3))
     await service.start(switch)
 
-    checkUntilTimeout:
-      acmeApi.requestedUris.len == 1
+    check acmeApi.requestedUris.len == 1
 
     await service.stop(switch).wait(1.seconds)
 

--- a/tests/libp2p/autotls/test_service.nim
+++ b/tests/libp2p/autotls/test_service.nim
@@ -11,7 +11,7 @@ import
 import ../../tools/[unittest, crypto, multiaddress, switch_builder]
 import ../../stubs/[acme_api_stub, peer_id_auth_client_stub]
 
-suite "AutoTLS certificate renewal":
+suite "AutoTLS certificate issuance and renewal":
   const
     RenewCheckTime = 20.milliseconds
     RenewBufferTime = 1.hours
@@ -25,7 +25,11 @@ suite "AutoTLS certificate renewal":
   var service {.threadvar.}: AutotlsService
   var switch {.threadvar.}: Switch
 
-  proc newService(): AutotlsService =
+  proc newService(
+      config: AutotlsConfig = AutotlsConfig.new(
+        renewCheckTime = RenewCheckTime, renewBufferTime = RenewBufferTime
+      )
+  ): AutotlsService =
     AutotlsService(
       acmeClient:
         ACMEClient.new(rng(), api = ACMEApi(acmeApi), key = Opt.some(accountKey)),
@@ -33,9 +37,7 @@ suite "AutoTLS certificate renewal":
       cert: Opt.none(AutotlsCert),
       certReady: newAsyncEvent(),
       running: newAsyncEvent(),
-      config: AutotlsConfig.new(
-        renewCheckTime = RenewCheckTime, renewBufferTime = RenewBufferTime
-      ),
+      config: config,
       rng: rng(),
     )
 
@@ -70,3 +72,42 @@ suite "AutoTLS certificate renewal":
     await sleepAsync(10 * RenewCheckTime)
 
     check acmeApi.requestedUris.len == 0
+
+  asyncTest "issuance is retried issueRetries times":
+    # The default renew check time keeps the run to a single round.
+    service =
+      newService(AutotlsConfig.new(issueRetries = 3, issueRetryTime = 0.seconds))
+    await service.start(switch)
+
+    # Every attempt fails on its first ACME request, so a request is an attempt:
+    # the first one, then three retries.
+    checkUntilTimeout:
+      acmeApi.requestedUris.len == 4
+
+  asyncTest "a failed round is retried on the next heartbeat":
+    # No retries, so a round is one request.
+    service = newService(
+      AutotlsConfig.new(
+        issueRetries = 0, issueRetryTime = 0.seconds, renewCheckTime = 200.milliseconds
+      )
+    )
+    await service.start(switch)
+
+    checkUntilTimeout:
+      acmeApi.requestedUris.len == 2
+
+  asyncTest "a service stopped during issuance makes no further attempt":
+    acmeApi.stalls = true
+    service = newService(
+      AutotlsConfig.new(
+        issueRetries = 3, issueRetryTime = 0.seconds, renewCheckTime = RenewCheckTime
+      )
+    )
+    await service.start(switch)
+
+    checkUntilTimeout:
+      acmeApi.requestedUris.len == 1
+
+    await service.stop(switch).wait(1.seconds)
+
+    check acmeApi.requestedUris.len == 1

--- a/tests/stubs/acme_api_stub.nim
+++ b/tests/stubs/acme_api_stub.nim
@@ -13,7 +13,9 @@ export api
 
 type ACMEApiStub* = ref object of ACMEApi
   ## Refuses every ACME request, recording what was requested.
+  ## While `stalls` is set the request stays pending instead, until it is cancelled.
   requestedUris*: seq[Uri]
+  stalls*: bool
 
 proc new*(T: typedesc[ACMEApiStub]): ACMEApiStub =
   ACMEApiStub(session: HttpSessionRef.new(), acmeServerURL: parseUri(LetsEncryptURL))
@@ -22,6 +24,8 @@ proc refuse(
     self: ACMEApiStub, uri: Uri
 ): Future[HTTPResponse] {.async: (raises: [ACMEError, CancelledError]).} =
   self.requestedUris.add(uri)
+  if self.stalls:
+    await Future[void].Raising([CancelledError]).init("ACMEApiStub.stall")
   raise newException(ACMEError, "ACMEApiStub refused " & $uri)
 
 method post*(


### PR DESCRIPTION
## Summary

Two fixes in `AutotlsService`, with the tests that pin them.

**A failed issuance round ended certificate management for good.** `manageCert` read the certificate with `valueOr: return`, so a round that finished without one returned out of the `heartbeat` loop and the service went quiet until the process restarted. It now uses `withValue`, so the round falls through to the heartbeat's sleep and the next one tries again. 

**The retry loop counted wrong and slept at the wrong time.** `for _ in 0 ..< issueRetries` made `issueRetries` the total attempt count, and the `sleepAsync` sat after the final failed attempt where nothing waited on it. It now runs `for attempt in 0 .. issueRetries` with the sleep at the top of each retry.

The same loop fix clears a potential config bug. `issueRetries = 0` used to disable issuance entirely, because `0 ..< 0` never runs the body. Now 0 means one attempt and no retries, which is what the name says.

Three new cases in `tests/libp2p/autotls/test_service.nim` cover the attempt count, a failed round being retried on the next heartbeat, and a service stopped mid-issuance making no further attempt. `ACMEApiStub` gains a `stalls` flag that parks a request on a never-completing future instead of raising, which is what makes the cancellation case reachable.

## Affected Areas

- [x] Other
    AutoTLS certificate issuance and renewal (`libp2p/autotls/service.nim`).

## Impact on Library Users

`issueRetries` changes meaning. It is now the number of retries after the first attempt, not the total. At the default of 3 a failed round makes 4 ACME attempts instead of 3, and 0 now means one attempt instead of none. No API change, `AutotlsConfig.new` and its defaults are untouched.

A service that fails its first issuance now keeps trying once per `renewCheckTime` (default 1 hour) instead of stopping forever.

## Risk Assessment

One extra attempt per round, and rounds now repeat instead of stopping after the first failure.