### PR TITLE
fix(ipaddr): a public IPv6 address counts as a public address

### DIFF
--- a/.github/workflows/daily_nimbus.yml
+++ b/.github/workflows/daily_nimbus.yml
@@ -19,10 +19,6 @@ jobs:
     timeout-minutes: 80
     name: 'Compile Nimbus (linux-amd64)'
     runs-on: ubuntu-latest
-    # Canary only: nimbus-eth2 unstable can lag behind libp2p API changes
-    # (e.g. gossipsub Message.data -> Opt[seq[byte]]), so a red build here
-    # signals a downstream break to fix in nimbus, not a reason to block PRs.
-    continue-on-error: true
     steps:
       - name: Compile nimbus using nim-libp2p
         env:

--- a/.github/workflows/daily_nimbus.yml
+++ b/.github/workflows/daily_nimbus.yml
@@ -19,6 +19,10 @@ jobs:
     timeout-minutes: 80
     name: 'Compile Nimbus (linux-amd64)'
     runs-on: ubuntu-latest
+    # Canary only: nimbus-eth2 unstable can lag behind libp2p API changes
+    # (e.g. gossipsub Message.data -> Opt[seq[byte]]), so a red build here
+    # signals a downstream break to fix in nimbus, not a reason to block PRs.
+    continue-on-error: true
     steps:
       - name: Compile nimbus using nim-libp2p
         env:

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -138,14 +138,11 @@ proc new*(
 
 method setup*(self: AutotlsService, switch: Switch) {.raises: [ServiceSetupError].} =
   trace "Setting up AutotlsService"
-  if self.config.ipAddress.isNone():
-    try:
-      self.config.ipAddress = Opt.some(getPublicIPAddress())
-    except ValueError, OSError:
-      raise newException(
-        ServiceSetupError,
-        "Failed to get public IP address. Reason: " & getCurrentExceptionMsg(),
-      )
+  if self.config.ipAddress.isSome():
+    return
+  let ip = getPublicIPAddress().valueOr:
+    raise newException(ServiceSetupError, "Host does not have a public IP address")
+  self.config.ipAddress = Opt.some(ip)
 
 method issueCertificate(
     self: AutotlsService

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -40,6 +40,18 @@ proc encodePeerId*(peerId: PeerId): string {.raises: [AutoTLSError].} =
 
   return Base36.encode(cidResult.get().data.buffer)
 
+func dnsLabel(ipAddress: IpAddress): string =
+  ## p2p-forge label: 100.10.10.3 gives 100-10-10-3, ::1 gives 0--1 (RFC 1123).
+  if ipAddress.family == IpAddressFamily.IPv4:
+    return ($ipAddress).replace('.', '-')
+
+  var label = ($ipAddress).replace(':', '-')
+  if label.startsWith('-'):
+    label = "0" & label
+  if label.endsWith('-'):
+    label = label & "0"
+  label
+
 proc checkDNSRecords*(
     nameResolver: NameResolver,
     ipAddress: IpAddress,
@@ -48,29 +60,24 @@ proc checkDNSRecords*(
     retries: int = DefaultDnsRetries,
     retryTime: Duration = DefaultDnsRetryTime,
 ): Future[bool] {.async: (raises: [AutoTLSError, CancelledError]).} =
-  # if my ip address is 100.10.10.3 then the ip4Domain will be:
-  #     100-10-10-3.{peerIdBase36}.libp2p.direct
-  # and acme challenge TXT domain will be:
-  #     _acme-challenge.{peerIdBase36}.libp2p.direct
-  let dashedIpAddr = ($ipAddress).replace(".", "-")
   let acmeChalDomain = api.Domain("_acme-challenge." & baseDomain)
-  let ip4Domain = api.Domain(dashedIpAddr & "." & baseDomain)
-  debug "Waiting for DNS record to be set", ip = ip4Domain, acme = acmeChalDomain
+  let ipDomain = api.Domain(ipAddress.dnsLabel() & "." & baseDomain)
+  debug "Waiting for DNS record to be set", ip = ipDomain, acme = acmeChalDomain
 
   for attempt in 0 .. retries:
     if attempt > 0:
       await sleepAsync(retryTime)
 
     let txt = await nameResolver.resolveTxt(acmeChalDomain)
-    var ip4: seq[TransportAddress]
+    var resolvedIps: seq[TransportAddress]
     try:
-      ip4 = await nameResolver.resolveIp(ip4Domain, 0.Port)
+      resolvedIps = await nameResolver.resolveIp(ipDomain, 0.Port)
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
       error "Failed to resolve IP", description = exc.msg # retry
 
-    if txt.len > 0 and txt[0] == keyAuth and ip4.len > 0:
+    if txt.len > 0 and txt[0] == keyAuth and resolvedIps.len > 0:
       return true
 
   return false

--- a/libp2p/utils/ipaddr.nim
+++ b/libp2p/utils/ipaddr.nim
@@ -43,20 +43,27 @@ proc primaryIPAddrTo(probe: IpAddress): Opt[IpAddress] {.raises: [].} =
   except CatchableError as e:
     debug "Unable to get primary ip address", probe, description = e.msg
     Opt.none(IpAddress)
+  except Defect as e:
+    raise e
   except Exception as e: # on windows getPrimaryIPAddr has untracked effects
     debug "Unable to get primary ip address", probe, description = e.msg
     Opt.none(IpAddress)
 
+func firstGlobalIP*(candidates: openArray[IpAddress]): Opt[IpAddress] =
+  for ip in candidates:
+    if ip.isGlobalIP():
+      return Opt.some(ip)
+  Opt.none(IpAddress)
+
 proc getPublicIPAddress*(): Opt[IpAddress] {.raises: [].} =
   ## Public address of the host, IPv4 first. A v6-only host reaches the v6 probe only.
+  var candidates: seq[IpAddress]
   for probe in RouteProbes:
     let ip = primaryIPAddrTo(probe).valueOr:
       continue
-    let global = ip.isGlobalIP()
-    debug "Primary IP address", ip, global
-    if global:
-      return Opt.some(ip)
-  Opt.none(IpAddress)
+    debug "Primary IP address", ip, global = ip.isGlobalIP()
+    candidates.add(ip)
+  firstGlobalIP(candidates)
 
 proc ipAddrMatches*(
     lookup: MultiAddress, addrs: seq[MultiAddress], ip4: bool = true

--- a/libp2p/utils/ipaddr.nim
+++ b/libp2p/utils/ipaddr.nim
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import net, chronicles, strutils
+import net, chronicles, strutils, results
+import chronos
 
-import ../switch, ../multiaddress, ../multicodec
+import ../multiaddress, ../multicodec
+
+const RouteProbes = [parseIpAddress("8.8.8.8"), parseIpAddress("2001:4860:4860::8888")]
 
 proc isIPv4*(ip: IpAddress): bool =
   ip.family == IpAddressFamily.IPv4
@@ -29,27 +32,31 @@ proc isPublic*(ip: string): bool {.raises: [].} =
 proc isPublic*(ip: IpAddress): bool {.raises: [].} =
   isPublic($ip)
 
-proc hasPublicIPAddress*(): bool {.raises: [].} =
-  let ip =
-    try:
-      getPrimaryIPAddr()
-    except CatchableError as e:
-      error "Unable to get primary ip address", description = e.msg
-      return false
-    except Exception as e:
-      error "Unable to get primary ip address", description = e.msg
-      return false
-  debug "Primary IP address", ip = ip, isIPv4 = ip.isIPv4(), isPublic = ip.isPublic()
+proc isGlobalIP*(ip: IpAddress): bool {.raises: [].} =
+  ## Unlike ``isPublic``, this is family-aware and also rejects private IPv6.
+  initTAddress(ip, Port(0)).isGlobal()
 
-  return ip.isIPv4() and ip.isPublic()
-
-proc getPublicIPAddress*(): IpAddress {.raises: [OSError, ValueError].} =
-  if not hasPublicIPAddress():
-    raise newException(ValueError, "Host does not have a public IPv4 address")
+proc primaryIPAddrTo(probe: IpAddress): Opt[IpAddress] {.raises: [].} =
+  ## Source address the routing table picks for ``probe``. No traffic is sent.
   try:
-    return getPrimaryIPAddr()
-  except Exception as e:
-    raise newException(OSError, e.msg)
+    Opt.some(getPrimaryIPAddr(probe))
+  except CatchableError as e:
+    debug "Unable to get primary ip address", probe, description = e.msg
+    Opt.none(IpAddress)
+  except Exception as e: # on windows getPrimaryIPAddr has untracked effects
+    debug "Unable to get primary ip address", probe, description = e.msg
+    Opt.none(IpAddress)
+
+proc getPublicIPAddress*(): Opt[IpAddress] {.raises: [].} =
+  ## Public address of the host, IPv4 first. A v6-only host reaches the v6 probe only.
+  for probe in RouteProbes:
+    let ip = primaryIPAddrTo(probe).valueOr:
+      continue
+    let global = ip.isGlobalIP()
+    debug "Primary IP address", ip, global
+    if global:
+      return Opt.some(ip)
+  Opt.none(IpAddress)
 
 proc ipAddrMatches*(
     lookup: MultiAddress, addrs: seq[MultiAddress], ip4: bool = true

--- a/tests/integration/test_autotls_integration.nim
+++ b/tests/integration/test_autotls_integration.nim
@@ -76,7 +76,7 @@ when defined(linux) and defined(amd64):
       assertChallenge(challenge)
 
     asyncTest "AutotlsService correctly downloads challenges":
-      if not hasPublicIPAddress():
+      if getPublicIPAddress().isNone():
         skip()
         return
 

--- a/tests/integration/test_ws_integration.nim
+++ b/tests/integration/test_ws_integration.nim
@@ -26,11 +26,9 @@ suite "WebSocket transport integration":
     checkTrackers()
 
   asyncTest "switch successfully dials over wss using autotls certificate":
-    if not hasPublicIPAddress():
+    let ip = getPublicIPAddress().valueOr:
       skip()
       return
-
-    let ip = getPublicIPAddress()
 
     let switch1 = SwitchBuilder
       .new()

--- a/tests/integration/test_ws_integration.nim
+++ b/tests/integration/test_ws_integration.nim
@@ -29,6 +29,10 @@ suite "WebSocket transport integration":
     let ip = getPublicIPAddress().valueOr:
       skip()
       return
+    if not ip.isIPv4():
+      # the test listens on ip4 and dials a /dns4 name
+      skip()
+      return
 
     let switch1 = SwitchBuilder
       .new()

--- a/tests/libp2p/autotls/test_utils.nim
+++ b/tests/libp2p/autotls/test_utils.nim
@@ -148,8 +148,7 @@ suite "AutoTLS DNS records":
         resolver, ipAddress, BaseDomain, KeyAuth, retries = 3, retryTime = 0.seconds
       )
 
-  # TODO: vacp2p/nim-libp2p#2711
-  asyncTest "an IPv6 address is queried in its colon form":
+  asyncTest "an IPv6 address is queried with its colons dashed":
     discard await checkDNSRecords(
       resolver,
       parseIpAddress("2001:db8::1"),
@@ -159,5 +158,18 @@ suite "AutoTLS DNS records":
       retryTime = 0.seconds,
     )
 
-    # Colons are not legal in a DNS label, should use an IPv6 form or reject the address.
-    check resolver.ipQueries == @["2001:db8::1.k51qzi5uqu5dhkzk3z.libp2p.direct"]
+    check resolver.ipQueries == @["2001-db8--1.k51qzi5uqu5dhkzk3z.libp2p.direct"]
+
+  asyncTest "a leading or trailing colon becomes a 0 in the queried name":
+    for ip in ["::1", "2001:db8::", "::"]:
+      discard await checkDNSRecords(
+        resolver,
+        parseIpAddress(ip),
+        BaseDomain,
+        KeyAuth,
+        retries = 0,
+        retryTime = 0.seconds,
+      )
+
+    check resolver.ipQueries ==
+      @["0--1." & BaseDomain, "2001-db8--0." & BaseDomain, "0--0." & BaseDomain]

--- a/tests/libp2p/utils/test_ipaddr.nim
+++ b/tests/libp2p/utils/test_ipaddr.nim
@@ -95,6 +95,17 @@ suite "IpAddr Utils":
     check not isGlobalIP(parseIpAddress("::1"))
     check not isGlobalIP(parseIpAddress("::"))
 
+  test "firstGlobalIP picks the first global address":
+    let
+      privateV4 = parseIpAddress("192.168.1.100")
+      publicV4 = parseIpAddress("1.1.1.1")
+      publicV6 = parseIpAddress("2606:4700::1111")
+      linkLocalV6 = parseIpAddress("fe80::1")
+    check firstGlobalIP(newSeq[IpAddress]()) == Opt.none(IpAddress)
+    check firstGlobalIP([privateV4, linkLocalV6]) == Opt.none(IpAddress)
+    check firstGlobalIP([privateV4, publicV6]) == Opt.some(publicV6)
+    check firstGlobalIP([publicV4, publicV6]) == Opt.some(publicV4)
+
   test "isIPv4, isIPv6":
     let ipv4 = parseIpAddress("1.2.3.4")
     let ipv6 = parseIpAddress("2001:db8::1")

--- a/tests/libp2p/utils/test_ipaddr.nim
+++ b/tests/libp2p/utils/test_ipaddr.nim
@@ -77,6 +77,24 @@ suite "IpAddr Utils":
     check not isPrivate("2606:4700::1")
     check isPublic("2606:4700::1")
 
+  test "isGlobalIP accepts a public address of either family":
+    check isGlobalIP(parseIpAddress("1.1.1.1"))
+    check isGlobalIP(parseIpAddress("185.199.108.153"))
+    check isGlobalIP(parseIpAddress("2606:4700::1111"))
+    check isGlobalIP(parseIpAddress("2a00:1450:4001:800::200e"))
+
+  test "isGlobalIP rejects a non-global address of either family":
+    check not isGlobalIP(parseIpAddress("192.168.1.100"))
+    check not isGlobalIP(parseIpAddress("10.0.0.25"))
+    check not isGlobalIP(parseIpAddress("127.0.0.1"))
+    check not isGlobalIP(parseIpAddress("169.254.12.34"))
+    # ULA (fc00::/7)
+    check not isGlobalIP(parseIpAddress("fd00::1"))
+    # link-local (fe80::/10)
+    check not isGlobalIP(parseIpAddress("fe80::1"))
+    check not isGlobalIP(parseIpAddress("::1"))
+    check not isGlobalIP(parseIpAddress("::"))
+
   test "isIPv4, isIPv6":
     let ipv4 = parseIpAddress("1.2.3.4")
     let ipv6 = parseIpAddress("2001:db8::1")


### PR DESCRIPTION
## Summary

`hasPublicIPAddress` returned `ip.isIPv4() and ip.isPublic()`, so a host whose only public address is IPv6 reported no public address. `getPublicIPAddress` raised on that, and `AutotlsService.setup` turned the raise into a `ServiceSetupError`, so autotls never started on a v6-only host. Closes #2711.

The family check was not the only blocker. `getPrimaryIPAddr` opens a UDP socket towards its probe destination, and the default probe is `8.8.8.8`. On a v6-only host that call fails with `OSError` before any family check runs. The fix therefore probes `8.8.8.8` first and `2001:4860:4860::8888` second, and answers with the first probe that yields a globally reachable address. Both probes are compile-time `IpAddress` constants, and no traffic is sent: the connect only asks the routing table for a source address.

`hasPublicIPAddress` and the raising `getPublicIPAddress` are replaced by a single `getPublicIPAddress(): Opt[IpAddress]`. The three call sites use `valueOr` / `isNone`.

Reachability is now decided by the new `isGlobalIP`, which converts to a chronos `TransportAddress` and calls `isGlobal()`. That predicate is family-aware, so link-local (`fe80::/10`), ULA (`fc00::/7`), loopback and the other special-purpose ranges of both families are rejected. The string-prefix `isPrivate` / `isPublic` are untouched: they match IPv4 dotted-decimal prefixes only and are tracked by #2710. Reusing them here would have made autotls accept `fe80::1` as a public address.

The second half of the issue is in autotls. `checkDNSRecords` built the A-record name with `replace(".", "-")`, which is a no-op on an IPv6 address, so the query kept its colons (`2001:db8::1.<peerid>.libp2p.direct`). Colons are not legal in a DNS label, the lookup could never match, and issuance failed with `AutoTLSError("DNS records not set")`. This path is reachable today without touching `hasPublicIPAddress`, because `AutotlsConfig.new` accepts an `Opt[IpAddress]` from the caller.

The new `dnsLabel` builds the name the way p2p-forge expects for both families: dots and colons become dashes, and a leading or trailing dash gets a `0` for RFC 1123. So `100.10.10.3` gives `100-10-10-3`, `2001:db8::1` gives `2001-db8--1`, `::1` gives `0--1` and `2001:db8::` gives `2001-db8--0`. `resolveIp` already queries `AF_UNSPEC`, so the AAAA lookup needs no other change.

## Affected Areas

- [x] Protocol Logic
  autotls setup and the DNS-01 record check.

- [x] Other
  `libp2p/utils/ipaddr.nim`.

## Compatibility & Downstream Validation

- **Nimbus:** N/A, no reference to `hasPublicIPAddress`, `getPublicIPAddress` or `checkDNSRecords`.
- **Waku:** N/A, same.
- **Codex:** N/A, same.

## Impact on Library Users

API change in `libp2p/utils/ipaddr.nim`: `hasPublicIPAddress()` is gone and `getPublicIPAddress()` returns `Opt[IpAddress]` instead of raising `ValueError` / `OSError`. A caller migrates with `getPublicIPAddress().valueOr: ...` or `.isNone()`.

Behavior change: a v6-only public host now starts autotls instead of failing setup, and autotls queries a legal DNS name for an IPv6 address. A host whose primary address is private is still refused, in both families.

`isGlobalIP` is new and exported. `isPrivate` and `isPublic` keep their current behavior.

## Risk Assessment

`getPublicIPAddress` now opens a second UDP socket when the IPv4 probe fails or is not global. No traffic is sent, and the call still runs one time per `AutotlsService.setup`.

`isGlobalIP` is stricter than the old `isIPv4() and isPublic()` for IPv4: it also rejects CGNAT (`100.64.0.0/10`), documentation, benchmarking and reserved ranges. A host on one of those ranges reported a public address before and is refused now, which is the correct answer for certificate issuance.

The old code caught `Exception` around `getPrimaryIPAddr` and answered `false`, which also swallowed `Defect`. The new code catches `CatchableError` only, so a `Defect` propagates.

The DNS name for an IPv4 address is byte-for-byte what it was, so no v4 deployment changes.

## References

- Closes #2711
- Related: #2710 (`isPrivate` classifies every IPv6 address as public)
- p2p-forge IPv6 subdomain rules: https://github.com/ipshipyard/p2p-forge#ipv6-subdomain-handling

## Additional Notes

The issue notes that `hasPublicIPAddress` could not be tested, because it reads the host address and takes no argument. The family decision now lives in the pure `isGlobalIP`, which is covered for both families in `tests/libp2p/utils/test_ipaddr.nim`. The probe selection in `getPublicIPAddress` still reads the host and stays uncovered.

`tests/libp2p/autotls/test_utils.nim` had a test pinning the colon form with a `TODO: vacp2p/nim-libp2p#2711`. It now asserts the dashed name, and a second test covers the leading and trailing `::` forms.

`libp2p/utils/ipaddr.nim` also drops its unused `../switch` import, so a utility module no longer pulls the switch. Every module that imports `utils/ipaddr` still compiles.