### PR TITLE
feat(quic): add stream idle timeouts

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -248,10 +248,17 @@ proc withWsTransport*(
       )
   )
 
-proc withQuicTransport*(b: SwitchBuilder): SwitchBuilder =
+proc withQuicTransport*(
+    b: SwitchBuilder,
+    inTimeout: Duration = DefaultChanTimeout,
+    outTimeout: Duration = DefaultChanTimeout,
+): SwitchBuilder =
   b.withTransport(
     proc(config: TransportConfig): Transport =
-      QuicTransport.new(config.upgr, config.privateKey, config.rng, config.connManager)
+      QuicTransport.new(
+        config.upgr, config.privateKey, config.rng, config.connManager, inTimeout,
+        outTimeout,
+      )
   )
 
 proc withMemoryTransport*(b: SwitchBuilder): SwitchBuilder =

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -43,6 +43,8 @@ type
   QuicSession* = ref object of P2PConnection
     connection: QuicConnection
     streams: HashSet[QuicStream]
+    inTimeout: Duration
+    outTimeout: Duration
     when defined(libp2p_agents_metrics):
       tracked: bool
 
@@ -58,6 +60,7 @@ proc new(
     stream: LsquicStream,
     dir: Direction,
     session: QuicSession,
+    timeout: Duration,
     oaddr: Opt[MultiAddress],
     laddr: Opt[MultiAddress],
     peerId: PeerId,
@@ -65,13 +68,16 @@ proc new(
   let quicstream = QuicStream(
     session: session,
     stream: stream,
-    timeout: 0.millis, # QUIC handles idle timeout at the transport layer
+    timeout: timeout,
     observedAddr: oaddr,
     localAddr: laddr,
     peerId: peerId,
   )
   quicstream.objName = "QuicStream"
   quicstream.dir = dir
+  quicstream.timeoutHandler = proc(): Future[void] {.async: (raises: [], raw: true).} =
+    trace "Idle timeout expired, resetting QuicStream"
+    quicstream.reset()
   procCall P2PConnection(quicstream).initStream()
   quicstream
 
@@ -126,6 +132,7 @@ method write*(
   try:
     await stream.stream.write(bytes)
     libp2p_network_bytes.inc(bytesLen.int64, labelValues = ["out"])
+    stream.activity = true
     when defined(libp2p_agents_metrics):
       stream.session.trackPeerIdentity()
       if stream.session.tracked:
@@ -188,8 +195,10 @@ proc getStream(
   of Direction.Out:
     stream = await session.connection.openStream()
 
+  let timeout = if direction == Direction.In: session.inTimeout else: session.outTimeout
   let qs = QuicStream.new(
-    stream, direction, session, session.observedAddr, session.localAddr, session.peerId
+    stream, direction, session, timeout, session.observedAddr, session.localAddr,
+    session.peerId,
   )
   when defined(libp2p_agents_metrics):
     qs.shortAgent = session.shortAgent
@@ -307,6 +316,8 @@ type QuicTransport* = ref object of Transport
   rng: Rng
   certGenerator: CertGenerator
   closeFuts: seq[Future[void]]
+  inTimeout: Duration
+  outTimeout: Duration
 
 type PeerIdCertificateVerifier = ref object of CertificateVerifier
   expectedPeerId: PeerId
@@ -366,6 +377,8 @@ proc new*(
     privateKey: PrivateKey,
     rng: Rng,
     connManager: ConnManager = nil,
+    inTimeout: Duration = DefaultChanTimeout,
+    outTimeout: Duration = DefaultChanTimeout,
 ): QuicTransport =
   doAssert not rng.isNil, "Rng is nil"
 
@@ -374,6 +387,8 @@ proc new*(
     privateKey: privateKey,
     rng: rng,
     certGenerator: defaultCertGenerator,
+    inTimeout: inTimeout,
+    outTimeout: outTimeout,
   )
   procCall Transport(self).initialize()
   self
@@ -385,6 +400,8 @@ proc new*(
     rng: Rng,
     certGenerator: CertGenerator,
     connManager: ConnManager = nil,
+    inTimeout: Duration = DefaultChanTimeout,
+    outTimeout: Duration = DefaultChanTimeout,
 ): QuicTransport =
   doAssert not rng.isNil, "Rng is nil"
 
@@ -393,6 +410,8 @@ proc new*(
     privateKey: privateKey,
     rng: rng,
     certGenerator: certGenerator,
+    inTimeout: inTimeout,
+    outTimeout: outTimeout,
   )
   procCall Transport(self).initialize()
   self
@@ -499,6 +518,8 @@ proc wrapConnection(
     connection: connection,
     observedAddr: Opt.some(observedAddr),
     localAddr: Opt.some(localAddr),
+    inTimeout: transport.inTimeout,
+    outTimeout: transport.outTimeout,
   )
   session.initStream()
 

--- a/tests/libp2p/transports/test_quic.nim
+++ b/tests/libp2p/transports/test_quic.nim
@@ -343,3 +343,67 @@ suite "Quic transport":
 
     expect QuicTransportAcceptStopped:
       discard await server.accept()
+
+  asyncTest "stream idle timeout resets only the idle stream":
+    let server = await createQuicTransport(
+      isServer = true, inTimeout = 2.seconds, outTimeout = 3.seconds
+    )
+    let client =
+      await createQuicTransport(inTimeout = 4.seconds, outTimeout = 100.milliseconds)
+
+    let acceptFut = server.accept()
+    let clientConn = await client.dial("", server.addrs[0])
+    let serverConn = await acceptFut
+    let clientMuxer = QuicMuxer.new(clientConn)
+    let serverMuxer = QuicMuxer.new(serverConn)
+    let inboundTimeout = newFuture[Duration]()
+
+    proc echo(stream: MuxedStream) {.async: (raises: []).} =
+      if not inboundTimeout.finished:
+        inboundTimeout.complete(stream.timeout)
+
+      try:
+        var data: array[1, byte]
+        while true:
+          let read = await stream.readOnce(addr data[0], data.len)
+          if read == 0:
+            break
+          await stream.write(@[data[0]])
+          if data[0] == 2:
+            break
+      except CancelledError, LPStreamError:
+        discard
+      finally:
+        await stream.close()
+
+    serverMuxer.streamHandler = echo
+    let serverHandle = serverMuxer.handle()
+
+    defer:
+      await clientMuxer.close()
+      await serverMuxer.close()
+      await allFutures(clientConn.close(), serverConn.close())
+      await client.stop()
+      await server.stop()
+      await serverHandle
+
+    let idleStream = await clientMuxer.newStream()
+    check idleStream.timeout == 100.milliseconds
+
+    for _ in 0 ..< 4:
+      await idleStream.write(@[byte 1])
+      await sleepAsync(60.milliseconds)
+      check not idleStream.closed
+
+    check (await inboundTimeout) == 2.seconds
+    check await idleStream.join().withTimeout(500.milliseconds)
+    check idleStream.wasResetLocally
+
+    # The stream timeout must not close the containing QUIC connection.
+    let activeStream = await clientMuxer.newStream()
+    await activeStream.write(@[byte 2])
+
+    var response: array[1, byte]
+    await activeStream.readExactly(addr response[0], response.len)
+    check response[0] == 2
+    await activeStream.close()

--- a/tests/libp2p/transports/utils.nim
+++ b/tests/libp2p/transports/utils.nim
@@ -78,6 +78,8 @@ proc createQuicTransport*(
     withInvalidCert: bool = false,
     privateKey: Opt[PrivateKey] = Opt.none(PrivateKey),
     addresses: seq[MultiAddress] = @[QuicAutoAddress],
+    inTimeout: Duration = DefaultChanTimeout,
+    outTimeout: Duration = DefaultChanTimeout,
 ): Future[QuicTransport] {.async.} =
   let key =
     if privateKey.isNone:
@@ -87,9 +89,18 @@ proc createQuicTransport*(
 
   let trans =
     if withInvalidCert:
-      QuicTransport.new(Upgrade(), key, rng(), invalidCertGenerator)
+      QuicTransport.new(
+        Upgrade(),
+        key,
+        rng(),
+        invalidCertGenerator,
+        inTimeout = inTimeout,
+        outTimeout = outTimeout,
+      )
     else:
-      QuicTransport.new(Upgrade(), key, rng())
+      QuicTransport.new(
+        Upgrade(), key, rng(), inTimeout = inTimeout, outTimeout = outTimeout
+      )
 
   if isServer: # servers are started because they need to listen
     await trans.start(addresses)


### PR DESCRIPTION
## Summary

- Add configurable inbound and outbound inactivity timeouts for QUIC streams.
- Reset an expired stream without closing its containing QUIC connection.
- Refresh stream activity after successful QUIC writes.

## Affected Areas

- [x] Transports — QUIC stream lifecycle and builder configuration

## Impact on Library Users

QUIC streams now use the same five-minute default inactivity timeout as mplex and yamux. Applications can customize the values through `withQuicTransport(inTimeout, outTimeout)` or the `QuicTransport` constructors.

## Risk Assessment

Long-lived QUIC streams with no reads or writes will now be reset after the configured timeout. Active sibling streams and the underlying QUIC connection remain open.