### PR TITLE
chore(release): prepare v2.3.1 with libplum v0.6.3

### DIFF
--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName = "libp2p"
-version = "2.3.0"
+version = "2.3.1"
 author = "Status Research & Development GmbH"
 description = "LibP2P implementation"
 license = "MIT"
@@ -14,7 +14,7 @@ requires "nim >= 2.2.4",
   "serialization >= 0.5.0", "json_serialization >= 0.4.4", "lsquic >= 0.8.1",
   "protobuf_serialization >= 0.6.0",
   "https://github.com/status-im/nim-websock >= 0.4.0",
-  "https://github.com/logos-storage/nim-libplum#acefbe424cf9d1f05f2d93533790c9ac4e034df8"
+  "https://github.com/logos-storage/nim-libplum#v0.6.3"
 
 import os
 


### PR DESCRIPTION
## Summary

- bump the nim-libp2p package version to 2.3.1
- pin libplum v0.6.3, which includes the Android linker fix

## Impact on Library Users

No API changes. Android consumers no longer inherit libplum's `-lpthread` linker flag.

## References

- https://github.com/logos-storage/nim-libplum/pull/23