### PR TITLE
fix(autotls): read ACME resources with POST-as-GET and CSR padding

### DIFF
--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -16,8 +16,9 @@ logScope:
   topics = "libp2p acme api"
 
 const
-  LetsEncryptURL* = "https://acme-v02.api.letsencrypt.org"
-  LetsEncryptURLStaging* = "https://acme-staging-v02.api.letsencrypt.org"
+  LetsEncryptDirectoryURL* = parseUri("https://acme-v02.api.letsencrypt.org/directory")
+  LetsEncryptStagingDirectoryURL* =
+    parseUri("https://acme-staging-v02.api.letsencrypt.org/directory")
 
 type Authorization* = string
 type Domain* = string
@@ -216,8 +217,7 @@ method get*(
 
 proc new*(
     T: typedesc[ACMEApi],
-    acmeServerURL: Uri = parseUri(LetsEncryptURL),
-    directoryURL: Uri = acmeServerURL / "directory",
+    directoryURL: Uri = LetsEncryptDirectoryURL,
     flags: HttpClientFlags = {},
 ): ACMEApi =
   let session = HttpSessionRef.new(flags)

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -32,7 +32,7 @@ type ACMEDirectory* = object
 type ACMEApi* = ref object of RootObj
   directory: Opt[ACMEDirectory]
   session: HttpSessionRef
-  acmeServerURL*: Uri
+  directoryURL*: Uri
 
 type HTTPResponse* = object
   body*: JsonNode
@@ -215,12 +215,15 @@ method get*(
 .}
 
 proc new*(
-    T: typedesc[ACMEApi], acmeServerURL: Uri = parseUri(LetsEncryptURL)
+    T: typedesc[ACMEApi],
+    acmeServerURL: Uri = parseUri(LetsEncryptURL),
+    directoryURL: Uri = acmeServerURL / "directory",
+    flags: HttpClientFlags = {},
 ): ACMEApi =
-  let session = HttpSessionRef.new()
+  let session = HttpSessionRef.new(flags)
 
   ACMEApi(
-    session: session, directory: Opt.none(ACMEDirectory), acmeServerURL: acmeServerURL
+    session: session, directory: Opt.none(ACMEDirectory), directoryURL: directoryURL
   )
 
 proc getDirectory(
@@ -228,7 +231,7 @@ proc getDirectory(
 ): Future[ACMEDirectory] {.async: (raises: [ACMEError, CancelledError]).} =
   handleError("getDirectory"):
     self.directory.valueOr:
-      let acmeResponse = await self.get(self.acmeServerURL / "directory")
+      let acmeResponse = await self.get(self.directoryURL)
       let directory = acmeResponse.body.to(ACMEDirectory)
       self.directory = Opt.some(directory)
       directory
@@ -307,6 +310,14 @@ proc createSignedAcmeRequest(
   handleError("createSignedAcmeRequest"):
     $toFlattenedJws(%*acmeHeader, %*payload, key)
 
+proc createPostAsGetRequest(
+    self: ACMEApi, uri: Uri, key: RsaPrivateKey, kid: Kid
+): Future[string] {.async: (raises: [ACMEError, CancelledError]).} =
+  ## RFC 8555 section 6.3: a POST-as-GET is a signed POST with a zero-length payload.
+  let acmeHeader = await self.acmeHeader(uri, key, needsJwk = false, Opt.some(kid))
+  handleError("createPostAsGetRequest"):
+    $toFlattenedJws(%*acmeHeader, "", key)
+
 proc requestRegister*(
     self: ACMEApi, key: RsaPrivateKey
 ): Future[ACMERegisterResponse] {.async: (raises: [ACMEError, CancelledError]).} =
@@ -358,7 +369,9 @@ proc requestAuthorizations*(
   handleError("requestAuthorizations"):
     doAssert authorizations.len > 0
 
-    let acmeResponse = await self.get(parseUri(authorizations[0]))
+    let authorizationURL = parseUri(authorizations[0])
+    let payload = await self.createPostAsGetRequest(authorizationURL, key, kid)
+    let acmeResponse = await self.post(authorizationURL, payload)
 
     var challenges: seq[ACMEChallenge]
     for challenge in acmeResponse.body.getOrDefault("challenges").getElems():
@@ -396,7 +409,8 @@ proc requestCheck*(
     self: ACMEApi, checkURL: Uri, checkKind: ACMECheckKind, key: RsaPrivateKey, kid: Kid
 ): Future[ACMECheckResponse] {.async: (raises: [ACMEError, CancelledError]).} =
   handleError("requestCheck"):
-    let acmeResponse = await self.get(checkURL)
+    let payload = await self.createPostAsGetRequest(checkURL, key, kid)
+    let acmeResponse = await self.post(checkURL, payload)
     let retryAfter =
       try:
         parseInt(acmeResponse.headers.keyOrError("Retry-After")).seconds
@@ -521,20 +535,30 @@ proc certificateFinalized*(
   return await self.checkCertFinalized(order, key, kid, retries = retries)
 
 proc requestGetOrder*(
-    self: ACMEApi, order: Uri
+    self: ACMEApi, order: Uri, key: RsaPrivateKey, kid: Kid
 ): Future[ACMEOrderResponse] {.async: (raises: [ACMEError, CancelledError]).} =
   handleError("requestGetOrder"):
-    let acmeResponse = await self.get(order)
+    let payload = await self.createPostAsGetRequest(order, key, kid)
+    let acmeResponse = await self.post(order, payload)
     acmeResponse.body.to(ACMEOrderResponse)
 
 proc downloadCertificate*(
-    self: ACMEApi, order: Uri
+    self: ACMEApi, order: Uri, key: RsaPrivateKey, kid: Kid
 ): Future[ACMECertificateResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-  let orderResponse = await self.requestGetOrder(order)
+  let orderResponse = await self.requestGetOrder(order, key, kid)
+
+  let certificateURL = parseUri(orderResponse.certificate)
+  let payload = await self.createPostAsGetRequest(certificateURL, key, kid)
 
   handleError("downloadCertificate"):
+    # not `self.post` as it reads the response as JSON, and a certificate is PEM
     let rawResponse = await HttpClientRequestRef
-      .get(self.session, orderResponse.certificate)
+      .post(
+        self.session,
+        orderResponse.certificate,
+        body = payload,
+        headers = ACMEHttpHeaders,
+      )
       .get()
       .send()
     ACMECertificateResponse(

--- a/libp2p/autotls/acme/client.nim
+++ b/libp2p/autotls/acme/client.nim
@@ -88,7 +88,7 @@ proc getCertificate*(
     raise newException(ACMEError, "Failed to finalize certificate for domain " & domain)
 
   trace "Downloading certificate"
-  await self.api.downloadCertificate(orderURL)
+  await self.api.downloadCertificate(orderURL, self.key, await self.getOrInitKid())
 
 proc close*(self: ACMEClient) {.async: (raises: [CancelledError]).} =
   await self.api.close()

--- a/libp2p/autotls/acme/client.nim
+++ b/libp2p/autotls/acme/client.nim
@@ -27,7 +27,7 @@ logScope:
 proc new*(
     T: typedesc[ACMEClient],
     rng: Rng,
-    api: ACMEApi = ACMEApi.new(acmeServerURL = parseUri(LetsEncryptURL)),
+    api: ACMEApi = ACMEApi.new(),
     key: Opt[RsaPrivateKey] = Opt.none(RsaPrivateKey),
     kid: Kid = Kid(""),
 ): T {.raises: [].} =

--- a/libp2p/autotls/acme/jws.nim
+++ b/libp2p/autotls/acme/jws.nim
@@ -20,11 +20,11 @@ import ../../crypto/rsa
 const SupportedAlg = "RS256"
 
 proc toFlattenedJws*(
-    protectedHeader: JsonNode, payload: JsonNode, key: rsa.RsaPrivateKey
+    protectedHeader: JsonNode, payload: string, key: rsa.RsaPrivateKey
 ): JsonNode {.raises: [ACMEError].} =
-  ## Signs `protectedHeader`/`payload` with `key` (RS256) and returns the
-  ## flattened JWS JSON serialization: the base64url-encoded `protected`,
-  ## `payload` and `signature` members.
+  ## Signs `protectedHeader` and the already-serialized `payload` with `key` (RS256)
+  ## and returns the flattened JWS JSON serialization: the base64url-encoded
+  ## `protected`, `payload` and `signature` members.
   ##
   ## The signature covers `BASE64URL(protected) || '.' || BASE64URL(payload)`
   ## exactly as transmitted, so the JSON key ordering of the inputs does not
@@ -35,7 +35,7 @@ proc toFlattenedJws*(
 
   let
     protectedB64 = base64UrlEncode(($protectedHeader).toBytes)
-    payloadB64 = base64UrlEncode(($payload).toBytes)
+    payloadB64 = base64UrlEncode(payload.toBytes)
     signingInput = protectedB64 & "." & payloadB64
 
   let signature = key.sign(signingInput).valueOr:
@@ -48,3 +48,8 @@ proc toFlattenedJws*(
     "protected": protectedB64,
     "signature": base64UrlEncode(signatureBytes),
   }
+
+proc toFlattenedJws*(
+    protectedHeader: JsonNode, payload: JsonNode, key: rsa.RsaPrivateKey
+): JsonNode {.raises: [ACMEError].} =
+  toFlattenedJws(protectedHeader, $payload, key)

--- a/libp2p/autotls/acme/utils.nim
+++ b/libp2p/autotls/acme/utils.nim
@@ -62,4 +62,4 @@ proc createCSR*(
   let derCSR = cert_signing_req(domain, certKey).valueOr:
     raise newException(ACMEError, "Failed to create CSR")
 
-  base64.encode(derCSR, safe = true)
+  base64UrlEncode(derCSR)

--- a/libp2p/autotls/broker.nim
+++ b/libp2p/autotls/broker.nim
@@ -20,8 +20,8 @@ logScope:
   topics = "libp2p autotls broker"
 
 const
-  DefaultRegistrationEndpoint* = parseUri("https://registration.libp2p.direct")
-  RegistrationPath = "v1/_acme-challenge"
+  DefaultRegistrationURL* =
+    parseUri("https://registration.libp2p.direct/v1/_acme-challenge")
   HttpOk = 200
 
 type AutotlsBroker* = ref object
@@ -32,13 +32,11 @@ type AutotlsBroker* = ref object
 proc new*(
     T: typedesc[AutotlsBroker],
     rng: Rng,
-    registrationEndpoint: Uri = DefaultRegistrationEndpoint,
+    registrationURL: Uri = DefaultRegistrationURL,
     peerIdAuthClient: PeerIDAuthClient = PeerIDAuthClient.new(rng),
 ): T =
-  ## `RegistrationPath` is p2p-forge's own API, so it is composed here rather
-  ## than asked of the caller.
   T(
-    registrationURL: registrationEndpoint / RegistrationPath,
+    registrationURL: registrationURL,
     peerIdAuthClient: peerIdAuthClient,
     bearer: Opt.none(BearerToken),
   )

--- a/libp2p/autotls/broker.nim
+++ b/libp2p/autotls/broker.nim
@@ -24,7 +24,7 @@ const
   HttpOk = 200
 
 type AutotlsBroker* = ref object
-  brokerURL: string
+  registrationURL: Uri
   peerIdAuthClient: PeerIDAuthClient
   bearer: Opt[BearerToken]
 
@@ -33,9 +33,10 @@ proc new*(
     rng: Rng,
     brokerURL: string = DefaultBrokerURL,
     peerIdAuthClient: PeerIDAuthClient = PeerIDAuthClient.new(rng),
+    registrationURL: Uri = parseUri("https://" & brokerURL & "/v1/_acme-challenge"),
 ): T =
   T(
-    brokerURL: brokerURL,
+    registrationURL: registrationURL,
     peerIdAuthClient: peerIdAuthClient,
     bearer: Opt.none(BearerToken),
   )
@@ -56,7 +57,6 @@ proc sendChallenge*(
 
   let strMultiaddresses = addrs.mapIt($it)
   let payload = %*{"value": keyAuth, "addresses": strMultiaddresses}
-  let registrationURL = parseUri("https://" & self.brokerURL & "/v1/_acme-challenge")
 
   # drop a bearer we already know to be expired so we re-authenticate
   # instead of looping on `PeerIDAuthError("Bearer expired")`
@@ -65,16 +65,17 @@ proc sendChallenge*(
     if cached.expires.isSome() and cached.expires.get() <= now():
       self.bearer = Opt.none(BearerToken)
 
-  trace "Sending challenge to AutoTLS broker", brokerURL = self.brokerURL
-  let (bearer, response) =
-    await self.peerIdAuthClient.send(registrationURL, peerInfo, payload, self.bearer)
+  trace "Sending challenge to AutoTLS broker", registrationURL = $self.registrationURL
+  let (bearer, response) = await self.peerIdAuthClient.send(
+    self.registrationURL, peerInfo, payload, self.bearer
+  )
   # remember the latest bearer in case the broker rotated it
   self.bearer = Opt.some(bearer)
 
   if response.status != HttpOk:
     raise newException(
       AutoTLSError,
-      "Failed to authenticate with AutoTLS broker " & self.brokerURL & " (status " &
+      "Failed to authenticate with AutoTLS broker " & $self.registrationURL & " (status " &
         $response.status & "): " & bytesToString(response.body),
     )
 

--- a/libp2p/autotls/broker.nim
+++ b/libp2p/autotls/broker.nim
@@ -20,7 +20,8 @@ logScope:
   topics = "libp2p autotls broker"
 
 const
-  DefaultBrokerURL* = "registration.libp2p.direct"
+  DefaultRegistrationEndpoint* = parseUri("https://registration.libp2p.direct")
+  RegistrationPath = "v1/_acme-challenge"
   HttpOk = 200
 
 type AutotlsBroker* = ref object
@@ -31,12 +32,13 @@ type AutotlsBroker* = ref object
 proc new*(
     T: typedesc[AutotlsBroker],
     rng: Rng,
-    brokerURL: string = DefaultBrokerURL,
+    registrationEndpoint: Uri = DefaultRegistrationEndpoint,
     peerIdAuthClient: PeerIDAuthClient = PeerIDAuthClient.new(rng),
-    registrationURL: Uri = parseUri("https://" & brokerURL & "/v1/_acme-challenge"),
 ): T =
+  ## `RegistrationPath` is p2p-forge's own API, so it is composed here rather
+  ## than asked of the caller.
   T(
-    registrationURL: registrationURL,
+    registrationURL: registrationEndpoint / RegistrationPath,
     peerIdAuthClient: peerIdAuthClient,
     bearer: Opt.none(BearerToken),
   )

--- a/libp2p/autotls/mockservice.nim
+++ b/libp2p/autotls/mockservice.nim
@@ -16,7 +16,7 @@ proc new*(
 ): T =
   T(
     acmeClient: ACMEClient.new(rng = rng, api = ACMEApi.new(config.acmeDirectoryURL)),
-    broker: AutotlsBroker.new(rng, config.registrationEndpoint),
+    broker: AutotlsBroker.new(rng, config.registrationURL),
     cert: Opt.none(AutotlsCert),
     certReady: newAsyncEvent(),
     running: newAsyncEvent(),

--- a/libp2p/autotls/mockservice.nim
+++ b/libp2p/autotls/mockservice.nim
@@ -15,9 +15,8 @@ proc new*(
     config: AutotlsConfig = AutotlsConfig.new(),
 ): T =
   T(
-    acmeClient:
-      ACMEClient.new(rng = rng, api = ACMEApi.new(acmeServerURL = config.acmeServerURL)),
-    broker: AutotlsBroker.new(rng, brokerURL = config.brokerURL),
+    acmeClient: ACMEClient.new(rng = rng, api = ACMEApi.new(config.acmeDirectoryURL)),
+    broker: AutotlsBroker.new(rng, config.registrationEndpoint),
     cert: Opt.none(AutotlsCert),
     certReady: newAsyncEvent(),
     running: newAsyncEvent(),

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -29,7 +29,7 @@ logScope:
   topics = "libp2p autotls"
 
 export
-  LetsEncryptDirectoryURL, AutoTLSError, DefaultDnsServers, DefaultRegistrationEndpoint,
+  LetsEncryptDirectoryURL, AutoTLSError, DefaultDnsServers, DefaultRegistrationURL,
   AutotlsBroker
 
 const
@@ -53,7 +53,7 @@ type AutotlsConfig* = object
   renewBufferTime*: Duration
   issueRetries*: int
   issueRetryTime*: Duration
-  registrationEndpoint*: Uri
+  registrationURL*: Uri
   dnsServerURL*: string
   dnsRetries*: int
   dnsRetryTime*: Duration
@@ -96,7 +96,7 @@ proc new*(
     renewBufferTime: Duration = DefaultRenewBufferTime,
     issueRetries: int = DefaultIssueRetries,
     issueRetryTime: Duration = DefaultIssueRetryTime,
-    registrationEndpoint: Uri = DefaultRegistrationEndpoint,
+    registrationURL: Uri = DefaultRegistrationURL,
     dnsServerURL: string = AutoTLSDNSServer,
     dnsRetries: int = 10,
     dnsRetryTime: Duration = 1.seconds,
@@ -113,7 +113,7 @@ proc new*(
     renewBufferTime: renewBufferTime,
     issueRetries: issueRetries,
     issueRetryTime: issueRetryTime,
-    registrationEndpoint: registrationEndpoint,
+    registrationURL: registrationURL,
     dnsServerURL: dnsServerURL,
     dnsRetries: dnsRetries,
     dnsRetryTime: dnsRetryTime,
@@ -128,7 +128,7 @@ proc new*(
 ): T =
   T(
     acmeClient: ACMEClient.new(api = ACMEApi.new(config.acmeDirectoryURL), rng = rng),
-    broker: AutotlsBroker.new(rng, config.registrationEndpoint),
+    broker: AutotlsBroker.new(rng, config.registrationURL),
     cert: Opt.none(AutotlsCert),
     certReady: newAsyncEvent(),
     running: newAsyncEvent(),

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -28,7 +28,9 @@ import
 logScope:
   topics = "libp2p autotls"
 
-export LetsEncryptURL, AutoTLSError, DefaultDnsServers, DefaultBrokerURL, AutotlsBroker
+export
+  LetsEncryptDirectoryURL, AutoTLSError, DefaultDnsServers, DefaultRegistrationEndpoint,
+  AutotlsBroker
 
 const
   DefaultRenewCheckTime* = 1.hours
@@ -44,14 +46,14 @@ type AutotlsCert* = ref object
   expiry*: DateTime
 
 type AutotlsConfig* = object
-  acmeServerURL*: Uri
+  acmeDirectoryURL*: Uri
   nameResolver*: NameResolver
   ipAddress: Opt[IpAddress]
   renewCheckTime*: Duration
   renewBufferTime*: Duration
   issueRetries*: int
   issueRetryTime*: Duration
-  brokerURL*: string
+  registrationEndpoint*: Uri
   dnsServerURL*: string
   dnsRetries*: int
   dnsRetryTime*: Duration
@@ -89,12 +91,12 @@ proc new*(
     T: typedesc[AutotlsConfig],
     ipAddress: Opt[IpAddress] = Opt.none(IpAddress),
     nameServers: seq[TransportAddress] = DefaultDnsServers,
-    acmeServerURL: Uri = parseUri(LetsEncryptURL),
+    acmeDirectoryURL: Uri = LetsEncryptDirectoryURL,
     renewCheckTime: Duration = DefaultRenewCheckTime,
     renewBufferTime: Duration = DefaultRenewBufferTime,
     issueRetries: int = DefaultIssueRetries,
     issueRetryTime: Duration = DefaultIssueRetryTime,
-    brokerURL: string = DefaultBrokerURL,
+    registrationEndpoint: Uri = DefaultRegistrationEndpoint,
     dnsServerURL: string = AutoTLSDNSServer,
     dnsRetries: int = 10,
     dnsRetryTime: Duration = 1.seconds,
@@ -105,13 +107,13 @@ proc new*(
 ): T =
   T(
     nameResolver: DnsResolver.new(nameServers),
-    acmeServerURL: acmeServerURL,
+    acmeDirectoryURL: acmeDirectoryURL,
     ipAddress: ipAddress,
     renewCheckTime: renewCheckTime,
     renewBufferTime: renewBufferTime,
     issueRetries: issueRetries,
     issueRetryTime: issueRetryTime,
-    brokerURL: brokerURL,
+    registrationEndpoint: registrationEndpoint,
     dnsServerURL: dnsServerURL,
     dnsRetries: dnsRetries,
     dnsRetryTime: dnsRetryTime,
@@ -125,9 +127,8 @@ proc new*(
     T: typedesc[AutotlsService], rng: Rng, config: AutotlsConfig = AutotlsConfig.new()
 ): T =
   T(
-    acmeClient:
-      ACMEClient.new(api = ACMEApi.new(acmeServerURL = config.acmeServerURL), rng = rng),
-    broker: AutotlsBroker.new(rng, brokerURL = config.brokerURL),
+    acmeClient: ACMEClient.new(api = ACMEApi.new(config.acmeDirectoryURL), rng = rng),
+    broker: AutotlsBroker.new(rng, config.registrationEndpoint),
     cert: Opt.none(AutotlsCert),
     certReady: newAsyncEvent(),
     running: newAsyncEvent(),

--- a/tests/integration/test_autotls_integration.nim
+++ b/tests/integration/test_autotls_integration.nim
@@ -38,7 +38,7 @@ when defined(linux) and defined(amd64):
 
     asyncTest "request challenge without ACMEClient (ACMEApi only)":
       let key = RsaPrivateKey.random(rng()).get()
-      let acmeApi = ACMEApi.new(acmeServerURL = parseUri(LetsEncryptURLStaging))
+      let acmeApi = ACMEApi.new(LetsEncryptStagingDirectoryURL)
       defer:
         await acmeApi.close()
 
@@ -61,9 +61,8 @@ when defined(linux) and defined(amd64):
       assertChallenge(challenge)
 
     asyncTest "request challenge with ACMEClient":
-      let acme = ACMEClient.new(
-        rng = rng(), api = ACMEApi.new(acmeServerURL = parseUri(LetsEncryptURLStaging))
-      )
+      let acme =
+        ACMEClient.new(rng = rng(), api = ACMEApi.new(LetsEncryptStagingDirectoryURL))
       defer:
         await acme.close()
 
@@ -86,7 +85,8 @@ when defined(linux) and defined(amd64):
         )
         .withAutotls(
           config = AutotlsConfig.new(
-            acmeServerURL = parseUri(LetsEncryptURLStaging), renewCheckTime = 1.seconds
+            acmeDirectoryURL = LetsEncryptStagingDirectoryURL,
+            renewCheckTime = 1.seconds,
           )
         )
         .build()

--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -322,6 +322,13 @@ suite "AutoTLS ACME API":
         parseUri("http://example.com/some-order-url"), key, "kid"
       )
 
+  asyncTest "the directory URL is used as given":
+    let acmeApi = ACMEApi.new(parseUri("http://acme.example/dir"))
+    defer:
+      await acmeApi.close()
+
+    check acmeApi.directoryURL == parseUri("http://acme.example/dir")
+
   asyncTest "the directory is fetched once and cached":
     # The cache is only observable on a stub that was not handed a directory.
     await api.close()
@@ -349,7 +356,7 @@ suite "AutoTLS ACME API":
 
     check api.requestedUris ==
       @[
-        parseUri(LetsEncryptURL & "/directory"),
+        parseUri(DirectoryURL),
         parseUri(StubDirectory.newNonce),
         parseUri(StubDirectory.newNonce),
       ]

--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -318,7 +318,9 @@ suite "AutoTLS ACME API":
       )
 
     expect(ACMEError):
-      discard await api.requestGetOrder(parseUri("http://example.com/some-order-url"))
+      discard await api.requestGetOrder(
+        parseUri("http://example.com/some-order-url"), key, "kid"
+      )
 
   asyncTest "the directory is fetched once and cached":
     # The cache is only observable on a stub that was not handed a directory.
@@ -443,15 +445,14 @@ suite "AutoTLS ACME API":
 
     check base64.decode(api.signedPayload(0)["csr"].getStr).contains(WildcardDomain)
 
-  asyncTest "the csr is sent with base64 padding":
-    # TODO: vacp2p/nim-libp2p#2982
+  asyncTest "the csr is sent as base64url without padding":
     api.queueStatus("valid")
 
     discard await api.requestFinalize(
       WildcardDomain, parseUri(FinalizeURL), rfc7517Key(), key, AccountURL
     )
 
-    check api.signedPayload(0)["csr"].getStr.endsWith('=')
+    check not api.signedPayload(0)["csr"].getStr.endsWith('=')
 
   asyncTest "an unrecognized challenge type does not discard the dns-01 beside it":
     api.queueChallenges(
@@ -473,13 +474,28 @@ suite "AutoTLS ACME API":
     check authorizations.challenges[0].`type` == ACMEChallengeType.DNS01
     check authorizations.challenges[0].url == ChallengeURL
 
+  asyncTest "authorization, status and order resources are read with POST-as-GET":
+    api.queueChallenges(
+      %*[{"type": "dns-01", "url": ChallengeURL, "status": "pending", "token": "t"}]
+    )
+    api.queueStatus("valid")
+    api.queueGetOrder("https://acme.example/cert/1", "2099-01-01T00:00:00Z")
+
+    discard await api.requestAuthorizations(@[AuthorizationsURL], key, AccountURL)
+    discard await api.requestCheck(parseUri(OrderURL), ACMEOrderCheck, key, AccountURL)
+    discard await api.requestGetOrder(parseUri(OrderURL), key, AccountURL)
+
+    check api.payloads.len == 3
+    for index in 0 ..< api.payloads.len:
+      check api.encodedPayload(index) == ""
+
   proc downloadWithExpires(expires: string): Future[ACMECertificateResponse] {.async.} =
     let certServer = startTestHttpServer(certPem)
     defer:
       await certServer.stop()
 
     api.queueGetOrder(certServer.url, expires)
-    await api.downloadCertificate(parseUri(OrderURL))
+    await api.downloadCertificate(parseUri(OrderURL), key, AccountURL)
 
   asyncTest "the order's expires is parsed in local time":
     # TODO: vacp2p/nim-libp2p#2975

--- a/tests/libp2p/autotls/test_autotls_config.nim
+++ b/tests/libp2p/autotls/test_autotls_config.nim
@@ -12,7 +12,7 @@ import
     nameresolving/dnsresolver,
     wire,
   ]
-import ../../tools/[unittest, crypto]
+import ../../tools/unittest
 
 suite "AutoTLS Configuration Tests":
   asyncTeardown:
@@ -22,13 +22,13 @@ suite "AutoTLS Configuration Tests":
     let config = AutotlsConfig.new()
 
     check:
-      config.acmeServerURL == parseUri(LetsEncryptURL)
+      config.acmeDirectoryURL == LetsEncryptDirectoryURL
       config.ipAddress == Opt.none(IpAddress)
       config.renewCheckTime == DefaultRenewCheckTime
       config.renewBufferTime == DefaultRenewBufferTime
       config.issueRetries == 3
       config.issueRetryTime == 1.seconds
-      config.brokerURL == DefaultBrokerURL
+      config.registrationEndpoint == DefaultRegistrationEndpoint
       config.dnsServerURL == AutoTLSDNSServer
       config.dnsRetries == 10
       config.dnsRetryTime == 1.seconds
@@ -41,11 +41,12 @@ suite "AutoTLS Configuration Tests":
     let customIpAddress = parseIpAddress("203.0.113.7")
     let customNameServers =
       @[initTAddress("192.0.2.53:53"), initTAddress("198.51.100.53:53")]
+    let customAcmeDirectoryURL = parseUri("https://acme.example.com/dir")
     let customRenewCheckTime = 7.minutes
     let customRenewBufferTime = 8.minutes
     let customIssueRetries = 7
     let customIssueRetryTime = 5.seconds
-    let customBrokerURL = "custom-broker.example.com"
+    let customRegistrationEndpoint = parseUri("https://custom-broker.example.com")
     let customDnsServerURL = "custom-dns.example.com"
     let customDnsRetries = 5
     let customDnsRetryTime = 2.seconds
@@ -57,11 +58,12 @@ suite "AutoTLS Configuration Tests":
     let config = AutotlsConfig.new(
       ipAddress = Opt.some(customIpAddress),
       nameServers = customNameServers,
+      acmeDirectoryURL = customAcmeDirectoryURL,
       renewCheckTime = customRenewCheckTime,
       renewBufferTime = customRenewBufferTime,
       issueRetries = customIssueRetries,
       issueRetryTime = customIssueRetryTime,
-      brokerURL = customBrokerURL,
+      registrationEndpoint = customRegistrationEndpoint,
       dnsServerURL = customDnsServerURL,
       dnsRetries = customDnsRetries,
       dnsRetryTime = customDnsRetryTime,
@@ -75,11 +77,12 @@ suite "AutoTLS Configuration Tests":
       config.ipAddress == Opt.some(customIpAddress)
       # nameServers reaches the config as the DnsResolver built out of it.
       DnsResolver(config.nameResolver).nameServers == customNameServers
+      config.acmeDirectoryURL == customAcmeDirectoryURL
       config.renewCheckTime == customRenewCheckTime
       config.renewBufferTime == customRenewBufferTime
       config.issueRetries == customIssueRetries
       config.issueRetryTime == customIssueRetryTime
-      config.brokerURL == customBrokerURL
+      config.registrationEndpoint == customRegistrationEndpoint
       config.dnsServerURL == customDnsServerURL
       config.dnsRetries == customDnsRetries
       config.dnsRetryTime == customDnsRetryTime
@@ -87,26 +90,3 @@ suite "AutoTLS Configuration Tests":
       config.acmeRetryTime == customAcmeRetryTime
       config.finalizeRetries == customFinalizeRetries
       config.finalizeRetryTime == customFinalizeRetryTime
-
-  asyncTest "AutotlsService uses custom broker URL in registration":
-    let customBrokerURL = "test-broker.example.com"
-    let config = AutotlsConfig.new(brokerURL = customBrokerURL)
-    let service = AutotlsService.new(rng(), config = config)
-
-    # Verify the config was stored correctly
-    check service.config.brokerURL == customBrokerURL
-
-  asyncTest "Backward compatibility with existing AutotlsConfig usage":
-    # Test that existing code using AutotlsConfig.new() without new parameters still works
-    let config1 = AutotlsConfig.new()
-    let config2 = AutotlsConfig.new(
-      acmeServerURL = parseUri(LetsEncryptURLStaging), renewCheckTime = 5.minutes
-    )
-
-    check:
-      config1.acmeServerURL == parseUri(LetsEncryptURL)
-      config2.acmeServerURL == parseUri(LetsEncryptURLStaging)
-      config2.renewCheckTime == 5.minutes
-      # New fields should have default values
-      config1.brokerURL == DefaultBrokerURL
-      config2.brokerURL == DefaultBrokerURL

--- a/tests/libp2p/autotls/test_autotls_config.nim
+++ b/tests/libp2p/autotls/test_autotls_config.nim
@@ -28,7 +28,7 @@ suite "AutoTLS Configuration Tests":
       config.renewBufferTime == DefaultRenewBufferTime
       config.issueRetries == 3
       config.issueRetryTime == 1.seconds
-      config.registrationEndpoint == DefaultRegistrationEndpoint
+      config.registrationURL == DefaultRegistrationURL
       config.dnsServerURL == AutoTLSDNSServer
       config.dnsRetries == 10
       config.dnsRetryTime == 1.seconds
@@ -46,7 +46,8 @@ suite "AutoTLS Configuration Tests":
     let customRenewBufferTime = 8.minutes
     let customIssueRetries = 7
     let customIssueRetryTime = 5.seconds
-    let customRegistrationEndpoint = parseUri("https://custom-broker.example.com")
+    let customRegistrationURL =
+      parseUri("https://custom-broker.example.com/v1/_acme-challenge")
     let customDnsServerURL = "custom-dns.example.com"
     let customDnsRetries = 5
     let customDnsRetryTime = 2.seconds
@@ -63,7 +64,7 @@ suite "AutoTLS Configuration Tests":
       renewBufferTime = customRenewBufferTime,
       issueRetries = customIssueRetries,
       issueRetryTime = customIssueRetryTime,
-      registrationEndpoint = customRegistrationEndpoint,
+      registrationURL = customRegistrationURL,
       dnsServerURL = customDnsServerURL,
       dnsRetries = customDnsRetries,
       dnsRetryTime = customDnsRetryTime,
@@ -82,7 +83,7 @@ suite "AutoTLS Configuration Tests":
       config.renewBufferTime == customRenewBufferTime
       config.issueRetries == customIssueRetries
       config.issueRetryTime == customIssueRetryTime
-      config.registrationEndpoint == customRegistrationEndpoint
+      config.registrationURL == customRegistrationURL
       config.dnsServerURL == customDnsServerURL
       config.dnsRetries == customDnsRetries
       config.dnsRetryTime == customDnsRetryTime

--- a/tests/libp2p/autotls/test_broker.nim
+++ b/tests/libp2p/autotls/test_broker.nim
@@ -20,9 +20,8 @@ import ../../stubs/peer_id_auth_client_stub
 
 suite "AutoTLS broker":
   const
-    BrokerURL = "broker.example"
+    RegistrationEndpoint = "https://broker.example"
     RegistrationURL = "https://broker.example/v1/_acme-challenge"
-    OverrideURL = "https://other.example/v1/_acme-challenge"
     KeyAuth = KeyAuthorization("expected-key-authorization")
     Addresses = ["/ip4/1.2.3.4/tcp/4001", "/ip4/1.2.3.4/tcp/4002/ws"]
 
@@ -37,7 +36,7 @@ suite "AutoTLS broker":
 
   asyncSetup:
     client = PeerIDAuthClientStub.new()
-    broker = AutotlsBroker.new(rng(), BrokerURL, client)
+    broker = AutotlsBroker.new(rng(), parseUri(RegistrationEndpoint), client)
     peerInfo = PeerInfo.new(PrivateKey.random(PKScheme.Ed25519, rng()).get())
     addrs = Addresses.mapIt(MultiAddress.init(it).get())
 
@@ -54,17 +53,10 @@ suite "AutoTLS broker":
       client.payloads.len == 1
       parseJson(client.payloads[0]) == %*{"value": KeyAuth, "addresses": Addresses}
 
-  asyncTest "the configured broker URL is the registration endpoint":
+  asyncTest "the challenge is registered under the endpoint's p2p-forge path":
     await broker.sendChallenge(peerInfo, addrs, KeyAuth)
 
     check client.requestedUris.mapIt($it) == @[RegistrationURL, RegistrationURL]
-
-  asyncTest "an explicit registration URL replaces the one derived from the broker URL":
-    broker = AutotlsBroker.new(rng(), BrokerURL, client, parseUri(OverrideURL))
-
-    await broker.sendChallenge(peerInfo, addrs, KeyAuth)
-
-    check client.requestedUris.mapIt($it) == @[OverrideURL, OverrideURL]
 
   asyncTest "a rejected registration raises":
     client.status = 403

--- a/tests/libp2p/autotls/test_broker.nim
+++ b/tests/libp2p/autotls/test_broker.nim
@@ -20,7 +20,6 @@ import ../../stubs/peer_id_auth_client_stub
 
 suite "AutoTLS broker":
   const
-    RegistrationEndpoint = "https://broker.example"
     RegistrationURL = "https://broker.example/v1/_acme-challenge"
     KeyAuth = KeyAuthorization("expected-key-authorization")
     Addresses = ["/ip4/1.2.3.4/tcp/4001", "/ip4/1.2.3.4/tcp/4002/ws"]
@@ -36,7 +35,7 @@ suite "AutoTLS broker":
 
   asyncSetup:
     client = PeerIDAuthClientStub.new()
-    broker = AutotlsBroker.new(rng(), parseUri(RegistrationEndpoint), client)
+    broker = AutotlsBroker.new(rng(), parseUri(RegistrationURL), client)
     peerInfo = PeerInfo.new(PrivateKey.random(PKScheme.Ed25519, rng()).get())
     addrs = Addresses.mapIt(MultiAddress.init(it).get())
 
@@ -53,7 +52,7 @@ suite "AutoTLS broker":
       client.payloads.len == 1
       parseJson(client.payloads[0]) == %*{"value": KeyAuth, "addresses": Addresses}
 
-  asyncTest "the challenge is registered under the endpoint's p2p-forge path":
+  asyncTest "the challenge is sent to the registration URL as given":
     await broker.sendChallenge(peerInfo, addrs, KeyAuth)
 
     check client.requestedUris.mapIt($it) == @[RegistrationURL, RegistrationURL]

--- a/tests/libp2p/autotls/test_broker.nim
+++ b/tests/libp2p/autotls/test_broker.nim
@@ -22,6 +22,7 @@ suite "AutoTLS broker":
   const
     BrokerURL = "broker.example"
     RegistrationURL = "https://broker.example/v1/_acme-challenge"
+    OverrideURL = "https://other.example/v1/_acme-challenge"
     KeyAuth = KeyAuthorization("expected-key-authorization")
     Addresses = ["/ip4/1.2.3.4/tcp/4001", "/ip4/1.2.3.4/tcp/4002/ws"]
 
@@ -57,6 +58,13 @@ suite "AutoTLS broker":
     await broker.sendChallenge(peerInfo, addrs, KeyAuth)
 
     check client.requestedUris.mapIt($it) == @[RegistrationURL, RegistrationURL]
+
+  asyncTest "an explicit registration URL replaces the one derived from the broker URL":
+    broker = AutotlsBroker.new(rng(), BrokerURL, client, parseUri(OverrideURL))
+
+    await broker.sendChallenge(peerInfo, addrs, KeyAuth)
+
+    check client.requestedUris.mapIt($it) == @[OverrideURL, OverrideURL]
 
   asyncTest "a rejected registration raises":
     client.status = 403

--- a/tests/libp2p/autotls/test_jws.nim
+++ b/tests/libp2p/autotls/test_jws.nim
@@ -46,8 +46,15 @@ suite "ACME JWS":
       check not jws[field].getStr.contains('+')
       check not jws[field].getStr.contains('/')
 
-  test "an empty payload still signs and verifies":
+  test "an empty JSON payload still signs and verifies":
     let jws = toFlattenedJws(%*{"alg": "RS256"}, %*{}, key)
+    let signingInput = jws["protected"].getStr & "." & jws["payload"].getStr
+    let sig = RsaSignature.init(b64UrlDecode(jws["signature"].getStr)).get()
+    check rsa.verify(sig, signingInput, key.getPublicKey())
+
+  test "a zero-length payload still signs and verifies":
+    let jws = toFlattenedJws(%*{"alg": "RS256"}, "", key)
+    check jws["payload"].getStr == ""
     let signingInput = jws["protected"].getStr & "." & jws["payload"].getStr
     let sig = RsaSignature.init(b64UrlDecode(jws["signature"].getStr)).get()
     check rsa.verify(sig, signingInput, key.getPublicKey())

--- a/tests/libp2p/autotls/test_service.nim
+++ b/tests/libp2p/autotls/test_service.nim
@@ -48,7 +48,7 @@ suite "AutoTLS certificate issuance and renewal":
     AutotlsService(
       acmeClient:
         ACMEClient.new(rng(), api = ACMEApi(acmeApi), key = Opt.some(accountKey)),
-      broker: AutotlsBroker.new(rng(), DefaultRegistrationEndpoint, authClient),
+      broker: AutotlsBroker.new(rng(), DefaultRegistrationURL, authClient),
       cert: Opt.none(AutotlsCert),
       certReady: newAsyncEvent(),
       running: newAsyncEvent(),

--- a/tests/libp2p/autotls/test_service.nim
+++ b/tests/libp2p/autotls/test_service.nim
@@ -48,7 +48,7 @@ suite "AutoTLS certificate issuance and renewal":
     AutotlsService(
       acmeClient:
         ACMEClient.new(rng(), api = ACMEApi(acmeApi), key = Opt.some(accountKey)),
-      broker: AutotlsBroker.new(rng(), DefaultBrokerURL, authClient),
+      broker: AutotlsBroker.new(rng(), DefaultRegistrationEndpoint, authClient),
       cert: Opt.none(AutotlsCert),
       certReady: newAsyncEvent(),
       running: newAsyncEvent(),
@@ -249,7 +249,7 @@ suite "AutoTLS on a switch":
       .withAutotls(
         AutotlsConfig.new(
           ipAddress = Opt.some(parseIpAddress("127.0.0.1")),
-          acmeServerURL =
+          acmeDirectoryURL =
             parseUri("http://" & $acmeServer.address.initTAddress().tryGet()),
         )
       )
@@ -261,7 +261,7 @@ suite "AutoTLS on a switch":
     defer:
       await startFut.cancelAndWait()
 
-    # Issuance would connect to acmeServerURL, so no connection means no attempt.
+    # Issuance would connect to acmeDirectoryURL, so no connection means no attempt.
     check not (await acmeServer.waitAccepted().withTimeout(200.milliseconds))
 
   asyncTest "a switch listening on wss never finishes starting without a certificate":
@@ -275,7 +275,7 @@ suite "AutoTLS on a switch":
           ipAddress = Opt.some(parseIpAddress("127.0.0.1")),
           # A refused connection fails issuance at once, leaving the certificate
           # wait as the only thing that can hang.
-          acmeServerURL = parseUri("http://127.0.0.1:1"),
+          acmeDirectoryURL = parseUri("http://127.0.0.1:1"),
         )
       )
       .build()

--- a/tests/stubs/acme_api_stub.nim
+++ b/tests/stubs/acme_api_stub.nim
@@ -40,7 +40,7 @@ proc new*(
   ACMEApiStub(
     session: HttpSessionRef.new(),
     directory: directory,
-    acmeServerURL: parseUri(LetsEncryptURL),
+    directoryURL: parseUri(LetsEncryptURL) / "directory",
   )
 
 proc jwsMember(self: ACMEApiStub, index: int, member: string): JsonNode =
@@ -56,6 +56,13 @@ proc protectedHeader*(self: ACMEApiStub, index: int): JsonNode =
 proc signedPayload*(self: ACMEApiStub, index: int): JsonNode =
   ## The payload of the `index`-th signed request.
   self.jwsMember(index, "payload")
+
+proc encodedPayload*(self: ACMEApiStub, index: int): string =
+  ## The payload of the `index`-th signed request, still base64url-encoded.
+  try:
+    parseJson(self.payloads[index])["payload"].getStr
+  except CatchableError as exc:
+    raiseAssert "stub could not read the JWS payload: " & exc.msg
 
 proc queueRegister*(self: ACMEApiStub) =
   ## Queues the response `requestRegister` consumes.
@@ -138,7 +145,7 @@ method requestNonce*(
     self: ACMEApiStub
 ): Future[Nonce] {.async: (raises: [ACMEError, CancelledError]).} =
   self.nonces += 1
-  $self.acmeServerURL & "/acme/" & $self.nonces
+  $self.directoryURL & "/acme/" & $self.nonces
 
 method post*(
     self: ACMEApiStub, uri: Uri, payload: string

--- a/tests/stubs/acme_api_stub.nim
+++ b/tests/stubs/acme_api_stub.nim
@@ -12,6 +12,7 @@ import ../../libp2p/autotls/acme/[api, utils]
 export api
 
 const
+  DirectoryURL* = "https://acme.example/directory"
   AccountURL* = "https://acme.example/acct/1"
   OrderURL* = "https://acme.example/order/1"
   FinalizeURL* = "https://acme.example/finalize/1"
@@ -19,9 +20,9 @@ const
   ChallengeURL* = "https://acme.example/chal/1"
 
 const StubDirectory* = ACMEDirectory(
-  newNonce: LetsEncryptURL & "/new-nonce",
-  newOrder: LetsEncryptURL & "/new-order",
-  newAccount: LetsEncryptURL & "/new-account",
+  newNonce: "https://acme.example/new-nonce",
+  newOrder: "https://acme.example/new-order",
+  newAccount: "https://acme.example/new-account",
 )
 
 type ACMEApiStub* = ref object of ACMEApi
@@ -40,7 +41,7 @@ proc new*(
   ACMEApiStub(
     session: HttpSessionRef.new(),
     directory: directory,
-    directoryURL: parseUri(LetsEncryptURL) / "directory",
+    directoryURL: parseUri(DirectoryURL),
   )
 
 proc jwsMember(self: ACMEApiStub, index: int, member: string): JsonNode =

--- a/tests/tools/http_server.nim
+++ b/tests/tools/http_server.nim
@@ -3,24 +3,46 @@
 
 {.used.}
 
-import chronicles, chronos
-import websock/http/[common, server]
+import std/sequtils
+import chronos
 
 type TestHttpServer* = ref object
-  ## Answers every request with one fixed body over plain HTTP.
-  server: HttpServer
+  ## Answers every request with one fixed body over plain HTTP, whatever its method.
+  server: StreamServer
+  accepted: seq[StreamTransport]
   url*: string
 
 proc startTestHttpServer*(body: string): TestHttpServer =
-  proc serve(request: HttpRequest) {.async.} =
-    await request.sendResponse(Http200, data = body)
+  let self = TestHttpServer()
+  let response =
+    "HTTP/1.1 200 OK\r\nContent-Length: " & $body.len & "\r\nConnection: close\r\n\r\n" &
+    body
 
-  let server = HttpServer.create(initTAddress("127.0.0.1:0"), serve, {ReuseAddr})
-  server.start()
+  proc serve(server: StreamServer, client: StreamTransport) {.async: (raises: []).} =
+    self.accepted.add(client)
+    try:
+      discard await client.write(response)
+      # read and discarded: an unread request stalls the sender
+      discard await client.read()
+    except CancelledError:
+      discard
+    except TransportUseClosedError:
+      # `stop` closed the connection while the read was still pending
+      discard
+    except TransportError as exc:
+      raiseAssert "test http server: " & exc.msg
+
+  self.server = createStreamServer(initTAddress("127.0.0.1:0"), serve, {ReuseAddr})
+  self.server.start()
 
   # `local` carries the address the socket really bound, port 0 resolved.
-  TestHttpServer(server: server, url: "http://" & $server.local & "/")
+  self.url = "http://" & $self.server.local & "/"
+  self
 
-proc stop*(self: TestHttpServer) {.async: (raises: [TransportOsError]).} =
-  self.server.stop()
+proc stop*(self: TestHttpServer) {.async: (raises: []).} =
+  self.server.stop2().isOkOr:
+    raiseAssert "test http server stop failed"
   await self.server.closeWait()
+  # closing a connection before the client has read the response resets it on
+  # Windows, so they stay open until now
+  await noCancel allFutures(self.accepted.mapIt(it.closeWait()))


### PR DESCRIPTION
## Summary

Fixes required for the local ACME integration. The follow-up branch runs the whole issuance flow against Pebble and p2p-forge in Docker, and Pebble rejects two things this code was doing. Pebble is stricter than a public CA so both problems surfaced immediately.

- ACMEApi reads order, authorization and certificate resources with POST-as-GET. 
  - [RFC 8555 section 6.3](https://datatracker.ietf.org/doc/html/rfc8555#section-6.3) requires a JWS-signed POST carrying a zero-length payload; the code used a plain GET.
  - Converted in requestAuthorizations, requestCheck, requestGetOrder and downloadCertificate.
  - Pebble rejects a GET at its router before any handler runs and reports malformed: Method not allowed. Boulder requires POST-as-GET too.
- The CSR is sent as unpadded base64url. createCSR sent it padded, which Pebble rejects at finalization with Error decoding Base64url-encoded CSR. It now uses the module's own base64UrlEncode, like every other base64url field. Fixes #2982.
- ACMEApi.new and AutotlsBroker.new each take one full URL, which is what makes the flow testable against local docker endpoints. Both used to compose the rest themselves.
  - acmeServerURL only ever fed acmeServerURL / "directory", which cannot reach Pebble's directory at /dir. ACMEApi.new now takes directoryURL and flags.
  - brokerURL was a bare hostname wrapped in "https://" & brokerURL & "/v1/_acme-challenge", so a broker on plain-HTTP loopback was unreachable. AutotlsBroker.new now takes registrationURL.
- AutotlsConfig carries acmeDirectoryURL and registrationURL, so withAutotls reaches both. Before it reached only the ACME one.
  - The constants are Uri now. LetsEncryptURL, LetsEncryptURLStaging and DefaultBrokerURL were deleted.
  - Defaults are unchanged, so callers that set no URL are unaffected, but the renames are breaking.
- Two signature changes fall out of the conversion.
  - toFlattenedJws gained a string payload overload, because no JsonNode serializes to a zero-length payload. The JsonNode overload delegates to it, so existing call sites are untouched.
  - requestGetOrder and downloadCertificate now take key and kid, since they have to sign what used to be an unauthenticated GET.
- tests/tools/http_server.nim runs on chronos createStreamServer. It was built on websock's HttpServer, which answers 405 to anything but GET, so once the certificate download became a POST the client parsed the 405 body as PEM.
  - stop closes the connections, not the request handler. On Windows chronos keeps a read posted on an accepted socket, so closing one as soon as the response is written resets the connection and the client reads EOF in place of the response.

## Affected Areas

- [x] Other

  AutoTLS ACME client and broker, under `libp2p/autotls/`.

## Impact on Library Users

Source-breaking for anyone who sets a non-default URL:
- AutotlsConfig.acmeServerURL → acmeDirectoryURL
- AutotlsConfig.brokerURL: string → registrationURL: Uri
- LetsEncryptURL → LetsEncryptDirectoryURL
- DefaultBrokerURL → DefaultRegistrationURL

The new Let's Encrypt constants include the /directory path the old ones omitted. Callers that set no URL are unaffected.

Behaviour does change. Certificate issuance now uses the request format Boulder accepts.

## Risk Assessment

Every ACME request path changed at once, and CI does not talk to a real CA, so the wire format is not exercised end to end here.
