### PR TITLE
feat(multiaddress): add SNI protocol support

### DIFF
--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -6,7 +6,7 @@
 {.push raises: [].}
 
 import pkg/[chronos, chronicles, results, protobuf_serialization]
-import std/[nativesockets, net, hashes]
+import std/[nativesockets, net, hashes, unicode]
 import tables, strutils, sets
 import
   multicodec,
@@ -341,6 +341,23 @@ proc dnsVB(vb: var VBuffer): bool =
   ## DNS name validateBuffer() implementation.
   pathValidateBufferNoSlash(vb)
 
+proc sniValid(s: string): bool =
+  s.len > 0 and s.find('/') == -1 and validateUtf8(s) == -1
+
+proc sniStB(s: string, vb: var VBuffer): bool =
+  if not sniValid(s):
+    return false
+  vb.writeSeq(s)
+  true
+
+proc sniBtS(vb: var VBuffer, s: var string): bool =
+  s = ""
+  vb.readSeq(s) > 0 and sniValid(s)
+
+proc sniVB(vb: var VBuffer): bool =
+  var s = ""
+  vb.readSeq(s) > 0 and sniValid(s)
+
 proc mapEq*(codec: string): MaPattern =
   ## ``Equal`` operator for pattern
   MaPattern(operator: Eq, value: multiCodec(codec))
@@ -375,6 +392,8 @@ const
   )
   TranscoderDNS* =
     Transcoder(stringToBuffer: dnsStB, bufferToString: dnsBtS, validateBuffer: dnsVB)
+  TranscoderSNI* =
+    Transcoder(stringToBuffer: sniStB, bufferToString: sniBtS, validateBuffer: sniVB)
   TranscoderMemory* = Transcoder(
     stringToBuffer: memoryStB, bufferToString: memoryBtS, validateBuffer: memoryVB
   )
@@ -404,6 +423,7 @@ const
     MAProtocol(mcodec: multiCodec("ws"), kind: Marker, size: 0),
     MAProtocol(mcodec: multiCodec("wss"), kind: Marker, size: 0),
     MAProtocol(mcodec: multiCodec("tls"), kind: Marker, size: 0),
+    MAProtocol(mcodec: multiCodec("sni"), kind: Length, size: 0, coder: TranscoderSNI),
     MAProtocol(mcodec: multiCodec("ipfs"), kind: Length, size: 0, coder: TranscoderP2P),
     MAProtocol(mcodec: multiCodec("p2p"), kind: Length, size: 0, coder: TranscoderP2P),
     MAProtocol(mcodec: multiCodec("unix"), kind: Path, size: 0, coder: TranscoderUnix),
@@ -455,7 +475,10 @@ const
   WS_DNS* = mapAnd(TCP_DNS, mapEq("ws"))
   WS_IP* = mapAnd(TCP_IP, mapEq("ws"))
   WS* = mapAnd(TCP, mapEq("ws"))
-  TLS_WS* = mapOr(mapEq("wss"), mapAnd(mapEq("tls"), mapEq("ws")))
+  TLS* = mapEq("tls")
+  SNI* = mapEq("sni")
+  TLS_SNI* = mapAnd(TLS, SNI)
+  TLS_WS* = mapOr(mapEq("wss"), mapAnd(mapOr(TLS, TLS_SNI), mapEq("ws")))
   WSS_DNS* = mapAnd(TCP_DNS, TLS_WS)
   WSS_IP* = mapAnd(TCP_IP, TLS_WS)
   WSS* = mapAnd(TCP, TLS_WS)
@@ -834,6 +857,13 @@ proc init*(
       if len(value) == 0:
         err("multiaddress: Value must not be empty array")
       else:
+        if protocol == multiCodec("sni"):
+          var validation = initVBuffer(len(value) + 10)
+          validation.writeSeq(value)
+          validation.finish()
+          if not proto.coder.validateBuffer(validation):
+            return err("multiaddress: Invalid sni protocol value")
+
         res.data.writeSeq(value)
         res.data.finish()
         ok(res)

--- a/tests/libp2p/multiformat/test_multiaddress.nim
+++ b/tests/libp2p/multiformat/test_multiaddress.nim
@@ -51,7 +51,8 @@ const
     "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
     "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
     "/dns/example.io/udp/65535", "/dns4/example.io/udp/65535",
-    "/dns6/example.io/udp/65535", "/dnsaddr/example.io/udp/65535",
+    "/dns6/example.io/udp/65535", "/dnsaddr/example.io/udp/65535", "/sni/example.com",
+    "/ip4/127.0.0.1/tcp/443/tls/sni/example.com/ws",
   ]
 
   FailureVectors = [
@@ -72,6 +73,7 @@ const
     "/ip4/127.0.0.1/tcp/jfodsajfidosajfoidsa", "/ip4/127.0.0.1/tcp",
     "/ip4/127.0.0.1/quic/1234", "/ip4/127.0.0.1/quic-v1/1234", "/ip4/127.0.0.1/ipfs",
     "/ip4/127.0.0.1/ipfs/tcp", "/ip4/127.0.0.1/p2p", "/ip4/127.0.0.1/p2p/tcp", "/unix",
+    "/sni", "/sni/",
   ]
 
   RustSuccessVectors = [
@@ -305,6 +307,25 @@ suite "MultiAddress test suite":
   test "rust-multiaddr failure test vectors":
     for item in RustFailureVectors:
       check MultiAddress.init(item).isErr()
+
+  test "SNI representation":
+    let
+      fromString = MultiAddress.init("/sni/example.com").tryGet()
+      fromValue = MultiAddress.init(multiCodec("sni"), "example.com".toBytes()).tryGet()
+      part = fromString.getPart(multiCodec("sni")).tryGet()
+
+    check:
+      $fromString == "/sni/example.com"
+      fromValue == fromString
+      hex(fromString) == "C1030B6578616D706C652E636F6D"
+      part.protoArgument().tryGet() == "example.com".toBytes()
+
+  test "SNI rejects malformed values":
+    check:
+      MultiAddress.init(multiCodec("sni"), newSeq[byte]()).isErr()
+      MultiAddress.init(multiCodec("sni"), @[0xFF'u8]).isErr()
+      MultiAddress.init(multiCodec("sni"), "a/b".toBytes()).isErr()
+      MultiAddress.init(@[0xC1'u8, 0x03'u8, 0x01'u8, 0xFF'u8]).isErr()
 
   test "Concatenation test":
     var ma1 = MultiAddress.init()


### PR DESCRIPTION
## Summary

Adds support for the upstream `/sni/<name>` multiaddress component and the canonical secure WebSocket form:

```text
/ip4/203.0.113.10/tcp/443/tls/sni/example.com/ws
```

This registers multicodec 449 as a variable-length UTF-8 component, validates string and binary input, and extends the TLS/WebSocket patterns to recognize explicit SNI. Existing `/tls/ws` and `/wss` addresses remain supported.

## Affected Areas

- [x] Transports — secure WebSocket address matching recognizes `/tls/sni/<name>/ws`.
- [x] Other — multiaddress parsing, binary encoding, construction, extraction, and round-tripping.

## Impact on Library Users

Users can construct, parse, extract, and round-trip explicit SNI multiaddresses through the existing `MultiAddress` APIs. No new transport or builder API is introduced.

## Risk Assessment

The change is additive for valid addresses. Empty, slash-containing, malformed, and invalid UTF-8 SNI values are rejected; existing secure WebSocket forms retain their current matching behavior.

## References

- [TLS/SNI Multiaddress roadmap](https://roadmap.vac.dev/p2p/ift/2026q3-nimlibp2p-tls-sni-multiaddr)
- [Upstream multiaddr protocol table](https://github.com/multiformats/multiaddr/blob/master/protocols.csv)
