### PR TITLE
fix(kad): keep peer addresses when the admission probe cap is full

### DIFF
--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -11,7 +11,7 @@ import
     routing_table, peer_registry, protobuf, types, find, get, put, keyspace, provider,
     ping, ip_diversity,
   ]
-import ./kademlia/[kademlia_metrics, netsize, probe_backoff]
+import ./kademlia/[kademlia_metrics, netsize, probe_backoff, rpc]
 
 export
   chronicles, routing_table, peer_registry, protobuf, types, find, get, put, keyspace,
@@ -87,7 +87,7 @@ proc checkAndEvictPeer(
     debug "Liveness probe skipped: peer no longer replaceable", peer = peerId.shortLog()
     return
 
-  let addrs = kad.switch.peerStore[AddressBook][peerId]
+  let addrs = kad.dialAddrs(peerId)
   if addrs.len == 0:
     var evicted = 0
     for rtable in dueTables:

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -55,6 +55,20 @@ proc getFarthest(
   else:
     Opt.none((PeerId, XorDistance))
 
+proc dropPeer(state: LookupState, pid: PeerId) {.raises: [].} =
+  state.shortlist.del(pid)
+  state.attempts.del(pid)
+  state.responded.del(pid)
+
+proc isDialable(kad: KadDHT, peerId: PeerId): bool {.raises: [].} =
+  kad.dialAddrs(peerId).len > 0 or kad.switch.isConnected(peerId)
+
+proc canBecomeDialable(
+    kad: KadDHT, peerId: PeerId, addrs: seq[MultiAddress]
+): bool {.raises: [].} =
+  ## Whether admission could keep one of `addrs`, or the peer is reachable already.
+  addrs.anyIt(kad.config.addressPolicy.accepts(it)) or kad.isDialable(peerId)
+
 proc tryEvictFarthest(state: LookupState, newDist: XorDistance): bool {.raises: [].} =
   ## Drop the worst (farthest) peer from the shortlist if it is farther than
   ## ``newDist``. Considers all peers — including ones that already responded —
@@ -65,9 +79,7 @@ proc tryEvictFarthest(state: LookupState, newDist: XorDistance): bool {.raises: 
     return false
   if newDist >= dist:
     return false
-  state.shortlist.del(pid)
-  state.attempts.del(pid)
-  state.responded.del(pid)
+  state.dropPeer(pid)
   return true
 
 proc updateShortlist*(state: LookupState, msg: Message): seq[PeerInfo] {.raises: [].} =
@@ -80,6 +92,8 @@ proc updateShortlist*(state: LookupState, msg: Message): seq[PeerInfo] {.raises:
     let pid = PeerId.init(raw).valueOr:
       continue
     if state.shortlist.contains(pid):
+      continue
+    if not state.kad.canBecomeDialable(pid, newPeer.addrs):
       continue
 
     let dist = xorDistance(pid, state.target, state.rtable.config.hasher)
@@ -216,6 +230,14 @@ proc admissibleAddrs(
     kad.config.addressPolicy, rtable, p, kad.config.limits.diversityCaps(), pending
   )
 
+proc recordAddrs(
+    switch: Switch,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    confidence = AddressConfidence.Low,
+) {.raises: [].} =
+  switch.peerStore[AddressBook].extend(peerId, addrs, confidence)
+
 proc updatePeers*(
     switch: Switch,
     addressPolicy: PeerAddressPolicy,
@@ -224,14 +246,11 @@ proc updatePeers*(
     caps: DiversityCaps = defaultDiversityCaps(),
 ) {.raises: [].} =
   ## Unprobed admission, for trusted seed peers only; see ``admitPeers``.
-  let addressBook = switch.peerStore[AddressBook]
   for p in peerInfos:
     let addrs = switch.admissibleAddrs(addressPolicy, rtable, p, caps)
     if addrs.len == 0:
       continue
-    # Store before insert: a peer rejected for lack of bucket space still reaches
-    # the lookup shortlist, and would be undialable without its addresses.
-    addressBook.extend(p.peerId, addrs, AddressConfidence.Low)
+    switch.recordAddrs(p.peerId, addrs, AddressConfidence.Medium)
     discard rtable.insert(p.peerId)
 
 proc updatePeers*(kad: KadDHT, peerInfos: seq[PeerInfo]) {.raises: [].} =
@@ -291,6 +310,9 @@ proc admitPeer(
     kad.probeRecordFailure(peerId, addrs)
     return
   kad.probeClearFailures(peerId)
+  # A seat outlives Low's TTL, so the addresses behind it must outlive it too.
+  kad.switch.recordAddrs(peerId, addrs, AddressConfidence.Medium)
+
   # Table may have been detachAll'd (e.g. service uninterest) while the probe ran.
   if rtable.detached:
     trace "Kad admission probe abandoned: table detached", peer = peerId.shortLog()
@@ -313,21 +335,46 @@ proc pendingAdmissions(kad: KadDHT, tableId: Key): seq[PeerId] {.raises: [].} =
   ## A probe for another table holds no slot in this one.
   kad.admissionProbes.keys.toSeq().filterIt(it.tableId == tableId).mapIt(it.peerId)
 
+proc tryRefreshAdmitted(rtable: RoutingTable, peerId: PeerId): bool {.raises: [].} =
+  ## True when the peer already holds a seat, refreshing it instead of re-probing.
+  if peerId.toKey() notin rtable:
+    return false
+  discard rtable.insert(peerId)
+  true
+
+proc scheduleAdmissionProbe(
+    kad: KadDHT,
+    rtable: RoutingTable,
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    onAdmit: AdmitHook,
+): bool {.raises: [].} =
+  ## False when no probe starts; the candidate is retried on a later reply.
+  let probeKey: ProbeKey = (rtable.selfId, peerId)
+  if kad.admissionProbes.hasKey(probeKey):
+    return false
+  if kad.probeBackedOff(peerId, addrs):
+    trace "Kad admission probe backed off", peer = peerId.shortLog()
+    kad_admission_probes_backed_off.inc()
+    return false
+  if not kad.admissionSem.tryAcquire():
+    trace "Kad admission probe dropped: no free slot", peer = peerId.shortLog()
+    kad_admission_probes_dropped.inc()
+    return false
+  kad.trackProbe(probeKey, kad.admitPeer(rtable, peerId, addrs, onAdmit))
+  true
+
 proc admitPeers*(
     kad: KadDHT,
     rtable: RoutingTable,
     peerInfos: seq[PeerInfo],
     onAdmit: AdmitHook = nil,
 ) {.raises: [].} =
-  ## Admit network-discovered peers into ``rtable`` behind a background probe.
-  ## Addresses are recorded up front regardless, so lookups can still dial them.
-  ## Probes are never queued — a candidate with no free slot is retried when a
-  ## later reply names it.
-  # A handler racing shutdown must not launch a probe: it would dial after the
-  # drain loop completed, leaking the stream past ``stop``.
+  ## Records the addresses, then admits into ``rtable`` behind a background probe.
+
+  # A probe launched while stopping dials past the drain loop and leaks its stream.
   if kad.stopping:
     return
-  let addressBook = kad.switch.peerStore[AddressBook]
   let selfPid = kad.switch.peerInfo.peerId
   var pending = kad.pendingAdmissions(rtable.selfId)
   for p in peerInfos:
@@ -336,22 +383,12 @@ proc admitPeers*(
     let addrs = kad.admissibleAddrs(rtable, p, pending)
     if addrs.len == 0:
       continue
-    addressBook.extend(p.peerId, addrs, AddressConfidence.Low)
-    if p.peerId.toKey() in rtable:
-      # already admitted, refresh recency without re-probing
-      discard rtable.insert(p.peerId)
+    kad.switch.recordAddrs(p.peerId, addrs)
+    if rtable.tryRefreshAdmitted(p.peerId):
       continue
-    let probeKey: ProbeKey = (rtable.selfId, p.peerId)
-    if kad.admissionProbes.hasKey(probeKey):
+    if not kad.scheduleAdmissionProbe(rtable, p.peerId, addrs, onAdmit):
       continue
-    if kad.probeBackedOff(p.peerId, addrs):
-      trace "Kad admission probe backed off", peer = p.peerId.shortLog()
-      kad_admission_probes_backed_off.inc()
-      continue
-    if not kad.admissionSem.tryAcquire():
-      break
     pending.add(p.peerId)
-    kad.trackProbe(probeKey, kad.admitPeer(rtable, p.peerId, addrs, onAdmit))
 
 proc admitPeers*(kad: KadDHT, peerInfos: seq[PeerInfo]) {.raises: [].} =
   kad.admitPeers(kad.rtable, peerInfos)
@@ -394,7 +431,7 @@ proc dispatchPeer(
 ): Future[DispatchResult] {.async: (raises: [CancelledError]).} =
   let res = await dispatch(kad, peerId, target)
   if res.isErr():
-    error "Kad lookup: RPC error", peer = peerId.shortLog(), msg = res.error()
+    debug "Kad lookup: RPC error", peer = peerId.shortLog(), msg = res.error()
     return DispatchResult(peer: peerId, outcome: Errored)
   DispatchResult(peer: peerId, outcome: Completed, msg: res.value())
 
@@ -404,6 +441,19 @@ func activePeers(pending: seq[Attempt]): HashSet[PeerId] {.raises: [].} =
     if not a.abandoned:
       peers.incl(a.peer)
   peers
+
+proc dropUndialable(
+    kad: KadDHT, state: LookupState, candidates: seq[PeerId]
+): seq[PeerId] {.raises: [].} =
+  ## Returns the candidates that can still be dialed, dropping the rest.
+  var dialable: seq[PeerId]
+  for peerId in candidates:
+    if kad.isDialable(peerId):
+      dialable.add(peerId)
+    else:
+      state.dropPeer(peerId)
+      kad_lookup_undialable_peers.inc()
+  dialable
 
 proc fillSlots(
     kad: KadDHT,
@@ -598,7 +648,8 @@ proc iterativeLookup*(
     await noCancel stale.cancelAndWait()
 
     if not earlyExit(state):
-      kad.fillSlots(state, pending, dispatch, phases.targets(state))
+      let candidates = kad.dropUndialable(state, phases.targets(state))
+      kad.fillSlots(state, pending, dispatch, candidates)
 
     # Dispatching nothing new only stops the lookup once the RPCs already in
     # flight have drained, so the returned peer set stays complete.

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -300,13 +300,6 @@ proc admitPeer(
     addrs: seq[MultiAddress],
     onAdmit: AdmitHook,
 ) {.async: (raises: []).} =
-  ## Takes ownership of one ``admissionSem`` slot already acquired by the caller.
-  defer:
-    try:
-      kad.admissionSem.release()
-    except AsyncSemaphoreError:
-      raiseAssert "admissionSem released without acquire"
-
   let reachable =
     try:
       await kad.lookupCheck(peerId, addrs)
@@ -356,15 +349,26 @@ proc scheduleAdmissionProbe(
   let probeKey: ProbeKey = (rtable.selfId, peerId)
   if kad.admissionProbes.hasKey(probeKey):
     return false
+
   if kad.probeBackedOff(peerId, addrs):
     trace "Kad admission probe backed off", peer = peerId.shortLog()
     kad_admission_probes_backed_off.inc()
     return false
+
   if not kad.admissionSem.tryAcquire():
     trace "Kad admission probe dropped: no free slot", peer = peerId.shortLog()
     kad_admission_probes_dropped.inc()
     return false
-  kad.trackProbe(probeKey, kad.admitPeer(rtable, peerId, addrs, onAdmit))
+
+  let probe = kad.admitPeer(rtable, peerId, addrs, onAdmit)
+  probe.addCallback(
+    proc(udata: pointer) {.gcsafe, raises: [].} =
+      try:
+        kad.admissionSem.release()
+      except AsyncSemaphoreError:
+        raiseAssert "admissionSem released without acquire"
+  )
+  kad.trackProbe(probeKey, probe)
   true
 
 proc admitPeers*(

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -63,11 +63,41 @@ proc dropPeer(state: LookupState, pid: PeerId) {.raises: [].} =
 proc isDialable(kad: KadDHT, peerId: PeerId): bool {.raises: [].} =
   kad.dialAddrs(peerId).len > 0 or kad.switch.isConnected(peerId)
 
+proc admissibleAddrs(
+    switch: Switch,
+    addressPolicy: PeerAddressPolicy,
+    rtable: RoutingTable,
+    p: PeerInfo,
+    caps: DiversityCaps,
+    pending: seq[PeerId] = @[],
+): seq[MultiAddress] {.raises: [].} =
+  let addrs = addressPolicy.filterAddrs(p.addrs)
+  if addrs.len == 0:
+    return @[]
+  if not switch.peerStore[AddressBook].hasIpDiversity(
+    rtable, p.peerId, addrs, caps, pending
+  ):
+    return @[]
+  addrs
+
+proc admissibleAddrs(
+    kad: KadDHT, rtable: RoutingTable, p: PeerInfo, pending: seq[PeerId]
+): seq[MultiAddress] {.raises: [].} =
+  kad.switch.admissibleAddrs(
+    kad.config.addressPolicy, rtable, p, kad.config.limits.diversityCaps(), pending
+  )
+
+proc pendingAdmissions(kad: KadDHT, tableId: Key): seq[PeerId] {.raises: [].} =
+  ## A probe for another table holds no slot in this one.
+  kad.admissionProbes.keys.toSeq().filterIt(it.tableId == tableId).mapIt(it.peerId)
+
 proc canBecomeDialable(
-    kad: KadDHT, peerId: PeerId, addrs: seq[MultiAddress]
+    state: LookupState, peerId: PeerId, addrs: seq[MultiAddress], pending: seq[PeerId]
 ): bool {.raises: [].} =
-  ## Whether admission could keep one of `addrs`, or the peer is reachable already.
-  addrs.anyIt(kad.config.addressPolicy.accepts(it)) or kad.isDialable(peerId)
+  ## Same conditions as ``admitPeers``, since nothing else records addresses.
+  let p = PeerInfo(peerId: peerId, addrs: addrs)
+  state.kad.admissibleAddrs(state.rtable, p, pending).len > 0 or
+    state.kad.isDialable(peerId)
 
 proc tryEvictFarthest(state: LookupState, newDist: XorDistance): bool {.raises: [].} =
   ## Drop the worst (farthest) peer from the shortlist if it is farther than
@@ -85,6 +115,7 @@ proc tryEvictFarthest(state: LookupState, newDist: XorDistance): bool {.raises: 
 proc updateShortlist*(state: LookupState, msg: Message): seq[PeerInfo] {.raises: [].} =
   var newPeerInfos: seq[PeerInfo]
   let cap = state.kad.config.limits.maxShortlistSize
+  let pending = state.kad.pendingAdmissions(state.rtable.selfId)
 
   for newPeer in msg.closerPeers:
     let raw = newPeer.id.valueOr:
@@ -93,7 +124,7 @@ proc updateShortlist*(state: LookupState, msg: Message): seq[PeerInfo] {.raises:
       continue
     if state.shortlist.contains(pid):
       continue
-    if not state.kad.canBecomeDialable(pid, newPeer.addrs):
+    if not state.canBecomeDialable(pid, newPeer.addrs, pending):
       continue
 
     let dist = xorDistance(pid, state.target, state.rtable.config.hasher)
@@ -206,30 +237,6 @@ proc dispatchFindNode*(
   let msg = Message(msgType: Opt.some(MessageType.findNode), key: Opt.some(target))
   await kad.dispatchRpc(peer, msg, addrs)
 
-proc admissibleAddrs(
-    switch: Switch,
-    addressPolicy: PeerAddressPolicy,
-    rtable: RoutingTable,
-    p: PeerInfo,
-    caps: DiversityCaps,
-    pending: seq[PeerId] = @[],
-): seq[MultiAddress] {.raises: [].} =
-  let addrs = addressPolicy.filterAddrs(p.addrs)
-  if addrs.len == 0:
-    return @[]
-  if not switch.peerStore[AddressBook].hasIpDiversity(
-    rtable, p.peerId, addrs, caps, pending
-  ):
-    return @[]
-  addrs
-
-proc admissibleAddrs(
-    kad: KadDHT, rtable: RoutingTable, p: PeerInfo, pending: seq[PeerId]
-): seq[MultiAddress] {.raises: [].} =
-  kad.switch.admissibleAddrs(
-    kad.config.addressPolicy, rtable, p, kad.config.limits.diversityCaps(), pending
-  )
-
 proc recordAddrs(
     switch: Switch,
     peerId: PeerId,
@@ -330,10 +337,6 @@ proc trackProbe(kad: KadDHT, probeKey: ProbeKey, probe: Future[void]) {.raises: 
       if kad.admissionProbes.getOrDefault(probeKey) == probe:
         kad.admissionProbes.del(probeKey)
   )
-
-proc pendingAdmissions(kad: KadDHT, tableId: Key): seq[PeerId] {.raises: [].} =
-  ## A probe for another table holds no slot in this one.
-  kad.admissionProbes.keys.toSeq().filterIt(it.tableId == tableId).mapIt(it.peerId)
 
 proc tryRefreshAdmitted(rtable: RoutingTable, peerId: PeerId): bool {.raises: [].} =
   ## True when the peer already holds a seat, refreshing it instead of re-probing.

--- a/libp2p/protocols/kademlia/kademlia_metrics.nim
+++ b/libp2p/protocols/kademlia/kademlia_metrics.nim
@@ -51,5 +51,9 @@ declarePublicCounter kad_routing_table_liveness_probes,
   "routing-table liveness probes", ["result"]
 declarePublicCounter kad_admission_probes_backed_off,
   "admission probes skipped because the peer's last probe failed"
+declarePublicCounter kad_admission_probes_dropped,
+  "admission probes skipped because no probe slot was free"
+declarePublicCounter kad_lookup_undialable_peers,
+  "lookup shortlist peers dropped for having no address in the peer store"
 declarePublicCounter kad_routing_table_reseeds,
   "re-seed attempts triggered by a peer count below the minimum"

--- a/libp2p/protocols/kademlia/rpc.nim
+++ b/libp2p/protocols/kademlia/rpc.nim
@@ -18,6 +18,10 @@ proc countSent*[T](
   kad_messages_sent.inc(labelValues = [$msgType])
   kad_message_bytes_sent.inc(sentBytes, labelValues = [$msgType])
 
+proc dialAddrs*(kad: KadDHT, peer: PeerId): seq[MultiAddress] {.raises: [].} =
+  ## The addresses an RPC to `peer` dials when its caller names none.
+  kad.switch.peerStore[AddressBook][peer]
+
 proc dispatchRpc*(
     kad: KadDHT,
     peer: PeerId,
@@ -36,10 +40,7 @@ proc dispatchRpc*(
   var sendRes: Result[seq[byte], SendError]
   kad_message_duration_ms.time(labelValues = [$msgType]):
     sendRes = await kad.msgSender.sendRequest(
-      peer,
-      addrs.valueOr(kad.switch.peerStore[AddressBook][peer]),
-      move encoded,
-      kad.config.timeout,
+      peer, addrs.valueOr(kad.dialAddrs(peer)), move encoded, kad.config.timeout
     )
   sendRes.countSent(msgType, sentBytes)
 

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -66,7 +66,7 @@ const
   DefaultMaxLocalRecords* = 500 ## upper bound on locally stored value records
   DefaultMaxConcurrentRpcs* = 100
     ## upper bound on in-flight outbound RPCs across find/get/put/provider
-  DefaultMaxConcurrentProbes* = 20
+  DefaultMaxConcurrentProbes* = 50
     ## upper bound on concurrent routing-table admission probes (lookupCheck)
   DefaultMaxConcurrentLivenessProbes* = 20
     ## upper bound on concurrent routing-table liveness/eviction probes

--- a/tests/libp2p/kademlia/test_ip_diversity.nim
+++ b/tests/libp2p/kademlia/test_ip_diversity.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import std/sequtils
+import std/[sequtils, tables]
 import results
 import ../../../libp2p/[protocols/kademlia, switch, peerid, peerstore]
 import ../../tools/[unittest, multiaddress]
@@ -84,6 +84,31 @@ suite "KadDHT IP diversity":
       addressBook.hasIpDiversity(
         kad.rtable, candidate, @[ma("/ip4/8.8.8.2/tcp/4001")], caps, @[probed]
       )
+
+  test "updateShortlist refuses a peer the IP diversity cap would not admit":
+    ## Admission is what records the addresses, so such a peer never gets dialed.
+    let kad = kadWithBucketSubnetCap(1)
+    let
+      admitted = kad.peerIdInBucket(0)
+      refused = kad.peerIdInBucket(0)
+
+    kad.updatePeers(
+      @[PeerInfo(peerId: admitted, addrs: @[ma("/ip4/8.8.8.1/tcp/4001")])]
+    )
+
+    let state = LookupState.init(kad, randomPeerId().toKey())
+    state.shortlist.clear()
+
+    let added = state.updateShortlist(
+      Message(
+        msgType: MessageType.findNode,
+        closerPeers: @[Peer(id: refused.toKey(), addrs: @[ma("/ip4/8.8.8.2/tcp/4001")])],
+      )
+    )
+
+    check:
+      added.len == 0
+      refused notin state.shortlist
 
   test "an unset per-bucket cap leaves the table-wide cap in charge":
     let kad = kadWithBucketSubnetCap(0)

--- a/tests/libp2p/kademlia/test_limits.nim
+++ b/tests/libp2p/kademlia/test_limits.nim
@@ -6,7 +6,7 @@
 import chronos, results, sequtils, tables
 import ../../../libp2p/[protocols/kademlia, switch, builders]
 import ../../../libp2p/utils/future
-import ../../tools/[lifecycle, stall_server, topology, unittest]
+import ../../tools/[lifecycle, multiaddress, stall_server, topology, unittest]
 import ./utils.nim
 
 suite "KadDHT - Limits":
@@ -17,12 +17,7 @@ suite "KadDHT - Limits":
     let kad = setupKad()
     kad.admissionSem = newAsyncSemaphore(2)
 
-    let peers = (0 ..< 5).mapIt(
-      PeerInfo(
-        peerId: randomPeerId(),
-        addrs: @[MultiAddress.init("/ip4/127.0.0.1/tcp/" & $(40000 + it)).tryGet()],
-      )
-    )
+    let peers = peersWithAddrs(5)
     kad.admitPeers(peers)
 
     # candidates beyond the semaphore are dropped, never queued
@@ -30,6 +25,40 @@ suite "KadDHT - Limits":
 
     let probes = move kad.admissionProbes
     await noCancel probes.values.toSeq().cancelAndWait()
+
+  asyncTest "admitPeers records addresses of candidates past the probe cap":
+    let kad = setupKad()
+    kad.admissionSem = newAsyncSemaphore(2)
+
+    let peers = peersWithAddrs(5)
+    kad.admitPeers(peers)
+
+    # a lookup shortlists every candidate, so all of them must stay dialable
+    let addressBook = kad.switch.peerStore[AddressBook]
+    for p in peers:
+      check addressBook[p.peerId] == p.addrs
+
+    let probes = move kad.admissionProbes
+    await noCancel probes.values.toSeq().cancelAndWait()
+
+  asyncTest "a candidate dropped for a full probe cap is probed on a later call":
+    let kad = setupKad()
+    kad.admissionSem = newAsyncSemaphore(1)
+
+    let peers = peersWithAddrs(2)
+    kad.admitPeers(peers)
+    check kad.admissionProbes.len == 1
+
+    let firstProbes = move kad.admissionProbes
+    # cancelling the probe releases its slot through ``admitPeer``'s defer
+    await noCancel firstProbes.values.toSeq().cancelAndWait()
+    check kad.admissionSem.availableSlots() == 1
+
+    kad.admitPeers(@[peers[1]])
+    check kad.admissionProbes.len == 1
+
+    let secondProbes = move kad.admissionProbes
+    await noCancel secondProbes.values.toSeq().cancelAndWait()
 
   asyncTest "an admission probe frees its slot at the probe timeout":
     let stall = startStallServer()
@@ -56,12 +85,7 @@ suite "KadDHT - Limits":
     kad.livenessSem = newAsyncSemaphore(1)
     check kad.livenessSem.tryAcquire() # hold the only liveness slot
 
-    let peers = (0 ..< 3).mapIt(
-      PeerInfo(
-        peerId: randomPeerId(),
-        addrs: @[MultiAddress.init("/ip4/127.0.0.1/tcp/" & $(40000 + it)).tryGet()],
-      )
-    )
+    let peers = peersWithAddrs(3)
     kad.admitPeers(peers)
 
     check kad.admissionProbes.len == 2
@@ -80,7 +104,7 @@ suite "KadDHT - Limits":
     # Generate 20 fresh peers and feed them through updateShortlist.
     var peers: seq[Peer]
     for i in 0 ..< 20:
-      peers.add(Peer(id: randomPeerId().toKey(), addrs: @[]))
+      peers.add(closerPeer(randomPeerId().toKey()))
 
     let msg = Message(msgType: MessageType.findNode, closerPeers: peers)
     discard state.updateShortlist(msg)
@@ -102,7 +126,8 @@ suite "KadDHT - Limits":
     # Insert a far peer first
     var farId: Key = newSeq[byte](32)
     farId[0] = 0xFF
-    let farMsg = Message(msgType: MessageType.findNode, closerPeers: @[Peer(id: farId)])
+    let farMsg =
+      Message(msgType: MessageType.findNode, closerPeers: @[closerPeer(farId)])
     discard state.updateShortlist(farMsg)
 
     # Now insert 5 close peers — they should evict the far one
@@ -110,11 +135,83 @@ suite "KadDHT - Limits":
     for i in 1 .. 5:
       var id: Key = newSeq[byte](32)
       id[31] = byte(i)
-      closePeers.add(Peer(id: id))
+      closePeers.add(closerPeer(id))
     let closeMsg = Message(msgType: MessageType.findNode, closerPeers: closePeers)
     discard state.updateShortlist(closeMsg)
 
     check state.shortlist.len == kad.config.limits.maxShortlistSize
+
+  test "updatePeers seeds addresses that outlive the liveness grace period":
+    ## Nothing dials a seed, so no `markConnected` or identify lifts it off Low.
+    let kad = setupKad()
+    let peers = peersWithAddrs(1)
+    kad.updatePeers(peers)
+
+    let entries = kad.switch.peerStore[AddressBook].entries(peers[0].peerId)
+    check:
+      kad.hasKey(peers[0].peerId.toKey())
+      entries[0].confidence >= AddressConfidence.Medium
+
+  test "updateShortlist rejects a closer peer no address can reach":
+    ## A remote that names bare ids must not displace peers the node can dial.
+    let kad = setupKad()
+    kad.config.limits.maxShortlistSize = 1
+
+    let targetKey = randomPeerId().toKey()
+    var state = LookupState.init(kad, targetKey)
+    state.shortlist.clear()
+
+    let ranked =
+      @[randomPeerId(), randomPeerId()].sortPeers(targetKey, kad.rtable.config.hasher)
+    let (near, far) = (ranked[0], ranked[1])
+
+    discard state.updateShortlist(
+      Message(msgType: MessageType.findNode, closerPeers: @[closerPeer(far.toKey())])
+    )
+    check state.shortlist.len == 1
+
+    let added = state.updateShortlist(
+      Message(msgType: MessageType.findNode, closerPeers: @[Peer(id: near.toKey())])
+    )
+
+    check:
+      added.len == 0
+      near notin state.shortlist
+      far in state.shortlist
+
+  test "updateShortlist rejects a closer peer whose addresses the policy drops":
+    ## An address the node would never dial must not buy what an absent one cannot.
+    let kad = setupKad()
+    kad.config.addressPolicy = publicRoutableAddressPolicy
+    kad.config.limits.maxShortlistSize = 1
+
+    let targetKey = randomPeerId().toKey()
+    var state = LookupState.init(kad, targetKey)
+    state.shortlist.clear()
+
+    let ranked =
+      @[randomPeerId(), randomPeerId()].sortPeers(targetKey, kad.rtable.config.hasher)
+    let (near, far) = (ranked[0], ranked[1])
+
+    discard state.updateShortlist(
+      Message(
+        msgType: MessageType.findNode,
+        closerPeers: @[Peer(id: far.toKey(), addrs: @[ma("/ip4/1.2.3.4/tcp/1")])],
+      )
+    )
+    check state.shortlist.len == 1
+
+    let added = state.updateShortlist(
+      Message(
+        msgType: MessageType.findNode,
+        closerPeers: @[Peer(id: near.toKey(), addrs: @[ma("/ip4/192.168.1.5/tcp/1")])],
+      )
+    )
+
+    check:
+      added.len == 0
+      near notin state.shortlist
+      far in state.shortlist
 
   asyncTest "putValue rejects values larger than maxValueSize":
     let kads = setupKadSwitches(2)

--- a/tests/libp2p/kademlia/test_lookup.nim
+++ b/tests/libp2p/kademlia/test_lookup.nim
@@ -160,9 +160,9 @@ suite "KadDHT Iterative Lookup":
     let msg = Message(
       msgType: MessageType.findNode,
       closerPeers: @[
-        Peer(id: existingPeer.toKey()),
-        Peer(id: newPeer.toKey()),
-        Peer(id: newPeer.toKey()), # Duplicate
+        closerPeer(existingPeer.toKey()),
+        closerPeer(newPeer.toKey()),
+        closerPeer(newPeer.toKey()), # Duplicate
       ],
     )
 
@@ -189,7 +189,7 @@ suite "KadDHT Iterative Lookup":
       closerPeers: @[
         Peer(id: Opt.none(seq[byte])), # Invalid: empty
         Peer(id: @[0'u8, 1]), # Invalid: malformed
-        Peer(id: validPeer.toKey()), # Valid
+        closerPeer(validPeer.toKey()), # Valid
       ],
     )
 
@@ -234,7 +234,7 @@ suite "KadDHT Iterative Lookup":
     let targetKey = randomPeerId().toKey()
     var state = LookupState.init(kad, targetKey)
 
-    let peers = state.addRandomPeers(4, targetKey, kad.rtable.config.hasher)
+    let peers = state.addRandomPeers(kad, 4, targetKey)
     kad.config.beta = 3
 
     # only 2 successes, need 3
@@ -252,7 +252,7 @@ suite "KadDHT Iterative Lookup":
     let targetKey = randomPeerId().toKey()
     var state = LookupState.init(kad, targetKey)
 
-    let peers = state.addRandomPeers(4, targetKey, kad.rtable.config.hasher)
+    let peers = state.addRandomPeers(kad, 4, targetKey)
     kad.config.beta = 3
 
     # Respond from 0, 2 and 3, but not 1
@@ -270,7 +270,7 @@ suite "KadDHT Iterative Lookup":
 
     let targetKey = randomPeerId().toKey()
     var state = LookupState.init(kad, targetKey)
-    let peers = state.addRandomPeers(4, targetKey, kad.rtable.config.hasher)
+    let peers = state.addRandomPeers(kad, 4, targetKey)
 
     kad.config.beta = 5
     kad.config.replication = 2
@@ -287,7 +287,7 @@ suite "KadDHT Iterative Lookup":
 
     let targetKey = randomPeerId().toKey()
     var state = LookupState.init(kad, targetKey)
-    let peers = state.addRandomPeers(5, targetKey, kad.rtable.config.hasher)
+    let peers = state.addRandomPeers(kad, 5, targetKey)
 
     state.responded[peers[0]] = RespondedStatus.Success
     state.responded[peers[1]] = RespondedStatus.Failed
@@ -331,7 +331,7 @@ suite "KadDHT Iterative Lookup":
     # Create message with 10 peers (more than k=3)
     var peers: seq[Peer]
     for i in 0 ..< 10:
-      peers.add(Peer(id: randomPeerId().toKey()))
+      peers.add(closerPeer(randomPeerId().toKey()))
 
     let msg = Message(msgType: MessageType.findNode, closerPeers: peers)
     let added = state.updateShortlist(msg)
@@ -354,6 +354,23 @@ suite "KadDHT Iterative Lookup":
     discard await kad.iterativeLookup(targetKey, recordingDispatch(queried), noopReply)
 
     check queried[] == known
+
+  asyncTest "Lookup drops a shortlisted peer it has no address for":
+    let kad = setupLookupKad()
+
+    let targetKey = randomPeerId().toKey()
+    let (closest, known) = kad.seedRoutingTableBelow(5, targetKey)
+    # a reply shortlists the id even when admission stores no address for it
+    kad.switch.peerStore[AddressBook][closest] = @[]
+
+    let queried = new(seq[PeerId])
+    let dispatch = recordingDispatch(queried, {known[2]: @[closest]}.toTable())
+    let state = await kad.iterativeLookup(targetKey, dispatch, noopReply)
+
+    check:
+      # dialing it would fail with an empty address list, so it never runs
+      queried[] == known
+      closest notin state.shortlist
 
   asyncTest "Follow-up phase defers a peer it hears about to the next round":
     let kad = setupLookupKad()

--- a/tests/libp2p/kademlia/utils.nim
+++ b/tests/libp2p/kademlia/utils.nim
@@ -221,11 +221,12 @@ proc randomServiceId*(): Key =
 
 proc populateRoutingTable*(kad: KadDHT, count: int) =
   for i in 0 ..< count:
-    discard kad.rtable.insert(randomPeerId())
+    let peerId = randomPeerId()
+    if kad.rtable.insert(peerId):
+      kad.switch.peerStore[AddressBook][peerId] = @[ma("/ip4/127.0.0.1/tcp/1")]
 
 proc insertRandomPeers*(kad: KadDHT, count: int): seq[PeerId] =
-  ## Inserts `count` random peers into the routing table. Unlike
-  ## `populateRoutingTable`, rejected ids are retried.
+  ## Inserts `count` random peers, each with an address the way admission does.
   const maxRetries = 1000
   let maxAttempts = count + maxRetries
   var peers: seq[PeerId]
@@ -237,12 +238,26 @@ proc insertRandomPeers*(kad: KadDHT, count: int): seq[PeerId] =
     # a full bucket rejects the insert and the id is simply redrawn.
     if not kad.rtable.insert(peerId):
       continue
+    kad.switch.peerStore[AddressBook][peerId] = @[ma("/ip4/127.0.0.1/tcp/1")]
     peers.add(peerId)
 
   doAssert peers.len == count,
     "routing table took only " & $peers.len & " of " & $count & " peers in " &
       $maxAttempts & " attempts"
   peers
+
+proc peersWithAddrs*(count: int): seq[PeerInfo] =
+  ## `count` fresh peers on distinct ports, so the IP-diversity caps admit them.
+  (0 ..< count).mapIt(
+    PeerInfo(
+      peerId: randomPeerId(),
+      addrs: @[MultiAddress.init("/ip4/127.0.0.1/tcp/" & $(40000 + it)).tryGet()],
+    )
+  )
+
+proc closerPeer*(id: Key): Peer =
+  ## `toPeer` refuses an address-free peer, so no real reply carries one.
+  Peer(id: id, addrs: @[ma("/ip4/127.0.0.1/tcp/1")])
 
 proc addPeersWithAddrs*(kad: KadDHT, count: int) =
   ## Adds `count` random peers to the routing table, with an address each so they
@@ -315,12 +330,14 @@ proc seedRoutingTableBelow*(
   (drawn[0], drawn[1 .. ^1])
 
 proc addRandomPeers*(
-    state: LookupState, count: int, target: Key, hasher: Opt[XorDHasher]
+    state: LookupState, kad: KadDHT, count: int, target: Key
 ): seq[PeerId] =
+  let hasher = kad.rtable.config.hasher
   var peers: seq[PeerId]
   for i in 0 ..< count:
     peers.add(randomPeerId())
     state.shortlist[peers[i]] = xorDistance(peers[i], target, hasher)
+    kad.switch.peerStore[AddressBook][peers[i]] = @[ma("/ip4/127.0.0.1/tcp/1")]
   peers.sortPeers(target, hasher)
 
 proc sendAddProviderAndGetStatus*(


### PR DESCRIPTION
## Summary

A lookup dialed peers with an empty address list and failed with `Unable to establish outgoing link in establishConnection: peer_id=... addrs=@[]`. The peers were reachable. The node had discarded their addresses.

`admitPeers` recorded a candidate's addresses and then started an admission probe, both in one loop, and the probe-slot check was a `break`. Every candidate after the first full slot skipped `addressBook.extend`. Their ids were already on the shortlist, because `applyReplies` calls `updateShortlist` before `admitPeers`, so `fillSlots` later dispatched to an id whose addresses were nowhere. The `break` gained nothing either: the loop is synchronous, so no slot can free during it, and `continue` starts the same number of probes.

With one bootstrap node and 500 joining nodes this is the normal case rather than an edge case. The first reply takes every probe slot and every reply after it stores nothing.

## What changed

1. **The probe cap no longer aborts address recording.** `scheduleAdmissionProbe` (`find.nim:334`) returns `false` instead of leaving the loop. Probes are still never queued: a candidate with no slot is retried when a later reply names it.
2. **An unreachable id can no longer evict a dialable peer.** `updateShortlist` (`find.nim:96`) let an id the node could not dial displace a closer one through `tryEvictFarthest`. `canBecomeDialable` now requires the local address policy to keep at least one offered address, or the peer to be reachable already. Under the permissive default policy this is a correctness gate; under `publicRoutableAddressPolicy` it is a real filter.
3. **The lookup drops candidates it cannot dial.** `dropUndialable` (`find.nim:431`) runs before `fillSlots` and removes shortlist entries with no stored address and no live connection. This covers candidates the address policy or the IP-diversity caps rejected during admission.
4. **The dialability decision is shared.** `dialAddrs` (`rpc.nim:21`) is now used by `dispatchRpc`, `isDialable` and `checkAndEvictPeer` (`kademlia.nim:89`), so the lookup guard and the liveness eviction cannot disagree about whether a peer is usable.
5. **`DefaultMaxConcurrentProbes` goes from 20 to 50,** so the routing table fills faster under a join storm. See Risk Assessment.
6. **`admitPeers` reads as its gate list.** Each step is a named call in order (`recordAddrs`, `tryRefreshAdmitted`, `scheduleAdmissionProbe`), which makes the two exits visible: a candidate is recorded once its addresses pass, and admitted once the probe answers. `updatePeers` is the same list minus the probe and shares `recordAddrs`. No behavior change.
7. **A routing-table seat now implies addresses that outlive it.** A seat resists liveness eviction for `DefaultLivenessGracePeriod` (1 hour) but `updatePeers` recorded its seeds at `AddressConfidence.Low` (15 minutes). A seed is never dialed and never connected, so neither `markConnected` nor identify lifts it, and its addresses expired under a standing seat. `updatePeers` and `admitPeer` now record at Medium.

## Affected Areas

- [x] Peer Management / Discovery: routing-table admission, the address book records it writes, and the lookup shortlist.
- [x] Protocol Logic: `kad-dht` `FIND_NODE` lookup dispatch and the shared outbound RPC path.
- [ ] Gossipsub
- [ ] Transports
- [ ] Build / Tooling
- [ ] Other

## Compatibility & Downstream Validation

No wire-format change and no public signature change, so no downstream integration branch is needed. Nimbus, Waku and Codex: N/A.

## Impact on Library Users

- A peer named in a reply keeps its addresses even when the probe cap is full, so lookups can dial it. This is the fix.
- A `closerPeers` entry whose addresses the local policy rejects, and that is unknown locally, no longer joins the shortlist. `toPeer` refuses to serialize an address-free `Peer`, so a conforming implementation never sends one.
- `findPeer` returns `err("peer not found")` instead of a `PeerInfo` with `addrs: @[]`. The old value was undialable.
- `dispatchPeer` logs a lookup RPC failure at `debug` instead of `error`. At 500 nodes the `error` line flooded the log.
- New metrics: `kad_admission_probes_dropped` and `kad_lookup_undialable_peers`.
- `DefaultMaxConcurrentProbes` rises to 50. A node pinning its own `KadDHTLimits` is unaffected.

## Risk Assessment

- **Probe fan-out.** This is the change worth arguing about. A cap of 50 means one reply can put 50 concurrent dials in flight instead of 20, and remote input drives that number. The IP-diversity caps still apply, so reaching 50 needs 50 distinct attacker-controlled addresses, the same requirement as reaching 20 before. The cost is higher peak socket and file-descriptor use. Reviewers who want the address fix without this can drop the `types.nim` hunk on its own.
- **Probe concurrency against the RPC cap.** 50 probes take up to half of `DefaultMaxConcurrentRpcs` (100). `rpcSem` waits rather than dropping, so the worst case is added lookup latency during a join storm. `DefaultMaxConcurrentRpcs` is left alone; raise it in a follow-up if measurement warrants.
- **Lookup completeness.** `dropUndialable` shrinks the shortlist, so a remote naming unresolvable ids reduces that lookup's candidate set. Those entries were undialable, so it replaces a certain dial failure with no dial, and change 2 stops such ids from displacing good peers first.

## References

None.

## Additional Notes

Test fixtures now give every seeded peer an address (`insertRandomPeers`, `populateRoutingTable`, `addRandomPeers`, plus new `closerPeer` and `peersWithAddrs` helpers). The old fixtures modelled states production never produces, since both admission paths write the address book before inserting, and `toPeer` refuses an address-free peer. `addRandomPeers` takes the `KadDHT` rather than the hasher, because `LookupState.kad` is not exported and the helper needs the peer store.

Each new guard was checked against a build with the guard removed, and fails there. Worth noting for a follow-up: the pre-existing `updateShortlist prefers closer peers when over cap` test builds fixture ids from raw 32-byte `Key` values that `PeerId.init` rejects, so its far peer never enters the shortlist and its assertion is met by the close peers alone. Left as found.

`test_limits` (16), `test_lookup` (20), `test_find` (20), `test_bootstrap` (19), `test_probe_backoff` (8), `test_ip_diversity` (4) and `test_fix_low_peers` (5) pass locally. The remaining kademlia suites were not run locally; CI is the gate for those.
