### PR TITLE
feat(dialer): overlap ranked dialing with name resolution

### DIFF
--- a/libp2p/dialcandidate.nim
+++ b/libp2p/dialcandidate.nim
@@ -10,3 +10,7 @@ type DialCandidate* = object
   address*: MultiAddress
   hostname*: string ## Host the address was reached under, for TLS and the Host header.
   peerId*: Opt[PeerId] ## Pinned by a dnsaddr record, otherwise the dialed peer's.
+
+func key*(candidate: DialCandidate): string =
+  ## Two candidates with the same key stand for the same dial.
+  $candidate.address & "|" & candidate.hostname & "|" & $candidate.peerId

--- a/libp2p/dialcandidate.nim
+++ b/libp2p/dialcandidate.nim
@@ -8,6 +8,5 @@ import multiaddress, peerid
 type DialCandidate* = object
   ## One address a dial can attempt, with dnsaddr and DNS already resolved.
   address*: MultiAddress
-  hostname*: string
-    ## Name the address was resolved from, empty when it is a wire address.
+  hostname*: string ## Host the address was reached under, for TLS and the Host header.
   peerId*: Opt[PeerId] ## Pinned by a dnsaddr record, otherwise the dialed peer's.

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -20,6 +20,7 @@ import
   transports/transport,
   nameresolving/nameresolver,
   upgrademngrs/upgrade,
+  utils/collections,
   utils/future,
   errors
 
@@ -50,6 +51,8 @@ const DefaultDialerTimeout* = 30.seconds
   ## that goes quiet mid-handshake holds the peer's dial lock forever.
 
 type
+  DialAttempt = Future[Muxer].Raising([CancelledError])
+
   DialLock = ref object
     lock: AsyncLock
     users: int ## dials holding or waiting for `lock`
@@ -63,7 +66,7 @@ type
     peerStore: PeerStore
     nameResolver: NameResolver
     ms: MultistreamSelect
-    dialRanking: bool ## resolve every address before the first dial
+    dialRanking: bool ## overlap the name lookups with the dials
     ongoingReleaseOnClose: seq[Future[void].Raising([])]
 
 proc transportFor(self: Dialer, address: MultiAddress): Opt[Transport] =
@@ -237,27 +240,20 @@ proc normalizedDialAddrs(
   else:
     addrs
 
-proc limitFanOut(candidates: seq[DialCandidate]): seq[DialCandidate] =
-  ## The peer picks the list, so cap the lookups and the addresses it can spawn.
-  var
-    kept: seq[DialCandidate]
-    lookups = 0
+proc remaining(limit: int): ref int =
+  ## One count shared by every holder, so concurrent lookups keep to one cap.
+  let left = new(int)
+  left[] = max(limit, 0)
+  left
 
-  for candidate in candidates:
-    if kept.len >= MaxExpandedAddresses:
-      debug "Dropping the addresses over the fan-out limit",
-        limit = MaxExpandedAddresses
-      break
-    if DNS.matchPartial(candidate.address):
-      lookups.inc()
-      if lookups > MaxDialCandidates:
-        continue
-    kept.add(candidate)
+proc takeCandidates(left: ref int, candidates: seq[DialCandidate]): seq[DialCandidate] =
+  let limit = left[]
+  if candidates.len > limit:
+    debug "Dropping the addresses over the candidate limit", limit
 
-  if lookups > MaxDialCandidates:
-    debug "Dropping the names over the lookup limit", limit = MaxDialCandidates
-
-  kept
+  let taken = candidates.take(limit)
+  left[] -= taken.len
+  taken
 
 proc expandCandidate(
     self: Dialer, candidate: DialCandidate, deadline: Moment
@@ -303,38 +299,38 @@ proc resolveCandidate(
 
   candidates
 
-proc expandAll(
-    self: Dialer, candidates: seq[DialCandidate], deadline: Moment
+proc resolveName(
+    self: Dialer, candidate: DialCandidate, left: ref int, deadline: Moment
 ): Future[seq[DialCandidate]] {.async: (raises: [CancelledError]).} =
-  let futs = limitFanOut(candidates).mapIt(self.expandCandidate(it, deadline))
-  concat(await collectCompleted(futs))
+  ## Every wire address one advertised name stands for, dnsaddr chain included.
 
-proc resolveAll(
-    self: Dialer, candidates: seq[DialCandidate], deadline: Moment
-): Future[seq[DialCandidate]] {.async: (raises: [CancelledError]).} =
-  let futs = limitFanOut(candidates).mapIt(self.resolveCandidate(it, deadline))
-  concat(await collectCompleted(futs))
+  let expanded = left.takeCandidates(await self.expandCandidate(candidate, deadline))
+  concat(await collectCompleted(expanded.mapIt(self.resolveCandidate(it, deadline))))
 
-proc collectCandidates(
-    self: Dialer, peerId: Opt[PeerId], addrs: seq[MultiAddress], deadline: Moment
-): Future[seq[DialCandidate]] {.async: (raises: [CancelledError]).} =
-  ## Resolve the addresses a transport handles, every lookup at once.
+proc directCandidates(
+    self: Dialer, peerId: Opt[PeerId], addrs: seq[MultiAddress]
+): seq[DialCandidate] =
+  ## The advertised addresses a transport can dial with no lookup at all.
 
-  if deadline.timeLeft().isZero():
-    debug "Out of time expanding the addresses", peerId, addrs
-    return @[]
+  var candidates: seq[DialCandidate]
+  for address in addrs:
+    if DNS.matchPartial(address):
+      continue
+    if self.transportFor(address).isNone():
+      debug "Skipping the address, no transport handles it", peerId, ma = address
+      continue
 
-  let
-    advertised = addrs.mapIt(DialCandidate(address: it, peerId: peerId))
-    expanded = await self.expandAll(advertised, deadline)
-    candidates = await self.resolveAll(expanded, deadline)
+    # `wstransport` sends this as the Host header, so a wire address needs it too.
+    candidates.add(
+      DialCandidate(address: address, hostname: address.getHostname(), peerId: peerId)
+    )
 
-  if candidates.len <= MaxDialCandidates:
-    return candidates
+  candidates
 
-  debug "Dropping the addresses over the candidate limit",
-    peerId, limit = MaxDialCandidates
-  candidates[0 ..< MaxDialCandidates]
+proc dnsCandidates(peerId: Opt[PeerId], addrs: seq[MultiAddress]): seq[DialCandidate] =
+  ## The advertised addresses that need a lookup before anything can dial them.
+
+  addrs.filterIt(DNS.matchPartial(it)).mapIt(DialCandidate(address: it, peerId: peerId))
 
 proc dialInOrder(
     self: Dialer,
@@ -359,6 +355,62 @@ proc dialInOrder(
         if not isNil(mux):
           return mux
 
+proc dropLosers(attempts: seq[DialAttempt]) {.async: (raises: []).} =
+  ## Give up every attempt that did not win, and close a muxer that landed anyway.
+
+  await noCancel attempts.cancelAndWait()
+  for attempt in attempts:
+    if attempt.completed():
+      let mux = attempt.value()
+      if not isNil(mux):
+        await mux.close()
+
+proc firstConnected(
+    attempts: seq[DialAttempt]
+): Future[Muxer] {.async: (raises: [CancelledError]).} =
+  ## The first attempt that connects. Nil when none of them does.
+
+  var pending = attempts
+  defer:
+    await dropLosers(pending)
+
+  while pending.len > 0:
+    let done =
+      try:
+        await one(pending)
+      except ValueError as e:
+        raiseAssert "one() over a non-empty seq: " & e.msg
+    pending.del(pending.find(done))
+
+    if not done.completed():
+      continue
+
+    let mux = done.value()
+    if not isNil(mux):
+      return mux
+
+proc dialAll(
+    self: Dialer, candidates: seq[DialCandidate], dir: Direction, deadline: Moment
+): Future[Muxer] {.async: (raises: [CancelledError]).} =
+  ## Dial every candidate at once. Nil when none of them connects.
+
+  await firstConnected(
+    candidates.mapIt(
+      self.dialAndUpgrade(it.peerId, it.hostname, it.address, dir, deadline)
+    )
+  )
+
+proc dialResolved(
+    self: Dialer,
+    lookup: Future[seq[DialCandidate]].Raising([CancelledError]),
+    left: ref int,
+    dir: Direction,
+    deadline: Moment,
+): Future[Muxer] {.async: (raises: [CancelledError]).} =
+  ## Dial one name's addresses the moment that name answers.
+
+  await self.dialAll(left.takeCandidates(await lookup), dir, deadline)
+
 proc dialRanked(
     self: Dialer,
     peerId: Opt[PeerId],
@@ -366,18 +418,21 @@ proc dialRanked(
     dir: Direction,
     deadline: Moment,
 ): Future[Muxer] {.async: (raises: [CancelledError]).} =
-  ## Resolve every address up front, then dial in the advertised order.
+  ## Dial the wire addresses at once, and each name's as soon as it resolves.
 
-  for candidate in await self.collectCandidates(peerId, addrs, deadline):
-    if deadline.timeLeft().isZero():
-      debug "Out of time for the remaining addresses", peerId, addrs
-      return nil
+  let
+    dialable = remaining(MaxDialCandidates)
+    names = remaining(MaxDialCandidates)
+    unresolved = remaining(MaxExpandedAddresses)
+    direct = dialable.takeCandidates(self.directCandidates(peerId, addrs))
+    lookups = names.takeCandidates(dnsCandidates(peerId, addrs)).mapIt(
+        self.resolveName(it, unresolved, deadline)
+      )
 
-    let mux = await self.dialAndUpgrade(
-      candidate.peerId, candidate.hostname, candidate.address, dir, deadline
-    )
-    if not isNil(mux):
-      return mux
+  await firstConnected(
+    @[self.dialAll(direct, dir, deadline)] &
+      lookups.mapIt(self.dialResolved(it, dialable, dir, deadline))
+  )
 
 proc dialAndUpgrade*(
     self: Dialer,

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import std/[sequtils, tables]
+import std/[sequtils, sets, tables]
 
 import pkg/[chronos, chronicles, metrics, results]
 
@@ -240,20 +240,48 @@ proc normalizedDialAddrs(
   else:
     addrs
 
-proc remaining(limit: int): ref int =
-  ## One count shared by every holder, so concurrent lookups keep to one cap.
-  let left = new(int)
-  left[] = max(limit, 0)
-  left
+type DialBudget = ref object
+  ## One cap and one seen set shared by every holder of the same dial.
+  left: int
+  seen: HashSet[string]
+  exhausted: AsyncEvent
 
-proc takeCandidates(left: ref int, candidates: seq[DialCandidate]): seq[DialCandidate] =
-  let limit = left[]
-  if candidates.len > limit:
-    debug "Dropping the addresses over the candidate limit", limit
+proc newBudget(limit: int): DialBudget =
+  let budget = DialBudget(left: max(limit, 0), exhausted: newAsyncEvent())
+  if budget.left == 0:
+    budget.exhausted.fire()
+  budget
 
-  let taken = candidates.take(limit)
-  left[] -= taken.len
+proc take(budget: DialBudget, candidates: seq[DialCandidate]): seq[DialCandidate] =
+  var fresh: seq[DialCandidate]
+  for candidate in candidates:
+    if not budget.seen.containsOrIncl(candidate.key()):
+      fresh.add(candidate)
+
+  if fresh.len > budget.left:
+    debug "Dropping the addresses over the candidate limit", limit = budget.left
+
+  let taken = fresh.take(budget.left)
+  budget.left -= taken.len
+  if budget.left == 0:
+    budget.exhausted.fire()
   taken
+
+proc awaitLookup(
+    budget: DialBudget, lookup: Future[seq[DialCandidate]].Raising([CancelledError])
+): Future[seq[DialCandidate]] {.async: (raises: [CancelledError]).} =
+  ## Empty once the budget leaves no room for the answer, so a stalling name ends here.
+
+  let exhausted = budget.exhausted.wait()
+  defer:
+    await noCancel allFutures(exhausted.cancelAndWait(), lookup.cancelAndWait())
+
+  discard await race(lookup, exhausted)
+  if lookup.completed():
+    return lookup.value()
+
+  debug "Giving up the lookup, the dial candidate limit is reached"
+  @[]
 
 proc expandCandidate(
     self: Dialer, candidate: DialCandidate, deadline: Moment
@@ -300,11 +328,11 @@ proc resolveCandidate(
   candidates
 
 proc resolveName(
-    self: Dialer, candidate: DialCandidate, left: ref int, deadline: Moment
+    self: Dialer, candidate: DialCandidate, budget: DialBudget, deadline: Moment
 ): Future[seq[DialCandidate]] {.async: (raises: [CancelledError]).} =
   ## Every wire address one advertised name stands for, dnsaddr chain included.
 
-  let expanded = left.takeCandidates(await self.expandCandidate(candidate, deadline))
+  let expanded = budget.take(await self.expandCandidate(candidate, deadline))
   concat(await collectCompleted(expanded.mapIt(self.resolveCandidate(it, deadline))))
 
 proc directCandidates(
@@ -403,13 +431,13 @@ proc dialAll(
 proc dialResolved(
     self: Dialer,
     lookup: Future[seq[DialCandidate]].Raising([CancelledError]),
-    left: ref int,
+    budget: DialBudget,
     dir: Direction,
     deadline: Moment,
 ): Future[Muxer] {.async: (raises: [CancelledError]).} =
   ## Dial one name's addresses the moment that name answers.
 
-  await self.dialAll(left.takeCandidates(await lookup), dir, deadline)
+  await self.dialAll(budget.take(await budget.awaitLookup(lookup)), dir, deadline)
 
 proc dialRanked(
     self: Dialer,
@@ -421,11 +449,11 @@ proc dialRanked(
   ## Dial the wire addresses at once, and each name's as soon as it resolves.
 
   let
-    dialable = remaining(MaxDialCandidates)
-    names = remaining(MaxDialCandidates)
-    unresolved = remaining(MaxExpandedAddresses)
-    direct = dialable.takeCandidates(self.directCandidates(peerId, addrs))
-    lookups = names.takeCandidates(dnsCandidates(peerId, addrs)).mapIt(
+    dialable = newBudget(MaxDialCandidates)
+    names = newBudget(MaxDialCandidates)
+    unresolved = newBudget(MaxExpandedAddresses)
+    direct = dialable.take(self.directCandidates(peerId, addrs))
+    lookups = names.take(dnsCandidates(peerId, addrs)).mapIt(
         self.resolveName(it, unresolved, deadline)
       )
 

--- a/tests/libp2p/test_dialer.nim
+++ b/tests/libp2p/test_dialer.nim
@@ -342,6 +342,65 @@ suite "Dialer":
     check failing.dialedAddrs == @[dead]
     check src.connManager.connCount(dst.peerInfo.peerId) == 1
 
+  asyncTest "Ranked dialing gives up the lookups once the candidate limit is reached":
+    let src = makeStandardSwitch()
+    await src.start()
+    defer:
+      await src.stop()
+
+    let
+      resolver = StallingResolver.new()
+      transport = FailingDialTransport.new(Upgrade(), rng())
+      dialer = Dialer.new(
+        src.peerInfo.peerId,
+        src.connManager,
+        src.peerStore,
+        @[Transport(transport)],
+        src.ms,
+        resolver,
+        dialRanking = true,
+      )
+
+    var addrs: seq[MultiAddress]
+    for i in 0 ..< MaxDialCandidates:
+      addrs.add(MultiAddress.init("/memorytransport/addr-" & $i).tryGet())
+    addrs.add(MultiAddress.init("/dnsaddr/stalls.example").tryGet())
+
+    expect DialFailedError:
+      await dialer.connect(PeerId.random(rng()).tryGet(), addrs).wait(1.seconds)
+
+    check resolver.cancelled
+
+  asyncTest "Ranked dialing dials each address one time":
+    let src = makeStandardSwitch()
+    await src.start()
+    defer:
+      await src.stop()
+
+    let wire = MultiAddress.init("/ip4/1.2.3.4/tcp/443").tryGet()
+    let resolver = MockResolver.new()
+    resolver.txtResponses["_dnsaddr.good.example"] = @["dnsaddr=" & $wire]
+
+    let
+      transport = FailingDialTransport.new(Upgrade(), rng(), handlesAny = true)
+      dialer = Dialer.new(
+        src.peerInfo.peerId,
+        src.connManager,
+        src.peerStore,
+        @[Transport(transport)],
+        src.ms,
+        resolver,
+        dialRanking = true,
+      )
+
+    let name = MultiAddress.init("/dnsaddr/good.example").tryGet()
+    expect DialFailedError:
+      await dialer.connect(PeerId.random(rng()).tryGet(), @[wire, wire, name]).wait(
+        5.seconds
+      )
+
+    check transport.dialedAddrs == @[wire]
+
   asyncTest "Ranked dialing carries the hostname of a wire address":
     let src = makeStandardSwitch()
     await src.start()

--- a/tests/libp2p/test_dialer.nim
+++ b/tests/libp2p/test_dialer.nim
@@ -15,7 +15,9 @@ import
     upgrademngrs/upgrade,
   ]
 import ../stubs/transportstub
-import ../tools/[unittest, futures, switch_builder, crypto, multiaddress, stall_server]
+import
+  ../tools/
+    [unittest, futures, switch_builder, crypto, multiaddress, resolver, stall_server]
 
 proc replaceIdentifyHandler(sw: Switch, handler: LPProtoHandler) =
   for holder in sw.ms.handlers:
@@ -220,6 +222,147 @@ suite "Dialer":
       await dialer.connect(PeerId.random(rng()).tryGet(), addrs)
 
     check transport.dialedAddrs == @[handled]
+
+  asyncTest "Ranked dialing dials a wire address while a name still stalls":
+    let
+      src = makeStandardSwitch(TcpAutoAddress)
+      dst = makeStandardSwitch(TcpAutoAddress)
+    await src.start()
+    await dst.start()
+    defer:
+      await allFutures(src.stop(), dst.stop())
+
+    let resolver = StallingResolver.new()
+    let dialer = Dialer.new(
+      src.peerInfo.peerId,
+      src.connManager,
+      src.peerStore,
+      src.transports,
+      src.ms,
+      resolver,
+      dialRanking = true,
+    )
+
+    let stalling = MultiAddress.init("/dnsaddr/stalls.example").tryGet()
+    await dialer.connect(dst.peerInfo.peerId, @[stalling] & dst.peerInfo.addrs).wait(
+      5.seconds
+    )
+
+    check src.connManager.connCount(dst.peerInfo.peerId) == 1
+    check resolver.cancelled
+
+  asyncTest "Ranked dialing dials a name that answers while another one stalls":
+    let
+      src = makeStandardSwitch(TcpAutoAddress)
+      dst = makeStandardSwitch(TcpAutoAddress)
+    await src.start()
+    await dst.start()
+    defer:
+      await allFutures(src.stop(), dst.stop())
+
+    let resolver = StallingResolver.new()
+    resolver.txtResponses["_dnsaddr.good.example"] =
+      @["dnsaddr=" & $dst.peerInfo.addrs[0]]
+
+    let dialer = Dialer.new(
+      src.peerInfo.peerId,
+      src.connManager,
+      src.peerStore,
+      src.transports,
+      src.ms,
+      resolver,
+      dialRanking = true,
+    )
+
+    let
+      stalling = MultiAddress.init("/dnsaddr/stalls.example").tryGet()
+      good = MultiAddress.init("/dnsaddr/good.example").tryGet()
+    await dialer.connect(dst.peerInfo.peerId, @[stalling, good]).wait(5.seconds)
+
+    check src.connManager.connCount(dst.peerInfo.peerId) == 1
+    check resolver.cancelled
+
+  asyncTest "Ranked dialing connects to a peer that advertises names only":
+    let
+      src = makeStandardSwitch(TcpAutoAddress)
+      dst = makeStandardSwitch(TcpAutoAddress)
+    await src.start()
+    await dst.start()
+    defer:
+      await allFutures(src.stop(), dst.stop())
+
+    let resolver = MockResolver.new()
+    resolver.txtResponses["_dnsaddr.good.example"] =
+      @["dnsaddr=" & $dst.peerInfo.addrs[0]]
+
+    let dialer = Dialer.new(
+      src.peerInfo.peerId,
+      src.connManager,
+      src.peerStore,
+      src.transports,
+      src.ms,
+      resolver,
+      dialRanking = true,
+    )
+
+    let name = MultiAddress.init("/dnsaddr/good.example").tryGet()
+    await dialer.connect(dst.peerInfo.peerId, @[name]).wait(5.seconds)
+
+    check src.connManager.connCount(dst.peerInfo.peerId) == 1
+
+  asyncTest "Ranked dialing reaches the resolved addresses when the wire ones fail":
+    let
+      src = makeStandardSwitch(TcpAutoAddress)
+      dst = makeStandardSwitch(TcpAutoAddress)
+    await src.start()
+    await dst.start()
+    defer:
+      await allFutures(src.stop(), dst.stop())
+
+    let resolver = MockResolver.new()
+    resolver.txtResponses["_dnsaddr.good.example"] =
+      @["dnsaddr=" & $dst.peerInfo.addrs[0]]
+
+    let failing = FailingDialTransport.new(Upgrade(), rng())
+    let dialer = Dialer.new(
+      src.peerInfo.peerId,
+      src.connManager,
+      src.peerStore,
+      @[Transport(failing)] & src.transports,
+      src.ms,
+      resolver,
+      dialRanking = true,
+    )
+
+    let
+      dead = MultiAddress.init("/memorytransport/addr-0").tryGet()
+      name = MultiAddress.init("/dnsaddr/good.example").tryGet()
+    await dialer.connect(dst.peerInfo.peerId, @[dead, name]).wait(5.seconds)
+
+    check failing.dialedAddrs == @[dead]
+    check src.connManager.connCount(dst.peerInfo.peerId) == 1
+
+  asyncTest "Ranked dialing carries the hostname of a wire address":
+    let src = makeStandardSwitch()
+    await src.start()
+    defer:
+      await src.stop()
+
+    let transport = FailingDialTransport.new(Upgrade(), rng(), handlesAny = true)
+    let dialer = Dialer.new(
+      src.peerInfo.peerId,
+      src.connManager,
+      src.peerStore,
+      @[Transport(transport)],
+      src.ms,
+      dialRanking = true,
+    )
+
+    let wss = MultiAddress.init("/ip4/1.2.3.4/tcp/443/wss").tryGet()
+    expect DialFailedError:
+      await dialer.connect(PeerId.random(rng()).tryGet(), @[wss])
+
+    check transport.dialedHosts == @["1.2.3.4"]
 
   asyncTest "Dialing skips an address that fails to resolve":
     let src = makeStandardSwitch()

--- a/tests/libp2p/utils/test_collections.nim
+++ b/tests/libp2p/utils/test_collections.nim
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import ../../../libp2p/utils/collections
+import ../../tools/[unittest]
+
+suite "take":
+  test "shorter than the count returns everything":
+    check @[1, 2, 3].take(5) == @[1, 2, 3]
+    check newSeq[int]().take(5).len == 0
+
+  test "longer than the count returns the prefix":
+    check @[1, 2, 3, 4].take(2) == @[1, 2]
+    check @[1, 2, 3, 4].take(4) == @[1, 2, 3, 4]
+
+  test "zero or negative count returns nothing":
+    check @[1, 2, 3].take(0).len == 0
+    check @[1, 2, 3].take(-1).len == 0

--- a/tests/stubs/transportstub.nim
+++ b/tests/stubs/transportstub.nim
@@ -63,13 +63,25 @@ proc new*(
   self
 
 type FailingDialTransport* = ref object of MemoryTransport
-  ## Records the addresses a dial reaches the transport with, and refuses each one.
+  ## Records what a dial reaches the transport with, and refuses each address.
   dialedAddrs*: seq[MultiAddress]
+  dialedHosts*: seq[string]
+  handlesAny: bool ## handle every address, not only the memory ones
 
-proc new*(T: typedesc[FailingDialTransport], upgrade: Upgrade, rng: Rng): T =
-  let self = T(upgrader: upgrade, rng: rng)
+proc new*(
+    T: typedesc[FailingDialTransport],
+    upgrade: Upgrade,
+    rng: Rng,
+    handlesAny: bool = false,
+): T =
+  let self = T(upgrader: upgrade, rng: rng, handlesAny: handlesAny)
   procCall Transport(self).initialize()
   self
+
+method handles*(
+    self: FailingDialTransport, ma: MultiAddress
+): bool {.gcsafe, raises: [].} =
+  self.handlesAny or procCall MemoryTransport(self).handles(ma)
 
 method dial*(
     self: FailingDialTransport,
@@ -79,6 +91,7 @@ method dial*(
     dir: Direction = Direction.Out,
 ): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =
   self.dialedAddrs.add(ma)
+  self.dialedHosts.add(hostname)
   raise newException(MemoryTransportError, "stub dial always fails")
 
 method accept*(

--- a/tests/tools/resolver.nim
+++ b/tests/tools/resolver.nim
@@ -12,6 +12,39 @@ proc default*(T: typedesc[MockResolver]): T =
   resolver.ipResponses[("localhost", true)] = @["::1"]
   resolver
 
+type StallingResolver* = ref object of NameResolver
+  ## Answers the scripted names, never answers any other, records a cancellation.
+  txtResponses*: Table[string, seq[string]]
+  cancelled*: bool
+
+proc stall(self: StallingResolver) {.async: (raises: [CancelledError]).} =
+  try:
+    await sleepAsync(1.hours)
+  except CancelledError as e:
+    self.cancelled = true
+    raise e
+
+method resolveIp*(
+    self: StallingResolver,
+    address: string,
+    port: Port,
+    domain: Domain = Domain.AF_UNSPEC,
+): Future[seq[TransportAddress]] {.
+    async: (raises: [CancelledError, TransportAddressError])
+.} =
+  await self.stall()
+  @[]
+
+method resolveTxt*(
+    self: StallingResolver, address: string
+): Future[seq[string]] {.async: (raises: [CancelledError]).} =
+  if address notin self.txtResponses:
+    await self.stall()
+  self.txtResponses.getOrDefault(address)
+
+proc new*(T: typedesc[StallingResolver]): T =
+  T()
+
 type StubNameResolverIpOutcome* {.pure.} = enum
   Resolve
   RaiseAddressError


### PR DESCRIPTION
## Summary

Follow-up to #2992. `dialRanked` could not dial anything before every name resolved.

`collectCandidates` calls `expandAll` and then `resolveAll`, and each one is a
barrier over `collectCompleted`. A peer that advertises `/ip4/1.2.3.4/tcp/4001`
and `/dnsaddr/bootstrap.example.org` could not touch the wire address until the
dnsaddr chain answered or the dial deadline killed it. The chain recurses up to
depth 6 and every hop is a TXT lookup, so the cost is worst where ranking helps
least: one good direct address and one dead name pay the full DNS timeout before
the first packet.

`dialRanked` now splits the advertised addresses on `DNS.matchPartial`. It starts
one lookup per name without awaiting them, dials the wire addresses while they
run, then dials each name's addresses the moment that name answers. Nothing waits
for the slowest name: `dialAsResolved` walks the lookups with `one()`, takes
whichever finished, and dials its batch before returning to wait for the next.

A wire address costs no round trip to try, so it goes first whatever its rank: a
dnsaddr that ranks above a direct address loses its place. Among the names, the
dial order is completion order, not the advertised order. Both are deliberate.

A dial that connects cancels the pending lookups in a `defer`, which also covers
the failure path and cancellation.

New procs in `libp2p/dialer.nim`:

- `directCandidates` keeps the advertised addresses that fail `DNS.matchPartial`
  and that a transport handles.
- `nameCandidates` keeps the rest, capped at `MaxDialCandidates` lookups.
- `resolveName` expands and resolves one name, and is the producer.
- `dialAsResolved` is the consumer.
- `dialEach` holds the dial loop that both halves need.
- `capCandidates` holds the cap that `collectCandidates` applied inline.

`collectCandidates`, `expandAll`, `resolveAll` and `limitFanOut` are gone: each
was a barrier over every address, which is the thing this PR removes.

All three caps survive the split. Lookups stay at `MaxDialCandidates`, applied to
the name list. Addresses resolved at once stay at `MaxExpandedAddresses`, now a
`FanOut` counter the lookups share instead of a per-batch filter. Addresses
dialed stay at `MaxDialCandidates` in total, the resolved side getting
`MaxDialCandidates - direct.len`.

`directCandidates` sets `hostname` from `getHostname()`, like `expandCandidate`
does. Without it `wstransport` falls back to `$initAddress` and sends
`1.2.3.4:443` as the Host header instead of `1.2.3.4`. The `DialCandidate.hostname`
doc comment claimed the field is "empty when it is a wire address", which was
already wrong before this PR. The comment is corrected, the code is not.

## Affected Areas

- [x] Peer Management / Discovery
  <!-- dial candidate selection and name resolution in `libp2p/dialer.nim` -->

## Compatibility & Downstream Validation

The path is behind the `dialRanking` flag, which is off by default and has no
downstream user yet. No integration branch needed.

- **Nimbus:** N/A
- **Waku:** N/A
- **Codex:** N/A

## Impact on Library Users

No API change. Behaviour changes only for a switch built with
`withDialRanking(true)`: a peer's wire addresses are dialed before its names,
instead of after every lookup finishes.

## Risk Assessment

- Backward compatibility: the default dial path (`dialInOrder`) is untouched.
- Ordering: the advertised rank no longer decides between a name and a wire
  address, nor between two names. A deployment that relies on a dnsaddr being
  tried first would see the direct address, or the faster name, win.
- Resource use: the lookups now run while a dial is in flight, so a dial holds
  both at once. The `defer` cancels them on every exit path, and the total
  candidate cap is unchanged at `MaxDialCandidates`.

## References

- #2992 — the ranking PR this builds on.

## Additional Notes

Tests in `tests/libp2p/test_dialer.nim`:

- A wire address connects while a name still stalls, and the stalled lookup is
  cancelled. This one fails without the change.
- A name that answers is dialed while another name still stalls. This one fails
  without the producer/consumer loop.
- A peer that advertises names only still connects.
- The resolved addresses are still reached when every wire address fails.
- A `/ip4/1.2.3.4/tcp/443/wss` address carries `hostname == "1.2.3.4"` into
  `Transport.dial`.

`tests/tools/resolver.nim` gains `StallingResolver`, which answers the names in
its `txtResponses` table, never answers any other, and records whether the caller
cancelled it. `FailingDialTransport` gains
`dialedHosts` and a `handlesAny` flag.

The tests are not run yet: the container's nimble packages are stale against
`libp2p.nimble` and `make setup` does not complete here.
