### PR TITLE
test(autotls): broker bearer lifecycle

### DIFF
--- a/tests/libp2p/autotls/test_broker.nim
+++ b/tests/libp2p/autotls/test_broker.nim
@@ -3,7 +3,7 @@
 
 {.used.}
 
-import json, sequtils, uri
+import json, sequtils, strutils, times, uri
 import chronos, stew/byteutils
 import
   ../../../libp2p/[
@@ -12,6 +12,7 @@ import
     autotls/acme/client,
     crypto/crypto,
     multiaddress,
+    peeridauth/client,
     peerinfo,
   ]
 import ../../tools/[unittest, crypto]
@@ -63,3 +64,44 @@ suite "AutoTLS broker":
 
     expect(AutoTLSError):
       await broker.sendChallenge(peerInfo, addrs, KeyAuth)
+
+  asyncTest "a live bearer authenticates the next registration without a handshake":
+    client.expires = Opt.some(now() + initDuration(hours = 1))
+
+    await broker.sendChallenge(peerInfo, addrs, KeyAuth)
+    await broker.sendChallenge(peerInfo, addrs, KeyAuth)
+
+    check:
+      client.requestedUris.len == 3
+      client.authHeaders.len == 2
+      client.authHeaders[1] == PeerIDAuthPrefix & " bearer=\"" & client.token & "\""
+
+  asyncTest "an expired bearer is dropped and the handshake runs again":
+    client.expires = Opt.some(now() - initDuration(hours = 1))
+
+    await broker.sendChallenge(peerInfo, addrs, KeyAuth)
+    await broker.sendChallenge(peerInfo, addrs, KeyAuth)
+
+    check:
+      client.requestedUris.len == 4
+      client.authHeaders.len == 2
+      client.authHeaders[1].startsWith(PeerIDAuthPrefix & " public-key=")
+
+  asyncTest "a bearer without an expiry is reused, not dropped":
+    await broker.sendChallenge(peerInfo, addrs, KeyAuth)
+    await broker.sendChallenge(peerInfo, addrs, KeyAuth)
+
+    check:
+      client.requestedUris.len == 3
+      client.authHeaders.len == 2
+      client.authHeaders[1] == PeerIDAuthPrefix & " bearer=\"" & client.token & "\""
+
+  asyncTest "a bearer obtained during a rejected registration is kept":
+    client.status = 500
+
+    expect(AutoTLSError):
+      await broker.sendChallenge(peerInfo, addrs, KeyAuth)
+    expect(AutoTLSError):
+      await broker.sendChallenge(peerInfo, addrs, KeyAuth)
+
+    check client.authHeaders[1] == PeerIDAuthPrefix & " bearer=\"" & client.token & "\""

--- a/tests/libp2p/autotls/test_broker.nim
+++ b/tests/libp2p/autotls/test_broker.nim
@@ -105,3 +105,17 @@ suite "AutoTLS broker":
       await broker.sendChallenge(peerInfo, addrs, KeyAuth)
 
     check client.authHeaders[1] == PeerIDAuthPrefix & " bearer=\"" & client.token & "\""
+
+  asyncTest "a 401 does not trigger re-authentication":
+    client.status = 401
+
+    expect(AutoTLSError):
+      await broker.sendChallenge(peerInfo, addrs, KeyAuth)
+    expect(AutoTLSError):
+      await broker.sendChallenge(peerInfo, addrs, KeyAuth)
+
+    # TODO: vacp2p/nim-libp2p#2972
+    check:
+      client.requestedUris.len == 3
+      client.authHeaders.len == 2
+      client.authHeaders[1] == PeerIDAuthPrefix & " bearer=\"" & client.token & "\""

--- a/tests/stubs/peer_id_auth_client_stub.nim
+++ b/tests/stubs/peer_id_auth_client_stub.nim
@@ -5,7 +5,7 @@
 
 {.push raises: [].}
 
-import base64, strutils, uri
+import base64, strutils, times, uri
 import chronos, chronos/apps/http/httpclient, stew/byteutils
 import ../../libp2p/[crypto/crypto, peeridauth/client, varint]
 import ../tools/crypto
@@ -21,10 +21,12 @@ type PeerIDAuthClientStub* = ref object of PeerIDAuthClient
   status*: int
   body*: seq[byte]
   token*: string
+  expires*: Opt[DateTime]
   wwwAuthenticate*: Opt[string]
   authenticationInfo*: Opt[string]
   requestedUris*: seq[Uri]
   payloads*: seq[string]
+  authHeaders*: seq[string]
 
 proc new*(T: typedesc[PeerIDAuthClientStub]): PeerIDAuthClientStub =
   PeerIDAuthClientStub(
@@ -33,6 +35,7 @@ proc new*(T: typedesc[PeerIDAuthClientStub]): PeerIDAuthClientStub =
     serverKey: PrivateKey.random(PKScheme.Ed25519, rng()).get(),
     status: 200,
     token: "somebearer",
+    expires: Opt.none(DateTime),
     wwwAuthenticate: Opt.none(string),
     authenticationInfo: Opt.none(string),
   )
@@ -81,6 +84,13 @@ method post*(
 ): Future[PeerIDAuthResponse] {.async: (raises: [HttpError, CancelledError]).} =
   self.requestedUris.add(uri)
   self.payloads.add(payload)
+  self.authHeaders.add(authHeader)
+
+  # a bearer-authenticated request carries no challenge to answer
+  if authHeader.extractField("bearer") != "":
+    return PeerIDAuthResponse(
+      status: self.status, headers: HttpTable.init(), body: self.body
+    )
 
   var authenticationInfo = self.authenticationInfo.valueOr:
     var clientPubkey: PublicKey
@@ -93,7 +103,12 @@ method post*(
     let sig = self.signAsServer(
       authHeader.extractField("challenge-server"), uri.hostname, clientPubkey
     )
-    PeerIDAuthPrefix & " sig=\"" & sig & "\", bearer=\"" & self.token & "\""
+    var expires = ""
+    if self.expires.isSome():
+      expires =
+        ", expires=\"" & self.expires.get().format("yyyy-MM-dd'T'HH:mm:ss") & ".000Z\""
+
+    PeerIDAuthPrefix & " sig=\"" & sig & "\", bearer=\"" & self.token & "\"" & expires
 
   var headers = HttpTable.init()
   headers.add("Authentication-Info", authenticationInfo)


### PR DESCRIPTION
## Summary

Covers the AutoTLS broker's bearer token lifecycle. `AutotlsBroker` caches the bearer from the PeerID Auth handshake and reuses it, dropping it first if it has expired.

Five tests:
- a live bearer authenticates the next registration with no second handshake
- an expired bearer is dropped and the handshake runs again
- a bearer with no `expires` is reused rather than dropped
- a bearer obtained during a rejected registration is still cached
- a 401 does not trigger re-authentication, documenting the behavior in #2972

`PeerIDAuthClientStub` gains `authHeaders`, an `expires` field, and a bearer branch in `post`.