### PR TITLE
fix(cbind): guard service discovery entry points on a started switch

### DIFF
--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -106,7 +106,9 @@ task examples, "Build and run the C bindings examples":
     cborObjs.add obj
   let cborObjsStr = cborObjs.join(" ")
 
-  for example in ["echo", "gossipsub", "kad", "relay", "peerstore", "metrics"]:
+  for example in [
+    "echo", "gossipsub", "kad", "service_disco", "relay", "peerstore", "metrics"
+  ]:
     let outBin = "../build/" & example
     exec "gcc -std=c11 -O2 -I c_bindings -I " & vendor & " examples/" & example & ".c " &
       cborObjsStr & " " & lib & " -pthread -Wl,-rpath,'$ORIGIN' -o " & outBin

--- a/cbind/examples/CMakeLists.txt
+++ b/cbind/examples/CMakeLists.txt
@@ -62,7 +62,7 @@ set_property(TARGET tinycbor PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 find_package(Threads REQUIRED)
 
-foreach(example echo gossipsub kad relay peerstore metrics)
+foreach(example echo gossipsub kad service_disco relay peerstore metrics)
   add_executable(${example} "${example}.c")
   target_include_directories(${example} PRIVATE "${GEN_DIR}")
   target_link_libraries(${example} PRIVATE "${LIB_FILE}" tinycbor Threads::Threads)

--- a/cbind/examples/README.md
+++ b/cbind/examples/README.md
@@ -7,6 +7,7 @@ The bindings are a header-only C API over a C ABI. Every generated method is asy
 - `echo.c` — two TCP nodes. The server mounts a custom protocol (`/cbind/echo/1.0.0`) and echoes the bytes it reads. The client dials the server and verifies the round-trip twice: the first dial passes the server's address, so it opens the connection and the stream in one call; the second passes only the peer id, opening a fresh stream over the connection the first dial left behind. The incoming-stream handler only hands the stream id to `main`, which serves it inline, since calling back into the library from the dispatch thread would deadlock.
 - `gossipsub.c` — two TCP nodes join a shared topic and exchange one message, delivered to the subscriber through its pub/sub-message listener.
 - `kad.c` — two TCP nodes form a Kademlia DHT (a server, and a client that lists the server as its bootstrap node), then round-trip a value (`kad_put_value` / `kad_get_value`) and a provider record (`create_cid`, `kad_start_providing` / `kad_get_providers`) over the wire.
+- `service_disco.c` — two TCP nodes on top of the DHT: a provider advertises a service id (`service_disco_start_advertising`) and a seeker that bootstraps off it finds the provider's extended peer record (`service_disco_lookup`). It also shows the lifecycle rule: `libp2p_ctx_start` starts discovery, so a `service_disco_*` call before it fails.
 - `relay.c` — three TCP nodes: a relay, a destination and a source. The destination reserves a slot on the relay (`circuit_relay_reserve`); the source reaches it over a `/p2p-circuit` address (`dial_circuit_relay`) and sends a message the destination reads off its relayed stream.
 - `peerstore.c` — drives one node's peerstore directly from a second node's PeerInfo: `peerstore_add_peer`, `peerstore_get_peers`, `peerstore_get_peer_info`, then `peerstore_delete_peer`. No dialing required.
 - `metrics.c` — a running node dumps the process-wide Prometheus registry as JSON via `collect_metrics`.
@@ -41,6 +42,7 @@ cmake -S . -B build -DTINYCBOR_VENDOR=$(nimble path ffi)/ffi/codegen/templates/c
 ./build/echo
 ./build/gossipsub
 ./build/kad
+./build/service_disco
 ./build/relay
 ./build/peerstore
 ./build/metrics

--- a/cbind/examples/common.h
+++ b/cbind/examples/common.h
@@ -145,3 +145,14 @@ static inline bool await_peerinfo(LibP2PCtx *ctx, PeerInfoWaiter *w,
   }
   return true;
 }
+
+// Dials `to` from `from` so identify runs and a live connection backs the RPCs.
+static inline bool await_connect(LibP2PCtx *from, const PeerInfoWaiter *to) {
+  NimFfiStr connAddrs[MAX_ADDRS];
+  for (size_t i = 0; i < to->naddrs; i++)
+    connAddrs[i] = nimffi_str(to->addrs[i]);
+  ConnectRequest req = {nimffi_str(to->peerId), {connAddrs, to->naddrs}, 0};
+  BoolWaiter bw;
+  return AWAIT_BOOL(bw, libp2p_ctx_connect(from, &req, on_bool, &bw),
+                    "connect");
+}

--- a/cbind/examples/kad.c
+++ b/cbind/examples/kad.c
@@ -111,18 +111,6 @@ static LibP2PCtx *kadNode(const char *listenAddr, const char *label,
   return await_create(&cfg, label);
 }
 
-// Dials `to` from `from` so identify runs and a live connection backs the DHT
-// RPCs that follow.
-static bool dial(LibP2PCtx *from, const PeerInfoWaiter *to) {
-  NimFfiStr connAddrs[MAX_ADDRS];
-  for (size_t i = 0; i < to->naddrs; i++)
-    connAddrs[i] = nimffi_str(to->addrs[i]);
-  ConnectRequest req = {nimffi_str(to->peerId), {connAddrs, to->naddrs}, 0};
-  BoolWaiter bw;
-  return AWAIT_BOOL(bw, libp2p_ctx_connect(from, &req, on_bool, &bw),
-                    "connect");
-}
-
 int main(void) {
   int status = 1;
   BoolWaiter bw;
@@ -141,7 +129,7 @@ int main(void) {
   if (!client)
     goto cleanup_server;
   if (!AWAIT_BOOL(bw, libp2p_ctx_start(client, on_bool, &bw), "start client") ||
-      !dial(client, &serverInfo))
+      !await_connect(client, &serverInfo))
     goto cleanup_client;
 
   // ── Value round-trip: server stores, client fetches over the DHT ──────────

--- a/cbind/examples/service_disco.c
+++ b/cbind/examples/service_disco.c
@@ -1,0 +1,185 @@
+// Service discovery: a provider advertises a service id in its extended peer
+// record, and a seeker that bootstraps off the provider looks the service up
+// over the DHT. The generated bindings are asynchronous, so every call is
+// wrapped with the blocking helpers in common.h.
+//
+// Ordering matters here. The switch lifecycle already starts and stops
+// discovery, so `libp2p_ctx_start` comes first and every
+// `libp2p_ctx_service_disco_*` call before it fails with an explicit error
+// rather than half-starting an undialable node.
+#include "common.h"
+
+static const char *ServiceId = "/cbind/disco/demo-service";
+static const char *ServiceData = "demo-payload";
+
+// A lookup answers with up to Default_F_lookup (30) records.
+#define MAX_RECORDS 32
+typedef struct {
+  atomic_int done;
+  int err_code;
+  char err[256];
+  char peerIds[MAX_RECORDS][128];
+  bool advertises[MAX_RECORDS];
+  char serviceData[MAX_RECORDS][128];
+  size_t n;
+} RecordsWaiter;
+
+static void copyServiceData(const ExtendedPeerRecordEntry *r, char *dst,
+                            size_t cap, bool *found) {
+  for (size_t i = 0; i < r->services.len; i++) {
+    const ServiceInfoEntry *s = &r->services.data[i];
+    if (!s->id.data || strcmp(s->id.data, ServiceId) != 0)
+      continue;
+    *found = true;
+    if (s->data.data)
+      snprintf(dst, cap, "%.*s", (int)s->data.len, (const char *)s->data.data);
+    return;
+  }
+}
+
+static void on_records(int ec, const ExtendedRecordsResponse *reply,
+                       const char *em, void *ud) {
+  RecordsWaiter *w = (RecordsWaiter *)ud;
+  w->err_code = ec;
+  if (reply) {
+    w->n = reply->records.len < MAX_RECORDS ? reply->records.len : MAX_RECORDS;
+    for (size_t i = 0; i < w->n; i++) {
+      const ExtendedPeerRecordEntry *r = &reply->records.data[i];
+      if (r->peerId.data)
+        snprintf(w->peerIds[i], sizeof(w->peerIds[i]), "%s", r->peerId.data);
+      copyServiceData(r, w->serviceData[i], sizeof(w->serviceData[i]),
+                      &w->advertises[i]);
+    }
+  }
+  if (em)
+    snprintf(w->err, sizeof(w->err), "%s", em);
+  atomic_store(&w->done, 1);
+}
+
+static LibP2PCtx *discoNode(const char *listenAddr, const char *label,
+                            const PeerInfoWaiter *boot) {
+  NimFfiStr addrSlot = nimffi_str(listenAddr);
+  Libp2pConfig cfg;
+  memset(&cfg, 0, sizeof(cfg));
+  cfg.mountServiceDiscovery = true;
+  cfg.addrs.data = &addrSlot;
+  cfg.addrs.len = 1;
+  cfg.muxer = MUXER_TYPE_MPLEX;
+  cfg.transport = TRANSPORT_TYPE_TCP;
+
+  NimFfiStr bootAddrs[MAX_ADDRS];
+  BootstrapNode bootNode;
+  if (boot) {
+    for (size_t i = 0; i < boot->naddrs; i++)
+      bootAddrs[i] = nimffi_str(boot->addrs[i]);
+    bootNode.peerId = nimffi_str(boot->peerId);
+    bootNode.multiaddrs.data = bootAddrs;
+    bootNode.multiaddrs.len = boot->naddrs;
+    cfg.bootstrapNodes.data = &bootNode;
+    cfg.bootstrapNodes.len = 1;
+  }
+  return await_create(&cfg, label);
+}
+
+// Registration is a background task, so the lookup retries.
+#define LOOKUP_ATTEMPTS 30
+static bool lookupProvider(LibP2PCtx *seeker, const char *providerId) {
+  LookupRequest req = {nimffi_str(ServiceId), {NULL, 0}};
+  for (int attempt = 0; attempt < LOOKUP_ATTEMPTS; attempt++) {
+    RecordsWaiter rw;
+    memset(&rw, 0, sizeof(rw));
+    libp2p_ctx_service_disco_lookup(seeker, &req, on_records, &rw);
+    if (!wait_done(&rw.done)) {
+      fprintf(stderr, "lookup: call did not complete\n");
+      return false;
+    }
+    if (rw.err_code != 0) {
+      fprintf(stderr, "lookup: %s\n", rw.err[0] ? rw.err : "unknown");
+      return false;
+    }
+    for (size_t i = 0; i < rw.n; i++) {
+      if (!rw.advertises[i] || strcmp(rw.peerIds[i], providerId) != 0)
+        continue;
+      if (strcmp(rw.serviceData[i], ServiceData) != 0) {
+        fprintf(stderr, "Error: service data did not round-trip\n");
+        return false;
+      }
+      printf("Seeker found %s advertising '%s' with '%s'\n", providerId,
+             ServiceId, ServiceData);
+      return true;
+    }
+    sleep_ms(500);
+  }
+  fprintf(stderr, "Error: provider never showed up in a lookup\n");
+  return false;
+}
+
+// Discovery cannot be driven before the switch listens (issue #3003).
+static bool rejectsDiscoBeforeStart(LibP2PCtx *ctx) {
+  BoolWaiter bw;
+  memset(&bw, 0, sizeof(bw));
+  libp2p_ctx_service_disco_start(ctx, on_bool, &bw);
+  if (!wait_done(&bw.done)) {
+    fprintf(stderr, "service_disco_start: call did not complete\n");
+    return false;
+  }
+  if (bw.err_code == 0) {
+    fprintf(stderr, "Error: service_disco_start succeeded before ctx_start\n");
+    return false;
+  }
+  // A bare err_code check also passes on an unmounted protocol.
+  if (strstr(bw.err, "switch not started") == NULL) {
+    fprintf(stderr, "Error: expected the not-started guard, got: %s\n", bw.err);
+    return false;
+  }
+  printf("service_disco_start before ctx_start rejected: %s\n", bw.err);
+  return true;
+}
+
+int main(void) {
+  int status = 1;
+  BoolWaiter bw;
+  PeerInfoWaiter providerInfo;
+
+  LibP2PCtx *provider = discoNode("/ip4/127.0.0.1/tcp/5041", "provider", NULL);
+  if (!provider)
+    return 1;
+  if (!rejectsDiscoBeforeStart(provider))
+    goto cleanup_provider;
+  if (!AWAIT_BOOL(bw, libp2p_ctx_start(provider, on_bool, &bw),
+                  "start provider"))
+    goto cleanup_provider;
+  if (!await_peerinfo(provider, &providerInfo, "provider peerinfo"))
+    goto cleanup_provider;
+  printf("Provider: %s\n", providerInfo.peerId);
+
+  LibP2PCtx *seeker =
+      discoNode("/ip4/127.0.0.1/tcp/5042", "seeker", &providerInfo);
+  if (!seeker)
+    goto cleanup_provider;
+  if (!AWAIT_BOOL(bw, libp2p_ctx_start(seeker, on_bool, &bw), "start seeker") ||
+      !await_connect(seeker, &providerInfo))
+    goto cleanup_seeker;
+
+  StartAdvertisingRequest adReq = {
+      nimffi_str(ServiceId),
+      {(uint8_t *)ServiceData, strlen(ServiceData)},
+      {NULL, 0}};
+  if (!AWAIT_BOOL(bw,
+                  libp2p_ctx_service_disco_start_advertising(provider, &adReq,
+                                                             on_bool, &bw),
+                  "start_advertising"))
+    goto cleanup_seeker;
+  printf("Provider advertises '%s'\n", ServiceId);
+
+  if (lookupProvider(seeker, providerInfo.peerId))
+    status = 0;
+
+cleanup_seeker:
+  AWAIT_BOOL(bw, libp2p_ctx_stop(seeker, on_bool, &bw), "stop seeker");
+  libp2p_ctx_destroy(seeker);
+cleanup_provider:
+  AWAIT_BOOL(bw, libp2p_ctx_stop(provider, on_bool, &bw), "stop provider");
+  libp2p_ctx_destroy(provider);
+  return status;
+}

--- a/cbind/libp2p.nim
+++ b/cbind/libp2p.nim
@@ -912,32 +912,35 @@ proc libp2pKadGetProviders*(
     providers.add(ProviderInfo(peerId: $peerId, addrs: provider.addrs.mapIt($it)))
   ok(ProvidersResponse(providers: providers))
 
-proc resolveServiceDiscovery(lib: LibP2P): Result[ServiceDiscovery, string] =
+proc runningServiceDiscovery(lib: LibP2P): Result[ServiceDiscovery, string] =
   let kad = lib.kad.valueOr:
     return err("service discovery not initialized")
   if not (kad of ServiceDiscovery):
     return err("service discovery not mounted")
+  # Before the switch runs there is no listen address and no signed peer record.
+  if not lib.running:
+    return err("switch not started; call libp2p_ctx_start first")
   ok(ServiceDiscovery(kad))
 
 proc libp2pKadRandomRecords*(
     lib: LibP2P
 ): Future[Result[ExtendedRecordsResponse, string]] {.ffi.} =
   ## Extended peer records collected from a random DHT walk.
-  let disco = resolveServiceDiscovery(lib).valueOr:
+  let disco = runningServiceDiscovery(lib).valueOr:
     return err(error)
   let records = await disco.lookupRandom()
   ok(toExtendedRecordsResponse(records))
 
 proc libp2pServiceDiscoStart*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} =
-  ## Starts the service-discovery background loops.
-  let disco = resolveServiceDiscovery(lib).valueOr:
+  ## Resumes discovery after `libp2p_ctx_service_disco_stop`; `libp2p_ctx_start` already starts it.
+  let disco = runningServiceDiscovery(lib).valueOr:
     return err(error)
   await disco.start()
   ok(true)
 
 proc libp2pServiceDiscoStop*(lib: LibP2P): Future[Result[bool, string]] {.ffi.} =
-  ## Stops the service-discovery background loops.
-  let disco = resolveServiceDiscovery(lib).valueOr:
+  ## Stops the discovery loops while the switch keeps running.
+  let disco = runningServiceDiscovery(lib).valueOr:
     return err(error)
   await disco.stop()
   ok(true)
@@ -951,7 +954,7 @@ proc libp2pServiceDiscoStartAdvertising*(
   ## record does not decode, is oversized, or does not list `serviceId`.
   ## A service that is already advertised fails here: stop it first, then start
   ## it again with the new advertisement.
-  let disco = resolveServiceDiscovery(lib).valueOr:
+  let disco = runningServiceDiscovery(lib).valueOr:
     return err(error)
 
   disco.startAdvertising(
@@ -966,7 +969,7 @@ proc libp2pServiceDiscoStopAdvertising*(
     lib: LibP2P, serviceId: string
 ): Future[Result[bool, string]] {.ffi.} =
   ## Stops advertising `serviceId`.
-  let disco = resolveServiceDiscovery(lib).valueOr:
+  let disco = runningServiceDiscovery(lib).valueOr:
     return err(error)
   await disco.stopAdvertising(serviceId)
   ok(true)
@@ -975,7 +978,7 @@ proc libp2pServiceDiscoRegisterInterest*(
     lib: LibP2P, serviceId: string
 ): Future[Result[bool, string]] {.ffi.} =
   ## Registers interest in `serviceId` so its providers are cached locally.
-  let disco = resolveServiceDiscovery(lib).valueOr:
+  let disco = runningServiceDiscovery(lib).valueOr:
     return err(error)
   discard disco.registerInterest(serviceId)
   ok(true)
@@ -984,7 +987,7 @@ proc libp2pServiceDiscoUnregisterInterest*(
     lib: LibP2P, serviceId: string
 ): Future[Result[bool, string]] {.ffi.} =
   ## Drops the interest previously registered for `serviceId`.
-  let disco = resolveServiceDiscovery(lib).valueOr:
+  let disco = runningServiceDiscovery(lib).valueOr:
     return err(error)
   disco.unregisterInterest(serviceId)
   ok(true)
@@ -993,7 +996,7 @@ proc libp2pServiceDiscoLookup*(
     lib: LibP2P, req: LookupRequest
 ): Future[Result[ExtendedRecordsResponse, string]] {.ffi.} =
   ## Looks up the extended peer records advertising `serviceId`.
-  let disco = resolveServiceDiscovery(lib).valueOr:
+  let disco = runningServiceDiscovery(lib).valueOr:
     return err(error)
   let service = ServiceInfo(id: req.serviceId, data: Opt.some(req.serviceData))
   let res = await disco.lookup(service)
@@ -1005,7 +1008,7 @@ proc libp2pServiceDiscoRandomLookup*(
     lib: LibP2P
 ): Future[Result[ExtendedRecordsResponse, string]] {.ffi.} =
   ## Extended peer records from a random walk, whatever they advertise.
-  let disco = resolveServiceDiscovery(lib).valueOr:
+  let disco = runningServiceDiscovery(lib).valueOr:
     return err(error)
   let records = await disco.lookupRandom()
   ok(toExtendedRecordsResponse(records))


### PR DESCRIPTION
## Summary

The switch lifecycle already starts and stops `ServiceDiscovery`, but nothing guarded the ordering: `libp2p_ctx_service_disco_start` before `libp2p_ctx_start` returned `ok(true)` and latched a node that advertised no addresses and served no inbound queries. Every `libp2p_ctx_service_disco_*` entry point now resolves through `runningServiceDiscovery`, which requires `lib.running` and otherwise fails with `switch not started; call libp2p_ctx_start first`.

Adds `cbind/examples/service_disco.c`, the first C example for this family: it asserts the guard, then advertises and looks up a service across two nodes.

Fixes #3003.

## Affected Areas

- [x] Peer Management / Discovery
- [x] Build / Tooling

## Impact on Library Users

C hosts only, on a sequence that was already broken: a `service_disco_*` call before `libp2p_ctx_start` now errors instead of half-starting the node. The intended order is unchanged.

## Risk Assessment

Low. Nothing that worked before stops working. Two known gaps left open: the `lib.running` read is a snapshot, so a concurrent `libp2p_ctx_stop` still races a call in flight (pre-existing, shared by every entry point in the file), and the `libp2p_ctx_kad_*` procs stay unguarded since they have no FFI start/stop and cannot latch.

## References

- Issue: #3003
- Verified in-sandbox: all 7 examples build and run to exit 0.
