### PR TITLE
test(autotls): certificate expiry parsing

### DIFF
--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -3,11 +3,11 @@
 
 {.used.}
 
-import sequtils, json, uri, chronos, chronos/apps/http/httpclient
+import sequtils, json, times, uri, chronos, chronos/apps/http/httpclient
 import
   ../../../libp2p/
     [stream/connection, upgrademngrs/upgrade, autotls/acme/client, crypto/rsa, wire]
-import ../../tools/[unittest, crypto]
+import ../../tools/[unittest, cert_server, crypto]
 import ../../stubs/acme_api_stub
 
 suite "AutoTLS ACME API":
@@ -442,6 +442,31 @@ suite "AutoTLS ACME API":
     check authorizations.challenges.len == 1
     check authorizations.challenges[0].`type` == ACMEChallengeType.DNS01
     check authorizations.challenges[0].url == ChallengeURL
+
+  proc downloadWithExpires(expires: string): Future[ACMECertificateResponse] {.async.} =
+    let certServer = startCertServer(tlsCertPemGenerator())
+    defer:
+      await certServer.stop()
+
+    api.queueGetOrder(certServer.url, expires)
+    await api.downloadCertificate(parseUri(OrderURL))
+
+  asyncTest "the order's expires is parsed in local time":
+    # TODO: vacp2p/nim-libp2p#2975
+    let expiry = (await downloadWithExpires("2026-11-02T14:30:00Z")).certificateExpiry
+
+    check expiry.timezone == local()
+    check expiry.format("yyyy-MM-dd'T'HH:mm:ss") == "2026-11-02T14:30:00"
+
+  asyncTest "an expires with a fractional second is rejected":
+    # TODO: vacp2p/nim-libp2p#2975
+    expect(ACMEError):
+      discard await downloadWithExpires("2026-11-02T14:30:00.000Z")
+
+  asyncTest "an expires with a numeric UTC offset is rejected":
+    # TODO: vacp2p/nim-libp2p#2975
+    expect(ACMEError):
+      discard await downloadWithExpires("2026-11-02T14:30:00+00:00")
 
 suite "AutoTLS ACME Client":
   const CertDomain = "some.domain"

--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -3,7 +3,8 @@
 
 {.used.}
 
-import sequtils, json, times, uri, chronos, chronos/apps/http/httpclient
+import sequtils, json, uri, chronos, chronos/apps/http/httpclient
+from times import format, local, timezone, `==`
 import
   ../../../libp2p/
     [stream/connection, upgrademngrs/upgrade, autotls/acme/client, crypto/rsa, wire]
@@ -17,6 +18,7 @@ suite "AutoTLS ACME API":
   let
     key = RsaPrivateKey.random(rng()).get()
     certKey = RsaPrivateKey.random(rng()).get()
+    certPem = tlsCertPemGenerator()
 
   var api {.threadvar.}: ACMEApiStub
 
@@ -444,7 +446,7 @@ suite "AutoTLS ACME API":
     check authorizations.challenges[0].url == ChallengeURL
 
   proc downloadWithExpires(expires: string): Future[ACMECertificateResponse] {.async.} =
-    let certServer = startCertServer(tlsCertPemGenerator())
+    let certServer = startCertServer(certPem)
     defer:
       await certServer.stop()
 

--- a/tests/libp2p/autotls/test_service.nim
+++ b/tests/libp2p/autotls/test_service.nim
@@ -4,7 +4,7 @@
 {.used.}
 
 import chronos, json, net, results, sequtils, uri
-from times import now, initDuration, `+`
+from times import now, format, initDuration, `+`
 import
   ../../../libp2p/[
     autotls/service,
@@ -161,13 +161,14 @@ suite "AutoTLS certificate issuance and renewal":
     check parseJson(authClient.payloads[0])["addresses"] == %AnnouncedAddrs
 
   asyncTest "a certificate is issued, installed, and not issued again":
+    const OrderExpires = "2099-01-01T00:00:00Z"
     let certPem = tlsCertPemGenerator()
     let certServer = startCertServer(certPem)
     defer:
       await certServer.stop()
 
     acmeApi.scriptChallenge(ChallengeToken)
-    acmeApi.scriptCertificate(certServer.url, initDuration(days = 365))
+    acmeApi.scriptCertificate(certServer.url, OrderExpires)
 
     # issueRetries must be higher than zero to prove it's done only once
     service = newService(
@@ -184,7 +185,7 @@ suite "AutoTLS certificate issuance and renewal":
     service.config.nameResolver = resolver
 
     await service.start(switch)
-    discard await service.getCertWhenReady().wait(10.seconds)
+    let autotlsCert = await service.getCertWhenReady().wait(10.seconds)
     # Nothing signals a round that ended, so wait out a three retries window.
     await sleepAsync(50.milliseconds)
 
@@ -192,6 +193,8 @@ suite "AutoTLS certificate issuance and renewal":
     check:
       # One round is 8 requests, so more would be a second attempt.
       acmeApi.requestedUris.len == 8
+      # TODO: vacp2p/nim-libp2p#2977
+      autotlsCert.expiry.format("yyyy-MM-dd'T'HH:mm:ss'Z'") == OrderExpires
       resolver.txtQueries == @["_acme-challenge." & baseDomain]
       resolver.ipQueries == @["127-0-0-1." & baseDomain]
       parseJson(authClient.payloads[0])["value"].getStr == keyAuth

--- a/tests/stubs/acme_api_stub.nim
+++ b/tests/stubs/acme_api_stub.nim
@@ -6,7 +6,6 @@
 {.push raises: [].}
 
 import base64, json, uri
-from times import Duration, now, format, `+`
 import chronos, chronos/apps/http/httpclient
 import ../../libp2p/autotls/acme/[api, utils]
 
@@ -104,23 +103,23 @@ proc scriptChallenge*(self: ACMEApiStub, token: string) =
     %*[{"url": ChallengeURL, "type": "dns-01", "status": "pending", "token": token}]
   )
 
-proc scriptCertificate*(
-    self: ACMEApiStub, certificateURL: string, expiresIn: times.Duration
-) =
-  ## Queues the five responses `getCertificate` consumes, ending in an order whose
-  ## certificate is served from `certificateURL`.
-  self.queueChallengeCompleted()
-  self.queueStatus("valid") # checkChallengeCompleted
-  self.queueStatus("valid") # requestFinalize
-  self.queueStatus("valid") # checkCertFinalized
-
-  let expires = (now() + expiresIn).format("yyyy-MM-dd'T'HH:mm:ss'Z'")
+proc queueGetOrder*(self: ACMEApiStub, certificateURL: string, expires: string) =
+  ## Queues the response `requestGetOrder` consumes.
   self.mockedResponses.add(
     HTTPResponse(
       body: %*{"certificate": certificateURL, "expires": expires},
       headers: HttpTable.init(),
     )
   )
+
+proc scriptCertificate*(self: ACMEApiStub, certificateURL: string, expires: string) =
+  ## Queues the five responses `getCertificate` consumes, ending in an order whose
+  ## certificate is served from `certificateURL`.
+  self.queueChallengeCompleted()
+  self.queueStatus("valid") # checkChallengeCompleted
+  self.queueStatus("valid") # requestFinalize
+  self.queueStatus("valid") # checkCertFinalized
+  self.queueGetOrder(certificateURL, expires)
 
 proc respond(
     self: ACMEApiStub, uri: Uri

--- a/tests/stubs/acme_api_stub.nim
+++ b/tests/stubs/acme_api_stub.nim
@@ -95,14 +95,6 @@ proc queueStatus*(self: ACMEApiStub, status: string) =
     )
   )
 
-proc scriptChallenge*(self: ACMEApiStub, token: string) =
-  ## Queues the three responses `getChallenge` consumes, carrying `token` in the challenge.
-  self.queueRegister()
-  self.queueOrder("pending", %*[AuthorizationsURL])
-  self.queueChallenges(
-    %*[{"url": ChallengeURL, "type": "dns-01", "status": "pending", "token": token}]
-  )
-
 proc queueGetOrder*(self: ACMEApiStub, certificateURL: string, expires: string) =
   ## Queues the response `requestGetOrder` consumes.
   self.mockedResponses.add(
@@ -110,6 +102,14 @@ proc queueGetOrder*(self: ACMEApiStub, certificateURL: string, expires: string) 
       body: %*{"certificate": certificateURL, "expires": expires},
       headers: HttpTable.init(),
     )
+  )
+
+proc scriptChallenge*(self: ACMEApiStub, token: string) =
+  ## Queues the three responses `getChallenge` consumes, carrying `token` in the challenge.
+  self.queueRegister()
+  self.queueOrder("pending", %*[AuthorizationsURL])
+  self.queueChallenges(
+    %*[{"url": ChallengeURL, "type": "dns-01", "status": "pending", "token": token}]
   )
 
 proc scriptCertificate*(self: ACMEApiStub, certificateURL: string, expires: string) =


### PR DESCRIPTION
## Summary

Three tests in `test_autotls.nim` cover the ACME half of #2975. 

One assertion in `test_service.nim` covers #2977.