### PR TITLE
fix(dialer): dial dnsaddr results without waiting for siblings

### DIFF
--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -350,14 +350,6 @@ proc resolveCandidate(
 
   candidates
 
-proc resolveName(
-    self: Dialer, candidate: DialCandidate, budget: DialBudget, deadline: Moment
-): Future[seq[DialCandidate]] {.async: (raises: [CancelledError]).} =
-  ## Every wire address one advertised name stands for, dnsaddr chain included.
-
-  let expanded = budget.take(await self.expandCandidate(candidate, deadline))
-  concat(await collectCompleted(expanded.mapIt(self.resolveCandidate(it, deadline))))
-
 proc directCandidates(
     self: Dialer, peerId: Opt[PeerId], addrs: seq[MultiAddress]
 ): seq[DialCandidate] =
@@ -476,6 +468,27 @@ proc dialResolved(
     budget.take(await budget.awaitLookup(lookup)), dir, deadline, forceDial, reach
   )
 
+proc dialName(
+    self: Dialer,
+    candidate: DialCandidate,
+    expandedBudget: DialBudget,
+    dialBudget: DialBudget,
+    dir: Direction,
+    deadline: Moment,
+    forceDial: bool,
+    reach: DialReach,
+): Future[Muxer] {.async: (raises: [CancelledError]).} =
+  ## Dial each address from one advertised name as soon as it resolves.
+
+  let expanded = expandedBudget.take(
+    await dialBudget.awaitLookup(self.expandCandidate(candidate, deadline))
+  )
+  let lookups = expanded.mapIt(self.resolveCandidate(it, deadline))
+
+  await firstConnected(
+    lookups.mapIt(self.dialResolved(it, dialBudget, dir, deadline, forceDial, reach))
+  )
+
 proc dialRanked(
     self: Dialer,
     peerId: Opt[PeerId],
@@ -492,13 +505,12 @@ proc dialRanked(
     names = newBudget(MaxDialCandidates)
     unresolved = newBudget(MaxExpandedAddresses)
     direct = dialable.take(self.directCandidates(peerId, addrs))
-    lookups = names.take(dnsCandidates(peerId, addrs)).mapIt(
-        self.resolveName(it, unresolved, deadline)
+    nameDials = names.take(dnsCandidates(peerId, addrs)).mapIt(
+        self.dialName(it, unresolved, dialable, dir, deadline, forceDial, reach)
       )
 
   await firstConnected(
-    @[self.dialAll(direct, dir, deadline, forceDial, reach)] &
-      lookups.mapIt(self.dialResolved(it, dialable, dir, deadline, forceDial, reach))
+    @[self.dialAll(direct, dir, deadline, forceDial, reach)] & nameDials
   )
 
 proc dialAndUpgrade*(

--- a/tests/libp2p/test_dialer.nim
+++ b/tests/libp2p/test_dialer.nim
@@ -251,6 +251,36 @@ suite "Dialer":
     check src.connManager.connCount(dst.peerInfo.peerId) == 1
     check resolver.cancelled
 
+  asyncTest "Ranked dialing does not wait for a stalled sibling resolution":
+    let
+      src = makeStandardSwitch(TcpAutoAddress)
+      dst = makeStandardSwitch(TcpAutoAddress)
+    await src.start()
+    await dst.start()
+    defer:
+      await allFutures(src.stop(), dst.stop())
+
+    let resolver = StallingResolver.new()
+    resolver.txtResponses["_dnsaddr.mixed.example"] =
+      @["dnsaddr=" & $dst.peerInfo.addrs[0], "dnsaddr=/dns4/stalls.example/tcp/1234"]
+
+    let dialer = Dialer.new(
+      src.peerInfo.peerId,
+      src.connManager,
+      src.peerStore,
+      src.transports,
+      src.ms,
+      resolver,
+      dialTimeout = 1.seconds,
+      dialRanking = true,
+    )
+
+    let mixed = MultiAddress.init("/dnsaddr/mixed.example").tryGet()
+    await dialer.connect(dst.peerInfo.peerId, @[mixed]).wait(5.seconds)
+
+    check src.connManager.connCount(dst.peerInfo.peerId) == 1
+    check resolver.cancelled
+
   asyncTest "Ranked dialing dials a name that answers while another one stalls":
     let
       src = makeStandardSwitch(TcpAutoAddress)


### PR DESCRIPTION
## Summary

- dial each expanded DNSADDR child as soon as it resolves
- avoid delaying a usable address behind a stalled sibling resolution
- add a regression test covering the mixed ready/stalled DNSADDR case

## References

Follow-up to #3001.
