### PR TITLE
fix(ipaddr): compare IPv6 clients too

### DIFF
--- a/libp2p/protocols/connectivity/autonatv2/server.nim
+++ b/libp2p/protocols/connectivity/autonatv2/server.nim
@@ -238,9 +238,8 @@ proc handleDialRequest(
     await dialBackConn.close()
     await dialBackMux.close()
 
-  # if observed address for peer is not in address list to try
-  # then we perform Amplification Attack Prevention
-  if not ipAddrMatches(observedIPAddr, req.addrs):
+  # the spec exempts only a selected addr whose IP equals the observed IP
+  if not ipAddrMatches(observedIPAddr, [req.addrs[addrIdx]]):
     debug "Starting amplification attack prevention",
       observedIPAddr = observedIPAddr, testAddr = req.addrs[addrIdx]
     # send DialDataRequest and wait until dataReceived is enough

--- a/libp2p/utils/ipaddr.nim
+++ b/libp2p/utils/ipaddr.nim
@@ -65,23 +65,16 @@ proc getPublicIPAddress*(): Opt[IpAddress] {.raises: [].} =
     candidates.add(ip)
   firstGlobalIP(candidates)
 
-proc ipAddrMatches*(
-    lookup: MultiAddress, addrs: seq[MultiAddress], ip4: bool = true
-): bool =
-  ## Checks ``lookup``'s IP is in any of addrs
+func ipAddrMatches*(lookup: MultiAddress, addrs: openArray[MultiAddress]): bool =
+  ## Returns true when the ip4 or ip6 component of ``lookup`` equals that of any addr
 
-  let ipType =
-    if ip4:
-      multiCodec("ip4")
-    else:
-      multiCodec("ip6")
-
-  let lookup = lookup.getPart(ipType).valueOr:
-    return false
+  let lookupIp = lookup.getPart(multiCodec("ip4")).valueOr:
+    lookup.getPart(multiCodec("ip6")).valueOr:
+      return false
 
   for ma in addrs:
     ma[0].withValue(ipAddr):
-      if ipAddr == lookup:
+      if ipAddr == lookupIp:
         return true
   false
 

--- a/tests/libp2p/protocols/test_autonat_v2.nim
+++ b/tests/libp2p/protocols/test_autonat_v2.nim
@@ -283,12 +283,8 @@ suite "AutonatV2":
         addrs: Opt.some(src.peerInfo.addrs[0]),
       )
 
-  asyncTest "Amplification attack prevention not skipped when observed IPv6 addr matches a requested addr":
-    # TODO: nim-libp2p#2731
-    # the requested addr matches the observed addr of the client,
-    # yet the server demands dial data before the dial back
-    # dialDataSize is set above what the client accepts to prove the demand:
-    # the DialDataRequest fails the request with AutonatV2Error
+  asyncTest "Amplification attack prevention skipped when observed IPv6 addr matches a requested addr":
+    # dialDataSize above the client cap proves the skip: a DialDataRequest would fail with AutonatV2Error
     let
       ipv6Addrs = @[TcpAutoAddressIP6]
       (src, dst, client) = await setupAutonat(
@@ -302,8 +298,16 @@ suite "AutonatV2":
     defer:
       await allFutures(src.stop(), dst.stop())
 
-    expect(AutonatV2Error):
-      discard await client.sendDialRequest(dst.peerInfo.peerId, src.peerInfo.addrs)
+    check (await client.sendDialRequest(dst.peerInfo.peerId, src.peerInfo.addrs)) ==
+      AutonatV2Response(
+        reachability: Reachable,
+        dialResp: DialResponse(
+          status: ResponseStatus.Ok,
+          dialStatus: Opt.some(DialStatus.Ok),
+          addrIdx: Opt.some(0.AddrIdx),
+        ),
+        addrs: Opt.some(src.peerInfo.addrs[0]),
+      )
 
   asyncTest "Server responding with invalid messages":
     let

--- a/tests/libp2p/utils/test_ipaddr.nim
+++ b/tests/libp2p/utils/test_ipaddr.nim
@@ -22,6 +22,21 @@ suite "IpAddr Utils":
       MultiAddress.init("/ip4/127.0.0.2/tcp/4041").get(),
       @[MultiAddress.init("/ip4/127.0.0.1/tcp/4040").get()],
     )
+    # same ipv6 address
+    check ipAddrMatches(
+      MultiAddress.init("/ip6/2001:db8::1/tcp/4041").get(),
+      @[MultiAddress.init("/ip6/2001:db8::1/tcp/4040").get()],
+    )
+    # different ipv6 address
+    check not ipAddrMatches(
+      MultiAddress.init("/ip6/2001:db8::2/tcp/4041").get(),
+      @[MultiAddress.init("/ip6/2001:db8::1/tcp/4040").get()],
+    )
+    # different family
+    check not ipAddrMatches(
+      MultiAddress.init("/ip6/::1/tcp/4041").get(),
+      @[MultiAddress.init("/ip4/127.0.0.1/tcp/4040").get()],
+    )
 
   test "ipSupport":
     check ipSupport(@[MultiAddress.init("/ip4/127.0.0.1/tcp/4040").get()]) ==


### PR DESCRIPTION
The autonat v2 server skips amplification attack prevention when the requested addr matches the observed IP address of the client. `ipAddrMatches` compared only the ip4 component, so the exemption never applied to an IPv6 client. The proc now extracts the ip4 or the ip6 component of the observed addr and compares plain IP equality, per the spec.

The exemption also compared the observed IP against the whole request list. The spec exempts only the selected addr, so the server now checks `req.addrs[addrIdx]` alone.

The pinned test flips to assert the skip for IPv6, and the ipaddr unit test gains IPv6 and mixed-family cases. `ipAddrMatches` also drops the dead `ip4` parameter and becomes a `func` over `openArray`.

Closes #2731