### PR TITLE
fix(stream): free the read buffer when a BufferStream closes

### DIFF
--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -148,6 +148,8 @@ method closeImpl*(s: BufferStream): Future[void] {.async: (raises: [], raw: true
   s.isEof = true
   s.pushedEof = true
 
+  s.readBuf.clear()
+
   # Essentially we need to handle the following cases
   #
   # - If a push was in progress but no reader is

--- a/tests/libp2p/muxers/test_mplex.nim
+++ b/tests/libp2p/muxers/test_mplex.nim
@@ -424,6 +424,23 @@ suite "Mplex":
 
       await conn.close()
 
+    asyncTest "reset should clear buffered data":
+      let
+        conn = TestBufferStream.new(noopWriteHandler)
+        chann = LPChannel.init(1, conn, true)
+
+      await chann.pushData(@[0'u8, 1, 2, 3, 4])
+      var first: array[1, byte]
+      check 1 == await chann.readOnce(addr first[0], first.len)
+      check chann.len == 4
+
+      await chann.reset()
+
+      check chann.len == 0
+      check chann.atEof()
+
+      await conn.close()
+
     asyncTest "channel should reset on timeout":
       let
         conn = TestBufferStream.new(noopWriteHandler)

--- a/tests/libp2p/stream/test_bufferstream.nim
+++ b/tests/libp2p/stream/test_bufferstream.nim
@@ -252,3 +252,31 @@ suite "BufferStream":
     check (await readFut) == 0
     check stream.closed
     check await stream.closeWithEOF().withTimeout(100.milliseconds)
+
+  asyncTest "close clears the read buffer":
+    let stream = BufferStream.new()
+    await stream.pushData("12345".toBytes())
+
+    var first: array[1, byte]
+    check 1 == await stream.readOnce(addr first[0], first.len)
+    check stream.len == 4
+
+    await stream.close()
+
+    check stream.len == 0
+    check stream.atEof()
+
+  asyncTest "close completes a parked reader with EOF":
+    let stream = BufferStream.new()
+    await stream.pushData("12345".toBytes())
+
+    var first: array[1, byte]
+    check 1 == await stream.readOnce(addr first[0], first.len)
+
+    var rest: array[10, byte]
+    let readFut = stream.readOnce(addr rest[0], rest.len)
+
+    await stream.close()
+
+    check await readFut.withTimeout(100.milliseconds)
+    check (await readFut) == 0


### PR DESCRIPTION
## Summary

`BufferStream.closeImpl` says "close the stream and clear the buffer", but it never clears `readBuf`. The buffered bytes stay resident for as long as anything holds the stream. For an `LPChannel` that means a channel which mplex already reset keeps its payload, because a reset channel is still a channel that somebody can hold.

`0d8ccf276` (#2901) made this visible. Kademlia now keeps one long-lived stream per peer, so `PeerMessageSender.stream` holds a channel that mplex reset. A reply that arrived after its RPC timed out is exactly the payload that sits in `readBuf`. The kad sender drops that reference on its next send to the peer, when `prepStream` calls `discardStream` (`libp2p/protocols/kademlia/message_sender.nim:73`), so the bytes live until the next send. For an idle peer, that is no deadline at all.

`readBuf` also decides `atEof` (`bufferstream.nim:102`: `s.isEof and s.readBuf.isEmpty`), so a reset channel that still holds bytes never reports EOF. `Connection.pollActivity` (`libp2p/stream/connection.nim:107`) stops monitoring only on `s.closed and s.atEof`, so the timeout monitor keeps polling a dead channel and keeps holding it.

The fix is one line in `closeImpl`, after `s.isEof = true` and `s.pushedEof = true`:

```nim
s.readBuf.clear()
```

`clear` is `libp2p/utils/zeroqueue.nim:27`. It drops the chunks and zeroes `queuedBytes`.

## Affected Areas

- [x] Protocol Logic
  Stream layer: `BufferStream.closeImpl`. `LPChannel` inherits it, so every mplex channel close and reset now frees its read buffer.

- [ ] Gossipsub
- [ ] Transports
- [ ] Peer Management / Discovery
- [ ] Build / Tooling

## Compatibility & Downstream Validation

No downstream integration run yet. The change is one line in a method that every muxed stream reaches, so a reviewer may want a Nimbus or Waku build before this merges. Ask and I will drive one.

- **Nimbus:** not run
- **Waku:** not run
- **Codex:** not run

The nim-libp2p suites for the touched paths pass: 16/16 in `tests/libp2p/stream/test_bufferstream.nim` and 44/44 in `tests/libp2p/muxers/test_mplex.nim`.

## Impact on Library Users

No API change. One behavior change: a reader that is parked in `readOnce` when the stream closes now gets a 0-byte read (EOF) instead of the bytes that were still in `readBuf`.

Memory use goes down for any code that holds a closed or reset stream. `atEof()` becomes true as soon as the stream closes, so a reset channel stops looking half-alive to the timeout monitor.

## Risk Assessment

The parked-reader case above is the only visible change, and it is limited to reset and forced close. A graceful close reaches `closeImpl` through `LPChannel.closeUnderlying()` (`libp2p/muxers/mplex/lpchannel.nim:91`) only when `atEof()` already holds, and then `readBuf` is empty. `tests/libp2p/muxers/test_mplex.nim:121` "(local close) - should allow reads until remote closes" already covers that path: it pushes data, calls `close()`, and reads every byte back. On reset, libp2p discards stream data anyway.

`clear()` frees the chunks, it does not wipe them. Plaintext stays readable in the freed block until the allocator reuses it. A wipe is a separate change and it is not safe to add here, because `clone()` (`zeroqueue.nim:11`) lets two chunks share one `data` seq, so a wipe can hit a chunk a reader still holds.

This frees the payload, not the channel. `PeerMessageSender.stream` still pins the `LPChannel` object and its `conn` reference until the next `prepStream` for that peer.

The patch does not touch the path from #2946, which serves buffered data after the connection drops. That path works on a channel that is not closed yet.

Wire format and network behavior are untouched.

## References

- #2901 (`0d8ccf276`) gave Kademlia one long-lived stream per peer, which exposed this.
- #2946 changed `LPChannel.readOnce` to serve buffered data after the connection drops. This PR is independent of it.

## Additional Notes

Three tests cover the change, and all three fail without the one-line fix:

- `test_bufferstream.nim` "close clears the read buffer": `len == 0` and `atEof()` after `close()`.
- `test_bufferstream.nim` "close completes a parked reader with EOF": the parked reader returns 0 instead of the leftover bytes. This pins the behavior change named under Risk Assessment.
- `test_mplex.nim` "reset should clear buffered data": `chann.len == 0` and `chann.atEof()` after `reset()`.

Each test reads one byte before it closes the stream. A plain `pushData` with nobody reading parks the data in `readQueue`, not in `readBuf`, and `s.len` counts `readQueue[0]` too. The partial read moves the rest into `readBuf`, which is the buffer this patch frees.

The `Run AutoNATv2 interoperability tests` job is red for a reason outside this diff. It dies in `waitForTCPServer` (`libp2p/utils/future.nim:129`), which is 20 retries at 500ms against the Go peer's TCP port: `[Exec]` at `18:10:23.9`, `timeout waiting for service` at `18:10:33.95`, exactly 10 seconds of raw `connect()` with no libp2p stream open on either side. It needs a rerun.

The same patch applies to `release/v2.3`, where the file is identical.
