### PR TITLE
fix(switch): prevent accept-loop resource exhaustion

### DIFF
--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -535,6 +535,11 @@ proc getIncomingSlot*(
     await c.inSema.acquire()
   return ConnectionSlot(connManager: c, direction: In)
 
+proc tryGetIncomingSlot*(c: ConnManager): Opt[ConnectionSlot] =
+  if c.inSema != nil and not c.inSema.tryAcquire():
+    return Opt.none(ConnectionSlot)
+  Opt.some(ConnectionSlot(connManager: c, direction: In))
+
 proc getOutgoingSlot*(
     c: ConnManager, forceDial = false
 ): ConnectionSlot {.raises: [TooManyConnectionsError].} =
@@ -783,6 +788,12 @@ proc triggerTrim(c: ConnManager) {.gcsafe, raises: [].} =
       if Moment.now() - lastTrim < wm.silencePeriod:
         return
     c.trimFut = c.trimConnections()
+
+proc triggerTrimIfNeeded*(c: ConnManager) {.gcsafe, raises: [].} =
+  ## Retries watermark trimming while the peer count remains above the high watermark.
+  c.watermark.withValue(wm):
+    if c.muxerStore.countPeers() > wm.highWater:
+      c.triggerTrim()
 
 proc drainOnCloseTasks(c: ConnManager) {.async: (raises: []).} =
   ## Drains the per-muxer onClose tasks once muxers are closed, so they finish

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -445,7 +445,7 @@ proc selectMuxer*(c: ConnManager, peerId: PeerId): Muxer =
     trace "connection not found", peerId
   return mux
 
-proc triggerTrim(c: ConnManager) {.gcsafe, raises: [].}
+proc triggerTrim*(c: ConnManager) {.gcsafe, raises: [].}
 
 proc triggerTrimAfter(
     c: ConnManager, fut: Future[void].Raising([CancelledError])
@@ -455,8 +455,7 @@ proc triggerTrimAfter(
       await fut
   except CancelledError:
     return
-  if c.watermark.isSome and c.muxerStore.countPeers() > c.watermark.get().highWater:
-    c.triggerTrim()
+  c.triggerTrim()
 
 proc storeMuxer*(
     c: ConnManager, muxer: Muxer
@@ -777,23 +776,19 @@ proc trimConnections(c: ConnManager) {.async: (raises: []).} =
 
   c.lastTrim = Opt.some(Moment.now())
 
-proc triggerTrim(c: ConnManager) {.gcsafe, raises: [].} =
+proc triggerTrim*(c: ConnManager) {.gcsafe, raises: [].} =
   ## Schedules a trim cycle if none is running and the silence period has elapsed.
   if not c.trimFut.isNil and not c.trimFut.finished:
     # trim is ongoing
     return
 
   c.watermark.withValue(wm):
+    if c.muxerStore.countPeers() <= wm.highWater:
+      return
     c.lastTrim.withValue(lastTrim):
       if Moment.now() - lastTrim < wm.silencePeriod:
         return
     c.trimFut = c.trimConnections()
-
-proc triggerTrimIfNeeded*(c: ConnManager) {.gcsafe, raises: [].} =
-  ## Retries watermark trimming while the peer count remains above the high watermark.
-  c.watermark.withValue(wm):
-    if c.muxerStore.countPeers() > wm.highWater:
-      c.triggerTrim()
 
 proc drainOnCloseTasks(c: ConnManager) {.async: (raises: []).} =
   ## Drains the per-muxer onClose tasks once muxers are closed, so they finish

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -41,8 +41,11 @@ logScope:
 # and only if the channel has been secured (i.e. if a secure manager has been
 # previously provided)
 
-const ConcurrentUpgrades* = 32
-const UpgradeTimeout* = 30.seconds
+const
+  ConcurrentUpgrades* = 32
+  MaxRejectedConnectionCloses = ConcurrentUpgrades
+  UpgradeTimeout* = 30.seconds
+  AcceptRetryDelay = 100.millis
 
 type
   Switch* = ref object of Dial
@@ -53,6 +56,7 @@ type
     ms*: MultistreamSelect
     acceptFuts: seq[Future[void]]
     upgradeFuts: seq[Future[void]]
+    rejectedConnCloseFuts: seq[Future[void]]
     dialer*: Dialer
     peerStore*: PeerStore
     nameResolver*: NameResolver
@@ -278,16 +282,12 @@ proc accept(s: Switch, transport: Transport) {.async: (raises: []).} =
     var conn: RawConn
     try:
       debug "About to accept incoming connection"
-      let slot = await s.connManager.getIncomingSlot()
-
       conn =
         try:
           await transport.accept()
         except CancelledError as exc:
-          slot.release()
           raise exc
         except CatchableError as exc:
-          slot.release()
           raise
             newException(CatchableError, "failed to accept connection: " & exc.msg, exc)
       if isNil(conn):
@@ -295,10 +295,19 @@ proc accept(s: Switch, transport: Transport) {.async: (raises: []).} =
         # file-handle limit (or another non-fatal error),
         # we can get one on the next try
         debug "Unable to get a connection"
-        slot.release()
+        await sleepAsync(AcceptRetryDelay)
         continue
 
-      slot.trackConnection(conn)
+      let slot = s.connManager.tryGetIncomingSlot()
+      if slot.isNone:
+        debug "Incoming connection limit reached", conn
+        s.rejectedConnCloseFuts.trackFut(conn.close())
+        s.connManager.triggerTrimIfNeeded()
+        if s.rejectedConnCloseFuts.len >= MaxRejectedConnectionCloses:
+          discard await one(s.rejectedConnCloseFuts)
+        continue
+
+      slot.get().trackConnection(conn)
 
       # set the direction of this bottom level transport
       # in order to be able to consume this information in gossipsub if required
@@ -337,6 +346,9 @@ proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
 
   await s.upgradeFuts.cancelAndWait()
   s.upgradeFuts = @[]
+
+  await noCancel allFutures(s.rejectedConnCloseFuts)
+  s.rejectedConnCloseFuts = @[]
 
   for service in s.services:
     await service.stop(s)

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -298,8 +298,7 @@ proc accept(s: Switch, transport: Transport) {.async: (raises: []).} =
         await sleepAsync(AcceptRetryDelay)
         continue
 
-      let slot = s.connManager.tryGetIncomingSlot()
-      if slot.isNone:
+      let slot = s.connManager.tryGetIncomingSlot().valueOr:
         debug "Incoming connection limit reached", conn
         s.rejectedConnCloseFuts.trackFut(conn.close())
         s.connManager.triggerTrim()
@@ -307,7 +306,7 @@ proc accept(s: Switch, transport: Transport) {.async: (raises: []).} =
           discard await one(s.rejectedConnCloseFuts)
         continue
 
-      slot.get().trackConnection(conn)
+      slot.trackConnection(conn)
 
       # set the direction of this bottom level transport
       # in order to be able to consume this information in gossipsub if required

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -45,7 +45,7 @@ const
   ConcurrentUpgrades* = 32
   MaxRejectedConnectionCloses = ConcurrentUpgrades
   UpgradeTimeout* = 30.seconds
-  AcceptRetryDelay = 100.millis
+  AcceptRetryDelay* = 100.millis
 
 type
   Switch* = ref object of Dial

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -302,7 +302,7 @@ proc accept(s: Switch, transport: Transport) {.async: (raises: []).} =
       if slot.isNone:
         debug "Incoming connection limit reached", conn
         s.rejectedConnCloseFuts.trackFut(conn.close())
-        s.connManager.triggerTrimIfNeeded()
+        s.connManager.triggerTrim()
         if s.rejectedConnCloseFuts.len >= MaxRejectedConnectionCloses:
           discard await one(s.rejectedConnCloseFuts)
         continue

--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -346,6 +346,20 @@ suite "Connection Manager":
 
     await connMngr.close()
 
+  asyncTest "try incoming connection slot":
+    let connMngr = newMaxTotal(1)
+
+    let slot = connMngr.tryGetIncomingSlot()
+    check slot.isSome
+    check connMngr.tryGetIncomingSlot().isNone
+
+    slot.get().release()
+    let reacquired = connMngr.tryGetIncomingSlot()
+    check reacquired.isSome
+    reacquired.get().release()
+
+    await connMngr.close()
+
   asyncTest "track total outgoing connection limits":
     let connMngr = newMaxTotal(3)
 

--- a/tests/libp2p/test_conn_manager_component.nim
+++ b/tests/libp2p/test_conn_manager_component.nim
@@ -399,11 +399,10 @@ suite "Connection Manager Watermark/Scoring Component":
 
     # both guards run at once: the watermark trims to lowWater, the semaphore tracks the cap
     # the trimmed connections release their slots back to the semaphore
-    # the accept loop keeps one slot pre-acquired for the next incoming dial
-    # so the available inbound slots settle at cap - lowWater - 1
+    # the accept loop does not reserve a slot before a connection arrives
     checkUntilTimeout:
       node.peerCount == lowWater
-      node.connManager.availableSlots(Direction.In) == maxConnections - lowWater - 1
+      node.connManager.availableSlots(Direction.In) == maxConnections - lowWater
 
   asyncTest "hard cap rejects new connections when the trim cannot free slots":
     # every peer is protected, so the trim has nothing to prune
@@ -435,6 +434,35 @@ suite "Connection Manager Watermark/Scoring Component":
     check not (await node.connManager.getIncomingSlot().withTimeout(100.millis))
     expect TooManyConnectionsError:
       discard node.connManager.getOutgoingSlot()
+
+  asyncTest "cap rejection retries watermark trimming after grace":
+    const
+      lowWater = 1
+      highWater = 2
+      maxConnections = 3
+      gracePeriod = 1.seconds
+    let node = newWatermarkSwitch(
+      lowWater, highWater, gracePeriod = gracePeriod, maxConnections = maxConnections
+    )
+    let peers = newSwitches(maxConnections + 1)
+    let all = @[node] & peers
+
+    startAndDeferStop(all)
+
+    for peer in peers[0 ..< maxConnections]:
+      await connect(peer, node)
+
+    checkUntilTimeout:
+      node.peerCount == maxConnections
+      node.connManager.availableSlots(Direction.In) == 0
+
+    await sleepAsync(gracePeriod)
+    let rejectedDial = peers[^1].connect(node.peerInfo.peerId, node.peerInfo.addrs)
+    defer:
+      await rejectedDial.cancelAndWait()
+
+    checkUntilTimeout:
+      node.peerCount == lowWater
 
   asyncTest "dial fails when the trim prunes the new connection":
     # reaching lowWater can force the trim to drop the dialing peer's own freshly stored connection

--- a/tests/libp2p/test_switch.nim
+++ b/tests/libp2p/test_switch.nim
@@ -790,11 +790,8 @@ suite "Switch":
     switches.add(switchFail)
     await switchFail.start()
 
-    check not (
-      await switchFail.connect(destPeerInfo.peerId, destPeerInfo.addrs).withTimeout(
-        1000.millis
-      )
-    )
+    expect DialFailedError:
+      await switchFail.connect(destPeerInfo.peerId, destPeerInfo.addrs).wait(10.seconds)
 
     await allFuturesRaising(switches.mapIt(it.stop()))
 
@@ -846,11 +843,8 @@ suite "Switch":
     switches.add(switchFail)
     await switchFail.start()
 
-    check not (
-      await switchFail.connect(destPeerInfo.peerId, destPeerInfo.addrs).withTimeout(
-        1000.millis
-      )
-    )
+    expect DialFailedError:
+      await switchFail.connect(destPeerInfo.peerId, destPeerInfo.addrs).wait(10.seconds)
 
     await allFuturesRaising(switches.mapIt(it.stop()))
 

--- a/tests/libp2p/test_switch_accept.nim
+++ b/tests/libp2p/test_switch_accept.nim
@@ -67,8 +67,8 @@ suite "Switch accept-loop failure handling":
     let (server, transport) = newStubAcceptSwitch(NilAlways)
     startAndDeferStop(@[server])
 
-    await sleepAsync(250.millis)
-    check transport.acceptCalls < 10
+    await sleepAsync(2 * AcceptRetryDelay + 50.millis)
+    check transport.acceptCalls <= 3
     # nil remains non-fatal, so the loop keeps accepting after the backoff
     checkUntilTimeout:
       transport.acceptCalls >= 5

--- a/tests/libp2p/test_switch_accept.nim
+++ b/tests/libp2p/test_switch_accept.nim
@@ -68,7 +68,10 @@ suite "Switch accept-loop failure handling":
     startAndDeferStop(@[server])
 
     await sleepAsync(2 * AcceptRetryDelay + 50.millis)
-    check transport.acceptCalls <= 3
+    let delay = 2 * AcceptRetryDelay + 50.milliseconds
+    let retries = (delay.inMilliseconds / AcceptRetryDelay.inMilliseconds).ceil
+    await sleepAsync(delay)
+    check transport.acceptCalls <= retries
     # nil remains non-fatal, so the loop keeps accepting after the backoff
     checkUntilTimeout:
       transport.acceptCalls >= 5

--- a/tests/libp2p/test_switch_accept.nim
+++ b/tests/libp2p/test_switch_accept.nim
@@ -12,7 +12,11 @@ import ../stubs/transportstub
 import ../tools/[unittest, crypto, lifecycle, multiaddress, switch_builder]
 
 proc newStubAcceptSwitch(
-    behavior: StubAcceptBehavior, nilCount = 0, withTcp = false, maxIn = 0
+    behavior: StubAcceptBehavior,
+    nilCount = 0,
+    withTcp = false,
+    maxIn = 0,
+    acceptLimit = 0,
 ): (Switch, MemoryTransportStub) =
   var addrs = @[MemoryAutoAddress()]
   if withTcp:
@@ -26,7 +30,9 @@ proc newStubAcceptSwitch(
     .withAddresses(addrs)
     .withTransport(
       proc(config: TransportConfig): Transport =
-        MemoryTransportStub.new(config.upgr, rng(), behavior, nilCount)
+        MemoryTransportStub.new(
+          config.upgr, rng(), behavior, nilCount, acceptLimit = acceptLimit
+        )
     )
   if withTcp:
     b = b.withTcpTransport()
@@ -41,7 +47,7 @@ suite "Switch accept-loop failure handling":
     checkTrackers()
 
   asyncTest "accept raising exits the loop while the transport still looks reachable":
-    # a single inbound slot lets us check the loop hands it back when accept fails
+    # A failed accept must not consume inbound capacity.
     let (server, transport) = newStubAcceptSwitch(RaiseAlways, maxIn = 1)
     startAndDeferStop(@[server])
 
@@ -57,13 +63,15 @@ suite "Switch accept-loop failure handling":
 
     check server.connManager.availableSlots(Direction.In) == 1
 
-  asyncTest "accept returning nil is non-fatal and the loop keeps retrying":
+  asyncTest "accept returning nil retries with backoff":
     let (server, transport) = newStubAcceptSwitch(NilAlways)
     startAndDeferStop(@[server])
 
-    # nil is treated as a transient miss, so the loop keeps calling accept indefinitely
+    await sleepAsync(250.millis)
+    check transport.acceptCalls < 10
+    # nil remains non-fatal, so the loop keeps accepting after the backoff
     checkUntilTimeout:
-      transport.acceptCalls >= 5 # arbitrary count
+      transport.acceptCalls >= 5
     check not server.acceptFuts[0].finished
 
   asyncTest "inbound connections are dropped after a transport's accept loop dies":
@@ -81,11 +89,8 @@ suite "Switch accept-loop failure handling":
     expect DialFailedError:
       await client.connect(server.peerInfo.peerId, server.peerInfo.addrs)
 
-  asyncTest "the accept loop releases its slot on each nil so a one-slot transport recovers":
+  asyncTest "nil accepts do not consume a slot and a one-slot transport recovers":
     const nilCount = 3
-    # only one inbound slot and the loop pre-acquires it before every accept.
-    # reaching a real accept after nilCount nils is possible only if each
-    # nil released that slot, else the next getIncomingSlot would block forever
     let (server, transport) =
       newStubAcceptSwitch(NilThenAccept, nilCount = nilCount, maxIn = 1)
     let client = makeStandardSwitch(MemoryAutoAddress())
@@ -93,11 +98,42 @@ suite "Switch accept-loop failure handling":
 
     checkUntilTimeout:
       transport.acceptCalls > nilCount
+    check server.connManager.availableSlots(Direction.In) == 1
 
     # the recovered accept serves a real inbound connection, and the one slot is used
     await client.connect(server.peerInfo.peerId, server.peerInfo.addrs)
     check client.isConnected(server.peerInfo.peerId)
     check server.connManager.availableSlots(Direction.In) == 0
+
+  asyncTest "rejecting a connection does not wait for its close":
+    let (server, transport) =
+      newStubAcceptSwitch(BlockingClose, maxIn = 1, acceptLimit = 2)
+    let slot = await server.connManager.getIncomingSlot()
+    defer:
+      slot.release()
+    startAndDeferStop(@[server])
+    defer:
+      transport.closeGate.fire()
+
+    checkUntilTimeout:
+      transport.closeCalls > 0
+      transport.acceptCalls > 1
+
+  asyncTest "pending rejected connection closes are bounded":
+    let (server, transport) = newStubAcceptSwitch(
+      BlockingClose, maxIn = 1, acceptLimit = ConcurrentUpgrades + 1
+    )
+    let slot = await server.connManager.getIncomingSlot()
+    defer:
+      slot.release()
+    startAndDeferStop(@[server])
+    defer:
+      transport.closeGate.fire()
+
+    checkUntilTimeout:
+      transport.closeCalls == ConcurrentUpgrades
+    await sleepAsync(100.millis)
+    check transport.acceptCalls == ConcurrentUpgrades
 
   asyncTest "one transport's accept failure does not stop other transports from accepting":
     let (server, _) = newStubAcceptSwitch(RaiseAlways, withTcp = true)

--- a/tests/libp2p/test_switch_accept.nim
+++ b/tests/libp2p/test_switch_accept.nim
@@ -67,7 +67,6 @@ suite "Switch accept-loop failure handling":
     let (server, transport) = newStubAcceptSwitch(NilAlways)
     startAndDeferStop(@[server])
 
-    await sleepAsync(2 * AcceptRetryDelay + 50.millis)
     let delay = 2 * AcceptRetryDelay + 50.milliseconds
     let retries = (delay.inMilliseconds / AcceptRetryDelay.inMilliseconds).ceil
     await sleepAsync(delay)

--- a/tests/libp2p/test_switch_accept.nim
+++ b/tests/libp2p/test_switch_accept.nim
@@ -67,10 +67,9 @@ suite "Switch accept-loop failure handling":
     let (server, transport) = newStubAcceptSwitch(NilAlways)
     startAndDeferStop(@[server])
 
-    let delay = 2 * AcceptRetryDelay + 50.milliseconds
-    let retries = (delay.inMilliseconds / AcceptRetryDelay.inMilliseconds).ceil
-    await sleepAsync(delay)
-    check transport.acceptCalls <= retries
+    await sleepAsync(2 * AcceptRetryDelay + 50.milliseconds)
+    # One immediate accept, then retries after 100ms and 200ms.
+    check transport.acceptCalls <= 3
     # nil remains non-fatal, so the loop keeps accepting after the backoff
     checkUntilTimeout:
       transport.acceptCalls >= 5

--- a/tests/stubs/transportstub.nim
+++ b/tests/stubs/transportstub.nim
@@ -19,11 +19,27 @@ type
     RaiseAlways ## every accept raises: the transport can never accept
     NilAlways ## every accept returns nil: the switch's non-fatal branch
     NilThenAccept ## return nil `nilCount` times, then accept normally
+    BlockingClose ## return connections whose close waits for `closeGate`
 
   MemoryTransportStub* = ref object of MemoryTransport
     behavior: StubAcceptBehavior
     nilCount: int ## for NilThenAccept: how many nils before accepting normally
+    acceptLimit: int ## for BlockingClose: block after this many accepts
     acceptCalls*: int ## number of times accept was invoked
+    closeCalls*: int ## number of blocking connection closes started
+    closeGate*: AsyncEvent
+
+  BlockingCloseConnection = ref object of Connection
+    transport: MemoryTransportStub
+
+method closeImpl(conn: BlockingCloseConnection) {.async: (raises: []).} =
+  inc conn.transport.closeCalls
+  try:
+    await conn.transport.closeGate.wait()
+  except CancelledError:
+    # Model a transport that cannot finish its close bookkeeping after cancellation.
+    return
+  await procCall Connection(conn).closeImpl()
 
 proc new*(
     T: typedesc[MemoryTransportStub],
@@ -31,8 +47,16 @@ proc new*(
     rng: Rng,
     behavior: StubAcceptBehavior,
     nilCount: int = 0,
+    acceptLimit: int = 0,
 ): T =
-  let self = T(upgrader: upgrade, rng: rng, behavior: behavior, nilCount: nilCount)
+  let self = T(
+    upgrader: upgrade,
+    rng: rng,
+    behavior: behavior,
+    nilCount: nilCount,
+    acceptLimit: acceptLimit,
+    closeGate: newAsyncEvent(),
+  )
   procCall Transport(self).initialize()
   self
 
@@ -60,3 +84,10 @@ method accept*(
       return nil
     # accept normally by delegating to the base transport
     return await procCall MemoryTransport(self).accept()
+  of BlockingClose:
+    if self.acceptLimit > 0 and self.acceptCalls > self.acceptLimit:
+      await sleepAsync(1.hours)
+    await sleepAsync(0.milliseconds)
+    let conn = BlockingCloseConnection(transport: self)
+    conn.initStream()
+    return conn


### PR DESCRIPTION
## Summary

- acquire inbound slots after transport accept and reject excess connections without blocking the accept loop
- bound rejected-connection close concurrency and drain cleanup safely during shutdown
- back off transient nil accepts to prevent Linux file-descriptor exhaustion from causing a CPU spin
- retry watermark trimming when inbound capacity remains exhausted

Also fixes #2335.

## Affected Areas

- [x] Transports — incoming accept, rejection cleanup, and retry backoff
- [x] Peer Management / Discovery — connection limits and watermark trimming

## Impact on Library Users

Nodes at their inbound limit keep accepting without serializing on graceful closes. Repeated transient accept failures retry every 100 ms, and rejected closes use bounded backpressure.

## Risk Assessment

The accept loop waits once 32 rejected closes are in flight, bounding retained sessions while avoiding the previous per-rejection stall. Shutdown waits for those closes to finish so transport cleanup bookkeeping is not abandoned.