### PR TITLE
fix(tests): autotls DNS test segfault on Nim devel with refc

### DIFF
--- a/tests/libp2p/autotls/test_utils.nim
+++ b/tests/libp2p/autotls/test_utils.nim
@@ -161,15 +161,31 @@ suite "AutoTLS DNS records":
     check resolver.ipQueries == @["2001-db8--1.k51qzi5uqu5dhkzk3z.libp2p.direct"]
 
   asyncTest "a leading or trailing colon becomes a 0 in the queried name":
-    for ip in ["::1", "2001:db8::", "::"]:
-      discard await checkDNSRecords(
-        resolver,
-        parseIpAddress(ip),
-        BaseDomain,
-        KeyAuth,
-        retries = 0,
-        retryTime = 0.seconds,
-      )
+    # don't use a `for` here: an await inside a `for` over an array literal segfaults on Nim devel refc.
+    discard await checkDNSRecords(
+      resolver,
+      parseIpAddress("::1"),
+      BaseDomain,
+      KeyAuth,
+      retries = 0,
+      retryTime = 0.seconds,
+    )
+    discard await checkDNSRecords(
+      resolver,
+      parseIpAddress("2001:db8::"),
+      BaseDomain,
+      KeyAuth,
+      retries = 0,
+      retryTime = 0.seconds,
+    )
+    discard await checkDNSRecords(
+      resolver,
+      parseIpAddress("::"),
+      BaseDomain,
+      KeyAuth,
+      retries = 0,
+      retryTime = 0.seconds,
+    )
 
     check resolver.ipQueries ==
       @["0--1." & BaseDomain, "2001-db8--0." & BaseDomain, "0--0." & BaseDomain]

--- a/tests/libp2p/autotls/test_utils.nim
+++ b/tests/libp2p/autotls/test_utils.nim
@@ -161,31 +161,17 @@ suite "AutoTLS DNS records":
     check resolver.ipQueries == @["2001-db8--1.k51qzi5uqu5dhkzk3z.libp2p.direct"]
 
   asyncTest "a leading or trailing colon becomes a 0 in the queried name":
-    # don't use a `for` here: an await inside a `for` over an array literal segfaults on Nim devel refc.
-    discard await checkDNSRecords(
-      resolver,
-      parseIpAddress("::1"),
-      BaseDomain,
-      KeyAuth,
-      retries = 0,
-      retryTime = 0.seconds,
-    )
-    discard await checkDNSRecords(
-      resolver,
-      parseIpAddress("2001:db8::"),
-      BaseDomain,
-      KeyAuth,
-      retries = 0,
-      retryTime = 0.seconds,
-    )
-    discard await checkDNSRecords(
-      resolver,
-      parseIpAddress("::"),
-      BaseDomain,
-      KeyAuth,
-      retries = 0,
-      retryTime = 0.seconds,
-    )
+    # a seq variable, not an array literal: await over an array literal segfaults on Nim devel refc
+    let ips = @["::1", "2001:db8::", "::"]
+    for ip in ips:
+      discard await checkDNSRecords(
+        resolver,
+        parseIpAddress(ip),
+        BaseDomain,
+        KeyAuth,
+        retries = 0,
+        retryTime = 0.seconds,
+      )
 
     check resolver.ipQueries ==
       @["0--1." & BaseDomain, "2001-db8--0." & BaseDomain, "0--0." & BaseDomain]


### PR DESCRIPTION
tldr: some deep magic made a simple operation fail, so an unintuitive fix was applied with a comment for all that might thread this path in the future are aware.

## Summary

Unroll the `for` loop in the autotls test "a leading or trailing colon becomes a 0 in the queried name" (`tests/libp2p/autotls/test_utils.nim`) into three plain `checkDNSRecords` calls. The assertion on `resolver.ipQueries` is unchanged, so the test keeps the same coverage.

Why: the daily "Test all (latest dependencies)" run of 2026-08-18 fails with SIGSEGV on all five Nim devel + refc jobs (linux amd64/i386/gcc-14, windows gcc/clang), every one in this test ([run](https://github.com/vacp2p/nim-libp2p/actions/runs/32108311564)). The test landed in #2944, after the last passing daily run, so this is not a Nim devel regression between the two days.

The trigger is an `await` inside a `for` over an array literal. The async transform lifts the array into the closure environment, and the crash happens in the refc deep copy on resume:

```
tests/libp2p/autotls/test_utils.nim(164)  closure resume
system/assign.nim(140)  genericAssignAux
system/gc.nim(308)  unsureAsgnRef
system/gc.nim(234)  incRef   -> SIGSEGV (read from nil)
```

Release Nim is not affected: the pinned "Test All" workflow passes on the same commit (`1c6dcfdf`).

## Affected Areas

- [x] Other: test-only change in `tests/libp2p/autotls/test_utils.nim`

## Compatibility & Downstream Validation

N/A: test-only change, no production code is touched.

## Impact on Library Users

No impact: internal test change.

## Risk Assessment

None. The test keeps the same assertions on the same three queried names.

## References

- Failing run: https://github.com/vacp2p/nim-libp2p/actions/runs/32108311564
- Test introduced in #2944

## Additional Notes

The miscompilation itself is a Nim devel bug (refc, closure iterator, array literal in a `for` with `await`). No upstream issue is filed yet; a minimal repro is the next step.