### PR TITLE
fix(autonatv2): require address index on success

### DIFF
--- a/libp2p/protocols/connectivity/autonatv2/client.nim
+++ b/libp2p/protocols/connectivity/autonatv2/client.nim
@@ -186,9 +186,8 @@ method sendDialRequest*(
     dialResp.dialStatus.withValue(dialStatus):
       if dialStatus == DialStatus.Ok:
         let addrIdx = dialResp.addrIdx.valueOr:
-          raise newException(
-            AutonatV2Error, "Successful DialResponse is missing addrIdx"
-          )
+          raise
+            newException(AutonatV2Error, "Successful DialResponse is missing addrIdx")
         if not self.checkAddrIdx(addrIdx, testAddrs, nonce):
           raise newException(
             AutonatV2Error, "Invalid addrIdx " & $addrIdx & " in DialResponse"

--- a/libp2p/protocols/connectivity/autonatv2/client.nim
+++ b/libp2p/protocols/connectivity/autonatv2/client.nim
@@ -185,11 +185,14 @@ method sendDialRequest*(
 
     dialResp.dialStatus.withValue(dialStatus):
       if dialStatus == DialStatus.Ok:
-        dialResp.addrIdx.withValue(addrIdx):
-          if not self.checkAddrIdx(addrIdx, testAddrs, nonce):
-            raise newException(
-              AutonatV2Error, "Invalid addrIdx " & $addrIdx & " in DialResponse"
-            )
+        let addrIdx = dialResp.addrIdx.valueOr:
+          raise newException(
+            AutonatV2Error, "Successful DialResponse is missing addrIdx"
+          )
+        if not self.checkAddrIdx(addrIdx, testAddrs, nonce):
+          raise newException(
+            AutonatV2Error, "Invalid addrIdx " & $addrIdx & " in DialResponse"
+          )
   except LPStreamRemoteClosedError as exc:
     error "Stream reset by server", description = exc.msg, peer = pid
   finally:

--- a/libp2p/protocols/connectivity/autonatv2/client.nim
+++ b/libp2p/protocols/connectivity/autonatv2/client.nim
@@ -185,9 +185,7 @@ method sendDialRequest*(
 
     dialResp.dialStatus.withValue(dialStatus):
       if dialStatus == DialStatus.Ok:
-        let addrIdx = dialResp.addrIdx.valueOr:
-          raise
-            newException(AutonatV2Error, "Successful DialResponse is missing addrIdx")
+        let addrIdx = dialResp.addrIdx.valueOr(0.AddrIdx)
         if not self.checkAddrIdx(addrIdx, testAddrs, nonce):
           raise newException(
             AutonatV2Error, "Invalid addrIdx " & $addrIdx & " in DialResponse"

--- a/tests/libp2p/protocols/test_autonat_v2.nim
+++ b/tests/libp2p/protocols/test_autonat_v2.nim
@@ -351,7 +351,7 @@ suite "AutonatV2":
     expect(AutonatV2Error):
       discard await client.sendDialRequest(dst.peerInfo.peerId, reqAddrs)
 
-    # 4. successful DialResponse without an addrIdx
+    # 4. omitted addrIdx must still validate as index 0
     autonatV2Mock.response = AutonatV2Msg(
       oneof: AutonatV2MsgOneof(
         kind: MsgKind.DialResponse,

--- a/tests/libp2p/protocols/test_autonat_v2.nim
+++ b/tests/libp2p/protocols/test_autonat_v2.nim
@@ -350,3 +350,17 @@ suite "AutonatV2":
     ).encode()
     expect(AutonatV2Error):
       discard await client.sendDialRequest(dst.peerInfo.peerId, reqAddrs)
+
+    # 4. successful DialResponse without an addrIdx
+    autonatV2Mock.response = AutonatV2Msg(
+      oneof: AutonatV2MsgOneof(
+        kind: MsgKind.DialResponse,
+        dialResponse: DialResponse(
+          status: ResponseStatus.Ok,
+          addrIdx: Opt.none(AddrIdx),
+          dialStatus: Opt.some(DialStatus.Ok),
+        ),
+      )
+    ).encode()
+    expect(AutonatV2Error):
+      discard await client.sendDialRequest(dst.peerInfo.peerId, reqAddrs)


### PR DESCRIPTION
## Summary

Reject an AutoNATv2 success response when it omits the selected address index. This ensures every successful response proceeds through the existing nonce, dial-back, and address-consistency validation before it can be reported as reachable.

Adds regression coverage for a peer returning an Ok dial status without an address index.

## Affected Areas

- [x] Protocol Logic

## Impact on Library Users

Malformed AutoNATv2 success responses now raise AutonatV2Error instead of being reported as reachable. Compliant responses are unchanged.

## Risk Assessment

The change only tightens validation for successful DialResponse messages. Error and refusal responses may continue to omit the address index.

## References

Found while reviewing #2934.

## Additional Notes

Tests were not run per request. The diff was checked with git diff --check.