### PR TITLE
fix(autotls): raise an http error when a request url cannot be resolved

### DIFF
--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -278,10 +278,11 @@ method post*(
 ): Future[HTTPResponse] {.
     async: (raises: [ACMEError, HttpError, CancelledError]), base
 .} =
-  let rawResponse = await HttpClientRequestRef
-    .post(self.session, $uri, body = payload, headers = ACMEHttpHeaders)
-    .get()
-    .send()
+  let request = HttpClientRequestRef.post(
+    self.session, $uri, body = payload, headers = ACMEHttpHeaders
+  ).valueOr:
+    raiseHttpAddressError(error)
+  let rawResponse = await request.send()
   let body = await rawResponse.getResponseBody()
   let resp = HTTPResponse(body: body, headers: rawResponse.headers)
   checkAPIError(resp)
@@ -292,7 +293,9 @@ method get*(
 ): Future[HTTPResponse] {.
     async: (raises: [ACMEError, HttpError, CancelledError]), base
 .} =
-  let rawResponse = await HttpClientRequestRef.get(self.session, $uri).get().send()
+  let request = HttpClientRequestRef.get(self.session, $uri).valueOr:
+    raiseHttpAddressError(error)
+  let rawResponse = await request.send()
   let body = await rawResponse.getResponseBody()
   let resp = HTTPResponse(body: body, headers: rawResponse.headers)
   checkAPIError(resp)
@@ -552,15 +555,11 @@ proc downloadCertificate*(
 
   handleError("downloadCertificate"):
     # not `self.post` as it reads the response as JSON, and a certificate is PEM
-    let rawResponse = await HttpClientRequestRef
-      .post(
-        self.session,
-        orderResponse.certificate,
-        body = payload,
-        headers = ACMEHttpHeaders,
-      )
-      .get()
-      .send()
+    let request = HttpClientRequestRef.post(
+      self.session, orderResponse.certificate, body = payload, headers = ACMEHttpHeaders
+    ).valueOr:
+      raiseHttpAddressError(error)
+    let rawResponse = await request.send()
     ACMECertificateResponse(
       rawCertificate: bytesToString(await rawResponse.getBodyBytes()),
       certificateExpiry: parse(orderResponse.expires, "yyyy-MM-dd'T'HH:mm:ss'Z'"),

--- a/libp2p/peeridauth/client.nim
+++ b/libp2p/peeridauth/client.nim
@@ -146,19 +146,18 @@ proc checkSignature*(
 method post*(
     self: PeerIDAuthClient, uri: Uri, payload: string, authHeader: string
 ): Future[PeerIDAuthResponse] {.async: (raises: [HttpError, CancelledError]), base.} =
-  let rawResponse = await HttpClientRequestRef
-    .post(
-      self.session,
-      $uri,
-      body = payload,
-      headers = [
-        ("Content-Type", "application/json"),
-        ("User-Agent", NimLibp2pUserAgent),
-        ("Authorization", authHeader),
-      ],
-    )
-    .get()
-    .send()
+  let request = HttpClientRequestRef.post(
+    self.session,
+    $uri,
+    body = payload,
+    headers = [
+      ("Content-Type", "application/json"),
+      ("User-Agent", NimLibp2pUserAgent),
+      ("Authorization", authHeader),
+    ],
+  ).valueOr:
+    raiseHttpAddressError(error)
+  let rawResponse = await request.send()
 
   PeerIDAuthResponse(
     status: rawResponse.status,

--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -521,6 +521,50 @@ suite "AutoTLS ACME API":
     expect(ACMEError):
       discard await downloadWithExpires("2026-11-02T14:30:00+00:00")
 
+  asyncTest "an order whose certificate url has no hostname is a network error":
+    api.queueGetOrder("", "2026-11-02T14:30:00Z")
+
+    expect(ACMENetworkError):
+      discard await api.downloadCertificate(parseUri(OrderURL), key, AccountURL)
+
+suite "AutoTLS ACME API over HTTP":
+  # The stub overrides get and post, so these drive the real ones.
+
+  asyncTeardown:
+    checkTrackers()
+
+  asyncTest "a url the session cannot turn into an address is an http error":
+    let api = ACMEApi.new()
+    defer:
+      await api.close()
+
+    expect(HttpError):
+      discard await api.get(parseUri(""))
+
+    expect(HttpError):
+      discard await api.post(parseUri(""), "{}")
+
+  asyncTest "a post carries the server's response body back":
+    let server = startTestHttpServer($ %*{"status": "valid"})
+    let api = ACMEApi.new()
+    defer:
+      await api.close()
+      await server.stop()
+
+    check (await api.post(parseUri(server.url), "{}")).body == %*{"status": "valid"}
+
+  asyncTest "a directory url with no hostname is a network error":
+    let server = startTestHttpServer(
+      $ %*{"newNonce": "", "newOrder": OrderURL, "newAccount": AccountURL}
+    )
+    let api = ACMEApi.new(directoryURL = parseUri(server.url))
+    defer:
+      await api.close()
+      await server.stop()
+
+    expect(ACMENetworkError):
+      discard await api.requestNonce()
+
 suite "AutoTLS ACME Client":
   const
     CertDomain = "some.domain"

--- a/tests/libp2p/autotls/test_peer_id_auth.nim
+++ b/tests/libp2p/autotls/test_peer_id_auth.nim
@@ -4,7 +4,7 @@
 {.used.}
 {.push raises: [].}
 
-import chronos, uri, base64, times
+import chronos, chronos/apps/http/httpclient, uri, base64, times
 import
   ../../../libp2p/
     [stream/connection, upgrademngrs/upgrade, peeridauth/client, wire, crypto/crypto]
@@ -148,6 +148,15 @@ suite "PeerID Auth Client":
     # TODO: vacp2p/nim-libp2p#2975
     expect IndexDefect:
       discard await requestWithExpires("2026-08-21T12:00:00")
+
+  asyncTest "a url the session cannot turn into an address is an http error":
+    # The stub overrides post, so this drives the real one.
+    let realClient = PeerIDAuthClient.new(rng())
+    defer:
+      await realClient.close()
+
+    expect(HttpError):
+      discard await realClient.post(parseUri(""), "somepayload", "someauthheader")
 
   asyncTest "checkSignature successful":
     # example from peer-id-auth spec


### PR DESCRIPTION
## Summary

`HttpClientRequestRef.get` and `.post` build a request but do not send it. Building resolves the hostname synchronously, so both return a `Result` that can fail before the request is sent. Unwrapping it with `.get()` turned a name that does not resolve into a `ResultDefect`, and a `Defect` is not a `CatchableError`. `handleError` catches `CatchableError` and so does `tryIssueCertificate`, so the retry loop meant for transient network failures never caught it.

Missing the retry is the lesser problem. The Defect is raised from a chronos continuation, so instead of failing the future it escapes the event loop. A name that does not resolve terminates the process instead of failing one renewal.

The fix is `valueOr` with chronos's `raiseHttpAddressError`. `HttpAddressError` descends from `HttpError`, which was already in the `raises` list of every proc changed, so no signatures change and no caller needs updating. `handleError` already maps `HttpError` onto `ACMENetworkError`. `PeerIDAuthClient.post` carried the same unwrap on the same path through `AutotlsBroker.sendChallenge`, where `get` already used `valueOr`.

## Affected Areas

- [x] Other

  AutoTLS ACME client, and the PeerID Auth client it authenticates the broker with.

## Impact on Library Users

`ACMEApi.get`, `ACMEApi.post` and `PeerIDAuthClient.post` now raise `HttpError` where they used to terminate the process. All three already declared `HttpError`, so there is no API change and no migration. For anyone running `AutotlsService`, an ACME server or broker that fails to resolve now logs a failure and retries on the next heartbeat.

## Risk Assessment

Low. Behaviour differs only on the path that previously terminated the process.
