### PR TITLE
test(autotls): certificate renewal is not propagated to the wss listener

### DIFF
--- a/tests/libp2p/transports/test_ws.nim
+++ b/tests/libp2p/transports/test_ws.nim
@@ -4,6 +4,7 @@
 {.used.}
 
 import chronos, stew/byteutils
+from times import now
 import
   ../../../libp2p/[
     autotls/service,
@@ -358,3 +359,37 @@ suite "WebSocket transport with autotls":
 
     let startFut = wstransport.start(ma)
     check not (await startFut.withTimeout(200.milliseconds))
+
+  asyncTest "a renewed certificate does not reach a running transport":
+    # TODO: vacp2p/nim-libp2p#2994
+    let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0/tls/ws").tryGet()]
+
+    let autotls = AutotlsService(
+      cert: Opt.some(AutotlsCert.new(secureCert, secureKey, now())),
+      certReady: newAsyncEvent(),
+      running: newAsyncEvent(),
+    )
+    autotls.running.fire()
+    autotls.certReady.fire()
+
+    let wstransport = WsTransport.new(
+      Upgrade(),
+      nil, # TLSPrivateKey
+      nil, # TLSCertificate
+      Opt.some(autotls),
+      rng(),
+    )
+    await wstransport.start(ma)
+    defer:
+      await wstransport.stop()
+
+    check wstransport.tlsCertificate == secureCert
+
+    # what issueCertificate does once a renewal completes
+    let (renewedKey, renewedCert) = tlsCertGenerator()
+    autotls.cert = Opt.some(AutotlsCert.new(renewedCert, renewedKey, now()))
+    autotls.certReady.fire()
+
+    check:
+      wstransport.tlsCertificate == secureCert
+      wstransport.tlsPrivateKey == secureKey


### PR DESCRIPTION
## Summary

Pins the behaviour reported in #2994. `AutotlsService` keeps renewing its certificate on the management heartbeat, but `WsTransport` copies the certificate into its own fields once at `start` and never reads the service again, so a listener that stays up serves its day-0 certificate until the process restarts.

`certReady` is fired a second time after the swap on purpose. The event is already set by then so the fire wakes nobody, and firing it is what shows the existing signal path is not a way out.