### PR TITLE
chore(pubsub): `sendResponse` improvement

### DIFF
--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -679,7 +679,11 @@ proc sendResponse*(
     trace "sending response msg to peer", peer = p, rpcMsg = shortLog(toSendMsg)
     p.trackSend(p.sendEncoded(move(encoded), priority, useCustomStream))
 
-  if msg.encodedSize() <= p.maxMessageSize:
+  template wireSize(toSizeMsg: RPCMsg): int =
+    toSizeMsg.anonymize(anonymize).encodedSize()
+
+  let msgSize = wireSize(msg)
+  if msgSize <= p.maxMessageSize:
     send(msg) # The whole RPC fits the limits, send it as-is.
     return
 
@@ -687,7 +691,7 @@ proc sendResponse*(
     # Nothing to split and nothing to send - the RPC only carries non-message
     # data that still exceeds `maxMessageSize`.
     warn "message exceeds maximum message size and contains no messages; message will not be sent",
-      encodedSize = msg.encodedSize(), maxMessageSize = p.maxMessageSize
+      encodedSize = msgSize, maxMessageSize = p.maxMessageSize
     return
 
   # Batch as many messages as possible into a single encoded RPC so that each
@@ -695,13 +699,13 @@ proc sendResponse*(
   # first batch only, so they are neither lost nor duplicated.
   var batch = msg
   batch.messages.setLen(0)
-  let firstBatchSize = batch.encodedSize()
+  let firstBatchSize = wireSize(batch)
   var isFirstBatch = true
 
   for m in msg.messages:
     batch.messages.add(m)
 
-    if batch.encodedSize() <= p.maxMessageSize:
+    if wireSize(batch) <= p.maxMessageSize:
       continue
 
     # The last message caused an overflow, send the batch without it.
@@ -721,9 +725,9 @@ proc sendResponse*(
     isFirstBatch = false
     batch.messages.add(m)
 
-    if batch.encodedSize() > p.maxMessageSize:
+    let messageSize = wireSize(batch)
+    if messageSize > p.maxMessageSize:
       # The message alone exceeds `maxMessageSize`.
-      let messageSize = batch.encodedSize()
       discard batch.messages.pop()
       warn "message exceeds maximum message size; message will not be sent",
         messageSize = messageSize, maxMessageSize = p.maxMessageSize

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -666,44 +666,70 @@ proc sendResponse*(
 ) {.raises: [].} =
   ## Sends a protocol response `RPCMsg` to this peer, batching multi-message
   ## responses together so that none exceed `maxMessageSize`.
-  ## Batching is only performed for message-only RPCs - if the RPC carries other
-  ## data (subscriptions, control or extensions), it is sent as-is.
   ##
-  ## This is an internal, protocol-facing send path - individual messages that
-  ## still exceed `maxMessageSize` are silently dropped.
+  ## The RPC is sent as-is when it fits within `maxMessageSize`. Otherwise, when
+  ## it contains messages, the messages are split into batches. Non-message
+  ## fields (subscriptions, control and extensions) are attached to the first
+  ## batch so they are not lost. RPCs without messages that still exceed
+  ## `maxMessageSize`, and individual messages that still exceed
+  ## `maxMessageSize`, are dropped with a warning.
 
   proc send(toSendMsg: RPCMsg) =
     var encoded = encodeRpcMsg(p, toSendMsg, anonymize)
     trace "sending response msg to peer", peer = p, rpcMsg = shortLog(toSendMsg)
     p.trackSend(p.sendEncoded(move(encoded), priority, useCustomStream))
 
-  if msg.messages.len > 1 and msg.hasOnlyMessages():
-    # Batch as many messages as possible into a single encoded RPC instead of
-    # encoding one RPC per message. 
-    var batch = RPCMsg()
+  if msg.encodedSize() <= p.maxMessageSize:
+    send(msg) # The whole RPC fits the limits, send it as-is.
+    return
 
-    for m in msg.messages:
-      batch.messages.add(m)
+  if msg.messages.len == 0:
+    # Nothing to split and nothing to send - the RPC only carries non-message
+    # data that still exceeds `maxMessageSize`.
+    warn "message exceeds maximum message size and contains no messages; message will not be sent",
+      encodedSize = msg.encodedSize(), maxMessageSize = p.maxMessageSize
+    return
 
-      if batch.messages.len > 0 and batch.encodedSize() > p.maxMessageSize:
-        # Last message has caused overflow, send batch without last message
-        discard batch.messages.pop()
+  # Batch as many messages as possible into a single encoded RPC so that each
+  # batch stays within `maxMessageSize`. Non-message fields are carried by the
+  # first batch only, so they are neither lost nor duplicated.
+  var batch = msg
+  batch.messages.setLen(0)
+  let firstBatchSize = batch.encodedSize()
+  var isFirstBatch = true
 
-        if batch.messages.len > 0:
-          # Send batch only if there were some messages
-          send(batch)
+  for m in msg.messages:
+    batch.messages.add(m)
 
-        batch = RPCMsg()
-        batch.messages.add(m)
+    if batch.encodedSize() <= p.maxMessageSize:
+      continue
 
-        if batch.encodedSize() > p.maxMessageSize:
-          # Last message was alone larger then max message size
-          discard batch.messages.pop()
+    # The last message caused an overflow, send the batch without it.
+    discard batch.messages.pop()
 
     if batch.messages.len > 0:
       send(batch)
-  else:
-    send(msg)
+    elif isFirstBatch and firstBatchSize > p.maxMessageSize:
+      warn "RPC non-message fields exceed maximum message size; they will not be sent",
+        encodedSize = firstBatchSize, maxMessageSize = p.maxMessageSize
+    elif isFirstBatch and firstBatchSize > 0:
+      # No message fits alongside the non-message fields. Send them on their own
+      # so they are not lost.
+      send(batch)
+
+    batch = RPCMsg()
+    isFirstBatch = false
+    batch.messages.add(m)
+
+    if batch.encodedSize() > p.maxMessageSize:
+      # The message alone exceeds `maxMessageSize`.
+      let messageSize = batch.encodedSize()
+      discard batch.messages.pop()
+      warn "message exceeds maximum message size; message will not be sent",
+        messageSize = messageSize, maxMessageSize = p.maxMessageSize
+
+  if batch.messages.len > 0:
+    send(batch)
 
 proc canAskIWant*(p: PubSubPeer, msgId: MessageId): bool =
   for sentIHave in p.sentIHaves.mitems():

--- a/libp2p/protocols/pubsub/rpc/messages.nim
+++ b/libp2p/protocols/pubsub/rpc/messages.nim
@@ -487,11 +487,6 @@ func anonymize*(msg: RPCMsg, anonymize: bool): RPCMsg =
   else:
     msg
 
-func hasOnlyMessages*(msg: RPCMsg): bool =
-  msg.subscriptions.len == 0 and msg.control.isNone and
-    msg.partialMessageExtension.isNone and msg.testExtension.isNone and
-    msg.pingpongExtension.isNone and msg.preambleExtension.isNone
-
 func validate*(sub: SubOpts): Result[void, string] =
   if sub.topic.isNone:
     return err("Subsciption topic must be set")

--- a/tests/libp2p/pubsub/test_message.nim
+++ b/tests/libp2p/pubsub/test_message.nim
@@ -347,30 +347,3 @@ suite "Message":
     let rpc = RPCMsg(subscriptions: @[SubOpts(subscribe: true, topic: topic)])
     let anon = rpc.anonymize(true)
     check anon.messages.len == 0
-
-  test "hasOnlyMessages - message-only RPC returns true":
-    let rpc = RPCMsg.withMessages(@[Message(topic: topic), Message(topic: topic)])
-    check rpc.hasOnlyMessages()
-
-  test "hasOnlyMessages - empty RPC returns true":
-    check RPCMsg().hasOnlyMessages()
-
-  test "hasOnlyMessages - false when any non-message field is set":
-    # Reflection guard: iterate every RPCMsg field except `messages`, set it to a
-    # non-empty value, and assert `hasOnlyMessages` returns false. If a new field
-    # is added to RPCMsg in the future and `hasOnlyMessages` is not updated to
-    # account for it, this test fails.
-    var rpc = RPCMsg()
-    for name, value in fieldPairs(rpc):
-      when name != "messages":
-        when compiles(value.isSome): # Opt field (control/extensions)
-          value = Opt.some(default(typeof(value.get())))
-          check not rpc.hasOnlyMessages()
-          value = Opt.none(typeof(value.get()))
-        elif compiles(value.len): # seq field (subscriptions)
-          value = @[default(typeof(value[0]))]
-          check not rpc.hasOnlyMessages()
-          value.setLen(0)
-        else:
-          doAssert false, "RPCMsg field '" & name & "' has an unsupported type"
-    check rpc.hasOnlyMessages()

--- a/tests/libp2p/pubsub/test_priority_queues.nim
+++ b/tests/libp2p/pubsub/test_priority_queues.nim
@@ -450,6 +450,8 @@ suite "PubSubPeer sendResponse":
   teardown:
     checkTrackers()
 
+  const topic = "🌞"
+
   asyncTest "sendResponse sends a fitting RPC as-is":
     let peer = createTestPeer(maxMessageSize = 4096)
     let conn = createRecorderConnection()
@@ -458,10 +460,10 @@ suite "PubSubPeer sendResponse":
       peer.stopTasks()
 
     let msg = RPCMsg(
-      control: Opt.some(ControlMessage(graft: @[ControlGraft(topicID: "topic")])),
+      control: Opt.some(ControlMessage(graft: @[ControlGraft(topicID: topic)])),
       messages: @[
-        Message(data: @[1'u8, 2, 3], topic: "topic"),
-        Message(data: @[4'u8, 5, 6], topic: "topic"),
+        Message(data: @[1'u8, 2, 3], topic: topic),
+        Message(data: @[4'u8, 5, 6], topic: topic),
       ],
     )
 
@@ -475,7 +477,6 @@ suite "PubSubPeer sendResponse":
 
   asyncTest "sendResponse batches an oversized RPC, keeping non-message fields in the first batch":
     let
-      topic = "t"
       control = ControlMessage(graft: @[ControlGraft(topicID: topic)])
       m1 = Message(data: newSeq[byte](50), topic: topic)
       m2 = Message(data: newSeq[byte](60), topic: topic)
@@ -495,8 +496,6 @@ suite "PubSubPeer sendResponse":
 
     check:
       conn.writes.len == 2
-      conn.writes[0].len <= maxSize
-      conn.writes[1].len <= maxSize
       conn.writes[0] == firstBatch.encode(false)
       conn.writes[1] == RPCMsg(messages: @[m2]).encode(false)
 
@@ -504,7 +503,6 @@ suite "PubSubPeer sendResponse":
 
   asyncTest "sendResponse drops an oversized message but still sends non-message fields":
     let
-      topic = "t"
       control = ControlMessage(graft: @[ControlGraft(topicID: topic)])
       oversized = Message(data: newSeq[byte](200), topic: topic)
       controlOnly = RPCMsg(control: Opt.some(control))
@@ -527,7 +525,7 @@ suite "PubSubPeer sendResponse":
   asyncTest "sendResponse drops an oversized RPC with no messages":
     var grafts: seq[ControlGraft]
     for i in 0 ..< 20:
-      grafts.add(ControlGraft(topicID: "topic" & $i))
+      grafts.add(ControlGraft(topicID: topic & $i))
 
     let
       control = ControlMessage(graft: grafts)

--- a/tests/libp2p/pubsub/test_priority_queues.nim
+++ b/tests/libp2p/pubsub/test_priority_queues.nim
@@ -6,6 +6,7 @@
 import chronos
 import ../../../libp2p/protocols/pubsub/pubsubpeer
 import ../../../libp2p/protocols/pubsub/gossipsub/types
+import ../../../libp2p/protocols/pubsub/rpc/[messages, protobuf]
 import ../../../libp2p/peerid
 import ../../../libp2p/utils/future
 import ../../tools/[unittest, crypto]
@@ -444,3 +445,101 @@ suite "Priority queue behavior":
       lowBlockedByMedium.priority == MessagePriority.Low
       lowBlockedByMedium.send == true
       lowBlockedByMedium.slowPeerPenaltyDelta == 0.0
+
+suite "PubSubPeer sendResponse":
+  teardown:
+    checkTrackers()
+
+  asyncTest "sendResponse sends a fitting RPC as-is":
+    let peer = createTestPeer(maxMessageSize = 4096)
+    let conn = createRecorderConnection()
+    peer.sendStream = conn
+    defer:
+      peer.stopTasks()
+
+    let msg = RPCMsg(
+      control: Opt.some(ControlMessage(graft: @[ControlGraft(topicID: "topic")])),
+      messages: @[
+        Message(data: @[1'u8, 2, 3], topic: "topic"),
+        Message(data: @[4'u8, 5, 6], topic: "topic"),
+      ],
+    )
+
+    peer.sendResponse(msg, false, MessagePriority.High)
+
+    check:
+      conn.writes.len == 1
+      conn.writes[0] == msg.encode(false)
+
+    conn.releaseFirstWrite()
+
+  asyncTest "sendResponse batches an oversized RPC, keeping non-message fields in the first batch":
+    let
+      topic = "t"
+      control = ControlMessage(graft: @[ControlGraft(topicID: topic)])
+      m1 = Message(data: newSeq[byte](50), topic: topic)
+      m2 = Message(data: newSeq[byte](60), topic: topic)
+
+    let
+      firstBatch = RPCMsg(control: Opt.some(control), messages: @[m1])
+      fullMsg = RPCMsg(control: Opt.some(control), messages: @[m1, m2])
+      maxSize = fullMsg.encodedSize() - 1
+
+    let peer = createTestPeer(maxMessageSize = maxSize)
+    let conn = createRecorderConnection()
+    peer.sendStream = conn
+    defer:
+      peer.stopTasks()
+
+    peer.sendResponse(fullMsg, false, MessagePriority.High)
+
+    check:
+      conn.writes.len == 2
+      conn.writes[0].len <= maxSize
+      conn.writes[1].len <= maxSize
+      conn.writes[0] == firstBatch.encode(false)
+      conn.writes[1] == RPCMsg(messages: @[m2]).encode(false)
+
+    conn.releaseFirstWrite()
+
+  asyncTest "sendResponse drops an oversized message but still sends non-message fields":
+    let
+      topic = "t"
+      control = ControlMessage(graft: @[ControlGraft(topicID: topic)])
+      oversized = Message(data: newSeq[byte](200), topic: topic)
+      controlOnly = RPCMsg(control: Opt.some(control))
+      fullMsg = RPCMsg(control: Opt.some(control), messages: @[oversized])
+
+    let peer = createTestPeer(maxMessageSize = controlOnly.encodedSize())
+    let conn = createRecorderConnection()
+    peer.sendStream = conn
+    defer:
+      peer.stopTasks()
+
+    peer.sendResponse(fullMsg, false, MessagePriority.High)
+
+    check:
+      conn.writes.len == 1
+      conn.writes[0] == controlOnly.encode(false)
+
+    conn.releaseFirstWrite()
+
+  asyncTest "sendResponse drops an oversized RPC with no messages":
+    var grafts: seq[ControlGraft]
+    for i in 0 ..< 20:
+      grafts.add(ControlGraft(topicID: "topic" & $i))
+
+    let
+      control = ControlMessage(graft: grafts)
+      msg = RPCMsg(control: Opt.some(control))
+      maxSize = msg.encodedSize() - 1
+
+    let peer = createTestPeer(maxMessageSize = maxSize)
+    let conn = createRecorderConnection()
+    peer.sendStream = conn
+    defer:
+      peer.stopTasks()
+
+    peer.sendResponse(msg, false, MessagePriority.High)
+
+    check conn.writes.len == 0

--- a/tests/libp2p/pubsub/test_priority_queues.nim
+++ b/tests/libp2p/pubsub/test_priority_queues.nim
@@ -475,6 +475,27 @@ suite "PubSubPeer sendResponse":
 
     conn.releaseFirstWrite()
 
+  asyncTest "sendResponse sizes an anonymized RPC after anonymization":
+    let msg = RPCMsg.withMessages(
+      @[Message(data: @[1'u8, 2, 3], topic: topic, signature: newSeq[byte](200))]
+    )
+    let encoded = msg.encode(true)
+    check msg.encodedSize() > encoded.len
+
+    let peer = createTestPeer(maxMessageSize = encoded.len)
+    let conn = createRecorderConnection()
+    peer.sendStream = conn
+    defer:
+      peer.stopTasks()
+
+    peer.sendResponse(msg, true, MessagePriority.High)
+
+    check:
+      conn.writes.len == 1
+      conn.writes[0] == encoded
+
+    conn.releaseFirstWrite()
+
   asyncTest "sendResponse batches an oversized RPC, keeping non-message fields in the first batch":
     let
       control = ControlMessage(graft: @[ControlGraft(topicID: topic)])


### PR DESCRIPTION
made logic more intuitive. general improvements to message batching (splitting). 