### PR TITLE
test(autotls): certificate handoff

### DIFF
--- a/tests/libp2p/autotls/test_service.nim
+++ b/tests/libp2p/autotls/test_service.nim
@@ -7,8 +7,9 @@ import chronos, json, net, sequtils, uri
 from times import now, initDuration, `+`
 import
   ../../../libp2p/
-    [autotls/service, autotls/broker, autotls/acme/client, crypto/rsa, switch]
-import ../../tools/[unittest, crypto, multiaddress, resolver, switch_builder]
+    [autotls/service, autotls/broker, autotls/acme/client, crypto/rsa, switch, wire]
+import
+  ../../tools/[unittest, crypto, multiaddress, resolver, stall_server, switch_builder]
 import ../../stubs/[acme_api_stub, peer_id_auth_client_stub]
 
 suite "AutoTLS certificate issuance and renewal":
@@ -148,14 +149,40 @@ suite "AutoTLS certificate issuance and renewal":
 
     check parseJson(authClient.payloads[0])["addresses"] == %AnnouncedAddrs
 
-suite "AutoTLS certificate handoff":
+suite "AutoTLS on a switch":
   asyncTeardown:
     checkTrackers()
+
+  asyncTest "no ACME request is made, the service starts before its transports":
+    # TODO: vacp2p/nim-libp2p#2957
+    let acmeServer = startStallServer()
+    defer:
+      await acmeServer.stop()
+
+    let switch = makeStandardSwitchBuilder(
+        @[TcpAutoAddress, ma("/ip4/127.0.0.1/tcp/0/wss")]
+      )
+      .withAutotls(
+        AutotlsConfig.new(
+          ipAddress = Opt.some(parseIpAddress("127.0.0.1")),
+          acmeServerURL =
+            parseUri("http://" & $acmeServer.address.initTAddress().tryGet()),
+        )
+      )
+      .build()
+
+    let startFut = switch.start()
+
+    # Issuance would connect to acmeServerURL, so no connection means no attempt.
+    check not (await acmeServer.waitAccepted().withTimeout(200.milliseconds))
+
+    await startFut.cancelAndWait()
+    await switch.stop()
 
   asyncTest "a switch listening on wss never finishes starting without a certificate":
     # TODO: vacp2p/nim-libp2p#2957
     let switch = makeStandardSwitchBuilder(
-        @[TcpAutoAddress, ma"/ip4/127.0.0.1/tcp/0/wss"]
+        @[TcpAutoAddress, ma("/ip4/127.0.0.1/tcp/0/wss")]
       )
       .withAutotls(
         AutotlsConfig.new(

--- a/tests/libp2p/autotls/test_service.nim
+++ b/tests/libp2p/autotls/test_service.nim
@@ -155,6 +155,7 @@ suite "AutoTLS on a switch":
 
   asyncTest "no ACME request is made, the service starts before its transports":
     # TODO: vacp2p/nim-libp2p#2957
+    # The service never begins issuance: no TcpTransport is running when it starts.
     let acmeServer = startStallServer()
     defer:
       await acmeServer.stop()
@@ -170,31 +171,33 @@ suite "AutoTLS on a switch":
         )
       )
       .build()
+    defer:
+      await switch.stop()
 
     let startFut = switch.start()
+    defer:
+      await startFut.cancelAndWait()
 
     # Issuance would connect to acmeServerURL, so no connection means no attempt.
     check not (await acmeServer.waitAccepted().withTimeout(200.milliseconds))
 
-    await startFut.cancelAndWait()
-    await switch.stop()
-
   asyncTest "a switch listening on wss never finishes starting without a certificate":
     # TODO: vacp2p/nim-libp2p#2957
+    # The transport waits for a certificate with no timeout, so start never returns.
     let switch = makeStandardSwitchBuilder(
         @[TcpAutoAddress, ma("/ip4/127.0.0.1/tcp/0/wss")]
       )
       .withAutotls(
         AutotlsConfig.new(
           ipAddress = Opt.some(parseIpAddress("127.0.0.1")),
-          # An issuance attempt must not reach the network.
+          # A refused connection fails issuance at once, leaving the certificate
+          # wait as the only thing that can hang.
           acmeServerURL = parseUri("http://127.0.0.1:1"),
         )
       )
       .build()
+    defer:
+      await switch.stop()
 
     let startFut = switch.start()
     check not (await startFut.withTimeout(500.milliseconds))
-
-    await startFut.cancelAndWait()
-    await switch.stop()

--- a/tests/libp2p/autotls/test_service.nim
+++ b/tests/libp2p/autotls/test_service.nim
@@ -153,7 +153,7 @@ suite "AutoTLS certificate handoff":
     checkTrackers()
 
   asyncTest "a switch listening on wss never finishes starting without a certificate":
-    # TODO: vacp2p/nim-libp2p#NNNN
+    # TODO: vacp2p/nim-libp2p#2957
     let switch = makeStandardSwitchBuilder(
         @[TcpAutoAddress, ma"/ip4/127.0.0.1/tcp/0/wss"]
       )

--- a/tests/libp2p/autotls/test_service.nim
+++ b/tests/libp2p/autotls/test_service.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import chronos, json, net, sequtils
+import chronos, json, net, sequtils, uri
 from times import now, initDuration, `+`
 import
   ../../../libp2p/
@@ -44,6 +44,7 @@ suite "AutoTLS certificate issuance and renewal":
 
   proc installCert(service: AutotlsService, expiresIn: times.Duration) =
     service.cert = Opt.some(AutotlsCert.new(cert, certKey, now() + expiresIn))
+    service.certReady.fire()
 
   asyncSetup:
     acmeApi = ACMEApiStub.new()
@@ -105,6 +106,30 @@ suite "AutoTLS certificate issuance and renewal":
 
     check acmeApi.requestedUris.len == 1
 
+  asyncTest "the certificate is handed over once issuance fires":
+    service = newService()
+
+    let certFut = service.getCertWhenReady()
+    check not certFut.finished
+
+    service.installCert(initDuration(hours = 2))
+
+    let autotlsCert = await certFut.wait(1.seconds)
+    check:
+      autotlsCert.cert == cert
+      autotlsCert.privkey == certKey
+
+  asyncTest "the certificate in place is handed over while its renewal is in flight":
+    acmeApi.stalls = true
+    service = newService()
+    service.installCert(initDuration(minutes = 5))
+    await service.start(switch)
+
+    check acmeApi.requestedUris.len == 1
+
+    let autotlsCert = await service.getCertWhenReady().wait(1.seconds)
+    check autotlsCert.cert == cert
+
   asyncTest "the broker is sent the addresses the peer announces":
     const
       NodeIP = "127.0.0.1"
@@ -122,3 +147,27 @@ suite "AutoTLS certificate issuance and renewal":
     await service.start(switch)
 
     check parseJson(authClient.payloads[0])["addresses"] == %AnnouncedAddrs
+
+suite "AutoTLS certificate handoff":
+  asyncTeardown:
+    checkTrackers()
+
+  asyncTest "a switch listening on wss never finishes starting without a certificate":
+    # TODO: vacp2p/nim-libp2p#NNNN
+    let switch = makeStandardSwitchBuilder(
+        @[TcpAutoAddress, ma"/ip4/127.0.0.1/tcp/0/wss"]
+      )
+      .withAutotls(
+        AutotlsConfig.new(
+          ipAddress = Opt.some(parseIpAddress("127.0.0.1")),
+          # An issuance attempt must not reach the network.
+          acmeServerURL = parseUri("http://127.0.0.1:1"),
+        )
+      )
+      .build()
+
+    let startFut = switch.start()
+    check not (await startFut.withTimeout(500.milliseconds))
+
+    await startFut.cancelAndWait()
+    await switch.stop()

--- a/tests/libp2p/transports/test_ws.nim
+++ b/tests/libp2p/transports/test_ws.nim
@@ -297,7 +297,7 @@ suite "WebSocket transport with autotls":
       wstransport.addrs.len == 0
 
   asyncTest "start never returns when the autotls certificate never arrives":
-    # TODO: vacp2p/nim-libp2p#NNNN
+    # TODO: vacp2p/nim-libp2p#2957
     let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
 
     let autotls = AutotlsService(certReady: newAsyncEvent(), running: newAsyncEvent())

--- a/tests/libp2p/transports/test_ws.nim
+++ b/tests/libp2p/transports/test_ws.nim
@@ -203,6 +203,9 @@ suite "WebSocket transport":
     await transport1.stop()
 
 suite "WebSocket transport with autotls":
+  teardown:
+    checkTrackers()
+
   asyncTest "autotls certificate is used when manual tlscertificate is not specified":
     let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
 
@@ -273,3 +276,39 @@ suite "WebSocket transport with autotls":
 
     # TLSPrivateKey and TLSCertificate should not be set
     check not wstransport.secure
+
+  asyncTest "the transport stops when the autotls service never runs":
+    let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
+
+    let autotls = AutotlsService(certReady: newAsyncEvent(), running: newAsyncEvent())
+    let wstransport = WsTransport.new(
+      Upgrade(),
+      nil, # TLSPrivateKey
+      nil, # TLSCertificate
+      Opt.some(autotls),
+      rng(),
+    )
+
+    # The wait for a running service is bounded by DefaultAutotlsWaitTimeout, 3 seconds.
+    await wstransport.start(ma).wait(5.seconds)
+
+    check:
+      not wstransport.running
+      wstransport.addrs.len == 0
+
+  asyncTest "start never returns when the autotls certificate never arrives":
+    # TODO: vacp2p/nim-libp2p#NNNN
+    let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
+
+    let autotls = AutotlsService(certReady: newAsyncEvent(), running: newAsyncEvent())
+    autotls.running.fire()
+    let wstransport = WsTransport.new(
+      Upgrade(),
+      nil, # TLSPrivateKey
+      nil, # TLSCertificate
+      Opt.some(autotls),
+      rng(),
+    )
+
+    let startFut = wstransport.start(ma)
+    check not (await startFut.withTimeout(200.milliseconds))


### PR DESCRIPTION
## Summary

Adds test coverage for the autotls certificate handoff, the path where `WsTransport.start` waits for `AutotlsService` to produce a certificate.

Three cover behavior that works today:
- `getCertWhenReady` pends until a certificate is installed, then hands over the pair it installed.
- A renewal in flight does not disturb the certificate already in place.
- A WS transport whose autotls service never fires `running` gives up after `DefaultAutotlsWaitTimeout` and stops instead of hanging.

Two pin the hang reported in #2957, at the transport level and at the switch level. Both carry `TODO: vacp2p/nim-libp2p#2957` and will need updating when it is fixed.