### PR TITLE
chore: remove deprecated unsafeAddr usage

### DIFF
--- a/docs/compile_time_flags.md
+++ b/docs/compile_time_flags.md
@@ -38,13 +38,13 @@ For example, a file called `multihash_exts.nim` could be created and contain `Mu
 
 ```nim
 proc coder1(data: openArray[byte], output: var openArray[byte]) =
-  copyMem(addr output[0], unsafeAddr data[0], len(output))
+  copyMem(addr output[0], addr data[0], len(output))
 
 proc coder2(data: openArray[byte], output: var openArray[byte]) =
-  copyMem(addr output[0], unsafeAddr data[0], len(output))
+  copyMem(addr output[0], addr data[0], len(output))
 
 proc sha2_256_override(data: openArray[byte], output: var openArray[byte]) =
-  copyMem(addr output[0], unsafeAddr data[0], len(output))
+  copyMem(addr output[0], addr data[0], len(output))
 
 const HashExts = [
   MHash(mcodec: multiCodec("codec_mc1"), size: 0, coder: coder1),

--- a/libp2p/nameresolving/nameresolver.nim
+++ b/libp2p/nameresolving/nameresolver.nim
@@ -5,7 +5,7 @@
 
 import std/[sets, sequtils, strutils]
 import chronos, chronicles, stew/endians2
-import ".."/[multiaddress, multicodec]
+import ../[multiaddress, multicodec]
 
 logScope:
   topics = "libp2p nameresolver"

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -5,9 +5,9 @@
 
 import std/[tables, sequtils, sets, algorithm, deques]
 import chronos, chronicles, metrics
-import "."/[types, scoring, extensions]
-import ".."/[pubsubpeer, peertable, mcache, floodsub, pubsub, rpc_send, timedcache]
-import "../rpc"/[messages]
+import ./[types, scoring, extensions]
+import ../[pubsubpeer, peertable, mcache, floodsub, pubsub, rpc_send, timedcache]
+import ../rpc/[messages]
 import
   "../../.."/[
     peerid,

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -9,7 +9,7 @@ import chronos/ratelimit
 import ./[types]
 import ../[pubsubpeer]
 import ../rpc/messages
-import ../../../[peerid, multiaddress, switch, utils/heartbeat, utils/future]
+import "../../.."/[peerid, multiaddress, switch, utils/heartbeat, utils/future]
 import ../pubsub
 
 logScope:

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -6,10 +6,10 @@
 import std/[tables, sets]
 import chronos, chronicles, metrics
 import chronos/ratelimit
-import "."/[types]
-import ".."/[pubsubpeer]
+import ./[types]
+import ../[pubsubpeer]
 import ../rpc/messages
-import "../../.."/[peerid, multiaddress, switch, utils/heartbeat, utils/future]
+import ../../../[peerid, multiaddress, switch, utils/heartbeat, utils/future]
 import ../pubsub
 
 logScope:

--- a/libp2p/utils/debug.nim
+++ b/libp2p/utils/debug.nim
@@ -106,7 +106,7 @@ proc dumpMessage*(conn: SecureConn, direction: FlowDirection, data: openArray[by
   try:
     if open(handle, pathName, fmAppend):
       if bytes.len > 0:
-        discard writeBuffer(handle, unsafeAddr bytes[0], bytes.len)
+        discard writeBuffer(handle, addr bytes[0], bytes.len)
   finally:
     close(handle)
 


### PR DESCRIPTION
https://nim-lang.org/docs/manual.html#statements-and-expressions-the-unsafeaddr-operator
> `The unsafeAddr operator is a deprecated alias for the addr operator`

This is as of Nim 2.0, but `nim-libp2p` doesn't support pre-2.0 Nim anyway anymore.

All the "."/foo and ".."/foo imports can be just ./foo and ../foo. They're workarounds for a since-fixed Nim bug:
- https://github.com/nim-lang/Nim/issues/8792
- https://github.com/nim-lang/Nim/issues/17102
- https://github.com/nim-lang/Nim/pull/21636