### PR TITLE
test(transports): cover accept-after-stop / autotls private key and ws address downgrade

### DIFF
--- a/tests/libp2p/transports/basic_tests.nim
+++ b/tests/libp2p/transports/basic_tests.nim
@@ -87,6 +87,22 @@ template basicTransportTest*(
       expect TransportClosedError:
         discard await acceptFut
 
+    asyncTest "accept on a stopped transport reports it closed without waiting":
+      let ma = MultiAddress.init(address).tryGet()
+
+      let server = transportProvider()
+      await server.start(@[ma])
+      await server.stop()
+
+      let acceptFut = server.accept()
+      if isWsTransport(ma):
+        # TODO: vacp2p/nim-libp2p#2961
+        check not (await acceptFut.withTimeout(200.milliseconds))
+      else:
+        check:
+          await acceptFut.withTimeout(200.milliseconds)
+          acceptFut.failed()
+
     asyncTest "transport start/stop events":
       let ma = @[MultiAddress.init(address).tryGet()]
       let transport = transportProvider()

--- a/tests/libp2p/transports/test_ws.nim
+++ b/tests/libp2p/transports/test_ws.nim
@@ -230,6 +230,7 @@ suite "WebSocket transport with autotls":
     # autotls should be used
     let autotlsCert = await autotls.getCertWhenReady()
     check wstransport.tlsCertificate == autotlsCert.cert
+    check wstransport.tlsPrivateKey == autotlsCert.privkey
 
   asyncTest "manually set tlscertificate is preferred over autotls when both are specified":
     let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
@@ -273,3 +274,8 @@ suite "WebSocket transport with autotls":
 
     # TLSPrivateKey and TLSCertificate should not be set
     check not wstransport.secure
+
+    # the address it listens on and advertises drops to /ws
+    check:
+      WS.match(wstransport.addrs[0])
+      not WSS.match(wstransport.addrs[0])


### PR DESCRIPTION
 ## Summary

Adds transport test coverage in three areas:

1. A new shared test that `accept()` on an already-stopped transport fails immediately instead of hanging. WebSocket transport currently hangs in this scenario, so the test documents the issue (#2961).
2. The autotls WebSocket test was only checking the certificate. Now it also verifies the private key matches.
3. When a WebSocket transport starts without TLS (no manual cert, no autotls), the listened address should drop from `/tls/ws` to `/ws`. Added assertions for that.