### PR TITLE
fix(TcpTransport): dual-stack reuse bug

### DIFF
--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -304,14 +304,17 @@ method dial*(
 
   let ta = initTAddress(address).valueOr:
     raise (ref TcpTransportError)(msg: "Unsupported address: " & $address)
-  let local = findAddressByFamily(self.addrs, ta.family)
+  let local =
+    if self.networkReachability == NetworkReachability.NotReachable:
+      findAddressByFamily(self.addrs, ta.family)
+    else:
+      Opt.none(TransportAddress)
 
   trace "Dialing remote peer", address = $address
   let transp =
     try:
       await(
-        if self.networkReachability == NetworkReachability.NotReachable and
-            local.isSome():
+        if local.isSome():
           self.clientFlags.incl(SocketFlags.ReusePort)
           connect(ta, flags = self.clientFlags, localAddress = local.get())
         else:

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -304,10 +304,10 @@ method dial*(
 
   let ta = initTAddress(address).valueOr:
     raise (ref TcpTransportError)(msg: "Unsupported address: " & $address)
+  let local = findAddressByFamily(self.addrs, ta.family)
 
   trace "Dialing remote peer", address = $address
   let transp =
-    let local = findAddressByFamily(self.addrs, ta.family)
     try:
       await(
         if self.networkReachability == NetworkReachability.NotReachable and

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -314,9 +314,9 @@ method dial*(
   let transp =
     try:
       await(
-        if local.isSome():
+        local.withValue(localAddr):
           self.clientFlags.incl(SocketFlags.ReusePort)
-          connect(ta, flags = self.clientFlags, localAddress = local.get())
+          connect(ta, flags = self.clientFlags, localAddress = localAddr)
         else:
           connect(ta, flags = self.clientFlags)
       )

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -281,6 +281,16 @@ method accept*(
       return nil
   self.connHandler(transp, Opt.some(observedAddr), Opt.some(localAddr), Direction.In)
 
+proc findAddressByFamily(
+    addrs: openArray[MultiAddress], family: AddressFamily
+): Opt[TransportAddress] =
+  for addr in addrs:
+    let transportAddress = initTAddress(addr).expect("self address is valid")
+    if transportAddress.family == family:
+      return Opt.some(transportAddress)
+
+  Opt.none(TransportAddress)
+
 method dial*(
     self: TcpTransport,
     hostname: string,
@@ -297,13 +307,13 @@ method dial*(
 
   trace "Dialing remote peer", address = $address
   let transp =
+    let local = findAddressByFamily(self.addrs, ta.family)
     try:
       await(
         if self.networkReachability == NetworkReachability.NotReachable and
-            self.addrs.len > 0:
-          let local = initTAddress(self.addrs[0]).expect("self address is valid")
+            local.isSome():
           self.clientFlags.incl(SocketFlags.ReusePort)
-          connect(ta, flags = self.clientFlags, localAddress = local)
+          connect(ta, flags = self.clientFlags, localAddress = local.get())
         else:
           connect(ta, flags = self.clientFlags)
       )

--- a/tests/libp2p/transports/tcp_tests.nim
+++ b/tests/libp2p/transports/tcp_tests.nim
@@ -188,19 +188,15 @@ template tcpTests*() =
       await streamTransport.closeWait()
       await server.stop()
 
-    asyncTest "NotReachable dual-stack dialer cannot reuse port across families":
-      # TODO: nim-libp2p#2703
-      # While NotReachable the dialer reuses self.addrs[0] as the local address for
-      # every dial, regardless of the dial target's family.
-      # On a dual-stack node addrs[0] is the IPv4 address, so dialing an IPv6 peer
-      # binds an IPv4 local address for an IPv6 remote and fails.
+    asyncTest "NotReachable dual-stack dialer reuses port within target family":
       let dialer = TcpTransport.new(upgrade = Upgrade())
       await dialer.start(@[TcpAutoAddressIP4, TcpAutoAddressIP6])
       defer:
         await dialer.stop()
 
-      # addrs keeps start order, so addrs[0] is the IPv4 address
+      # addrs keeps start order, so addrs[0] is IPv4 and addrs[1] is IPv6.
       check IP4.matchPartial(dialer.addrs[0])
+      check IP6.matchPartial(dialer.addrs[1])
 
       let serverV6 = TcpTransport.new(upgrade = Upgrade())
       await serverV6.start(@[TcpAutoAddressIP6])
@@ -209,9 +205,11 @@ template tcpTests*() =
 
       dialer.networkReachability = NetworkReachability.NotReachable
 
-      # binding the IPv4 local address for an IPv6 dial fails
-      expect TcpTransportError:
-        discard await dialer.dial(serverV6.addrs[0])
+      discard await dialer.dial(serverV6.addrs[0])
+      let acceptedConn = await serverV6.accept()
+      let acceptedPort = acceptedConn.observedAddr.get()[multiCodec("tcp")].get()
+      let listeningPort = dialer.addrs[1][multiCodec("tcp")].get()
+      check acceptedPort == listeningPort
 
     asyncTest "start cleans up bound servers when a later bind fails":
       let unbindable = MultiAddress.init("/ip4/192.0.2.1/tcp/0").tryGet()


### PR DESCRIPTION
fixed the dual-stack TCP reuse bug:
 - TCP now selects a listening address with the same family as the dial target before reusing the listener port
 - if no matching listener exists, it dials normally

Closes: #2703