### PR TITLE
feat(cbind): include peerId on IncomingStreamEvent

### DIFF
--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -217,6 +217,7 @@ type PeerStoreEntryResponse {.ffi.} = object
 type IncomingStreamEvent {.ffi.} = object
   proto: string
   streamId: uint64
+  peerId: string
 
 type PubsubMessageEvent {.ffi.} = object
   topic: string
@@ -741,7 +742,11 @@ proc libp2pMountProtocol*(
     let releaseWaiter =
       Future[void].Raising([CancelledError]).init("cbind custom protocol release")
     streams.releaseWaiters[streamId] = releaseWaiter
-    onIncomingStream(IncomingStreamEvent(proto: selectedProto, streamId: streamId))
+    onIncomingStream(
+      IncomingStreamEvent(
+        proto: selectedProto, streamId: streamId, peerId: $stream.peerId
+      )
+    )
     await releaseWaiter
 
   let mountedProtocol = LPProtocol.new(codecs = @[proto], handler = handle)


### PR DESCRIPTION
## Summary

A C consumer that mounts a custom protocol receives `IncomingStreamEvent` with the protocol string and the stream id, and nothing that names the remote peer. The consumer therefore cannot tell which peer opened the stream, and it cannot route the stream to a per-peer session before it reads the first byte.

This PR adds `peerId` to the event. The mounted-protocol handler in `libp2pMountProtocol` fills it from `stream.peerId`, so the value is the base58 peer id of the remote side of that stream.

## Affected Areas

- [x] Build / Tooling
- [x] Other: `cbind/` C bindings

## Compatibility & Downstream Validation

The change is confined to `cbind/libp2p.nim`. Nimbus, Waku and Codex do not consume the C bindings, so no downstream branch applies.

- **Nimbus:** N/A
- **Waku:** N/A
- **Codex:** N/A

Consumer: https://github.com/logos-co/logos-libp2p-module/pull/103 pins this branch and reads `evt->peerId`.

## Impact on Library Users

Nim users see no change. No Nim API is touched, and no behavior changes.

C users get one extra field on the generated `IncomingStreamEvent` struct. The addition is backward compatible at the source level: `examples/echo.c` and `examples/relay.c` compile unchanged. It is not ABI compatible, because the struct grows, so a prebuilt C consumer must regenerate the header with `genbindings_c` and recompile against this version.

## Risk Assessment

Low. The handler already holds the `stream` object, so the peer id costs one `$` conversion per incoming stream and no extra lookup. The event is fired on the same path as before, and the release-waiter flow is untouched.

The only break is the struct layout for C consumers, which the regeneration step covers.

## References

- Consumer PR: https://github.com/logos-co/logos-libp2p-module/pull/103
