### PR TITLE
refactor(pubsub): separate app's path from protocol messages send/brodcast path 

### DIFF
--- a/libp2p/protocols/pubsub/errors.nim
+++ b/libp2p/protocols/pubsub/errors.nim
@@ -4,24 +4,7 @@
 # this module will be further extended in PR
 # https://github.com/status-im/nim-libp2p/pull/107/
 
-import ../../errors
-
-type
-  ValidationResult* {.pure.} = enum
-    Accept
-    Reject
-    Ignore
-
-  MessageTooLargeError* = object of LPError
-    ## Raised when an application publishes a message whose encoded size
-    ## exceeds `maxMessageSize`.
-
-func new*(
-    T: type MessageTooLargeError, encodedSize, maxMessageSize: int
-): ref MessageTooLargeError =
-  doAssert encodedSize > maxMessageSize, "encodedSize must exceed maxMessageSize"
-
-  (ref MessageTooLargeError)(
-    msg:
-      "message of size " & $encodedSize & " exceeds maxMessageSize " & $maxMessageSize
-  )
+type ValidationResult* {.pure.} = enum
+  Accept
+  Reject
+  Ignore

--- a/libp2p/protocols/pubsub/errors.nim
+++ b/libp2p/protocols/pubsub/errors.nim
@@ -15,3 +15,13 @@ type
   MessageTooLargeError* = object of LPError
     ## Raised when an application publishes a message whose encoded size
     ## exceeds `maxMessageSize`.
+
+func new*(
+    T: type MessageTooLargeError, encodedSize, maxMessageSize: int
+): ref MessageTooLargeError =
+  doAssert encodedSize > maxMessageSize, "encodedSize must exceed maxMessageSize"
+
+  (ref MessageTooLargeError)(
+    msg: "message of size " & $encodedSize & " exceeds maxMessageSize " &
+      $maxMessageSize
+  )

--- a/libp2p/protocols/pubsub/errors.nim
+++ b/libp2p/protocols/pubsub/errors.nim
@@ -22,6 +22,6 @@ func new*(
   doAssert encodedSize > maxMessageSize, "encodedSize must exceed maxMessageSize"
 
   (ref MessageTooLargeError)(
-    msg: "message of size " & $encodedSize & " exceeds maxMessageSize " &
-      $maxMessageSize
+    msg:
+      "message of size " & $encodedSize & " exceeds maxMessageSize " & $maxMessageSize
   )

--- a/libp2p/protocols/pubsub/errors.nim
+++ b/libp2p/protocols/pubsub/errors.nim
@@ -4,7 +4,14 @@
 # this module will be further extended in PR
 # https://github.com/status-im/nim-libp2p/pull/107/
 
-type ValidationResult* {.pure.} = enum
-  Accept
-  Reject
-  Ignore
+import ../../errors
+
+type
+  ValidationResult* {.pure.} = enum
+    Accept
+    Reject
+    Ignore
+
+  MessageTooLargeError* = object of LPError
+    ## Raised when an application publishes a message whose encoded size
+    ## exceeds `maxMessageSize`.

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -212,7 +212,7 @@ method publish*(
   # Application-published messages are never split - reject oversized messages
   # up front so the caller can handle the error before any dedup side effects
   # occur.
-  let messageSize = RPCMsg.withMessages(msg).byteSize()
+  let messageSize = RPCMsg.withMessages(msg).encodedSize()
   if messageSize > f.maxMessageSize:
     warn "message exceeds maximum message size; message will not be published",
       messageSize, maxMessageSize = f.maxMessageSize

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -202,24 +202,12 @@ method publish*(
     debug "Empty topic, skipping publish", topic
     return 0
 
-  let peers = f.floodsub.getOrDefault(topic)
-
-  if peers.len == 0:
-    debug "No peers for topic, skipping publish", topic
-    return 0
-
-  let
-    msg =
-      if f.anonymize:
-        Message.init(Opt.none(PeerInfo), data, topic, Opt.none(uint64), false)
-      else:
-        inc f.msgSeqno
-        Message.init(Opt.some(f.peerInfo), data, topic, Opt.some(f.msgSeqno), f.sign)
-    msgId = f.msgIdProvider(msg).valueOr:
-      trace "Error generating message id, skipping publish", error = error
-      return 0
-
-  trace "Created new message", message = shortLog(msg), peers = peers.len, topic, msgId
+  let msg =
+    if f.anonymize:
+      Message.init(Opt.none(PeerInfo), data, topic, Opt.none(uint64), false)
+    else:
+      inc f.msgSeqno
+      Message.init(Opt.some(f.peerInfo), data, topic, Opt.some(f.msgSeqno), f.sign)
 
   # Application-published messages are never split - reject oversized messages
   # up front so the caller can handle the error before any dedup side effects
@@ -230,12 +218,24 @@ method publish*(
       messageSize, maxMessageSize = f.maxMessageSize
     return 0
 
+  f.handleSelfPublishing(topic, data)
+
+  let peers = f.floodsub.getOrDefault(topic)
+
+  if peers.len == 0:
+    debug "No peers for topic, skipping publish", topic
+    return 0
+
+  let msgId = f.msgIdProvider(msg).valueOr:
+    trace "Error generating message id, skipping publish", error = error
+    return 0
+
+  trace "Created new message", message = shortLog(msg), peers = peers.len, topic, msgId
+
   if f.addSeen(f.salt(msgId)):
     # custom msgid providers might cause this
     trace "Dropping already-seen message", msgId, topic
     return 0
-
-  f.handleSelfPublishing(topic, data)
 
   # Try to send to all peers that are known to be interested
   f.broadcast(peers, RPCMsg.withMessages(msg), MessagePriority.Medium)

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -196,21 +196,10 @@ method publish*(
     data: sink seq[byte],
     publishParams: Opt[PublishParams] = Opt.none(PublishParams),
 ): Future[int] {.async: (raises: []).} =
-  handleSelfPublishing(f, topic, data)
-
   trace "Publishing message on topic", data = data.shortLog, topic
 
   if topic.len <= 0: # data could be 0/empty
     debug "Empty topic, skipping publish", topic
-    return 0
-
-  # Application-published messages are never split - reject oversized messages
-  # up front so the caller can handle the error before any dedup side effects
-  # occur.
-  let messageSize = RPCMsg.withMessages(msg).byteSize()
-  if messageSize > f.maxMessageSize:
-    warn "message exceeds maximum message size",
-      encodedSize, maxMessageSize = f.maxMessageSize
     return 0
 
   let peers = f.floodsub.getOrDefault(topic)
@@ -232,10 +221,21 @@ method publish*(
 
   trace "Created new message", message = shortLog(msg), peers = peers.len, topic, msgId
 
+  # Application-published messages are never split - reject oversized messages
+  # up front so the caller can handle the error before any dedup side effects
+  # occur.
+  let messageSize = RPCMsg.withMessages(msg).byteSize()
+  if messageSize > f.maxMessageSize:
+    warn "message exceeds maximum message size",
+      messageSize, maxMessageSize = f.maxMessageSize
+    return 0
+
   if f.addSeen(f.salt(msgId)):
     # custom msgid providers might cause this
     trace "Dropping already-seen message", msgId, topic
     return 0
+
+  f.handleSelfPublishing(topic, data)
 
   # Try to send to all peers that are known to be interested
   f.broadcast(peers, RPCMsg.withMessages(msg), MessagePriority.Medium)

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -7,6 +7,7 @@ import std/[sets, hashes, tables, sequtils]
 import chronos, chronicles, metrics
 import
   ./pubsub,
+  ./rpc_send,
   ./pubsubpeer,
   ./timedcache,
   ./peertable,

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -226,7 +226,7 @@ method publish*(
   # occur.
   let messageSize = RPCMsg.withMessages(msg).byteSize()
   if messageSize > f.maxMessageSize:
-    warn "message exceeds maximum message size",
+    warn "message exceeds maximum message size; message will not be published",
       messageSize, maxMessageSize = f.maxMessageSize
     return 0
 

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -227,11 +227,7 @@ method publish*(
   # occur.
   let encodedSize = encode(RPCMsg.withMessages(msg), f.anonymize).len
   if encodedSize > f.maxMessageSize:
-    raise newException(
-      MessageTooLargeError,
-      "message of size " & $encodedSize & " exceeds maxMessageSize " &
-        $f.maxMessageSize,
-    )
+    raise MessageTooLargeError.new(encodedSize, f.maxMessageSize)
 
   if f.addSeen(f.salt(msgId)):
     # custom msgid providers might cause this

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -195,7 +195,7 @@ method publish*(
     topic: string,
     data: sink seq[byte],
     publishParams: Opt[PublishParams] = Opt.none(PublishParams),
-): Future[int] {.async: (raises: [MessageTooLargeError]).} =
+): Future[int] {.async: (raises: []).} =
   handleSelfPublishing(f, topic, data)
 
   trace "Publishing message on topic", data = data.shortLog, topic
@@ -228,7 +228,9 @@ method publish*(
   # occur.
   let encodedSize = encode(RPCMsg.withMessages(msg), f.anonymize).len
   if encodedSize > f.maxMessageSize:
-    raise MessageTooLargeError.new(encodedSize, f.maxMessageSize)
+    warn "message exceeds maximum message size",
+      encodedSize, maxMessageSize = f.maxMessageSize
+    return 0
 
   if f.addSeen(f.salt(msgId)):
     # custom msgid providers might cause this

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -169,7 +169,7 @@ method rpcHandler*(
 
     # In theory, if topics are the same in all messages, we could batch - we'd
     # also have to be careful to only include validated messages
-    f.broadcast(toSendPeers, RPCMsg.withMessages(msg), MessagePriority.Low)
+    f.broadcastResponse(toSendPeers, RPCMsg.withMessages(msg), MessagePriority.Low)
     trace "Forwared message to peers", peers = toSendPeers.len
 
   f.updateMetrics(rpcMsg)
@@ -194,7 +194,7 @@ method publish*(
     topic: string,
     data: sink seq[byte],
     publishParams: Opt[PublishParams] = Opt.none(PublishParams),
-): Future[int] {.async: (raises: []).} =
+): Future[int] {.async: (raises: [MessageTooLargeError]).} =
   handleSelfPublishing(f, topic, data)
 
   trace "Publishing message on topic", data = data.shortLog, topic
@@ -221,6 +221,17 @@ method publish*(
       return 0
 
   trace "Created new message", message = shortLog(msg), peers = peers.len, topic, msgId
+
+  # Application-published messages are never split - reject oversized messages
+  # up front so the caller can handle the error before any dedup side effects
+  # occur.
+  let encodedSize = encode(RPCMsg.withMessages(msg), f.anonymize).len
+  if encodedSize > f.maxMessageSize:
+    raise newException(
+      MessageTooLargeError,
+      "message of size " & $encodedSize & " exceeds maxMessageSize " &
+        $f.maxMessageSize,
+    )
 
   if f.addSeen(f.salt(msgId)):
     # custom msgid providers might cause this

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -204,6 +204,15 @@ method publish*(
     debug "Empty topic, skipping publish", topic
     return 0
 
+  # Application-published messages are never split - reject oversized messages
+  # up front so the caller can handle the error before any dedup side effects
+  # occur.
+  let messageSize = RPCMsg.withMessages(msg).byteSize()
+  if messageSize > f.maxMessageSize:
+    warn "message exceeds maximum message size",
+      encodedSize, maxMessageSize = f.maxMessageSize
+    return 0
+
   let peers = f.floodsub.getOrDefault(topic)
 
   if peers.len == 0:
@@ -222,15 +231,6 @@ method publish*(
       return 0
 
   trace "Created new message", message = shortLog(msg), peers = peers.len, topic, msgId
-
-  # Application-published messages are never split - reject oversized messages
-  # up front so the caller can handle the error before any dedup side effects
-  # occur.
-  let encodedSize = encode(RPCMsg.withMessages(msg), f.anonymize).len
-  if encodedSize > f.maxMessageSize:
-    warn "message exceeds maximum message size",
-      encodedSize, maxMessageSize = f.maxMessageSize
-    return 0
 
   if f.addSeen(f.salt(msgId)):
     # custom msgid providers might cause this

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -881,6 +881,15 @@ method publish*(
     debug "Empty topic, skipping publish"
     return 0
 
+  let msg =
+    if g.anonymize:
+      Message.init(Opt.none(PeerInfo), data, topic, Opt.none(uint64), false)
+    else:
+      inc g.msgSeqno
+      Message.init(Opt.some(g.peerInfo), data, topic, Opt.some(g.msgSeqno), g.sign)
+
+  g.handleSelfPublishing(topic, data)
+
   trace "Publishing message on topic", data = data.shortLog
 
   let pubParams = publishParams.get(PublishParams())
@@ -906,17 +915,10 @@ method publish*(
     libp2p_gossipsub_failed_publish.inc()
     return 0
 
-  let
-    msg =
-      if g.anonymize:
-        Message.init(Opt.none(PeerInfo), data, topic, Opt.none(uint64), false)
-      else:
-        inc g.msgSeqno
-        Message.init(Opt.some(g.peerInfo), data, topic, Opt.some(g.msgSeqno), g.sign)
-    msgId = g.msgIdProvider(msg).valueOr:
-      trace "Error generating message id, skipping publish", error = error
-      libp2p_gossipsub_failed_publish.inc()
-      return 0
+  let msgId = g.msgIdProvider(msg).valueOr:
+    trace "Error generating message id, skipping publish", error = error
+    libp2p_gossipsub_failed_publish.inc()
+    return 0
 
   logScope:
     msgId = shortLog(msgId)
@@ -950,8 +952,6 @@ method publish*(
       g.extensionsState.preambleBroadcast(
         RPCMsg.withPreamble(topic, msgId, msg.data.len), peers.mapIt(it.peerId)
       )
-
-  g.handleSelfPublishing(topic, data)
 
   g.broadcast(
     peers,

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -926,11 +926,7 @@ method publish*(
   # effects occur.
   let encodedSize = encode(RPCMsg.withMessages(msg), g.anonymize).len
   if encodedSize > g.maxMessageSize:
-    raise newException(
-      MessageTooLargeError,
-      "message of size " & $encodedSize & " exceeds maxMessageSize " &
-        $g.maxMessageSize,
-    )
+    raise MessageTooLargeError.new(encodedSize, g.maxMessageSize)
 
   if g.addSeen(g.salt(msgId)):
     # If the message was received or published recently, don't re-publish it -

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -881,6 +881,15 @@ method publish*(
     debug "Empty topic, skipping publish"
     return 0
 
+  # Application-published messages are never split - reject oversized messages
+  # up front so the caller can handle the error before any dedup/cache side
+  # effects occur.
+  let messageSize = RPCMsg.withMessages(msg).byteSize()
+  if messageSize > g.maxMessageSize:
+    warn "message exceeds maximum message size",
+      messageSize, maxMessageSize = g.maxMessageSize
+    return 0
+
   handleSelfPublishing(g, topic, data)
 
   trace "Publishing message on topic", data = data.shortLog
@@ -924,15 +933,6 @@ method publish*(
     msgId = shortLog(msgId)
 
   trace "Created new message", message = shortLog(msg), peers = peers.len
-
-  # Application-published messages are never split - reject oversized messages
-  # up front so the caller can handle the error before any dedup/cache side
-  # effects occur.
-  let encodedSize = encode(RPCMsg.withMessages(msg), g.anonymize).len
-  if encodedSize > g.maxMessageSize:
-    warn "message exceeds maximum message size",
-      encodedSize, maxMessageSize = g.maxMessageSize
-    return 0
 
   if g.addSeen(g.salt(msgId)):
     # If the message was received or published recently, don't re-publish it -

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -16,6 +16,7 @@ import
   ./peertable,
   ./mcache,
   ./timedcache,
+  ./rpc_send,
   ./rpc/[messages, message, protobuf],
   ../protocol,
   ../../stream/connection,
@@ -29,6 +30,9 @@ import
   ../../utils/future
 
 export types, scoring, behavior, pubsub, results
+
+when defined(libp2p_testing):
+  export sendResponse, broadcastResponse
 
 logScope:
   topics = "libp2p gossipsub"

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -881,17 +881,6 @@ method publish*(
     debug "Empty topic, skipping publish"
     return 0
 
-  # Application-published messages are never split - reject oversized messages
-  # up front so the caller can handle the error before any dedup/cache side
-  # effects occur.
-  let messageSize = RPCMsg.withMessages(msg).byteSize()
-  if messageSize > g.maxMessageSize:
-    warn "message exceeds maximum message size",
-      messageSize, maxMessageSize = g.maxMessageSize
-    return 0
-
-  handleSelfPublishing(g, topic, data)
-
   trace "Publishing message on topic", data = data.shortLog
 
   let pubParams = publishParams.get(PublishParams())
@@ -941,6 +930,15 @@ method publish*(
     trace "Dropping already-seen message"
     return 0
 
+  # Application-published messages are never split - reject oversized messages
+  # up front so the caller can handle the error before any dedup/cache side
+  # effects occur.
+  let messageSize = RPCMsg.withMessages(msg).byteSize()
+  if messageSize > g.maxMessageSize:
+    warn "message exceeds maximum message size",
+      messageSize, maxMessageSize = g.maxMessageSize
+    return 0
+
   if not pubParams.skipMCache:
     g.mcache.put(msgId, msg)
 
@@ -952,6 +950,8 @@ method publish*(
       g.extensionsState.preambleBroadcast(
         RPCMsg.withPreamble(topic, msgId, msg.data.len), peers.mapIt(it.peerId)
       )
+
+  g.handleSelfPublishing(topic, data)
 
   g.broadcast(
     peers,

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -888,6 +888,15 @@ method publish*(
       inc g.msgSeqno
       Message.init(Opt.some(g.peerInfo), data, topic, Opt.some(g.msgSeqno), g.sign)
 
+  # Application-published messages are never split - reject oversized messages
+  # up front so the caller can handle the error before any dedup/cache side
+  # effects occur.
+  let messageSize = RPCMsg.withMessages(msg).byteSize()
+  if messageSize > g.maxMessageSize:
+    warn "message exceeds maximum message size; message will not be published",
+      messageSize, maxMessageSize = g.maxMessageSize
+    return 0
+
   g.handleSelfPublishing(topic, data)
 
   trace "Publishing message on topic", data = data.shortLog
@@ -930,15 +939,6 @@ method publish*(
     # this might happen when not using sequence id:s and / or with a custom
     # message id provider
     trace "Dropping already-seen message"
-    return 0
-
-  # Application-published messages are never split - reject oversized messages
-  # up front so the caller can handle the error before any dedup/cache side
-  # effects occur.
-  let messageSize = RPCMsg.withMessages(msg).byteSize()
-  if messageSize > g.maxMessageSize:
-    warn "message exceeds maximum message size; message will not be published",
-      messageSize, maxMessageSize = g.maxMessageSize
     return 0
 
   if not pubParams.skipMCache:

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -294,7 +294,7 @@ proc sendExtensionsControl(g: GossipSub, peer: PubSubPeer) =
     return
 
   g.extensionsState.addPeer(peer.peerId)
-  g.send(
+  g.sendResponse(
     peer,
     RPCMsg.withControl(
       ControlMessage.withExtensions(g.extensionsState.makeControlExtensions())
@@ -455,7 +455,7 @@ proc handleControl(g: GossipSub, peer: PubSubPeer, control: ControlMessage) =
         libp2p_pubsub_broadcast_prune.inc(labelValues = [g.topicLabel(prune.topicID)])
 
     trace "sending control message", control = shortLog(respControl), peer
-    g.send(peer, RPCMsg.withControl(respControl), MessagePriority.High)
+    g.sendResponse(peer, RPCMsg.withControl(respControl), MessagePriority.High)
 
   if messages.len > 0:
     for i, smsg in messages:
@@ -469,7 +469,7 @@ proc handleControl(g: GossipSub, peer: PubSubPeer, control: ControlMessage) =
 
     # iwant replies have lower priority
     trace "sending iwant reply messages", peer
-    g.send(peer, RPCMsg.withMessages(messages), MessagePriority.Low)
+    g.sendResponse(peer, RPCMsg.withMessages(messages), MessagePriority.Low)
 
 proc sendIDontWant(
     g: GossipSub,
@@ -496,7 +496,7 @@ proc sendIDontWant(
       # skip sending IDONTWANT if peer has requested partial for topic
   )
 
-  g.broadcast(
+  g.broadcastResponse(
     peers, RPCMsg.withControl(ControlMessage.withIDontWant(msgId)), MessagePriority.High
   )
 
@@ -593,7 +593,7 @@ proc validateAndRelay(
 
     # In theory, if topics are the same in all messages, we could batch - we'd
     # also have to be careful to only include validated messages
-    g.broadcast(toSendPeers, RPCMsg.withMessages(msg), MessagePriority.Low)
+    g.broadcastResponse(toSendPeers, RPCMsg.withMessages(msg), MessagePriority.Low)
     trace "forwarded message to peers", peers = toSendPeers.len, msgId, peer
 
     libp2p_pubsub_messages_rebroadcasted.inc(
@@ -782,7 +782,7 @@ method onTopicSubscription*(g: GossipSub, topic: string, subscribed: bool) =
         topic, g.parameters.unsubscribeBackoff.seconds.uint64, g.peerExchangeList(topic)
       )
     )
-    g.broadcast(mpeers, msg, MessagePriority.High)
+    g.broadcastResponse(mpeers, msg, MessagePriority.High)
 
     for peer in mpeers:
       g.pruned(peer, topic, backoff = Opt.some(g.parameters.unsubscribeBackoff))
@@ -869,7 +869,7 @@ method publish*(
     topic: string,
     data: sink seq[byte],
     publishParams: Opt[PublishParams] = Opt.none(PublishParams),
-): Future[int] {.async: (raises: []).} =
+): Future[int] {.async: (raises: [MessageTooLargeError]).} =
   logScope:
     topic
 
@@ -920,6 +920,17 @@ method publish*(
     msgId = shortLog(msgId)
 
   trace "Created new message", message = shortLog(msg), peers = peers.len
+
+  # Application-published messages are never split - reject oversized messages
+  # up front so the caller can handle the error before any dedup/cache side
+  # effects occur.
+  let encodedSize = encode(RPCMsg.withMessages(msg), g.anonymize).len
+  if encodedSize > g.maxMessageSize:
+    raise newException(
+      MessageTooLargeError,
+      "message of size " & $encodedSize & " exceeds maxMessageSize " &
+        $g.maxMessageSize,
+    )
 
   if g.addSeen(g.salt(msgId)):
     # If the message was received or published recently, don't re-publish it -
@@ -1015,7 +1026,7 @@ proc createExtensionsState(g: GossipSub): ExtensionsState =
     if cfg.onNegotiated.isNil:
       cfg.onNegotiated = proc(peerId: PeerId) {.gcsafe, raises: [].} =
         g.peers.withValue(peerId, peer):
-          g.send(
+          g.sendResponse(
             peer[],
             RPCMsg(testExtension: Opt.some(TestExtensionRPC())),
             MessagePriority.High,
@@ -1031,7 +1042,7 @@ proc createExtensionsState(g: GossipSub): ExtensionsState =
           peerId: PeerId, rpc: PartialMessageExtensionRPC
       ) {.gcsafe, raises: [].} =
         g.peers.withValue(peerId, peer):
-          g.send(
+          g.sendResponse(
             peer[], RPCMsg(partialMessageExtension: Opt.some(rpc)), MessagePriority.Low
           )
 
@@ -1057,7 +1068,7 @@ proc createExtensionsState(g: GossipSub): ExtensionsState =
     if cfg.sendPong.isNil:
       cfg.sendPong = proc(peerId: PeerId, pong: seq[byte]) {.gcsafe, raises: [].} =
         g.peers.withValue(peerId, peer):
-          g.send(peer[], RPCMsg.withPong(pong), MessagePriority.High)
+          g.sendResponse(peer[], RPCMsg.withPong(pong), MessagePriority.High)
 
     g.parameters.pingpongExtensionConfig = Opt.some(cfg)
 
@@ -1068,7 +1079,7 @@ proc createExtensionsState(g: GossipSub): ExtensionsState =
       cfg.broadcastRPC = proc(msg: RPCMsg, peers: seq[PeerId]) {.gcsafe, raises: [].} =
         let peersToBroadcast =
           peers.filterIt(it in g.peers).mapIt(g.peers.getOrDefault(it))
-        g.broadcast(peersToBroadcast, msg, MessagePriority.High)
+        g.broadcastResponse(peersToBroadcast, msg, MessagePriority.High)
     if cfg.hasSeen.isNil:
       cfg.hasSeen = proc(mid: MessageId): bool {.gcsafe, raises: [].} =
         return g.hasSeen(g.salt(mid))

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -873,7 +873,7 @@ method publish*(
     topic: string,
     data: sink seq[byte],
     publishParams: Opt[PublishParams] = Opt.none(PublishParams),
-): Future[int] {.async: (raises: [MessageTooLargeError]).} =
+): Future[int] {.async: (raises: []).} =
   logScope:
     topic
 
@@ -930,7 +930,9 @@ method publish*(
   # effects occur.
   let encodedSize = encode(RPCMsg.withMessages(msg), g.anonymize).len
   if encodedSize > g.maxMessageSize:
-    raise MessageTooLargeError.new(encodedSize, g.maxMessageSize)
+    warn "message exceeds maximum message size",
+      encodedSize, maxMessageSize = g.maxMessageSize
+    return 0
 
   if g.addSeen(g.salt(msgId)):
     # If the message was received or published recently, don't re-publish it -

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -935,7 +935,7 @@ method publish*(
   # effects occur.
   let messageSize = RPCMsg.withMessages(msg).byteSize()
   if messageSize > g.maxMessageSize:
-    warn "message exceeds maximum message size",
+    warn "message exceeds maximum message size; message will not be published",
       messageSize, maxMessageSize = g.maxMessageSize
     return 0
 

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -891,7 +891,7 @@ method publish*(
   # Application-published messages are never split - reject oversized messages
   # up front so the caller can handle the error before any dedup/cache side
   # effects occur.
-  let messageSize = RPCMsg.withMessages(msg).byteSize()
+  let messageSize = RPCMsg.withMessages(msg).encodedSize()
   if messageSize > g.maxMessageSize:
     warn "message exceeds maximum message size; message will not be published",
       messageSize, maxMessageSize = g.maxMessageSize

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -6,7 +6,7 @@
 import std/[tables, sequtils, sets, algorithm, deques]
 import chronos, chronicles, metrics
 import "."/[types, scoring, extensions]
-import ".."/[pubsubpeer, peertable, mcache, floodsub, pubsub]
+import ".."/[pubsubpeer, peertable, mcache, floodsub, pubsub, rpc_send]
 import "../rpc"/[messages]
 import
   "../../.."/[

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -601,14 +601,14 @@ proc rebalanceMesh*(g: GossipSub, topic: string, metrics: ptr MeshMetrics = nil)
   # Send changes to peers after table updates to avoid stale state
   if grafts.len > 0:
     let graft = RPCMsg.withControl(ControlMessage.withGraft(topic))
-    g.broadcast(grafts, graft, MessagePriority.High)
+    g.broadcastResponse(grafts, graft, MessagePriority.High)
   if prunes.len > 0:
     let prune = RPCMsg.withControl(
       ControlMessage.withPrune(
         topic, g.parameters.pruneBackoff.seconds.uint64, g.peerExchangeList(topic)
       )
     )
-    g.broadcast(prunes, prune, MessagePriority.High)
+    g.broadcastResponse(prunes, prune, MessagePriority.High)
 
 proc dropFanoutPeers*(g: GossipSub) =
   # drop peers that we haven't published to in
@@ -744,7 +744,7 @@ proc onHeartbeat(g: GossipSub) =
           t, g.parameters.pruneBackoff.seconds.uint64, g.peerExchangeList(t)
         )
       )
-      g.broadcast(prunes, prune, MessagePriority.High)
+      g.broadcastResponse(prunes, prune, MessagePriority.High)
 
     # pass by ptr in order to both signal we want to update metrics
     # and as well update the struct for each topic during this iteration
@@ -762,7 +762,7 @@ proc onHeartbeat(g: GossipSub) =
     # only ihave from here
     for ihave in control.ihave:
       libp2p_pubsub_broadcast_ihave.inc(labelValues = [g.topicLabel(ihave.topicID)])
-    g.send(peer, RPCMsg.withControl(control), MessagePriority.High)
+    g.sendResponse(peer, RPCMsg.withControl(control), MessagePriority.High)
 
   g.mcache.shift() # shift the cache
 

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -11,7 +11,6 @@
 
 import std/[tables, sequtils, sets, strutils]
 import chronos, chronicles, metrics
-import chronos/ratelimit
 import
   ./errors as pubsub_errors,
   ./pubsubpeer,
@@ -335,11 +334,7 @@ proc broadcast*(
     # Fast path that only encodes message once
     let encoded = msg.encode(p.anonymize)
     if encoded.len > p.maxMessageSize:
-      raise newException(
-        MessageTooLargeError,
-        "message of size " & $encoded.len & " exceeds maxMessageSize " &
-          $p.maxMessageSize,
-      )
+      raise MessageTooLargeError.new(encoded.len, p.maxMessageSize)
     for peer in sendPeers:
       var peerEncoded = encoded
       peer.trackSend(peer.sendEncoded(move(peerEncoded), priority, useCustomStream))

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -267,7 +267,7 @@ proc sendResponse*(
   peer.sendResponse(msg, p.anonymize, priority, useCustomStream)
 
 proc countBroadcastMetrics(
-    p: PubSub, sendPeers: auto, msg: RPCMsg
+    p: PubSub, sendPeers: openArray[PubSubPeer], msg: RPCMsg
 ) {.raises: [].} =
   ## Increments the broadcast-related metrics for an outgoing RPC message.
   let npeers = sendPeers.len.int64
@@ -304,7 +304,7 @@ proc countBroadcastMetrics(
 
 proc broadcast*(
     p: PubSub,
-    sendPeers: auto, # Iteratble[PubSubPeer]
+    sendPeers: openArray[PubSubPeer],
     msg: RPCMsg,
     priority: MessagePriority,
     useCustomStream: bool = false,
@@ -318,7 +318,7 @@ proc broadcast*(
   ##
   ## Parameters:
   ## - `p`: The `PubSub` instance.
-  ## - `sendPeers`: An iterable of `PubSubPeer` instances representing the peers to whom the message should be sent.
+  ## - `sendPeers`: A sequence of `PubSubPeer` instances to which the message should be sent.
   ## - `msg`: The `RPCMsg` instance that contains the message to be broadcast.
   ## - `priority`: The message priority level (`High`, `Medium`, or `Low`).
   ##   High priority messages are sent immediately, medium and low priority messages are queued
@@ -344,9 +344,21 @@ proc broadcast*(
       var peerEncoded = encoded
       peer.trackSend(peer.sendEncoded(move(peerEncoded), priority, useCustomStream))
 
+proc broadcast*(
+    p: PubSub,
+    sendPeers: HashSet[PubSubPeer],
+    msg: RPCMsg,
+    priority: MessagePriority,
+    useCustomStream: bool = false,
+) {.raises: [MessageTooLargeError].} =
+  ## Overload for `HashSet[PubSubPeer]`: order is irrelevant for a broadcast,
+  ## so the peers are materialized into a sequence and delegated to the
+  ## `openArray` overload.
+  p.broadcast(sendPeers.toSeq, msg, priority, useCustomStream)
+
 proc broadcastResponse*(
     p: PubSub,
-    sendPeers: auto, # Iteratble[PubSubPeer]
+    sendPeers: openArray[PubSubPeer],
     msg: RPCMsg,
     priority: MessagePriority,
     useCustomStream: bool = false,
@@ -371,6 +383,18 @@ proc broadcastResponse*(
     for peer in sendPeers:
       var peerEncoded = encoded
       peer.trackSend(peer.sendEncoded(move(peerEncoded), priority, useCustomStream))
+
+proc broadcastResponse*(
+    p: PubSub,
+    sendPeers: HashSet[PubSubPeer],
+    msg: RPCMsg,
+    priority: MessagePriority,
+    useCustomStream: bool = false,
+) {.raises: [].} =
+  ## Overload for `HashSet[PubSubPeer]`: order is irrelevant for a broadcast,
+  ## so the peers are materialized into a sequence and delegated to the
+  ## `openArray` overload.
+  p.broadcastResponse(sendPeers.toSeq, msg, priority, useCustomStream)
 
 proc sendSubs*(
     p: PubSub, peer: PubSubPeer, subTopics: openArray[string], subscribe: bool

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -288,7 +288,7 @@ proc countBroadcastMetrics*(
 
 proc broadcast*(
     p: PubSub,
-    sendPeers: openArray[PubSubPeer],
+    sendPeers: openArray[PubSubPeer] | HashSet[PubSubPeer],
     msg: RPCMsg,
     priority: MessagePriority,
     useCustomStream: bool = false,
@@ -322,18 +322,6 @@ proc broadcast*(
     for peer in sendPeers:
       var peerEncoded = encoded
       peer.trackSend(peer.sendEncoded(move(peerEncoded), priority, useCustomStream))
-
-proc broadcast*(
-    p: PubSub,
-    sendPeers: HashSet[PubSubPeer],
-    msg: RPCMsg,
-    priority: MessagePriority,
-    useCustomStream: bool = false,
-) {.raises: [].} =
-  ## Overload for `HashSet[PubSubPeer]`: order is irrelevant for a broadcast,
-  ## so the peers are materialized into a sequence and delegated to the
-  ## `openArray` overload.
-  p.broadcast(sendPeers.toSeq, msg, priority, useCustomStream)
 
 proc sendSubs*(
     p: PubSub, peer: PubSubPeer, subTopics: openArray[string], subscribe: bool

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -348,7 +348,9 @@ proc sendSubs*(
         subOpt.supportsSendingPartial = Opt.some(topicData[].supportsSendingPartial)
     subscriptions.add(subOpt)
 
-  peer.sendResponse(RPCMsg.withSubscriptions(subscriptions), p.anonymize, MessagePriority.High)
+  peer.sendResponse(
+    RPCMsg.withSubscriptions(subscriptions), p.anonymize, MessagePriority.High
+  )
 
   for topic in subTopics:
     if subscribe:

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -248,24 +248,7 @@ proc send*(
   trace "sending pubsub message to peer", peer, rpcMsg = shortLog(msg)
   peer.send(msg, p.anonymize, priority, useCustomStream)
 
-proc sendResponse*(
-    p: PubSub,
-    peer: PubSubPeer,
-    msg: RPCMsg,
-    priority: MessagePriority,
-    useCustomStream: bool = false,
-) {.raises: [].} =
-  ## Sends a protocol response `msg` (of type `RPCMsg`) to the specified remote
-  ## peer. This is an internal, protocol-facing send path - messages that
-  ## together exceed `maxMessageSize` are split and sent individually.
-  ##
-  ## This should not be used for application-published messages; use `send`
-  ## instead.
-
-  trace "sending pubsub response to peer", peer, rpcMsg = shortLog(msg)
-  peer.sendResponse(msg, p.anonymize, priority, useCustomStream)
-
-proc countBroadcastMetrics(
+proc countBroadcastMetrics*(
     p: PubSub, sendPeers: openArray[PubSubPeer], msg: RPCMsg
 ) {.raises: [].} =
   ## Increments the broadcast-related metrics for an outgoing RPC message.
@@ -351,46 +334,6 @@ proc broadcast*(
   ## `openArray` overload.
   p.broadcast(sendPeers.toSeq, msg, priority, useCustomStream)
 
-proc broadcastResponse*(
-    p: PubSub,
-    sendPeers: openArray[PubSubPeer],
-    msg: RPCMsg,
-    priority: MessagePriority,
-    useCustomStream: bool = false,
-) {.raises: [].} =
-  ## Sends a protocol response `msg` (of type `RPCMsg`) to a specified group of
-  ## peers. This is an internal, protocol-facing broadcast path - messages that
-  ## together exceed `maxMessageSize` are split and sent individually.
-  ##
-  ## This should not be used for application-published messages; use `broadcast`
-  ## instead.
-
-  countBroadcastMetrics(p, sendPeers, msg)
-
-  trace "broadcasting responses to peers", peers = sendPeers.len, rpcMsg = shortLog(msg)
-
-  if anyIt(sendPeers, it.hasObservers) or msg.messages.len > 1:
-    for peer in sendPeers:
-      p.sendResponse(peer, msg, priority, useCustomStream)
-  else:
-    # Fast path that only encodes message once
-    let encoded = msg.encode(p.anonymize)
-    for peer in sendPeers:
-      var peerEncoded = encoded
-      peer.trackSend(peer.sendEncoded(move(peerEncoded), priority, useCustomStream))
-
-proc broadcastResponse*(
-    p: PubSub,
-    sendPeers: HashSet[PubSubPeer],
-    msg: RPCMsg,
-    priority: MessagePriority,
-    useCustomStream: bool = false,
-) {.raises: [].} =
-  ## Overload for `HashSet[PubSubPeer]`: order is irrelevant for a broadcast,
-  ## so the peers are materialized into a sequence and delegated to the
-  ## `openArray` overload.
-  p.broadcastResponse(sendPeers.toSeq, msg, priority, useCustomStream)
-
 proc sendSubs*(
     p: PubSub, peer: PubSubPeer, subTopics: openArray[string], subscribe: bool
 ) =
@@ -405,7 +348,7 @@ proc sendSubs*(
         subOpt.supportsSendingPartial = Opt.some(topicData[].supportsSendingPartial)
     subscriptions.add(subOpt)
 
-  p.sendResponse(peer, RPCMsg.withSubscriptions(subscriptions), MessagePriority.High)
+  peer.sendResponse(RPCMsg.withSubscriptions(subscriptions), p.anonymize, MessagePriority.High)
 
   for topic in subTopics:
     if subscribe:

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -288,7 +288,7 @@ proc countBroadcastMetrics*(
 
 proc broadcast*(
     p: PubSub,
-    sendPeers: openArray[PubSubPeer] | HashSet[PubSubPeer],
+    sendPeers: openArray[PubSubPeer]  | seq[PubSubPeer] | HashSet[PubSubPeer],
     msg: RPCMsg,
     priority: MessagePriority,
     useCustomStream: bool = false,

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -10,7 +10,7 @@
 {.push raises: [].}
 
 import std/[tables, sequtils, sets, strutils]
-import chronos, chronicles, metrics
+import chronos, chronicles, metrics, results
 import
   ./errors as pubsub_errors,
   ./pubsubpeer,
@@ -25,14 +25,8 @@ import
   ../../utils/opt,
   ../../utils/future
 
-import results
-export results
-
-export tables, sets
-export PubSubPeer
-export PubSubObserver
-export protocol
-export pubsub_errors
+export tables, sets, results, chronicles
+export PubSubPeer, PubSubObserver, protocol, pubsub_errors
 
 logScope:
   topics = "libp2p pubsub"
@@ -288,7 +282,7 @@ proc countBroadcastMetrics*(
 
 proc broadcast*(
     p: PubSub,
-    sendPeers: openArray[PubSubPeer]  | seq[PubSubPeer] | HashSet[PubSubPeer],
+    sendPeers: openArray[PubSubPeer] | seq[PubSubPeer] | HashSet[PubSubPeer],
     msg: RPCMsg,
     priority: MessagePriority,
     useCustomStream: bool = false,

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -231,8 +231,12 @@ proc send*(
     msg: RPCMsg,
     priority: MessagePriority,
     useCustomStream: bool = false,
-) {.raises: [].} =
-  ## This procedure attempts to send a `msg` (of type `RPCMsg`) to the specified remote peer in the PubSub network.
+) {.raises: [MessageTooLargeError].} =
+  ## Sends an application-published `msg` (of type `RPCMsg`) to the specified
+  ## remote peer in the PubSub network.
+  ##
+  ## The message is sent as-is, without splitting - the application is
+  ## responsible for ensuring the message fits within `maxMessageSize`.
   ##
   ## Parameters:
   ## - `p`: The `PubSub` instance.
@@ -245,23 +249,27 @@ proc send*(
   trace "sending pubsub message to peer", peer, rpcMsg = shortLog(msg)
   peer.send(msg, p.anonymize, priority, useCustomStream)
 
-proc broadcast*(
+proc sendResponse*(
     p: PubSub,
-    sendPeers: auto, # Iteratble[PubSubPeer]
+    peer: PubSubPeer,
     msg: RPCMsg,
     priority: MessagePriority,
     useCustomStream: bool = false,
 ) {.raises: [].} =
-  ## This procedure attempts to send a `msg` (of type `RPCMsg`) to a specified group of peers in the PubSub network.
+  ## Sends a protocol response `msg` (of type `RPCMsg`) to the specified remote
+  ## peer. This is an internal, protocol-facing send path - messages that
+  ## together exceed `maxMessageSize` are split and sent individually.
   ##
-  ## Parameters:
-  ## - `p`: The `PubSub` instance.
-  ## - `sendPeers`: An iterable of `PubSubPeer` instances representing the peers to whom the message should be sent.
-  ## - `msg`: The `RPCMsg` instance that contains the message to be broadcast.
-  ## - `priority`: The message priority level (`High`, `Medium`, or `Low`).
-  ##   High priority messages are sent immediately, medium and low priority messages are queued
-  ##   and sent only after all high priority messages have been sent.
+  ## This should not be used for application-published messages; use `send`
+  ## instead.
 
+  trace "sending pubsub response to peer", peer, rpcMsg = shortLog(msg)
+  peer.sendResponse(msg, p.anonymize, priority, useCustomStream)
+
+proc countBroadcastMetrics(
+    p: PubSub, sendPeers: auto, msg: RPCMsg
+) {.raises: [].} =
+  ## Increments the broadcast-related metrics for an outgoing RPC message.
   let npeers = sendPeers.len.int64
   for sub in msg.subscriptions:
     if sub.isSubscribe:
@@ -294,11 +302,69 @@ proc broadcast*(
         npeers, labelValues = [p.topicLabel(prune.topicID)]
       )
 
+proc broadcast*(
+    p: PubSub,
+    sendPeers: auto, # Iteratble[PubSubPeer]
+    msg: RPCMsg,
+    priority: MessagePriority,
+    useCustomStream: bool = false,
+) {.raises: [MessageTooLargeError].} =
+  ## Sends an application-published `msg` (of type `RPCMsg`) to a specified
+  ## group of peers in the PubSub network.
+  ##
+  ## The message is sent as-is, without splitting - the application is
+  ## responsible for ensuring the message fits within `maxMessageSize`. Raises
+  ## `MessageTooLargeError` if the encoded message exceeds `maxMessageSize`.
+  ##
+  ## Parameters:
+  ## - `p`: The `PubSub` instance.
+  ## - `sendPeers`: An iterable of `PubSubPeer` instances representing the peers to whom the message should be sent.
+  ## - `msg`: The `RPCMsg` instance that contains the message to be broadcast.
+  ## - `priority`: The message priority level (`High`, `Medium`, or `Low`).
+  ##   High priority messages are sent immediately, medium and low priority messages are queued
+  ##   and sent only after all high priority messages have been sent.
+
+  countBroadcastMetrics(p, sendPeers, msg)
+
   trace "broadcasting messages to peers", peers = sendPeers.len, rpcMsg = shortLog(msg)
 
   if anyIt(sendPeers, it.hasObservers):
     for peer in sendPeers:
       p.send(peer, msg, priority, useCustomStream)
+  else:
+    # Fast path that only encodes message once
+    let encoded = msg.encode(p.anonymize)
+    if encoded.len > p.maxMessageSize:
+      raise newException(
+        MessageTooLargeError,
+        "message of size " & $encoded.len & " exceeds maxMessageSize " &
+          $p.maxMessageSize,
+      )
+    for peer in sendPeers:
+      var peerEncoded = encoded
+      peer.trackSend(peer.sendEncoded(move(peerEncoded), priority, useCustomStream))
+
+proc broadcastResponse*(
+    p: PubSub,
+    sendPeers: auto, # Iteratble[PubSubPeer]
+    msg: RPCMsg,
+    priority: MessagePriority,
+    useCustomStream: bool = false,
+) {.raises: [].} =
+  ## Sends a protocol response `msg` (of type `RPCMsg`) to a specified group of
+  ## peers. This is an internal, protocol-facing broadcast path - messages that
+  ## together exceed `maxMessageSize` are split and sent individually.
+  ##
+  ## This should not be used for application-published messages; use `broadcast`
+  ## instead.
+
+  countBroadcastMetrics(p, sendPeers, msg)
+
+  trace "broadcasting responses to peers", peers = sendPeers.len, rpcMsg = shortLog(msg)
+
+  if anyIt(sendPeers, it.hasObservers) or msg.messages.len > 1:
+    for peer in sendPeers:
+      p.sendResponse(peer, msg, priority, useCustomStream)
   else:
     # Fast path that only encodes message once
     let encoded = msg.encode(p.anonymize)
@@ -320,7 +386,7 @@ proc sendSubs*(
         subOpt.supportsSendingPartial = Opt.some(topicData[].supportsSendingPartial)
     subscriptions.add(subOpt)
 
-  p.send(peer, RPCMsg.withSubscriptions(subscriptions), MessagePriority.High)
+  p.sendResponse(peer, RPCMsg.withSubscriptions(subscriptions), MessagePriority.High)
 
   for topic in subTopics:
     if subscribe:
@@ -619,13 +685,16 @@ method publish*(
     topic: string,
     data: sink seq[byte],
     publishParams: Opt[PublishParams] = Opt.none(PublishParams),
-): Future[int] {.base, async: (raises: []).} =
+): Future[int] {.base, async: (raises: [MessageTooLargeError]).} =
   ## publish to a ``topic``
   ##
   ## The return value is the number of neighbours that we attempted to send the
   ## message to, excluding self. Note that this is an optimistic number of
   ## attempts - the number of peers that actually receive the message might
   ## be lower.
+  ##
+  ## Raises `MessageTooLargeError` if the message is larger than
+  ## `maxMessageSize`.
   handleSelfPublishing(p, topic, data)
 
   return 0

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -249,7 +249,9 @@ proc send*(
   peer.send(msg, p.anonymize, priority, useCustomStream)
 
 proc countBroadcastMetrics*(
-    p: PubSub, sendPeers: openArray[PubSubPeer], msg: RPCMsg
+    p: PubSub,
+    sendPeers: openArray[PubSubPeer] | seq[PubSubPeer] | HashSet[PubSubPeer],
+    msg: RPCMsg,
 ) {.raises: [].} =
   ## Increments the broadcast-related metrics for an outgoing RPC message.
   let npeers = sendPeers.len.int64

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -230,7 +230,7 @@ proc send*(
     msg: RPCMsg,
     priority: MessagePriority,
     useCustomStream: bool = false,
-) {.raises: [MessageTooLargeError].} =
+) {.raises: [].} =
   ## Sends an application-published `msg` (of type `RPCMsg`) to the specified
   ## remote peer in the PubSub network.
   ##
@@ -290,13 +290,9 @@ proc broadcast*(
     msg: RPCMsg,
     priority: MessagePriority,
     useCustomStream: bool = false,
-) {.raises: [MessageTooLargeError].} =
+) {.raises: [].} =
   ## Sends an application-published `msg` (of type `RPCMsg`) to a specified
   ## group of peers in the PubSub network.
-  ##
-  ## The message is sent as-is, without splitting - the application is
-  ## responsible for ensuring the message fits within `maxMessageSize`. Raises
-  ## `MessageTooLargeError` if the encoded message exceeds `maxMessageSize`.
   ##
   ## Parameters:
   ## - `p`: The `PubSub` instance.
@@ -317,7 +313,10 @@ proc broadcast*(
     # Fast path that only encodes message once
     let encoded = msg.encode(p.anonymize)
     if encoded.len > p.maxMessageSize:
-      raise MessageTooLargeError.new(encoded.len, p.maxMessageSize)
+      warn "message exceeds maximum message size",
+        encodedSize = encoded.len, maxMessageSize = p.maxMessageSize
+      return
+
     for peer in sendPeers:
       var peerEncoded = encoded
       peer.trackSend(peer.sendEncoded(move(peerEncoded), priority, useCustomStream))
@@ -328,7 +327,7 @@ proc broadcast*(
     msg: RPCMsg,
     priority: MessagePriority,
     useCustomStream: bool = false,
-) {.raises: [MessageTooLargeError].} =
+) {.raises: [].} =
   ## Overload for `HashSet[PubSubPeer]`: order is irrelevant for a broadcast,
   ## so the peers are materialized into a sequence and delegated to the
   ## `openArray` overload.
@@ -649,16 +648,13 @@ method publish*(
     topic: string,
     data: sink seq[byte],
     publishParams: Opt[PublishParams] = Opt.none(PublishParams),
-): Future[int] {.base, async: (raises: [MessageTooLargeError]).} =
+): Future[int] {.base, async: (raises: []).} =
   ## publish to a ``topic``
   ##
   ## The return value is the number of neighbours that we attempted to send the
   ## message to, excluding self. Note that this is an optimistic number of
   ## attempts - the number of peers that actually receive the message might
   ## be lower.
-  ##
-  ## Raises `MessageTooLargeError` if the message is larger than
-  ## `maxMessageSize`.
   handleSelfPublishing(p, topic, data)
 
   return 0

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -315,7 +315,7 @@ proc broadcast*(
     # Fast path that only encodes message once
     let encoded = msg.encode(p.anonymize)
     if encoded.len > p.maxMessageSize:
-      warn "message exceeds maximum message size",
+      warn "message exceeds maximum message size; message will not be broadcasted",
         encodedSize = encoded.len, maxMessageSize = p.maxMessageSize
       return
 

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -654,11 +654,7 @@ proc send*(
   var encoded = encodeRpcMsg(p, msg, anonymize)
 
   if encoded.len > p.maxMessageSize:
-    raise newException(
-      MessageTooLargeError,
-      "message of size " & $encoded.len & " exceeds maxMessageSize " &
-        $p.maxMessageSize,
-    )
+    raise MessageTooLargeError.new(encoded.len, p.maxMessageSize)
 
   trace "sending msg to peer", peer = p, rpcMsg = shortLog(msg)
   p.trackSend(p.sendEncoded(move(encoded), priority, useCustomStream))

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -664,17 +664,35 @@ proc sendResponse*(
     priority: MessagePriority,
     useCustomStream: bool = false,
 ) {.raises: [].} =
-  ## Sends a protocol response `RPCMsg` to this peer, splitting multi-message
-  ## responses into individual messages so that none exceed `maxMessageSize`.
+  ## Sends a protocol response `RPCMsg` to this peer, batching multi-message
+  ## responses together so that none exceed `maxMessageSize`.
   ##
   ## This is an internal, protocol-facing send path - individual messages that
   ## still exceed `maxMessageSize` are silently dropped.
 
   if msg.messages.len > 1:
+    # Batch as many messages as possible into a single encoded RPC instead of
+    # encoding one RPC per message. 
+    # Batches are sized with the cheap `byteSize` estimate, leaving 10% headroom 
+    # for protobuf encoding overhead on top of the raw payload sizes.
+    let maxBatchSize = (p.maxMessageSize * 90) div 100
+
+    var batch = RPCMsg()
+
     for m in msg.messages:
-      var single = RPCMsg(messages: @[m])
-      var encoded = encodeRpcMsg(p, single, anonymize)
-      trace "sending response msg to peer", peer = p, rpcMsg = shortLog(single)
+      if batch.messages.len > 0 and batch.byteSize() + m.byteSize() > maxBatchSize:
+        # The batch is full - send it and start a new one.
+        var encoded = encodeRpcMsg(p, batch, anonymize)
+        trace "sending response msg to peer", peer = p, rpcMsg = shortLog(batch)
+        p.trackSend(p.sendEncoded(move(encoded), priority, useCustomStream))
+
+        batch = RPCMsg()
+
+      batch.messages.add(m)
+
+    if batch.messages.len > 0:
+      var encoded = encodeRpcMsg(p, batch, anonymize)
+      trace "sending response msg to peer", peer = p, rpcMsg = shortLog(batch)
       p.trackSend(p.sendEncoded(move(encoded), priority, useCustomStream))
   else:
     var encoded = encodeRpcMsg(p, msg, anonymize)

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -673,10 +673,6 @@ proc sendResponse*(
   if msg.messages.len > 1:
     # Batch as many messages as possible into a single encoded RPC instead of
     # encoding one RPC per message. 
-    # Batches are sized with the cheap `byteSize` estimate, leaving 10% headroom 
-    # for protobuf encoding overhead on top of the raw payload sizes.
-    let maxBatchSize = (p.maxMessageSize * 90) div 100
-
     var batch = RPCMsg()
 
     # Multi-message batching currently supports message-only RPCs.
@@ -684,15 +680,18 @@ proc sendResponse*(
     # splitting associated to the extension itself
 
     for m in msg.messages:
-      if batch.messages.len > 0 and batch.byteSize() + m.byteSize() > maxBatchSize:
+      batch.messages.add(m)
+
+      if batch.messages.len > 0 and batch.encodedSize() > p.maxMessageSize:
+        discard batch.messages.pop() # Remove last element
+
         # The batch is full - send it and start a new one.
         var encoded = encodeRpcMsg(p, batch, anonymize)
         trace "sending response msg to peer", peer = p, rpcMsg = shortLog(batch)
         p.trackSend(p.sendEncoded(move(encoded), priority, useCustomStream))
 
         batch = RPCMsg()
-
-      batch.messages.add(m)
+        batch.messages.add(m) # Add message to new batch
 
     if batch.messages.len > 0:
       var encoded = encodeRpcMsg(p, batch, anonymize)

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -678,7 +678,7 @@ proc sendResponse*(
     let maxBatchSize = (p.maxMessageSize * 90) div 100
 
     var batch = RPCMsg()
-    
+
     # Multi-message batching currently supports message-only RPCs.
     # If an extension is associated to multiple messages, it would require
     # splitting associated to the extension itself

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -678,6 +678,10 @@ proc sendResponse*(
     let maxBatchSize = (p.maxMessageSize * 90) div 100
 
     var batch = RPCMsg()
+    
+    # Multi-message batching currently supports message-only RPCs.
+    # If an extension is associated to multiple messages, it would require
+    # splitting associated to the extension itself
 
     for m in msg.messages:
       if batch.messages.len > 0 and batch.byteSize() + m.byteSize() > maxBatchSize:

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -615,7 +615,9 @@ proc sendEncoded*(
       else:
         p.dropNonHighPriorityMessage(action.slowPeerPenaltyDelta, action.priority)
 
-proc encodeRpcMsg(p: PubSubPeer, msg: RPCMsg, anonymize: bool): seq[byte] {.raises: [].} =
+proc encodeRpcMsg(
+    p: PubSubPeer, msg: RPCMsg, anonymize: bool
+): seq[byte] {.raises: [].} =
   ## Encodes an `RPCMsg` for sending, running send observers and metrics.
   ##
   ## We re-encode the message to protect against valid but redundantly encoded

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -666,18 +666,16 @@ proc sendResponse*(
 ) {.raises: [].} =
   ## Sends a protocol response `RPCMsg` to this peer, batching multi-message
   ## responses together so that none exceed `maxMessageSize`.
+  ## Batching is only performed for message-only RPCs - if the RPC carries other
+  ## data (subscriptions, control or extensions), it is sent as-is.
   ##
   ## This is an internal, protocol-facing send path - individual messages that
   ## still exceed `maxMessageSize` are silently dropped.
 
-  if msg.messages.len > 1:
+  if msg.messages.len > 1 and msg.hasOnlyMessages():
     # Batch as many messages as possible into a single encoded RPC instead of
     # encoding one RPC per message. 
     var batch = RPCMsg()
-
-    # Multi-message batching currently supports message-only RPCs.
-    # If an extension is associated to multiple messages, it would require
-    # splitting associated to the extension itself
 
     for m in msg.messages:
       batch.messages.add(m)

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -9,6 +9,7 @@ import chronos, chronicles, nimcrypto/sha2, metrics
 import chronos/ratelimit
 import
   rpc/[messages, message, protobuf],
+  ./errors,
   ../../peerid,
   ../../peerinfo,
   ../../stream/connection,
@@ -614,38 +615,20 @@ proc sendEncoded*(
       else:
         p.dropNonHighPriorityMessage(action.slowPeerPenaltyDelta, action.priority)
 
-iterator splitRPCMsg(
-    peer: PubSubPeer, rpcMsg: RPCMsg, maxSize: int, anonymize: bool
-): seq[byte] =
-  ## This iterator takes an `RPCMsg` and sequentially repackages its Messages into new `RPCMsg` instances.
-  ## Each new `RPCMsg` accumulates Messages until reaching the specified `maxSize`. If a single Message
-  ## exceeds the `maxSize` when trying to fit into an empty `RPCMsg`, the latter is skipped as too large to send.
-  ## Every constructed `RPCMsg` is then encoded, optionally anonymized, and yielded as a sequence of bytes.
-
-  var currentRPCMsg = RPCMsg()
-  var currentSize = 0
-
-  for msg in rpcMsg.messages:
-    let msgSize = byteSize(msg)
-
-    # Check if adding the next message will exceed maxSize
-    if currentSize + msgSize > maxSize:
-      if msgSize > maxSize:
-        warn "message too big to sent", peer, rpcMsg = shortLog(msg)
-        continue # Skip this message
-
-      trace "sending msg to peer", peer, rpcMsg = shortLog(currentRPCMsg)
-      yield encode(currentRPCMsg, anonymize)
-      currentRPCMsg = RPCMsg()
-      currentSize = 0
-
-    currentRPCMsg.messages.add(msg)
-    currentSize += msgSize
-
-  # Check if there is a non-empty currentRPCMsg left to be added
-  if currentRPCMsg.messages.len > 0:
-    trace "sending msg to peer", peer, rpcMsg = shortLog(currentRPCMsg)
-    yield encode(currentRPCMsg, anonymize)
+proc encodeRpcMsg(p: PubSubPeer, msg: RPCMsg, anonymize: bool): seq[byte] {.raises: [].} =
+  ## Encodes an `RPCMsg` for sending, running send observers and metrics.
+  ##
+  ## We re-encode the message to protect against valid but redundantly encoded
+  ## protobufs with unknown or duplicated fields.
+  if p.hasObservers():
+    var mm = msg
+    # trigger send hooks
+    p.sendObservers(mm)
+    sendMetrics(mm)
+    encode(mm, anonymize)
+  else:
+    sendMetrics(msg)
+    encode(msg, anonymize)
 
 proc send*(
     p: PubSubPeer,
@@ -653,8 +636,12 @@ proc send*(
     anonymize: bool,
     priority: MessagePriority,
     useCustomStream: bool = false,
-) {.raises: [].} =
-  ## Asynchronously sends an `RPCMsg` to a specified `PubSubPeer` with an option for anonymization.
+) {.raises: [MessageTooLargeError].} =
+  ## Sends an application-published `RPCMsg` to this peer, without splitting.
+  ##
+  ## The message is sent as-is - the application is responsible for ensuring it
+  ## fits within `maxMessageSize`. Raises `MessageTooLargeError` if the encoded
+  ## message exceeds `maxMessageSize`.
   ##
   ## Parameters:
   ## - `p`: The `PubSubPeer` instance to which the message is to be sent.
@@ -663,34 +650,41 @@ proc send*(
   ## - `priority`: The message priority level (`High`, `Medium`, or `Low`).
   ##   High priority messages are sent immediately, medium and low priority messages are queued
   ##   and sent only after all high priority messages have been sent.
-  # When sending messages, we take care to re-encode them with the right
-  # anonymization flag to ensure that we're not penalized for sending invalid
-  # or malicious data on the wire - in particular, re-encoding protects against
-  # some forms of valid but redundantly encoded protobufs with unknown or
-  # duplicated fields
-  var encoded =
-    if p.hasObservers():
-      var mm = msg
-      # trigger send hooks
-      p.sendObservers(mm)
-      sendMetrics(mm)
-      encode(mm, anonymize)
-    else:
-      # If there are no send hooks, we redundantly re-encode the message to
-      # protobuf for every peer - this could easily be improved!
-      sendMetrics(msg)
-      encode(msg, anonymize)
 
-  # Messages should not exceed 90% of maxMessageSize. Guessing 10% protobuf overhead.
-  let maxEncodedMsgSize = (p.maxMessageSize * 90) div 100
+  var encoded = encodeRpcMsg(p, msg, anonymize)
 
-  if encoded.len > maxEncodedMsgSize and msg.messages.len > 1:
-    for encodedSplitMsg in splitRPCMsg(p, msg, maxEncodedMsgSize, anonymize):
-      var ownedEncodedSplitMsg = encodedSplitMsg
-      p.trackSend(p.sendEncoded(move(ownedEncodedSplitMsg), priority, useCustomStream))
+  if encoded.len > p.maxMessageSize:
+    raise newException(
+      MessageTooLargeError,
+      "message of size " & $encoded.len & " exceeds maxMessageSize " &
+        $p.maxMessageSize,
+    )
+
+  trace "sending msg to peer", peer = p, rpcMsg = shortLog(msg)
+  p.trackSend(p.sendEncoded(move(encoded), priority, useCustomStream))
+
+proc sendResponse*(
+    p: PubSubPeer,
+    msg: RPCMsg,
+    anonymize: bool,
+    priority: MessagePriority,
+    useCustomStream: bool = false,
+) {.raises: [].} =
+  ## Sends a protocol response `RPCMsg` to this peer, splitting multi-message
+  ## responses into individual messages so that none exceed `maxMessageSize`.
+  ##
+  ## This is an internal, protocol-facing send path - individual messages that
+  ## still exceed `maxMessageSize` are silently dropped.
+
+  if msg.messages.len > 1:
+    for m in msg.messages:
+      var single = RPCMsg(messages: @[m])
+      var encoded = encodeRpcMsg(p, single, anonymize)
+      trace "sending response msg to peer", peer = p, rpcMsg = shortLog(single)
+      p.trackSend(p.sendEncoded(move(encoded), priority, useCustomStream))
   else:
-    # If the message size is within limits, send it as is
-    trace "sending msg to peer", peer = p, rpcMsg = shortLog(msg)
+    var encoded = encodeRpcMsg(p, msg, anonymize)
+    trace "sending response msg to peer", peer = p, rpcMsg = shortLog(msg)
     p.trackSend(p.sendEncoded(move(encoded), priority, useCustomStream))
 
 proc canAskIWant*(p: PubSubPeer, msgId: MessageId): bool =

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -672,6 +672,11 @@ proc sendResponse*(
   ## This is an internal, protocol-facing send path - individual messages that
   ## still exceed `maxMessageSize` are silently dropped.
 
+  proc send(toSendMsg: RPCMsg) =
+    var encoded = encodeRpcMsg(p, toSendMsg, anonymize)
+    trace "sending response msg to peer", peer = p, rpcMsg = shortLog(toSendMsg)
+    p.trackSend(p.sendEncoded(move(encoded), priority, useCustomStream))
+
   if msg.messages.len > 1 and msg.hasOnlyMessages():
     # Batch as many messages as possible into a single encoded RPC instead of
     # encoding one RPC per message. 
@@ -681,24 +686,24 @@ proc sendResponse*(
       batch.messages.add(m)
 
       if batch.messages.len > 0 and batch.encodedSize() > p.maxMessageSize:
-        discard batch.messages.pop() # Remove last element
+        # Last message has caused overflow, send batch without last message
+        discard batch.messages.pop()
 
-        # The batch is full - send it and start a new one.
-        var encoded = encodeRpcMsg(p, batch, anonymize)
-        trace "sending response msg to peer", peer = p, rpcMsg = shortLog(batch)
-        p.trackSend(p.sendEncoded(move(encoded), priority, useCustomStream))
+        if batch.messages.len > 0:
+          # Send batch only if there were some messages
+          send(batch)
 
         batch = RPCMsg()
-        batch.messages.add(m) # Add message to new batch
+        batch.messages.add(m)
+
+        if batch.encodedSize() > p.maxMessageSize:
+          # Last message was alone larger then max message size
+          discard batch.messages.pop()
 
     if batch.messages.len > 0:
-      var encoded = encodeRpcMsg(p, batch, anonymize)
-      trace "sending response msg to peer", peer = p, rpcMsg = shortLog(batch)
-      p.trackSend(p.sendEncoded(move(encoded), priority, useCustomStream))
+      send(batch)
   else:
-    var encoded = encodeRpcMsg(p, msg, anonymize)
-    trace "sending response msg to peer", peer = p, rpcMsg = shortLog(msg)
-    p.trackSend(p.sendEncoded(move(encoded), priority, useCustomStream))
+    send(msg)
 
 proc canAskIWant*(p: PubSubPeer, msgId: MessageId): bool =
   for sentIHave in p.sentIHaves.mitems():

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -651,7 +651,7 @@ proc send*(
   var encoded = encodeRpcMsg(p, msg, anonymize)
 
   if encoded.len > p.maxMessageSize:
-    warn "message exceeds maximum message size",
+    warn "message exceeds maximum message size; message will not be sent",
       encodedSize = encoded.len, maxMessageSize = p.maxMessageSize
 
   trace "sending msg to peer", peer = p, rpcMsg = shortLog(msg)

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -9,7 +9,6 @@ import chronos, chronicles, nimcrypto/sha2, metrics
 import chronos/ratelimit
 import
   rpc/[messages, message, protobuf],
-  ./errors,
   ../../peerid,
   ../../peerinfo,
   ../../stream/connection,
@@ -638,12 +637,8 @@ proc send*(
     anonymize: bool,
     priority: MessagePriority,
     useCustomStream: bool = false,
-) {.raises: [MessageTooLargeError].} =
+) {.raises: [].} =
   ## Sends an application-published `RPCMsg` to this peer, without splitting.
-  ##
-  ## The message is sent as-is - the application is responsible for ensuring it
-  ## fits within `maxMessageSize`. Raises `MessageTooLargeError` if the encoded
-  ## message exceeds `maxMessageSize`.
   ##
   ## Parameters:
   ## - `p`: The `PubSubPeer` instance to which the message is to be sent.
@@ -656,7 +651,8 @@ proc send*(
   var encoded = encodeRpcMsg(p, msg, anonymize)
 
   if encoded.len > p.maxMessageSize:
-    raise MessageTooLargeError.new(encoded.len, p.maxMessageSize)
+    warn "message exceeds maximum message size",
+      encodedSize = encoded.len, maxMessageSize = p.maxMessageSize
 
   trace "sending msg to peer", peer = p, rpcMsg = shortLog(msg)
   p.trackSend(p.sendEncoded(move(encoded), priority, useCustomStream))

--- a/libp2p/protocols/pubsub/rpc/messages.nim
+++ b/libp2p/protocols/pubsub/rpc/messages.nim
@@ -488,12 +488,9 @@ func anonymize*(msg: RPCMsg, anonymize: bool): RPCMsg =
     msg
 
 func hasOnlyMessages*(msg: RPCMsg): bool =
-  msg.subscriptions.len == 0 and
-    msg.control.isNone and
-    msg.partialMessageExtension.isNone and
-    msg.testExtension.isNone and
-    msg.pingpongExtension.isNone and
-    msg.preambleExtension.isNone
+  msg.subscriptions.len == 0 and msg.control.isNone and
+    msg.partialMessageExtension.isNone and msg.testExtension.isNone and
+    msg.pingpongExtension.isNone and msg.preambleExtension.isNone
 
 func validate*(sub: SubOpts): Result[void, string] =
   if sub.topic.isNone:

--- a/libp2p/protocols/pubsub/rpc/messages.nim
+++ b/libp2p/protocols/pubsub/rpc/messages.nim
@@ -487,6 +487,14 @@ func anonymize*(msg: RPCMsg, anonymize: bool): RPCMsg =
   else:
     msg
 
+func hasOnlyMessages*(msg: RPCMsg): bool =
+  msg.subscriptions.len == 0 and
+    msg.control.isNone and
+    msg.partialMessageExtension.isNone and
+    msg.testExtension.isNone and
+    msg.pingpongExtension.isNone and
+    msg.preambleExtension.isNone
+
 func validate*(sub: SubOpts): Result[void, string] =
   if sub.topic.isNone:
     return err("Subsciption topic must be set")

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -36,3 +36,6 @@ proc decode*(_: type RPCMsg, buf: seq[byte]): Result[RPCMsg, string] =
     ok(msg)
   except SerializationError as e:
     err("failed to decode RPCMsg from protobuf bytes. " & e.msg)
+
+proc encodedSize*(rpc: RPCMsg): int =
+  Protobuf.computeSize(rpc)

--- a/libp2p/protocols/pubsub/rpc_send.nim
+++ b/libp2p/protocols/pubsub/rpc_send.nim
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.push raises: [].}
+
+import std/[sequtils, sets]
+import chronicles
+import
+  ./pubsub,
+  ./pubsubpeer,
+  ./rpc/[messages, protobuf]
+
+logScope:
+  topics = "libp2p pubsub"
+
+proc sendResponse*(
+    p: PubSub,
+    peer: PubSubPeer,
+    msg: RPCMsg,
+    priority: MessagePriority,
+    useCustomStream: bool = false,
+) {.raises: [].} =
+  ## Sends a protocol response `msg` (of type `RPCMsg`) to the specified remote
+  ## peer. This is an internal, protocol-facing send path - messages that
+  ## together exceed `maxMessageSize` are split and sent individually.
+  ##
+  ## This should not be used for application-published messages; use `send`
+  ## instead.
+
+  trace "sending pubsub response to peer", peer, rpcMsg = shortLog(msg)
+  peer.sendResponse(msg, p.anonymize, priority, useCustomStream)
+
+proc broadcastResponse*(
+    p: PubSub,
+    sendPeers: openArray[PubSubPeer],
+    msg: RPCMsg,
+    priority: MessagePriority,
+    useCustomStream: bool = false,
+) {.raises: [].} =
+  ## Sends a protocol response `msg` (of type `RPCMsg`) to a specified group of
+  ## peers. This is an internal, protocol-facing broadcast path - messages that
+  ## together exceed `maxMessageSize` are split and sent individually.
+  ##
+  ## This should not be used for application-published messages; use `broadcast`
+  ## instead.
+
+  countBroadcastMetrics(p, sendPeers, msg)
+
+  trace "broadcasting responses to peers", peers = sendPeers.len, rpcMsg = shortLog(msg)
+
+  if anyIt(sendPeers, it.hasObservers) or msg.messages.len > 1:
+    for peer in sendPeers:
+      p.sendResponse(peer, msg, priority, useCustomStream)
+  else:
+    # Fast path that only encodes message once
+    let encoded = msg.encode(p.anonymize)
+    for peer in sendPeers:
+      var peerEncoded = encoded
+      peer.trackSend(peer.sendEncoded(move(peerEncoded), priority, useCustomStream))
+
+proc broadcastResponse*(
+    p: PubSub,
+    sendPeers: HashSet[PubSubPeer],
+    msg: RPCMsg,
+    priority: MessagePriority,
+    useCustomStream: bool = false,
+) {.raises: [].} =
+  ## Overload for `HashSet[PubSubPeer]`: order is irrelevant for a broadcast,
+  ## so the peers are materialized into a sequence and delegated to the
+  ## `openArray` overload.
+  p.broadcastResponse(sendPeers.toSeq, msg, priority, useCustomStream)

--- a/libp2p/protocols/pubsub/rpc_send.nim
+++ b/libp2p/protocols/pubsub/rpc_send.nim
@@ -10,6 +10,10 @@ import ./pubsub, ./pubsubpeer, ./rpc/[messages, protobuf]
 logScope:
   topics = "libp2p pubsub"
 
+## This file implements methods for sending protocol messages aka responses. 
+## They are intentionally implemented in separated file to avoid exporting
+## it to downstream dependencies.
+
 proc sendResponse*(
     p: PubSub,
     peer: PubSubPeer,

--- a/libp2p/protocols/pubsub/rpc_send.nim
+++ b/libp2p/protocols/pubsub/rpc_send.nim
@@ -5,10 +5,7 @@
 
 import std/[sequtils, sets]
 import chronicles
-import
-  ./pubsub,
-  ./pubsubpeer,
-  ./rpc/[messages, protobuf]
+import ./pubsub, ./pubsubpeer, ./rpc/[messages, protobuf]
 
 logScope:
   topics = "libp2p pubsub"

--- a/libp2p/protocols/pubsub/rpc_send.nim
+++ b/libp2p/protocols/pubsub/rpc_send.nim
@@ -33,7 +33,7 @@ proc sendResponse*(
 
 proc broadcastResponse*(
     p: PubSub,
-    sendPeers: openArray[PubSubPeer],
+    sendPeers: seq[PubSubPeer] | HashSet[PubSubPeer],
     msg: RPCMsg,
     priority: MessagePriority,
     useCustomStream: bool = false,
@@ -58,15 +58,3 @@ proc broadcastResponse*(
     for peer in sendPeers:
       var peerEncoded = encoded
       peer.trackSend(peer.sendEncoded(move(peerEncoded), priority, useCustomStream))
-
-proc broadcastResponse*(
-    p: PubSub,
-    sendPeers: HashSet[PubSubPeer],
-    msg: RPCMsg,
-    priority: MessagePriority,
-    useCustomStream: bool = false,
-) {.raises: [].} =
-  ## Overload for `HashSet[PubSubPeer]`: order is irrelevant for a broadcast,
-  ## so the peers are materialized into a sequence and delegated to the
-  ## `openArray` overload.
-  p.broadcastResponse(sendPeers.toSeq, msg, priority, useCustomStream)

--- a/tests/libp2p/pubsub/component/test_floodsub.nim
+++ b/tests/libp2p/pubsub/component/test_floodsub.nim
@@ -256,9 +256,8 @@ suite "FloodSub Component":
     checkUntilTimeout:
       messageReceived == 2
 
-    # Publishing a message larger than the configured maxMessageSize raises.
-    expect MessageTooLargeError:
-      discard await smallNode.publish(topic, bigMessage)
+    # Publishing a message larger than the configured maxMessageSize will not publish.
+    check (await smallNode.publish(topic, bigMessage)) == 0
 
     # The larger node can still publish, but the smaller node cannot receive it
     # because its maxMessageSize is exceeded on the wire.

--- a/tests/libp2p/pubsub/component/test_floodsub.nim
+++ b/tests/libp2p/pubsub/component/test_floodsub.nim
@@ -256,7 +256,12 @@ suite "FloodSub Component":
     checkUntilTimeout:
       messageReceived == 2
 
-    check (await smallNode.publish(topic, bigMessage)) > 0
+    # Publishing a message larger than the configured maxMessageSize raises.
+    expect MessageTooLargeError:
+      discard await smallNode.publish(topic, bigMessage)
+
+    # The larger node can still publish, but the smaller node cannot receive it
+    # because its maxMessageSize is exceeded on the wire.
     check (await bigNode.publish(topic, bigMessage)) > 0
 
     await sleepAsync(300.milliseconds) # Wait before checking

--- a/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
@@ -61,8 +61,8 @@ suite "GossipSub Component - Control Messages":
     # When a GRAFT message is sent
     let p0 = n1.getOrCreatePeer(n0.peerInfo.peerId, @[GossipSubCodec_12])
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(graftMessage), MessagePriority.High)
-    n1.broadcast(@[p0], RPCMsg.withControl(graftMessage), MessagePriority.High)
+    n0.broadcastResponse(@[p1], RPCMsg.withControl(graftMessage), MessagePriority.High)
+    n1.broadcastResponse(@[p0], RPCMsg.withControl(graftMessage), MessagePriority.High)
 
     checkUntilTimeout:
       nodes.allIt(it.mesh.getOrDefault(topic).len == 1)
@@ -102,7 +102,7 @@ suite "GossipSub Component - Control Messages":
 
     # When a GRAFT message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(graftMessage), MessagePriority.High)
+    n0.broadcastResponse(@[p1], RPCMsg.withControl(graftMessage), MessagePriority.High)
 
     # Then the peer is not GRAFTed
     checkUntilTimeout:
@@ -140,7 +140,7 @@ suite "GossipSub Component - Control Messages":
 
     # When a PRUNE message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(pruneMessage), MessagePriority.High)
+    n0.broadcastResponse(@[p1], RPCMsg.withControl(pruneMessage), MessagePriority.High)
 
     # Then the peer is PRUNEd
     checkUntilTimeout:
@@ -151,7 +151,7 @@ suite "GossipSub Component - Control Messages":
 
     # When another PRUNE message is sent
     let p0 = n1.getOrCreatePeer(n0.peerInfo.peerId, @[GossipSubCodec_12])
-    n1.broadcast(@[p0], RPCMsg.withControl(pruneMessage), MessagePriority.High)
+    n1.broadcastResponse(@[p0], RPCMsg.withControl(pruneMessage), MessagePriority.High)
 
     # Then the peer is PRUNEd
     checkUntilTimeout:
@@ -188,7 +188,7 @@ suite "GossipSub Component - Control Messages":
 
     # When a PRUNE message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(pruneMessage), MessagePriority.High)
+    n0.broadcastResponse(@[p1], RPCMsg.withControl(pruneMessage), MessagePriority.High)
 
     # Then the peer is not PRUNEd
     checkUntilTimeout:
@@ -228,7 +228,7 @@ suite "GossipSub Component - Control Messages":
 
     # When an IHAVE message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(ihaveMessage), MessagePriority.High)
+    n0.broadcastResponse(@[p1], RPCMsg.withControl(ihaveMessage), MessagePriority.High)
 
     # Wait until IHAVE response is received
     # Then the peer has exactly one IHAVE message with the correct message ID
@@ -265,7 +265,7 @@ suite "GossipSub Component - Control Messages":
 
     # When an IWANT message is sent
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(iwantMessage), MessagePriority.High)
+    n0.broadcastResponse(@[p1], RPCMsg.withControl(iwantMessage), MessagePriority.High)
 
     # Wait until IWANT response is received
     # Then the peer has exactly one IWANT message with the correct message ID
@@ -298,7 +298,7 @@ suite "GossipSub Component - Control Messages":
 
     # When an IHAVE message is sent from node0
     let p1 = n0.getOrCreatePeer(n1.peerInfo.peerId, @[GossipSubCodec_12])
-    n0.broadcast(@[p1], RPCMsg.withControl(ihaveMessage), MessagePriority.High)
+    n0.broadcastResponse(@[p1], RPCMsg.withControl(ihaveMessage), MessagePriority.High)
 
     # Wait until IWANT response is received
     # Then node0 should receive exactly one IWANT message from node1
@@ -325,7 +325,7 @@ suite "GossipSub Component - Control Messages":
       nodes[2].mesh.peers(topic) == 1
 
     # When we pre-emptively send a dontwant from C to B,
-    nodes[2].broadcast(
+    nodes[2].broadcastResponse(
       nodes[2].mesh[topic],
       RPCMsg.withControl(ControlMessage.withIDontWant(newSeq[byte](10))),
       MessagePriority.High,

--- a/tests/libp2p/pubsub/component/test_gossipsub_extensions.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_extensions.nim
@@ -455,7 +455,7 @@ suite "GossipSub Component - Extensions":
     )
 
     # send ping from nodes[0] to nodes[1]
-    nodes[0].send(
+    nodes[0].sendResponse(
       nodes[0].peers[nodes[1].peerInfo.peerId],
       RPCMsg.withPing(pingBytes),
       MessagePriority.High,

--- a/tests/libp2p/pubsub/component/test_gossipsub_message_cache.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_message_cache.nim
@@ -260,7 +260,7 @@ suite "GossipSub Component - Message Cache":
       not nodes[2].hasSeen(nodes[2].salt(messageId2))
 
     # And Node2 sends IWant to Node0 requesting both messages
-    nodes[2].broadcast(
+    nodes[2].broadcastResponse(
       @[nodes[2].getPeerByPeerId(topic, nodes[0].peerInfo.peerId)],
       RPCMsg.withControl(ControlMessage.withIWant(@[messageId1, messageId2])),
       MessagePriority.High,

--- a/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_message_handling.nim
@@ -90,7 +90,7 @@ suite "GossipSub Component - Message Handling":
     let (iwantMessageIds, sentMessages) =
       createMessages(gossip0, gossip1, topic, messageSize, messageSize)
 
-    gossip1.broadcast(
+    gossip1.broadcastResponse(
       gossip1.mesh[topic],
       RPCMsg.withControl(ControlMessage.withIHave(topic, iwantMessageIds)),
       MessagePriority.High,
@@ -110,7 +110,7 @@ suite "GossipSub Component - Message Handling":
     let (bigIWantMessageIds, _) =
       createMessages(gossip0, gossip1, topic, messageSize, messageSize)
 
-    gossip1.broadcast(
+    gossip1.broadcastResponse(
       gossip1.mesh[topic],
       RPCMsg.withControl(ControlMessage.withIHave(topic, bigIWantMessageIds)),
       MessagePriority.High,
@@ -133,7 +133,7 @@ suite "GossipSub Component - Message Handling":
     let (bigIWantMessageIds, sentMessages) =
       createMessages(gossip0, gossip1, topic, size1, size2)
 
-    gossip1.broadcast(
+    gossip1.broadcastResponse(
       gossip1.mesh[topic],
       RPCMsg.withControl(ControlMessage.withIHave(topic, bigIWantMessageIds)),
       MessagePriority.High,
@@ -154,7 +154,7 @@ suite "GossipSub Component - Message Handling":
     let (bigIWantMessageIds, sentMessages) =
       createMessages(gossip0, gossip1, topic, size1, size2)
 
-    gossip1.broadcast(
+    gossip1.broadcastResponse(
       gossip1.mesh[topic],
       RPCMsg.withControl(ControlMessage.withIHave(topic, bigIWantMessageIds)),
       MessagePriority.High,
@@ -557,6 +557,7 @@ suite "GossipSub Component - Message Handling":
         20,
         gossip = true,
         address = TcpAutoAddress, # use TCP because it's more reliable (temporarily)
+        maxMessageSize = 4_000_000, # 2.5MB messages must fit
       )
       .toGossipSub()
 
@@ -582,7 +583,8 @@ suite "GossipSub Component - Message Handling":
     check (await nodes[0].publish(topic, newSeq[byte](500_001))) == 17
 
   asyncTest "GossipSub floodPublish limit without bandwidthEstimatebps":
-    let nodes = generateNodes(20, gossip = true).toGossipSub()
+    let nodes =
+      generateNodes(20, gossip = true, maxMessageSize = 4_000_000).toGossipSub()
 
     nodes[0].parameters.floodPublish = true
     # should flood publish to all, when bandwidthEstimatebps is disabled

--- a/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
@@ -69,7 +69,7 @@ suite "GossipSub Component - Scoring":
 
     let rateLimitHits = currentRateLimitHits()
 
-    nodes[0].broadcast(
+    nodes[0].broadcastResponse(
       nodes[0].mesh[topic],
       RPCMsg.withMessages(Message(topic: topic, data: newSeq[byte](10))),
       MessagePriority.High,
@@ -81,7 +81,7 @@ suite "GossipSub Component - Scoring":
 
     # Disconnect peer when rate limiting is enabled
     nodes[1].parameters.disconnectPeerAboveRateLimit = true
-    nodes[0].broadcast(
+    nodes[0].broadcastResponse(
       nodes[0].mesh[topic],
       RPCMsg.withMessages(Message(topic: topic, data: newSeq[byte](12))),
       MessagePriority.High,
@@ -158,7 +158,7 @@ suite "GossipSub Component - Scoring":
         topic, 123'u64, @[PeerInfoMsg(peerId: PeerId(data: newSeq[byte](33)))]
       )
     )
-    nodes[0].broadcast(nodes[0].mesh[topic], msg, MessagePriority.High)
+    nodes[0].broadcastResponse(nodes[0].mesh[topic], msg, MessagePriority.High)
 
     checkUntilTimeout:
       currentRateLimitHits() == rateLimitHits + 1
@@ -172,7 +172,7 @@ suite "GossipSub Component - Scoring":
         topic, 123'u64, @[PeerInfoMsg(peerId: PeerId(data: newSeq[byte](35)))]
       )
     )
-    nodes[0].broadcast(nodes[0].mesh[topic], msg2, MessagePriority.High)
+    nodes[0].broadcastResponse(nodes[0].mesh[topic], msg2, MessagePriority.High)
 
     checkUntilTimeout:
       nodes[1].switch.isConnected(nodes[0].switch.peerInfo.peerId) == false
@@ -212,7 +212,7 @@ suite "GossipSub Component - Scoring":
     let rateLimitHits = currentRateLimitHits()
 
     let msg = RPCMsg.withMessages(Message(topic: topic, data: newSeq[byte](40)))
-    nodes[0].broadcast(nodes[0].mesh[topic], msg, MessagePriority.High)
+    nodes[0].broadcastResponse(nodes[0].mesh[topic], msg, MessagePriority.High)
 
     checkUntilTimeout:
       currentRateLimitHits() == rateLimitHits + 1
@@ -221,7 +221,7 @@ suite "GossipSub Component - Scoring":
     # Disconnect peer when rate limiting is enabled
     nodes[1].parameters.disconnectPeerAboveRateLimit = true
     let rateLimitHits2 = currentRateLimitHits()
-    nodes[0].broadcast(
+    nodes[0].broadcastResponse(
       nodes[0].mesh[topic],
       RPCMsg.withMessages(Message(topic: topic, data: newSeq[byte](35))),
       MessagePriority.High,
@@ -443,12 +443,12 @@ suite "GossipSub Component - Scoring":
     # When messages are broadcasted
     const messagesToSend = 5
     for i in 0 ..< messagesToSend:
-      nodes[1].broadcast(
+      nodes[1].broadcastResponse(
         nodes[1].mesh[topic],
         RPCMsg.withMessages(Message(topic: topic, data: ("valid_" & $i).toBytes())),
         MessagePriority.High,
       )
-      nodes[2].broadcast(
+      nodes[2].broadcastResponse(
         nodes[2].mesh[topic],
         RPCMsg.withMessages(Message(topic: topic, data: ("invalid_" & $i).toBytes())),
         MessagePriority.High,

--- a/tests/libp2p/pubsub/test_message.nim
+++ b/tests/libp2p/pubsub/test_message.nim
@@ -174,6 +174,8 @@ suite "Message":
     )
     check byteSize(rpcMsg) == 30 + 32 + 38 + 4 + 4 # Total: 108 bytes
 
+    check rpcMsg.encodedSize() == rpcMsg.encode(false).len
+
   test "downstream-compatible public pubsub fields":
     let
       peerId = PeerId(data: @[1'u8, 2, 3])

--- a/tests/libp2p/pubsub/test_message.nim
+++ b/tests/libp2p/pubsub/test_message.nim
@@ -347,3 +347,30 @@ suite "Message":
     let rpc = RPCMsg(subscriptions: @[SubOpts(subscribe: true, topic: topic)])
     let anon = rpc.anonymize(true)
     check anon.messages.len == 0
+
+  test "hasOnlyMessages - message-only RPC returns true":
+    let rpc = RPCMsg.withMessages(@[Message(topic: topic), Message(topic: topic)])
+    check rpc.hasOnlyMessages()
+
+  test "hasOnlyMessages - empty RPC returns true":
+    check RPCMsg().hasOnlyMessages()
+
+  test "hasOnlyMessages - false when any non-message field is set":
+    # Reflection guard: iterate every RPCMsg field except `messages`, set it to a
+    # non-empty value, and assert `hasOnlyMessages` returns false. If a new field
+    # is added to RPCMsg in the future and `hasOnlyMessages` is not updated to
+    # account for it, this test fails.
+    var rpc = RPCMsg()
+    for name, value in fieldPairs(rpc):
+      when name != "messages":
+        when compiles(value.isSome): # Opt field (control/extensions)
+          value = Opt.some(default(typeof(value.get())))
+          check not rpc.hasOnlyMessages()
+          value = Opt.none(typeof(value.get()))
+        elif compiles(value.len): # seq field (subscriptions)
+          value = @[default(typeof(value[0]))]
+          check not rpc.hasOnlyMessages()
+          value.setLen(0)
+        else:
+          doAssert false, "RPCMsg field '" & name & "' has an unsupported type"
+    check rpc.hasOnlyMessages()


### PR DESCRIPTION
- separated app messages path for broadcast/send message from path that sends protocol messages (aka responses)
- app messages are not being spitted anymore (dropping message if size exceeds)
- protocol messages are being splinted and batched up to max message size



closes: #1674