### PR TITLE
test(autotls): acme signed requests

### DIFF
--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -11,8 +11,37 @@ import ../../tools/[unittest, crypto]
 import ../../stubs/acme_api_stub
 
 suite "AutoTLS ACME API":
+  const WildcardDomain = "*.example.libp2p.direct"
+
+  # RSA generation dominates the runtime of every test here, so one pair for all.
+  let
+    key = RsaPrivateKey.random(rng()).get()
+    certKey = RsaPrivateKey.random(rng()).get()
+
   var api {.threadvar.}: ACMEApiStub
-  var key {.threadvar.}: RsaPrivateKey
+
+  proc queueRegister() =
+    api.mockedResponses.add(
+      HTTPResponse(
+        body: %*{"status": "valid"},
+        headers: HttpTable.init(@[("location", AccountURL)]),
+      )
+    )
+
+  proc queueOrder(status: string, authorizations: JsonNode) =
+    api.mockedResponses.add(
+      HTTPResponse(
+        body: %*{
+          "status": status, "authorizations": authorizations, "finalize": FinalizeURL
+        },
+        headers: HttpTable.init(@[("location", OrderURL)]),
+      )
+    )
+
+  proc queueChallenges(challenges: JsonNode) =
+    api.mockedResponses.add(
+      HTTPResponse(body: %*{"challenges": challenges}, headers: HttpTable.init())
+    )
 
   asyncTeardown:
     await api.close()
@@ -20,7 +49,6 @@ suite "AutoTLS ACME API":
 
   asyncSetup:
     api = ACMEApiStub.new()
-    key = RsaPrivateKey.random(rng()).get()
 
   asyncTest "register to acme server":
     api.mockedResponses.add(
@@ -168,7 +196,7 @@ suite "AutoTLS ACME API":
       "some-domain",
       parseUri("http://example.com/some-finalize-url"),
       parseUri("http://example.com/some-order-url"),
-      RsaPrivateKey.random(rng()).get,
+      certKey,
       key,
       "kid",
     )
@@ -187,7 +215,7 @@ suite "AutoTLS ACME API":
       "some-domain",
       parseUri("http://example.com/some-finalize-url"),
       parseUri("http://example.com/some-order-url"),
-      RsaPrivateKey.random(rng()).get,
+      certKey,
       key,
       "kid",
       retries = 1,
@@ -211,7 +239,7 @@ suite "AutoTLS ACME API":
       "some-domain",
       parseUri("http://example.com/some-finalize-url"),
       parseUri("http://example.com/some-order-url"),
-      RsaPrivateKey.random(rng()).get,
+      certKey,
       key,
       "kid",
     )
@@ -304,7 +332,7 @@ suite "AutoTLS ACME API":
       discard await api.requestFinalize(
         "some-domain",
         parseUri("http://example.com/some-finalize-url"),
-        RsaPrivateKey.random(rng()).get,
+        certKey,
         key,
         "kid",
       )
@@ -312,7 +340,138 @@ suite "AutoTLS ACME API":
     expect(ACMEError):
       discard await api.requestGetOrder(parseUri("http://example.com/some-order-url"))
 
+  asyncTest "the directory is fetched once and cached":
+    # The cache is only observable on a stub that was not handed a directory.
+    await api.close()
+    api = ACMEApiStub.new(directory = Opt.none(ACMEDirectory))
+    api.mockedResponses.add(
+      HTTPResponse(
+        body: %*{
+          "newNonce": StubDirectory.newNonce,
+          "newOrder": StubDirectory.newOrder,
+          "newAccount": StubDirectory.newAccount,
+        },
+        headers: HttpTable.init(),
+      )
+    )
+    for _ in 0 ..< 2:
+      api.mockedResponses.add(
+        HTTPResponse(
+          body: %*{}, headers: HttpTable.init(@[("Replay-Nonce", "some-nonce")])
+        )
+      )
+
+    # The stub overrides requestNonce, so call the real one that consults the directory.
+    discard await procCall requestNonce(ACMEApi(api))
+    discard await procCall requestNonce(ACMEApi(api))
+
+    check api.requestedUris ==
+      @[
+        parseUri(LetsEncryptURL & "/directory"),
+        parseUri(StubDirectory.newNonce),
+        parseUri(StubDirectory.newNonce),
+      ]
+
+  asyncTest "the replay nonce is read from the response header":
+    const nonce = "some-replay-nonce"
+    api.mockedResponses.add(
+      HTTPResponse(body: %*{}, headers: HttpTable.init(@[("Replay-Nonce", nonce)]))
+    )
+
+    check (await procCall requestNonce(ACMEApi(api))) == nonce
+
+  asyncTest "the register request is signed with a jwk":
+    queueRegister()
+
+    discard await api.requestRegister(key)
+
+    check api.protectedHeader(0).hasKey("jwk")
+
+  asyncTest "the register request agrees to the terms of service":
+    queueRegister()
+
+    discard await api.requestRegister(key)
+
+    check api.signedPayload(0)["termsOfServiceAgreed"].getBool
+
+  asyncTest "an order request is signed with the account kid":
+    queueOrder("pending", %*[AuthorizationsURL])
+
+    discard await api.requestNewOrder(@[WildcardDomain], key, AccountURL)
+
+    check api.protectedHeader(0)["kid"].getStr == AccountURL
+
+  asyncTest "the order payload names the domain as a dns identifier":
+    queueOrder("pending", %*[AuthorizationsURL])
+
+    discard await api.requestNewOrder(@[WildcardDomain], key, AccountURL)
+
+    check api.signedPayload(0)["identifiers"] ==
+      %*[{"type": "dns", "value": WildcardDomain}]
+
+  asyncTest "successive signed requests carry different nonces":
+    queueRegister()
+    queueOrder("pending", %*[AuthorizationsURL])
+
+    discard await api.requestRegister(key)
+    discard await api.requestNewOrder(@[WildcardDomain], key, AccountURL)
+
+    check api.protectedHeader(0)["nonce"] != api.protectedHeader(1)["nonce"]
+
+  asyncTest "an order with no authorizations is refused":
+    queueOrder("pending", %*[])
+
+    expect(ACMEError):
+      discard await api.requestNewOrder(@[WildcardDomain], key, AccountURL)
+
+  asyncTest "an order that is neither pending nor ready is refused":
+    queueOrder("invalid", %*[AuthorizationsURL])
+    # The authorization is in place, so only the status can stop the call.
+    queueChallenges(
+      %*[{"type": "dns-01", "url": ChallengeURL, "status": "pending", "token": "t"}]
+    )
+
+    expect(ACMEError):
+      discard await api.requestChallenge(@[WildcardDomain], key, AccountURL)
+
+  asyncTest "an authorization offering no dns-01 challenge is refused":
+    queueOrder("pending", %*[AuthorizationsURL])
+    queueChallenges(
+      %*[
+        {"type": "http-01", "url": ChallengeURL, "status": "pending", "token": "t"},
+        {"type": "tls-alpn-01", "url": ChallengeURL, "status": "pending", "token": "t"},
+      ]
+    )
+
+    expect(ACMEError):
+      discard await api.requestChallenge(@[WildcardDomain], key, AccountURL)
+
+  asyncTest "an unrecognized challenge type does not discard the dns-01 beside it":
+    queueChallenges(
+      %*[
+        {
+          "type": "dns-account-01",
+          "url": "https://acme.example/chal/2",
+          "status": "pending",
+          "token": "t",
+        },
+        {"type": "dns-01", "url": ChallengeURL, "status": "pending", "token": "t"},
+      ]
+    )
+
+    let authorizations =
+      await api.requestAuthorizations(@[AuthorizationsURL], key, AccountURL)
+
+    check authorizations.challenges.len == 1
+    check authorizations.challenges[0].`type` == ACMEChallengeType.DNS01
+    check authorizations.challenges[0].url == ChallengeURL
+
 suite "AutoTLS ACME Client":
+  # RSA generation dominates the runtime of every test here, so one pair for all.
+  let
+    key = RsaPrivateKey.random(rng()).get()
+    certKey = RsaPrivateKey.random(rng()).get()
+
   var acmeApi {.threadvar.}: ACMEApiStub
   var acme {.threadvar.}: ACMEClient
 
@@ -331,7 +490,7 @@ suite "AutoTLS ACME Client":
       )
     )
 
-    acme = ACMEClient.new(rng = rng(), api = ACMEApi(acmeApi))
+    acme = ACMEClient.new(rng = rng(), api = ACMEApi(acmeApi), key = Opt.some(key))
     let kid = await acme.getOrInitKid()
     check kid == "some-expected-kid"
 
@@ -362,7 +521,7 @@ suite "AutoTLS ACME Client":
         body: %*{"status": "invalid"}, headers: HttpTable.init(@[("Retry-After", "0")])
       )
     )
-    acme = ACMEClient.new(rng = rng(), api = ACMEApi(acmeApi))
+    acme = ACMEClient.new(rng = rng(), api = ACMEApi(acmeApi), key = Opt.some(key))
     let kid = await acme.getOrInitKid()
     check kid == "some-expected-kid"
 
@@ -377,6 +536,4 @@ suite "AutoTLS ACME Client":
       ),
     )
     expect(ACMEError):
-      discard await acme.getCertificate(
-        api.Domain("some.domain"), RsaPrivateKey.random(rng()).get, challenge
-      )
+      discard await acme.getCertificate(api.Domain("some.domain"), certKey, challenge)

--- a/tests/stubs/acme_api_stub.nim
+++ b/tests/stubs/acme_api_stub.nim
@@ -5,7 +5,7 @@
 
 {.push raises: [].}
 
-import json, uri
+import base64, json, uri
 from times import Duration, now, format, `+`
 import chronos, chronos/apps/http/httpclient
 import ../../libp2p/autotls/acme/[api, utils]
@@ -13,31 +13,50 @@ import ../../libp2p/autotls/acme/[api, utils]
 export api
 
 const
-  AccountURL = "https://acme.example/acct/1"
-  OrderURL = "https://acme.example/order/1"
-  FinalizeURL = "https://acme.example/finalize/1"
-  AuthorizationsURL = "https://acme.example/authz/1"
-  ChallengeURL = "https://acme.example/chal/1"
+  AccountURL* = "https://acme.example/acct/1"
+  OrderURL* = "https://acme.example/order/1"
+  FinalizeURL* = "https://acme.example/finalize/1"
+  AuthorizationsURL* = "https://acme.example/authz/1"
+  ChallengeURL* = "https://acme.example/chal/1"
+
+const StubDirectory* = ACMEDirectory(
+  newNonce: LetsEncryptURL & "/new-nonce",
+  newOrder: LetsEncryptURL & "/new-order",
+  newAccount: LetsEncryptURL & "/new-account",
+)
 
 type ACMEApiStub* = ref object of ACMEApi
-  ## Answers ACME requests from `mockedResponses`, recording what was requested.
-  ## An empty queue refuses the request instead. While `stalls` is set the request
-  ## stays pending, until it is cancelled.
+  ## Answers ACME requests from `mockedResponses`, recording what was requested
+  ## and the flattened JWS each POST carried. An empty queue refuses the request
+  ## instead. While `stalls` is set the request stays pending, until it is cancelled.
   mockedResponses*: seq[HTTPResponse]
   requestedUris*: seq[Uri]
+  payloads*: seq[string]
+  nonces: int
   stalls*: bool
 
-proc new*(T: typedesc[ACMEApiStub]): ACMEApiStub =
-  let directory = ACMEDirectory(
-    newNonce: LetsEncryptURL & "/new-nonce",
-    newOrder: LetsEncryptURL & "/new-order",
-    newAccount: LetsEncryptURL & "/new-account",
-  )
+proc new*(
+    T: typedesc[ACMEApiStub], directory: Opt[ACMEDirectory] = Opt.some(StubDirectory)
+): ACMEApiStub =
   ACMEApiStub(
     session: HttpSessionRef.new(),
-    directory: Opt.some(directory),
+    directory: directory,
     acmeServerURL: parseUri(LetsEncryptURL),
   )
+
+proc jwsMember(self: ACMEApiStub, index: int, member: string): JsonNode =
+  try:
+    parseJson(base64.decode(parseJson(self.payloads[index])[member].getStr))
+  except CatchableError as exc:
+    raiseAssert "stub could not read the JWS " & member & ": " & exc.msg
+
+proc protectedHeader*(self: ACMEApiStub, index: int): JsonNode =
+  ## The protected header of the `index`-th signed request.
+  self.jwsMember(index, "protected")
+
+proc signedPayload*(self: ACMEApiStub, index: int): JsonNode =
+  ## The payload of the `index`-th signed request.
+  self.jwsMember(index, "payload")
 
 proc scriptChallenge*(self: ACMEApiStub, token: string) =
   ## Queues the three responses `getChallenge` consumes, carrying `token` in the challenge.
@@ -103,11 +122,13 @@ proc respond(
 method requestNonce*(
     self: ACMEApiStub
 ): Future[Nonce] {.async: (raises: [ACMEError, CancelledError]).} =
-  $self.acmeServerURL & "/acme/1234"
+  self.nonces += 1
+  $self.acmeServerURL & "/acme/" & $self.nonces
 
 method post*(
     self: ACMEApiStub, uri: Uri, payload: string
 ): Future[HTTPResponse] {.async: (raises: [ACMEError, HttpError, CancelledError]).} =
+  self.payloads.add(payload)
   await self.respond(uri)
 
 method get*(


### PR DESCRIPTION
## Summary

Adds tests for what the ACME client sends and how it reads responses back. `ACMEApiStub` now records the signed request, so tests can decode the JWS and assert on the protected header and payload.

Eleven tests:
- The directory is fetched once and cached.
- The replay nonce comes from the `Replay-Nonce` header, and successive signed requests carry different nonces.
- `newAccount` is signed with a jwk and agrees to the terms of service. Later requests are signed with the kid.
- The order payload names the domain as a dns identifier, including the `*.` wildcard prefix.
- Four response guards: empty `authorizations`, an order that is neither pending nor ready, an authorization offering no dns-01, and an unrecognized challenge type alongside a usable dns-01.

Stub changes: records `payloads`, exposes `protectedHeader` and `signedPayload` to decode the JWS members, answers a distinct nonce per call, and takes an optional `directory` so a test can drive `getDirectory`.