### PR TITLE
fix(bufferstream): avoid stranding pushes on close

### DIFF
--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -20,6 +20,7 @@ type BufferStream* = ref object of Connection
   readBuf: ZeroQueue # zero queue buffer for readOnce
   pushing*: bool # number of ongoing push operations
   reading*: bool # is there an ongoing read? (only allow one)
+  pendingRead: Future[seq[byte]] # queue pop owned by the active read
   pushedEof*: bool # eof marker has been put on readQueue
   returnedEof*: bool # 0-byte readOnce has been completed
 
@@ -112,13 +113,22 @@ method readOnce*(
     raise newLPStreamEOFError()
 
   if not s.isEof and s.readBuf.len < nbytes:
+    s.reading = true
+    let pendingRead = s.readQueue.popFirst()
+    s.pendingRead = pendingRead
     let buf =
       try:
-        s.reading = true
-        await s.readQueue.popFirst()
+        await pendingRead
       except CancelledError as exc:
+        if s.isEof and not s.readQueue.empty() and s.readQueue[0].len == 0:
+          try:
+            # Do not leave the close marker blocking an admitted pusher.
+            discard s.readQueue.popFirstNoWait()
+          except AsyncQueueEmptyError as error:
+            raiseAssert("readOnce failed queue empty: " & error.msg)
         raise exc
       finally:
+        s.pendingRead = nil
         s.reading = false
 
     if buf.len == 0:
@@ -163,16 +173,18 @@ method closeImpl*(s: BufferStream): Future[void] {.async: (raises: [], raw: true
   # push.
   #
   # A read and a push can be in flight at the same time. The reader wins: a
-  # queued item belongs to it, so we must not pop that item out from under it.
+  # pending queue pop belongs to it, so we must not pop an item out from under
+  # it. `reading` remains true briefly after that pop completes, hence the
+  # separate future check.
   #
   # State       | Q Empty  | Q Full
   # ------------|----------|-------
   # Reading     | Push Eof | Na
   # Pushing     | Na       | Pop
   try:
-    if s.reading:
+    if s.reading and not s.pendingRead.finished():
       if s.readQueue.empty():
-        # There is an active reader
+        # There is a reader still waiting on the queue.
         s.readQueue.addLastNoWait(Eof)
     elif s.pushing:
       if not s.readQueue.empty():

--- a/tests/libp2p/stream/test_bufferstream.nim
+++ b/tests/libp2p/stream/test_bufferstream.nim
@@ -303,6 +303,50 @@ suite "BufferStream":
     check readCompleted
     check await pushFut.withTimeout(100.milliseconds)
 
+  asyncTest "close does not strand a push after the reader dequeues data":
+    let stream = BufferStream.new()
+
+    var data: array[1, byte]
+    let readFut = stream.readOnce(addr data[0], data.len)
+    await stream.pushData("A".toBytes())
+    let pushFut = stream.pushData("B".toBytes())
+
+    proc closeStream(udata: pointer) {.gcsafe, raises: [].} =
+      discard cast[BufferStream](udata).close()
+
+    # The queue getter runs before close, while the outer read resumes later.
+    callSoon(closeStream, cast[pointer](stream))
+
+    check await readFut.withTimeout(100.milliseconds)
+    check (await readFut) == 1
+    check ['A'] == string.fromBytes(data)
+    check await pushFut.withTimeout(100.milliseconds)
+    await pushFut
+
+  asyncTest "close does not strand a push after reader cancellation":
+    let stream = BufferStream.new()
+    await stream.pushData("A".toBytes())
+    let pushFut = stream.pushData("B".toBytes())
+
+    var first: array[1, byte]
+    let firstRead = stream.readOnce(addr first[0], first.len)
+    check firstRead.finished()
+    check (await firstRead) == 1
+
+    var second: array[1, byte]
+    let secondRead = stream.readOnce(addr second[0], second.len)
+    check:
+      stream.reading
+      stream.pushing
+      stream.readQueue.empty()
+
+    secondRead.cancelSoon()
+    await stream.close()
+    await secondRead.cancelAndWait()
+
+    check await pushFut.withTimeout(100.milliseconds)
+    await pushFut
+
   asyncTest "reset is terminal and closeWithEOF returns immediately after reset":
     let stream = BufferStream.new()
 


### PR DESCRIPTION
## Summary

- Distinguish a queue read that is still pending from a read coroutine that already dequeued data.
- Remove an orphaned close marker when concurrent reader cancellation would otherwise block an admitted pusher.
- Cover both scheduler orderings with public-API regression tests.

## Affected Areas

- [x] Other — BufferStream lifecycle and backpressure.

## Impact on Library Users

Prevents BufferStream subclasses from leaving push or write futures pending indefinitely during concurrent close and read activity. There are no public API changes.

## Risk Assessment

The change adds internal future tracking and only removes a zero-length EOF marker after terminal close or reset. Non-empty application data remains untouched.

## References

- Follow-up to #2989