### PR TITLE
test(autotls): PeerID Auth client

### DIFF
--- a/tests/libp2p/autotls/test_peer_id_auth.nim
+++ b/tests/libp2p/autotls/test_peer_id_auth.nim
@@ -125,7 +125,7 @@ suite "PeerID Auth Client":
       )
 
   asyncTest "bearer expiry is parsed in local time":
-    # TODO: vacp2p/nim-libp2p#NNNN
+    # TODO: vacp2p/nim-libp2p#2975
     let expires =
       (await requestWithExpires("2026-08-21T12:00:00.000Z")).bearer.expires.get()
 
@@ -133,7 +133,7 @@ suite "PeerID Auth Client":
     check expires.format("yyyy-MM-dd'T'HH:mm:ss") == "2026-08-21T12:00:00"
 
   asyncTest "bearer expiry reads a nanosecond fraction as milliseconds":
-    # TODO: vacp2p/nim-libp2p#NNNN
+    # TODO: vacp2p/nim-libp2p#2975
     let expires =
       (await requestWithExpires("2026-08-21T11:36:41.621940726Z")).bearer.expires.get()
 
@@ -141,11 +141,11 @@ suite "PeerID Auth Client":
       initDuration(milliseconds = 621_940_726)
 
   asyncTest "bearer expiry without a fractional second is dropped":
-    # TODO: vacp2p/nim-libp2p#NNNN
+    # TODO: vacp2p/nim-libp2p#2975
     check (await requestWithExpires("2026-08-21T12:00:00Z")).bearer.expires.isNone()
 
   asyncTest "bearer expiry without a zone raises IndexDefect":
-    # TODO: vacp2p/nim-libp2p#NNNN
+    # TODO: vacp2p/nim-libp2p#2975
     expect IndexDefect:
       discard await requestWithExpires("2026-08-21T12:00:00")
 

--- a/tests/libp2p/autotls/test_peer_id_auth.nim
+++ b/tests/libp2p/autotls/test_peer_id_auth.nim
@@ -131,6 +131,14 @@ suite "PeerID Auth Client":
     check expires.timezone == local()
     check expires.format("yyyy-MM-dd'T'HH:mm:ss") == "2026-08-21T12:00:00"
 
+  asyncTest "bearer expiry reads a nanosecond fraction as milliseconds":
+    # TODO: vacp2p/nim-libp2p#NNNN
+    let expires =
+      (await requestWithExpires("2026-08-21T11:36:41.621940726Z")).bearer.expires.get()
+
+    check expires - dateTime(2026, mAug, 21, 11, 36, 41, zone = local()) ==
+      initDuration(milliseconds = 621_940_726)
+
   asyncTest "bearer expiry without a fractional second is dropped":
     # TODO: vacp2p/nim-libp2p#NNNN
     check (await requestWithExpires("2026-08-21T12:00:00Z")).bearer.expires.isNone()

--- a/tests/libp2p/autotls/test_peer_id_auth.nim
+++ b/tests/libp2p/autotls/test_peer_id_auth.nim
@@ -104,7 +104,8 @@ suite "PeerID Auth Client":
       "somepayload",
     )
 
-    check client.authHeaders[0].extractField("sig") ==
+    # expected signature from peer-id-auth spec
+    check client.authField(0, "sig") ==
       "OrwJPO4buHKJdKXP2av8PFwv3XF_-m5MqndskeVV5UzufYzBCTm7RBaFnBS1sEhuQHZSZPh9RJgN5NmLzrUrBQ=="
 
   asyncTest "each handshake draws a fresh challenge-server":
@@ -112,8 +113,8 @@ suite "PeerID Auth Client":
     discard await client.send(uri, peerInfo, "somepayload")
     discard await client.send(uri, peerInfo, "somepayload")
 
-    check client.authHeaders[0].extractField("challenge-server") !=
-      client.authHeaders[1].extractField("challenge-server")
+    check client.authField(0, "challenge-server") !=
+      client.authField(1, "challenge-server")
 
   asyncTest "server signature over another challenge is rejected":
     client.challengeServer = Opt.some("someotherchallenge")
@@ -155,9 +156,7 @@ suite "PeerID Auth Client":
     let hostname = "example.com"
     let sig =
       "UA88qZbLUzmAxrD9KECbDCgSKAUBAvBHrOCF2X0uPLR1uUCF7qGfLPc7dw3Olo-LaFCDpk5sXN7TkLWPVvuXAA=="
-    let clientPublicKey = PublicKey
-      .init("080112208139770ea87d175f56a35466c34c7ecccb8d8a91b4ee37a25df60f5b8fc9b394")
-      .get()
+    let clientPublicKey = specClientKey.getPublicKey().get()
     check checkSignature(sig, serverPublicKey, challenge, clientPublicKey, hostname)
 
   asyncTest "checkSignature failed":
@@ -167,8 +166,6 @@ suite "PeerID Auth Client":
     let hostname = "example.com"
     let sig =
       "ZZZZZZZZZZZZZZZ9KECbDCgSKAUBAvBHrOCF2X0uPLR1uUCF7qGfLPc7dw3Olo-LaFCDpk5sXN7TkLWPVvuXAA=="
-    let clientPublicKey = PublicKey
-      .init("080112208139770ea87d175f56a35466c34c7ecccb8d8a91b4ee37a25df60f5b8fc9b394")
-      .get()
+    let clientPublicKey = specClientKey.getPublicKey().get()
     check checkSignature(sig, serverPublicKey, challenge, clientPublicKey, hostname) ==
       false

--- a/tests/libp2p/autotls/test_peer_id_auth.nim
+++ b/tests/libp2p/autotls/test_peer_id_auth.nim
@@ -12,8 +12,27 @@ import ../../tools/[unittest, crypto]
 import ../../stubs/peer_id_auth_client_stub
 
 suite "PeerID Auth Client":
+  # keys from the peer-id-auth spec's handshake examples
+  let
+    specServerKey = PrivateKey
+      .init(
+        "0801124001010101010101010101010101010101010101010101010101010101010101018a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
+      )
+      .get()
+    specClientKey = PrivateKey
+      .init(
+        "0801124002020202020202020202020202020202020202020202020202020202020202028139770ea87d175f56a35466c34c7ecccb8d8a91b4ee37a25df60f5b8fc9b394"
+      )
+      .get()
+
+  # RSA generation dominates the runtime of every test here, so one key for all.
+  let peerInfo =
+    try:
+      PeerInfo.new(PrivateKey.random(PKScheme.RSA, rng()).get())
+    except LPError as exc:
+      raiseAssert "could not build the client PeerInfo: " & exc.msg
+
   var client {.threadvar.}: PeerIDAuthClientStub
-  var peerInfo {.threadvar.}: PeerInfo
 
   asyncTeardown:
     await client.close()
@@ -21,7 +40,24 @@ suite "PeerID Auth Client":
 
   asyncSetup:
     client = PeerIDAuthClientStub.new()
-    peerInfo = PeerInfo.new(PrivateKey.random(PKScheme.RSA, rng()).get())
+
+  proc requestWithExpires(
+      expires: string
+  ): Future[PeerIDAuthAuthorizationResponse] {.
+      async: (raises: [PeerIDAuthError, CancelledError])
+  .} =
+    client.authenticationInfo = Opt.some(
+      "libp2p-PeerID sig=\"somesig\", bearer=\"somebearer\", expires=\"" & expires & "\""
+    )
+    await client.requestAuthorization(
+      peerInfo,
+      parseUri("https://example.com/some/uri"),
+      "some-challenge-client",
+      "some-challenge-server",
+      specServerKey.getPublicKey().get(),
+      "some-opaque",
+      "some-payload",
+    )
 
   asyncTest "request authentication":
     let serverPrivateKey = PrivateKey.random(PKScheme.RSA, rng()).get()
@@ -57,15 +93,56 @@ suite "PeerID Auth Client":
     check authorizationResponse.bearer == bearer
     check authorizationResponse.sig == sig
 
+  asyncTest "client signature matches the peer-id-auth spec vector":
+    discard await client.requestAuthorization(
+      PeerInfo.new(specClientKey),
+      parseUri("https://example.com/some/uri"),
+      "ERERERERERERERERERERERERERERERERERERERERERE=",
+      "MzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMz",
+      specServerKey.getPublicKey().get(),
+      "someopaque",
+      "somepayload",
+    )
+
+    check client.authHeaders[0].extractField("sig") ==
+      "OrwJPO4buHKJdKXP2av8PFwv3XF_-m5MqndskeVV5UzufYzBCTm7RBaFnBS1sEhuQHZSZPh9RJgN5NmLzrUrBQ=="
+
+  asyncTest "each handshake draws a fresh challenge-server":
+    let uri = parseUri("https://example.com/some/uri")
+    discard await client.send(uri, peerInfo, "somepayload")
+    discard await client.send(uri, peerInfo, "somepayload")
+
+    check client.authHeaders[0].extractField("challenge-server") !=
+      client.authHeaders[1].extractField("challenge-server")
+
+  asyncTest "server signature over another challenge is rejected":
+    client.challengeServer = Opt.some("someotherchallenge")
+
+    expect PeerIDAuthError:
+      discard await client.send(
+        parseUri("https://example.com/some/uri"), peerInfo, "somepayload"
+      )
+
+  asyncTest "bearer expiry is parsed in local time":
+    # TODO: vacp2p/nim-libp2p#NNNN
+    let expires =
+      (await requestWithExpires("2026-08-21T12:00:00.000Z")).bearer.expires.get()
+
+    check expires.timezone == local()
+    check expires.format("yyyy-MM-dd'T'HH:mm:ss") == "2026-08-21T12:00:00"
+
+  asyncTest "bearer expiry without a fractional second is dropped":
+    # TODO: vacp2p/nim-libp2p#NNNN
+    check (await requestWithExpires("2026-08-21T12:00:00Z")).bearer.expires.isNone()
+
+  asyncTest "bearer expiry without a zone raises IndexDefect":
+    # TODO: vacp2p/nim-libp2p#NNNN
+    expect IndexDefect:
+      discard await requestWithExpires("2026-08-21T12:00:00")
+
   asyncTest "checkSignature successful":
     # example from peer-id-auth spec
-    let serverPrivateKey = PrivateKey
-      .init(
-        "0801124001010101010101010101010101010101010101010101010101010101010101018a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
-      )
-      .get()
-
-    let serverPublicKey = serverPrivateKey.getPublicKey().get()
+    let serverPublicKey = specServerKey.getPublicKey().get()
     let challenge = "ERERERERERERERERERERERERERERERERERERERERERE="
     let hostname = "example.com"
     let sig =
@@ -77,12 +154,7 @@ suite "PeerID Auth Client":
 
   asyncTest "checkSignature failed":
     # example from peer-id-auth spec (but with sig altered)
-    let serverPrivateKey = PrivateKey
-      .init(
-        "0801124001010101010101010101010101010101010101010101010101010101010101018a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
-      )
-      .get()
-    let serverPublicKey = serverPrivateKey.getPublicKey().get()
+    let serverPublicKey = specServerKey.getPublicKey().get()
     let challenge = "ERERERERERERERERERERERERERERERERERERERERERE="
     let hostname = "example.com"
     let sig =

--- a/tests/stubs/peer_id_auth_client_stub.nim
+++ b/tests/stubs/peer_id_auth_client_stub.nim
@@ -43,11 +43,15 @@ proc new*(T: typedesc[PeerIDAuthClientStub]): PeerIDAuthClientStub =
     challengeServer: Opt.none(string),
   )
 
-proc extractField*(data, key: string): string =
+proc extractField(data, key: string): string =
   for segment in data.split(","):
     if key in segment:
       return segment.split("=", 1)[1].strip(chars = {' ', '"'})
   ""
+
+proc authField*(self: PeerIDAuthClientStub, index: int, key: string): string =
+  ## Reads one field back out of the Authorization header of the index'th request.
+  self.authHeaders[index].extractField(key)
 
 proc signAsServer(
     self: PeerIDAuthClientStub,

--- a/tests/stubs/peer_id_auth_client_stub.nim
+++ b/tests/stubs/peer_id_auth_client_stub.nim
@@ -16,7 +16,8 @@ const
 
 type PeerIDAuthClientStub* = ref object of PeerIDAuthClient
   ## Answers the PeerID Auth handshake as a server would, recording what was sent.
-  ## Either header can be replaced to serve a malformed or absent one instead.
+  ## Either header can be replaced to serve a malformed or absent one instead, and
+  ## `challengeServer` signs over a challenge other than the one the client sent.
   serverKey: PrivateKey
   status*: int
   body*: seq[byte]
@@ -24,6 +25,7 @@ type PeerIDAuthClientStub* = ref object of PeerIDAuthClient
   expires*: Opt[DateTime]
   wwwAuthenticate*: Opt[string]
   authenticationInfo*: Opt[string]
+  challengeServer*: Opt[string]
   requestedUris*: seq[Uri]
   payloads*: seq[string]
   authHeaders*: seq[string]
@@ -38,9 +40,10 @@ proc new*(T: typedesc[PeerIDAuthClientStub]): PeerIDAuthClientStub =
     expires: Opt.none(DateTime),
     wwwAuthenticate: Opt.none(string),
     authenticationInfo: Opt.none(string),
+    challengeServer: Opt.none(string),
   )
 
-proc extractField(data, key: string): string =
+proc extractField*(data, key: string): string =
   for segment in data.split(","):
     if key in segment:
       return segment.split("=", 1)[1].strip(chars = {' ', '"'})
@@ -100,9 +103,9 @@ method post*(
     except ValueError as exc:
       raiseAssert "stub could not read the client public key: " & exc.msg
 
-    let sig = self.signAsServer(
-      authHeader.extractField("challenge-server"), uri.hostname, clientPubkey
-    )
+    let challengeServer =
+      self.challengeServer.valueOr(authHeader.extractField("challenge-server"))
+    let sig = self.signAsServer(challengeServer, uri.hostname, clientPubkey)
     var expires = ""
     if self.expires.isSome():
       expires =


### PR DESCRIPTION
## Summary

Adds test coverage for the PeerID Auth client, which AutoTLS uses to authenticate against the registration broker. Seven new tests.

Three cover working behaviour:
- Client signature golden vector, reproducing the peer-id-auth spec's client-initiated example at `requestAuthorization`.
- Challenge freshness. Two handshakes must draw different `challenge-server` values, otherwise the server signature check is replayable.
- Server signature rejection. A server that signs over the wrong challenge must be refused, covering the `checkSignature` guard in `sendWithoutBearer`.

Four are reproduction tests for #2975. They assert the current, wrong behaviour of `parse3339DateTime`:
- offset read as local time,
- nanosecond fraction read as milliseconds,
- fraction-less timestamp silently dropped,
- and zone-less one raising `IndexDefect`.

`PeerIDAuthClientStub` gains a `challengeServer` override so it can sign over a challenge other than the one the client sent, and an `authField(index, key)` accessor for reading a field back out of a recorded Authorization header.