### PR TITLE
feat(websocket): support explicit SNI addresses

### DIFF
--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -6,7 +6,7 @@
 {.push raises: [].}
 
 import pkg/[chronos, chronicles, results, protobuf_serialization]
-import std/[nativesockets, net, hashes]
+import std/[nativesockets, net, hashes, unicode]
 import tables, strutils, sets
 import
   multicodec,
@@ -341,6 +341,23 @@ proc dnsVB(vb: var VBuffer): bool =
   ## DNS name validateBuffer() implementation.
   pathValidateBufferNoSlash(vb)
 
+proc sniValid(s: string): bool =
+  s.len > 0 and s.find('/') == -1 and validateUtf8(s) == -1
+
+proc sniStB(s: string, vb: var VBuffer): bool =
+  if not sniValid(s):
+    return false
+  vb.writeSeq(s)
+  true
+
+proc sniBtS(vb: var VBuffer, s: var string): bool =
+  s = ""
+  vb.readSeq(s) > 0 and sniValid(s)
+
+proc sniVB(vb: var VBuffer): bool =
+  var s = ""
+  vb.readSeq(s) > 0 and sniValid(s)
+
 proc mapEq*(codec: string): MaPattern =
   ## ``Equal`` operator for pattern
   MaPattern(operator: Eq, value: multiCodec(codec))
@@ -375,6 +392,8 @@ const
   )
   TranscoderDNS* =
     Transcoder(stringToBuffer: dnsStB, bufferToString: dnsBtS, validateBuffer: dnsVB)
+  TranscoderSNI* =
+    Transcoder(stringToBuffer: sniStB, bufferToString: sniBtS, validateBuffer: sniVB)
   TranscoderMemory* = Transcoder(
     stringToBuffer: memoryStB, bufferToString: memoryBtS, validateBuffer: memoryVB
   )
@@ -404,6 +423,7 @@ const
     MAProtocol(mcodec: multiCodec("ws"), kind: Marker, size: 0),
     MAProtocol(mcodec: multiCodec("wss"), kind: Marker, size: 0),
     MAProtocol(mcodec: multiCodec("tls"), kind: Marker, size: 0),
+    MAProtocol(mcodec: multiCodec("sni"), kind: Length, size: 0, coder: TranscoderSNI),
     MAProtocol(mcodec: multiCodec("ipfs"), kind: Length, size: 0, coder: TranscoderP2P),
     MAProtocol(mcodec: multiCodec("p2p"), kind: Length, size: 0, coder: TranscoderP2P),
     MAProtocol(mcodec: multiCodec("unix"), kind: Path, size: 0, coder: TranscoderUnix),
@@ -455,7 +475,10 @@ const
   WS_DNS* = mapAnd(TCP_DNS, mapEq("ws"))
   WS_IP* = mapAnd(TCP_IP, mapEq("ws"))
   WS* = mapAnd(TCP, mapEq("ws"))
-  TLS_WS* = mapOr(mapEq("wss"), mapAnd(mapEq("tls"), mapEq("ws")))
+  TLS* = mapEq("tls")
+  SNI* = mapEq("sni")
+  TLS_SNI* = mapAnd(TLS, SNI)
+  TLS_WS* = mapOr(mapEq("wss"), mapAnd(mapOr(TLS, TLS_SNI), mapEq("ws")))
   WSS_DNS* = mapAnd(TCP_DNS, TLS_WS)
   WSS_IP* = mapAnd(TCP_IP, TLS_WS)
   WSS* = mapAnd(TCP, TLS_WS)
@@ -834,6 +857,13 @@ proc init*(
       if len(value) == 0:
         err("multiaddress: Value must not be empty array")
       else:
+        if protocol == multiCodec("sni"):
+          var validation = initVBuffer(len(value) + 10)
+          validation.writeSeq(value)
+          validation.finish()
+          if not proto.coder.validateBuffer(validation):
+            return err("multiaddress: Invalid sni protocol value")
+
         res.data.writeSeq(value)
         res.data.finish()
         ok(res)

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -6,7 +6,7 @@
 {.push raises: [].}
 
 import std/[sequtils]
-import chronos, chronicles, results, metrics
+import chronos, chronicles, results, metrics, stew/byteutils
 import
   transport,
   ../autotls/service,
@@ -153,6 +153,21 @@ type WsTransport* = ref object of Transport
   concurrentAccepts: int
   factories: seq[ExtFactory]
   rng: Rng
+
+type HostHeaderHook = ref object of Hook
+  host: string
+
+proc hostHeaderHook(host: string): Hook =
+  let hook = HostHeaderHook(host: host)
+  hook.append = proc(ctx: Hook, headers: var HttpTable): Result[void, string] =
+    headers.set("Host", HostHeaderHook(ctx).host)
+    ok()
+  hook
+
+proc getSni(address: MultiAddress): string =
+  let value = address.getProtocolArgument(multiCodec("sni")).valueOr:
+    return ""
+  string.fromBytes(value)
 
 proc secure*(self: WsTransport): bool =
   not (isNil(self.tlsPrivateKey) or isNil(self.tlsCertificate))
@@ -380,10 +395,7 @@ method start*(
 
     let codec =
       if isWss:
-        if ma.contains(multiCodec("tls")) == MaResult[bool].ok(true):
-          MultiAddress.init("/tls/ws")
-        else:
-          MultiAddress.init("/wss")
+        ma[2 .. ^1]
       else:
         MultiAddress.init("/ws")
 
@@ -517,13 +529,30 @@ method dial*(
   try:
     let secure = WSS.match(address)
     let initAddress = address.initTAddress().tryGet()
+    let
+      sni = address.getSni()
+      httpHostname =
+        if hostname.len > 0:
+          hostname
+        else:
+          $initAddress
+      serverName = if sni.len > 0: sni else: httpHostname
+      hooks =
+        if serverName != httpHostname:
+          @[hostHeaderHook(httpHostname)]
+        else:
+          @[]
     debug "creating websocket",
-      address = initAddress, secure = secure, hostName = hostname
+      address = initAddress,
+      secure = secure,
+      hostName = httpHostname,
+      serverName = serverName
     transp = await WebSocket.connect(
       initAddress,
       "",
       secure = secure,
-      hostName = hostname,
+      hostName = serverName,
+      hooks = hooks,
       flags = self.tlsFlags,
       rng = bearSslDrbgRef(self.rng),
     )

--- a/tests/libp2p/multiformat/test_multiaddress.nim
+++ b/tests/libp2p/multiformat/test_multiaddress.nim
@@ -51,7 +51,8 @@ const
     "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
     "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
     "/dns/example.io/udp/65535", "/dns4/example.io/udp/65535",
-    "/dns6/example.io/udp/65535", "/dnsaddr/example.io/udp/65535",
+    "/dns6/example.io/udp/65535", "/dnsaddr/example.io/udp/65535", "/sni/example.com",
+    "/ip4/127.0.0.1/tcp/443/tls/sni/example.com/ws",
   ]
 
   FailureVectors = [
@@ -72,6 +73,7 @@ const
     "/ip4/127.0.0.1/tcp/jfodsajfidosajfoidsa", "/ip4/127.0.0.1/tcp",
     "/ip4/127.0.0.1/quic/1234", "/ip4/127.0.0.1/quic-v1/1234", "/ip4/127.0.0.1/ipfs",
     "/ip4/127.0.0.1/ipfs/tcp", "/ip4/127.0.0.1/p2p", "/ip4/127.0.0.1/p2p/tcp", "/unix",
+    "/sni", "/sni/",
   ]
 
   RustSuccessVectors = [
@@ -305,6 +307,25 @@ suite "MultiAddress test suite":
   test "rust-multiaddr failure test vectors":
     for item in RustFailureVectors:
       check MultiAddress.init(item).isErr()
+
+  test "SNI representation":
+    let
+      fromString = MultiAddress.init("/sni/example.com").tryGet()
+      fromValue = MultiAddress.init(multiCodec("sni"), "example.com".toBytes()).tryGet()
+      part = fromString.getPart(multiCodec("sni")).tryGet()
+
+    check:
+      $fromString == "/sni/example.com"
+      fromValue == fromString
+      hex(fromString) == "C1030B6578616D706C652E636F6D"
+      part.protoArgument().tryGet() == "example.com".toBytes()
+
+  test "SNI rejects malformed values":
+    check:
+      MultiAddress.init(multiCodec("sni"), newSeq[byte]()).isErr()
+      MultiAddress.init(multiCodec("sni"), @[0xFF'u8]).isErr()
+      MultiAddress.init(multiCodec("sni"), "a/b".toBytes()).isErr()
+      MultiAddress.init(@[0xC1'u8, 0x03'u8, 0x01'u8, 0xFF'u8]).isErr()
 
   test "Concatenation test":
     var ma1 = MultiAddress.init()

--- a/tests/libp2p/test_name_resolve.nim
+++ b/tests/libp2p/test_name_resolve.nim
@@ -84,6 +84,11 @@ suite "Name resolving":
         "/ip6/::1/tcp/4001/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
       )
 
+      await testOne(
+        "/dns4/localhost/tcp/443/tls/sni/example.com/ws",
+        "/ip4/127.0.0.1/tcp/443/tls/sni/example.com/ws",
+      )
+
     asyncTest "test non dns resolve":
       resolver.ipResponses[("localhost", false)] = @["127.0.0.1"]
       resolver.ipResponses[("localhost", true)] = @["::1"]

--- a/tests/libp2p/transports/test_ws.nim
+++ b/tests/libp2p/transports/test_ws.nim
@@ -57,6 +57,7 @@ const
     # Secure WebSocket
     "/ip4/127.0.0.1/tcp/1234/wss",
     "/ip4/127.0.0.1/tcp/1234/tls/ws",
+    "/ip4/127.0.0.1/tcp/1234/tls/sni/example.com/ws",
     "/ip6/::1/tcp/1234/wss",
   ]
   validNonWireAddresses = @[
@@ -65,12 +66,18 @@ const
     # Secure WebSocket
     "/dns/example.com/tcp/1234/wss",
     "/dns/example.com/tcp/1234/tls/ws",
+    "/dns/example.com/tcp/1234/tls/sni/ws.example.com/ws",
   ]
   invalidAddresses = @[
     "/ip4/127.0.0.1/tcp/1234", # Missing /ws or /wss
     "/ip4/127.0.0.1/udp/1234/ws", # UDP instead of TCP
     "/ip4/127.0.0.1/udp/1234/wss", # UDP instead of TCP
     "/ip4/127.0.0.1/tcp/1234/quic-v1", # QUIC instead of WebSocket
+    "/ip4/127.0.0.1/tcp/1234/sni/example.com/ws", # SNI without TLS
+    "/ip4/127.0.0.1/tcp/1234/tls/ws/sni/example.com", # SNI after WebSocket
+    "/ip4/127.0.0.1/tcp/1234/wss/sni/example.com", # SNI with deprecated alias
+    "/ip4/127.0.0.1/tcp/1234/tls/sni/one/sni/two/ws", # Repeated SNI
+    "/ip4/127.0.0.1/tcp/1234/tls/sni/example.com", # Missing WebSocket
   ]
 
 suite "WebSocket transport":
@@ -201,6 +208,40 @@ suite "WebSocket transport":
     await closing
 
     await transport1.stop()
+
+  asyncTest "explicit SNI is preserved and controls hostname verification":
+    let testKeyPair = KeyPair.random(PKScheme.RSA, rng()).get()
+    let expectedPeerId = PeerId.init(testKeyPair.pubkey).tryGet()
+    let (secureKey, secureCert) = tlsCertGenerator(Opt.some(testKeyPair))
+
+    let transport1 = WsTransport.new(
+      Upgrade(),
+      secureKey,
+      secureCert,
+      Opt.none(AutotlsService),
+      rng(),
+      tlsFlags = {TLSFlags.NoVerifyHost},
+    )
+    let
+      sniSuffix = MultiAddress.init("/tls/sni/" & $expectedPeerId & "/ws").tryGet()
+      listenAddr =
+        MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet() & sniSuffix
+    await transport1.start(@[listenAddr])
+    defer:
+      await transport1.stop()
+
+    let
+      base = MultiAddress.init(transport1.addrs[0].initTAddress().tryGet()).tryGet()
+      wrongAddress = base & MultiAddress.init("/tls/sni/ws.wronghostname/ws").tryGet()
+    check transport1.addrs[0][2 .. ^1].tryGet() == sniSuffix
+
+    let inboundFut = transport1.accept()
+    let outbound = await transport1.dial("different.http.host", transport1.addrs[0])
+    let inbound = await inboundFut
+    await allFutures(outbound.close(), inbound.close())
+
+    expect TransportDialError:
+      discard await transport1.dial("different.http.host", wrongAddress)
 
 suite "WebSocket transport with autotls":
   asyncTest "autotls certificate is used when manual tlscertificate is not specified":

--- a/tests/libp2p/transports/test_ws.nim
+++ b/tests/libp2p/transports/test_ws.nim
@@ -224,8 +224,7 @@ suite "WebSocket transport":
     )
     let
       sniSuffix = MultiAddress.init("/tls/sni/" & $expectedPeerId & "/ws").tryGet()
-      listenAddr =
-        MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet() & sniSuffix
+      listenAddr = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet() & sniSuffix
     await transport1.start(@[listenAddr])
     defer:
       await transport1.stop()


### PR DESCRIPTION
## Summary

Adds explicit SNI support to the secure WebSocket transport using addresses such as:

```text
/ip4/203.0.113.10/tcp/443/tls/sni/example.com/ws
```

The SNI component controls TLS server-name verification while the dial hostname continues to control the HTTP `Host` header. Listener address normalization and DNS resolution preserve the complete `/tls/sni/<name>/ws` suffix.

Existing `/wss` and `/tls/ws` addresses retain their current behavior.

## Affected Areas

- [x] Transports — secure WebSocket dialing, listener advertisement, and address validation.
- [x] Other — DNS address resolution preserves explicit SNI components.

## Impact on Library Users

Users can dial and advertise secure WebSocket endpoints with a TLS server name that differs from the resolved IP address or HTTP hostname. No new transport or builder API is introduced.

## Risk Assessment

The change is additive for valid SNI addresses. The main behavioral risk is selecting the wrong TLS identity or changing the HTTP `Host` header; integration coverage verifies matching and mismatched SNI values while keeping those two names separate.

## References

- Parent multiaddress support: #2963
- [TLS/SNI Multiaddress roadmap](https://roadmap.vac.dev/p2p/ift/2026q3-nimlibp2p-tls-sni-multiaddr)
