### PR TITLE
chore(ci): drop i386

### DIFF
--- a/.github/actions/install_nim/action.yml
+++ b/.github/actions/install_nim/action.yml
@@ -16,38 +16,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install build dependencies (Linux i386)
-      shell: ${{ inputs.shell }}
-      if: inputs.os == 'Linux' && inputs.cpu == 'i386'
-      run: |
-        sudo dpkg --add-architecture i386
-        sudo apt-get update -qq
-        sudo DEBIAN_FRONTEND='noninteractive' apt-get install \
-          --no-install-recommends -yq gcc-multilib g++-multilib \
-          libssl-dev:i386
-        mkdir -p external/bin
-        cat << EOF > external/bin/gcc
-        #!/bin/bash
-        exec $(which gcc) -m32 "\$@"
-        EOF
-        cat << EOF > external/bin/g++
-        #!/bin/bash
-        exec $(which g++) -m32 "\$@"
-        EOF
-        chmod 755 external/bin/gcc external/bin/g++
-        echo '${{ github.workspace }}/external/bin' >> $GITHUB_PATH
-
-    - name: MSYS2 (Windows i386)
-      if: inputs.os == 'Windows' && inputs.cpu == 'i386'
-      uses: msys2/setup-msys2@v2
-      with:
-        path-type: inherit
-        msystem: MINGW32
-        install: >-
-          base-devel
-          git
-          mingw-w64-i686-toolchain
-
     - name: MSYS2 (Windows amd64)
       if: inputs.os == 'Windows' && inputs.cpu == 'amd64'
       uses: msys2/setup-msys2@v2
@@ -98,13 +66,18 @@ runs:
     - name: Derive environment variables
       shell: ${{ inputs.shell }}
       run: |
-        if [[ '${{ inputs.cpu }}' == 'amd64' ]]; then
+        case '${{ inputs.cpu }}' in
+        'amd64')
           PLATFORM=x64
-        elif [[ '${{ inputs.cpu }}' == 'arm64' ]]; then
+          ;;
+        'arm64')
           PLATFORM=arm64
-        else
-          PLATFORM=x86
-        fi
+          ;;
+        *)
+          echo "unsupported cpu: ${{ inputs.cpu }}" >&2
+          exit 1
+          ;;
+        esac
         echo "PLATFORM=$PLATFORM" >> $GITHUB_ENV
 
         ncpu=

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -501,7 +501,7 @@ nimble genbindings_cddl # Generate the CDDL schema
 
 | Workflow | Description |
 |----------|-------------|
-| `ci.yml` | Main CI: Linux (amd64/i386), macOS (arm64), Windows; Nim v2.2.4 & v2.2.10 |
+| `test_all.yml` | Main CI: Linux (amd64), macOS (arm64), Windows (amd64); Nim v2.2.4 & v2.2.10 |
 | `daily_test_all_latest_deps.yml` | Daily tests that run using latests dependencies |
 | `daily_test_all_no_flags.yml` | Tests without experimental flags |
 | `daily_ci_report.yml` | Daily CI failure reporting: opens/updates GitHub issues for failed daily CI runs |

--- a/.github/workflows/daily_test_all_latest_deps_matrix.yml
+++ b/.github/workflows/daily_test_all_latest_deps_matrix.yml
@@ -55,11 +55,6 @@ jobs:
             cc: gcc
             builder: windows-2022
             shell: "msys2 {0}"
-          - os: linux
-            cpu: i386
-            cc: gcc
-            builder: ubuntu-22.04
-            shell: bash
         nim:
           - ref: v2.2.4
             memory_management: refc

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -29,9 +29,6 @@ jobs:
           - os: linux
             cpu: amd64
             cc: gcc
-          - os: linux
-            cpu: i386
-            cc: gcc
           - os: linux-gcc-14
             cpu: amd64
             cc: gcc
@@ -51,14 +48,6 @@ jobs:
             memory_management: refc
           - ref: v2.2.10
             memory_management: orc
-        exclude:
-          - platform:
-              os: linux
-              cpu: i386
-              cc: gcc
-            nim:
-              ref: v2.2.10
-              memory_management: orc
         include:
           - platform:
               os: linux

--- a/.github/workflows/test_multiformat_exts.yml
+++ b/.github/workflows/test_multiformat_exts.yml
@@ -30,12 +30,12 @@ jobs:
       - name: Pick random platform
         id: pick
         run: |
-          declare -a OSS=("linux" "linux" "linux-gcc-14" "macos-15" "windows" "windows")
-          declare -a CPUS=("amd64" "i386" "amd64" "arm64" "amd64" "amd64")
-          declare -a CCS=("gcc" "gcc" "gcc" "clang" "clang" "gcc")
-          declare -a BUILDERS=("ubuntu-22.04" "ubuntu-22.04" "ubuntu-24.04" "macos-15" "windows-2022" "windows-2022")
-          declare -a SHELLS=("bash" "bash" "bash" "bash" "bash" "msys2 {0}")
-          PLATFORM_INDEX=$((RANDOM % 6))
+          declare -a OSS=("linux" "linux-gcc-14" "macos-15" "windows" "windows")
+          declare -a CPUS=("amd64" "amd64" "arm64" "amd64" "amd64")
+          declare -a CCS=("gcc" "gcc" "clang" "clang" "gcc")
+          declare -a BUILDERS=("ubuntu-22.04" "ubuntu-24.04" "macos-15" "windows-2022" "windows-2022")
+          declare -a SHELLS=("bash" "bash" "bash" "bash" "msys2 {0}")
+          PLATFORM_INDEX=$((RANDOM % ${#OSS[@]}))
           echo "os=${OSS[$PLATFORM_INDEX]}" >> $GITHUB_OUTPUT
           echo "cpu=${CPUS[$PLATFORM_INDEX]}" >> $GITHUB_OUTPUT
           echo "cc=${CCS[$PLATFORM_INDEX]}" >> $GITHUB_OUTPUT


### PR DESCRIPTION

Removes the `linux-i386` job from `test_all.yml` and from the daily latest-deps matrix, drops `i386` from the random platform picker in `test_multiformat_exts.yml`, and deletes the i386 toolchain setup from the `install_nim` action.

The i386 job runs a 32-bit process, so the test binary is capped at a 32-bit address space no matter how much RAM the runner has. `test_all` has outgrown that cap. It dies with `...out of memory` about a second into the run, before it reports a single test result.

Context (failed runs): [32994580485](https://github.com/vacp2p/nim-libp2p/actions/runs/32994580485), [32994150217](https://github.com/vacp2p/nim-libp2p/actions/runs/32994150217), [32403679103](https://github.com/vacp2p/nim-libp2p/actions/runs/32403679103), [32364637943](https://github.com/vacp2p/nim-libp2p/actions/runs/32364637943), [32359973527](https://github.com/vacp2p/nim-libp2p/actions/runs/32359973527), [32189579555](https://github.com/vacp2p/nim-libp2p/actions/runs/32189579555), [32148503489](https://github.com/vacp2p/nim-libp2p/actions/runs/32148503489), [32077334010](https://github.com/vacp2p/nim-libp2p/actions/runs/32077334010), [32058000764](https://github.com/vacp2p/nim-libp2p/actions/runs/32058000764), [32057515488](https://github.com/vacp2p/nim-libp2p/actions/runs/32057515488), [32055119428](https://github.com/vacp2p/nim-libp2p/actions/runs/32055119428), [32054955194](https://github.com/vacp2p/nim-libp2p/actions/runs/32054955194), [32029645146](https://github.com/vacp2p/nim-libp2p/actions/runs/32029645146)
