### PR TITLE
test(transports): quic dialer does not observe a remote connection close

### DIFF
--- a/tests/libp2p/test_dialer.nim
+++ b/tests/libp2p/test_dialer.nim
@@ -54,6 +54,7 @@ suite "Dialer":
     await allFutures(src.stop(), dst.stop())
 
   asyncTest "Max connections reached":
+    # TODO: vacp2p/nim-lsquic#162
     var switches: seq[Switch]
 
     let dst = makeStandardSwitchBuilder()

--- a/tests/libp2p/transports/test_quic.nim
+++ b/tests/libp2p/transports/test_quic.nim
@@ -348,6 +348,9 @@ suite "Quic transport":
     # TODO: vacp2p/nim-lsquic#162
     let server = await createQuicTransport(isServer = true)
     let client = await createQuicTransport()
+    defer:
+      await client.stop()
+      await server.stop()
 
     let acceptFut = server.accept()
     let clientConn = await client.dial("", server.addrs[0])
@@ -357,11 +360,16 @@ suite "Quic transport":
     await serverConn.close()
 
     let muxer = QuicMuxer.new(clientConn)
+    defer:
+      await muxer.close()
+
     let stream = await muxer.newStream()
     await stream.write("client")
 
     var response: array[1, byte]
     let readFut = stream.readOnce(addr response[0], response.len)
+    defer:
+      await readFut.cancelAndWait()
 
     # a CONNECTION_CLOSE crosses loopback in well under a millisecond
     # the dialer instead waits out lsquic's 30s idle timeout
@@ -369,11 +377,6 @@ suite "Quic transport":
       not (await readFut.withTimeout(1.seconds))
       serverConn.closed
       not clientConn.closed
-
-    await readFut.cancelAndWait()
-    await muxer.close()
-    await client.stop()
-    await server.stop()
 
   asyncTest "stream idle timeout resets only the idle stream":
     let server = await createQuicTransport(

--- a/tests/libp2p/transports/test_quic.nim
+++ b/tests/libp2p/transports/test_quic.nim
@@ -359,7 +359,7 @@ suite "Quic transport":
     # what the switch does when the incoming connection limit is reached
     await serverConn.close()
 
-    let muxer = QuicMuxer.new(clientConn)
+    let muxer = await client.upgrade(clientConn, Opt.none(PeerId))
     defer:
       await muxer.close()
 

--- a/tests/libp2p/transports/test_quic.nim
+++ b/tests/libp2p/transports/test_quic.nim
@@ -344,6 +344,37 @@ suite "Quic transport":
     expect QuicTransportAcceptStopped:
       discard await server.accept()
 
+  asyncTest "remote connection close leaves the dialer with a live session":
+    # TODO: vacp2p/nim-lsquic#162
+    let server = await createQuicTransport(isServer = true)
+    let client = await createQuicTransport()
+
+    let acceptFut = server.accept()
+    let clientConn = await client.dial("", server.addrs[0])
+    let serverConn = await acceptFut
+
+    # what the switch does when the incoming connection limit is reached
+    await serverConn.close()
+
+    let muxer = QuicMuxer.new(clientConn)
+    let stream = await muxer.newStream()
+    await stream.write("client")
+
+    var response: array[1, byte]
+    let readFut = stream.readOnce(addr response[0], response.len)
+
+    # a CONNECTION_CLOSE crosses loopback in well under a millisecond
+    # the dialer instead waits out lsquic's 30s idle timeout
+    check:
+      not (await readFut.withTimeout(1.seconds))
+      serverConn.closed
+      not clientConn.closed
+
+    await readFut.cancelAndWait()
+    await muxer.close()
+    await client.stop()
+    await server.stop()
+
   asyncTest "stream idle timeout resets only the idle stream":
     let server = await createQuicTransport(
       isServer = true, inTimeout = 2.seconds, outTimeout = 3.seconds


### PR DESCRIPTION
## Summary

Pins that the dialer does not see when a peer closes a QUIC connection. The `serverConn.close()` in the test is what `switch.nim` does when `tryGetIncomingSlot` fails, so this is the path a switch takes to reject a dial once it is at its connection limit. The dialer goes on reporting a live connection for 30 seconds, hands it to callers, and lets them write into it.

The assertions describe the current behaviour, so this test starts failing once https://github.com/vacp2p/nim-lsquic/issues/162 is fixed and has to be updated along with it.

## Additional Notes

`Dialer :: Max connections reached` in `tests/libp2p/test_dialer.nim` asserts the third dial is still pending after 1s, which holds only while this behaviour does. It runs over QUIC because `makeStandardSwitch()` defaults to `QuicAutoAddress`, so it needs changing in the same PR that fixes the lsquic side.

## Related

https://github.com/vacp2p/nim-libp2p/issues/2985