### PR TITLE
test(autotls): certificate issuance

### DIFF
--- a/tests/libp2p/autotls/test_service.nim
+++ b/tests/libp2p/autotls/test_service.nim
@@ -17,7 +17,8 @@ import
   ]
 import
   ../../tools/[
-    unittest, cert_server, crypto, multiaddress, resolver, stall_server, switch_builder
+    unittest, cert_server, crypto, lifecycle, multiaddress, resolver, stall_server,
+    switch_builder,
   ]
 import ../../stubs/[acme_api_stub, peer_id_auth_client_stub]
 
@@ -166,7 +167,7 @@ suite "AutoTLS certificate issuance and renewal":
       await certServer.stop()
 
     acmeApi.scriptChallenge(ChallengeToken)
-    acmeApi.scriptCertificate(certServer.url, "2035-01-01T00:00:00Z")
+    acmeApi.scriptCertificate(certServer.url, initDuration(days = 365))
 
     # issueRetries must be higher than zero to prove it's done only once
     service = newService(
@@ -189,7 +190,6 @@ suite "AutoTLS certificate issuance and renewal":
 
     let baseDomain = encodePeerId(switch.peerInfo.peerId) & "." & DnsServerURL
     check:
-      service.cert.isSome()
       # One round is 8 requests, so more would be a second attempt.
       acmeApi.requestedUris.len == 8
       resolver.txtQueries == @["_acme-challenge." & baseDomain]
@@ -211,9 +211,7 @@ suite "AutoTLS certificate issuance and renewal":
 
   asyncTest "no certificate is issued without a TcpTransport, and the service still runs":
     let memSwitch = makeStandardSwitch(MemoryAutoAddress())
-    await memSwitch.start()
-    defer:
-      await memSwitch.stop()
+    startAndDeferStop(@[memSwitch])
 
     service = newService()
     await service.start(memSwitch)

--- a/tests/libp2p/autotls/test_service.nim
+++ b/tests/libp2p/autotls/test_service.nim
@@ -3,19 +3,31 @@
 
 {.used.}
 
-import chronos, json, net, sequtils, uri
+import chronos, json, net, results, sequtils, uri
 from times import now, initDuration, `+`
 import
-  ../../../libp2p/
-    [autotls/service, autotls/broker, autotls/acme/client, crypto/rsa, switch, wire]
+  ../../../libp2p/[
+    autotls/service,
+    autotls/broker,
+    autotls/utils,
+    autotls/acme/client,
+    crypto/rsa,
+    switch,
+    wire,
+  ]
 import
-  ../../tools/[unittest, crypto, multiaddress, resolver, stall_server, switch_builder]
+  ../../tools/[
+    unittest, cert_server, crypto, multiaddress, resolver, stall_server, switch_builder
+  ]
 import ../../stubs/[acme_api_stub, peer_id_auth_client_stub]
 
 suite "AutoTLS certificate issuance and renewal":
   const
     RenewCheckTime = 20.milliseconds
     RenewBufferTime = 1.hours
+    ChallengeToken = "some-token"
+    NodeIP = "127.0.0.1"
+    DnsServerURL = "example.test"
 
   # RSA generation dominates the runtime of every test here, so one key pair each.
   let
@@ -132,13 +144,11 @@ suite "AutoTLS certificate issuance and renewal":
     check autotlsCert.cert == cert
 
   asyncTest "the broker is sent the addresses the peer announces":
-    const
-      NodeIP = "127.0.0.1"
-      AnnouncedAddrs =
-        ["/ip4/" & NodeIP & "/tcp/9000", "/ip4/" & NodeIP & "/tcp/9001/ws"]
+    const AnnouncedAddrs =
+      ["/ip4/" & NodeIP & "/tcp/9000", "/ip4/" & NodeIP & "/tcp/9001/ws"]
     switch.peerInfo.announcedAddrs = AnnouncedAddrs.mapIt(ma(it))
 
-    acmeApi.scriptChallenge("some-token")
+    acmeApi.scriptChallenge(ChallengeToken)
 
     var config = AutotlsConfig.new(
       ipAddress = Opt.some(parseIpAddress(NodeIP)), issueRetries = 0, dnsRetries = 0
@@ -148,6 +158,78 @@ suite "AutoTLS certificate issuance and renewal":
     await service.start(switch)
 
     check parseJson(authClient.payloads[0])["addresses"] == %AnnouncedAddrs
+
+  asyncTest "a certificate is issued, installed, and not issued again":
+    let certPem = tlsCertPemGenerator()
+    let certServer = startCertServer(certPem)
+    defer:
+      await certServer.stop()
+
+    acmeApi.scriptChallenge(ChallengeToken)
+    acmeApi.scriptCertificate(certServer.url, "2035-01-01T00:00:00Z")
+
+    # issueRetries must be higher than zero to prove it's done only once
+    service = newService(
+      AutotlsConfig.new(
+        ipAddress = Opt.some(parseIpAddress(NodeIP)),
+        dnsServerURL = DnsServerURL,
+        issueRetries = 3,
+        issueRetryTime = 0.seconds,
+      )
+    )
+    let keyAuth = service.acmeClient.genKeyAuthorization(ChallengeToken)
+    let resolver =
+      StubNameResolver.new(txtRecords = @[keyAuth], ipAddresses = @[NodeIP])
+    service.config.nameResolver = resolver
+
+    await service.start(switch)
+    discard await service.getCertWhenReady().wait(10.seconds)
+    # Nothing signals a round that ended, so wait out a three retries window.
+    await sleepAsync(50.milliseconds)
+
+    let baseDomain = encodePeerId(switch.peerInfo.peerId) & "." & DnsServerURL
+    check:
+      service.cert.isSome()
+      # One round is 8 requests, so more would be a second attempt.
+      acmeApi.requestedUris.len == 8
+      resolver.txtQueries == @["_acme-challenge." & baseDomain]
+      resolver.ipQueries == @["127-0-0-1." & baseDomain]
+      parseJson(authClient.payloads[0])["value"].getStr == keyAuth
+
+  asyncTest "the certificate is not requested until the DNS records are published":
+    acmeApi.scriptChallenge(ChallengeToken)
+
+    var config = AutotlsConfig.new(
+      ipAddress = Opt.some(parseIpAddress(NodeIP)), issueRetries = 0, dnsRetries = 0
+    )
+    # The A record resolves, so only the missing TXT record holds issuance back.
+    config.nameResolver = StubNameResolver.new(ipAddresses = @[NodeIP])
+    service = newService(config)
+    await service.start(switch)
+
+    check acmeApi.requestedUris.len == 3
+
+  asyncTest "no certificate is issued without a TcpTransport, and the service still runs":
+    let memSwitch = makeStandardSwitch(MemoryAutoAddress())
+    await memSwitch.start()
+    defer:
+      await memSwitch.stop()
+
+    service = newService()
+    await service.start(memSwitch)
+
+    check:
+      acmeApi.requestedUris.len == 0
+      service.running.isSet
+
+  asyncTest "issuance aborts when no IP address is configured":
+    # TODO: vacp2p/nim-libp2p#2957
+    # tryIssueCertificate catches CatchableError, so a Defect propagates out of start.
+    acmeApi.scriptChallenge(ChallengeToken)
+    service = newService(AutotlsConfig.new())
+
+    expect(ResultDefect):
+      await service.start(switch)
 
 suite "AutoTLS on a switch":
   asyncTeardown:

--- a/tests/stubs/acme_api_stub.nim
+++ b/tests/stubs/acme_api_stub.nim
@@ -65,6 +65,24 @@ proc scriptChallenge*(self: ACMEApiStub, token: string) =
     )
   )
 
+proc scriptCertificate*(self: ACMEApiStub, certificateURL: string, expires: string) =
+  ## Queues the five responses `getCertificate` consumes, ending in an order whose
+  ## certificate is served from `certificateURL`.
+  for body in [
+    %*{"url": ChallengeURL}, # sendChallengeCompleted
+    %*{"status": "valid"}, # checkChallengeCompleted
+    %*{"status": "valid"}, # requestFinalize
+    %*{"status": "valid"}, # checkCertFinalized
+  ]:
+    self.mockedResponses.add(HTTPResponse(body: body, headers: HttpTable.init()))
+
+  self.mockedResponses.add(
+    HTTPResponse(
+      body: %*{"certificate": certificateURL, "expires": expires},
+      headers: HttpTable.init(),
+    )
+  )
+
 proc respond(
     self: ACMEApiStub, uri: Uri
 ): Future[HTTPResponse] {.async: (raises: [ACMEError, CancelledError]).} =

--- a/tests/stubs/acme_api_stub.nim
+++ b/tests/stubs/acme_api_stub.nim
@@ -6,6 +6,7 @@
 {.push raises: [].}
 
 import json, uri
+from times import Duration, now, format, `+`
 import chronos, chronos/apps/http/httpclient
 import ../../libp2p/autotls/acme/[api, utils]
 
@@ -65,9 +66,12 @@ proc scriptChallenge*(self: ACMEApiStub, token: string) =
     )
   )
 
-proc scriptCertificate*(self: ACMEApiStub, certificateURL: string, expires: string) =
+proc scriptCertificate*(
+    self: ACMEApiStub, certificateURL: string, expiresIn: times.Duration
+) =
   ## Queues the five responses `getCertificate` consumes, ending in an order whose
   ## certificate is served from `certificateURL`.
+  let expires = (now() + expiresIn).format("yyyy-MM-dd'T'HH:mm:ss'Z'")
   for body in [
     %*{"url": ChallengeURL}, # sendChallengeCompleted
     %*{"status": "valid"}, # checkChallengeCompleted

--- a/tests/tools/cert_server.nim
+++ b/tests/tools/cert_server.nim
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import chronicles, chronos
+import websock/http/[common, server]
+
+type CertServer* = ref object
+  ## Serves one certificate over plain HTTP.
+  ## `downloadCertificate` fetches the order's certificate URL through the session,
+  ## so it is the one ACME request a stub cannot answer.
+  server: HttpServer
+  url*: string
+
+proc startCertServer*(certificate: string): CertServer =
+  proc serve(request: HttpRequest) {.async.} =
+    await request.sendResponse(Http200, data = certificate)
+
+  let server = HttpServer.create(initTAddress("127.0.0.1:0"), serve, {ReuseAddr})
+  server.start()
+
+  # `local` carries the address the socket really bound, port 0 resolved.
+  CertServer(server: server, url: "http://" & $server.local & "/certificate")
+
+proc stop*(cert: CertServer) {.async: (raises: [TransportOsError]).} =
+  cert.server.stop()
+  await cert.server.closeWait()

--- a/tests/tools/crypto.nim
+++ b/tests/tools/crypto.nim
@@ -27,3 +27,14 @@ proc tlsCertGenerator*(
     (secureKey, secureCert)
   except TLSStreamProtocolError, TLSCertificateError:
     raiseAssert "should not happen"
+
+proc tlsCertPemGenerator*(): string {.gcsafe, raises: [].} =
+  ## The certificate as a server hands it over, before `TLSCertificate.init`.
+  try:
+    let keyPair = KeyPair.random(PKScheme.RSA, rng()).get()
+    let certX509 =
+      generateX509(keyPair, encodingFormat = EncodingFormat.PEM).certificate
+
+    string.fromBytes(certX509)
+  except TLSCertificateError:
+    raiseAssert "should not happen"


### PR DESCRIPTION
## Summary

Adds test coverage for AutoTLS certificate issuance in `autotls/test_service`:
- `a certificate is issued, installed, and not issued again`. Full issuance through to a downloaded certificate. Asserts the challenge domain, the key authorization sent to the broker, and that a successful round does not start again.
- `the certificate is not requested until the DNS records are published`. The A record resolves but the TXT record is missing, so the round stops before finalizing an order.
- `no certificate is issued without a TcpTransport, and the service still runs`. On a memory-only switch, no issuance runs and `running` still fires.
- `issuance aborts when no IP address is configured`. Currently ends in a `ResultDefect` and carries a TODO for #2957.

New fixtures: `tests/tools/cert_server.nim` serves one certificate over plain HTTP, since `downloadCertificate` fetches the order's certificate URL through the session rather than the overridable `get`. `tlsCertPemGenerator` in `tests/tools/crypto.nim` returns the certificate as a PEM string, before `TLSCertificate.init` parses it. `scriptCertificate` on `ACMEApiStub` queues the five responses `getCertificate` consumes.

## References

  #2957. The `no IP address` test documents that nothing calls `AutotlsService.setup` in the builder path, so `config.ipAddress` stays `Opt.none`. The `Opt.get` in `issueCertificate` is then a Defect, which `tryIssueCertificate` does not catch. The TcpTransport guard returns first, so nothing reaches it today.