### PR TITLE
chore(autotls): rename dnsServerURL to domainSuffix

### DIFF
--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -38,7 +38,7 @@ const
   DefaultIssueRetries = 3
   DefaultIssueRetryTime = 1.seconds
 
-  AutoTLSDNSServer* = "libp2p.direct"
+  DefaultDomainSuffix* = "libp2p.direct"
 
 type AutotlsCert* = ref object
   cert*: TLSCertificate
@@ -54,7 +54,7 @@ type AutotlsConfig* = object
   issueRetries*: int
   issueRetryTime*: Duration
   registrationURL*: Uri
-  dnsServerURL*: string
+  domainSuffix*: string
   dnsRetries*: int
   dnsRetryTime*: Duration
   acmeRetries*: int
@@ -97,7 +97,7 @@ proc new*(
     issueRetries: int = DefaultIssueRetries,
     issueRetryTime: Duration = DefaultIssueRetryTime,
     registrationURL: Uri = DefaultRegistrationURL,
-    dnsServerURL: string = AutoTLSDNSServer,
+    domainSuffix: string = DefaultDomainSuffix,
     dnsRetries: int = 10,
     dnsRetryTime: Duration = 1.seconds,
     acmeRetries: int = 10,
@@ -114,7 +114,7 @@ proc new*(
     issueRetries: issueRetries,
     issueRetryTime: issueRetryTime,
     registrationURL: registrationURL,
-    dnsServerURL: dnsServerURL,
+    domainSuffix: domainSuffix,
     dnsRetries: dnsRetries,
     dnsRetryTime: dnsRetryTime,
     acmeRetries: acmeRetries,
@@ -156,9 +156,9 @@ method issueCertificate(
   if self.peerInfo.isNil():
     raise newException(AutoTLSError, "Cannot issue new certificate: peerInfo not set")
 
-  # generate autotls domain string: "*.{peerID}.{dnsServerURL}"
+  # generate autotls domain string: "*.{peerID}.{domainSuffix}"
   let baseDomain =
-    api.Domain(encodePeerId(self.peerInfo.peerId) & "." & self.config.dnsServerURL)
+    api.Domain(encodePeerId(self.peerInfo.peerId) & "." & self.config.domainSuffix)
 
   trace "Requesting ACME challenge"
   let dns01Challenge =

--- a/tests/integration/autotls_docker/test_autotls_docker.nim
+++ b/tests/integration/autotls_docker/test_autotls_docker.nim
@@ -138,7 +138,7 @@ suite "AutoTLS against a local ACME server and broker":
     let port = server.peerInfo.listenAddrs[0].initTAddress().tryGet().port
     let serverDomain =
       NodeIP.replace('.', '-') & "." & encodePeerId(server.peerInfo.peerId) & "." &
-      AutoTLSDNSServer
+      DefaultDomainSuffix
 
     await client.connect(
       server.peerInfo.peerId, @[ma("/dns4/" & serverDomain & "/tcp/" & $port & "/wss")]

--- a/tests/libp2p/autotls/test_autotls_config.nim
+++ b/tests/libp2p/autotls/test_autotls_config.nim
@@ -24,12 +24,13 @@ suite "AutoTLS Configuration Tests":
     check:
       config.acmeDirectoryURL == LetsEncryptDirectoryURL
       config.ipAddress == Opt.none(IpAddress)
+      DnsResolver(config.nameResolver).nameServers == DefaultDnsServers
       config.renewCheckTime == DefaultRenewCheckTime
       config.renewBufferTime == DefaultRenewBufferTime
       config.issueRetries == 3
       config.issueRetryTime == 1.seconds
       config.registrationURL == DefaultRegistrationURL
-      config.dnsServerURL == AutoTLSDNSServer
+      config.domainSuffix == DefaultDomainSuffix
       config.dnsRetries == 10
       config.dnsRetryTime == 1.seconds
       config.acmeRetries == 10
@@ -48,7 +49,7 @@ suite "AutoTLS Configuration Tests":
     let customIssueRetryTime = 5.seconds
     let customRegistrationURL =
       parseUri("https://custom-broker.example.com/v1/_acme-challenge")
-    let customDnsServerURL = "custom-dns.example.com"
+    let customDomainSuffix = "custom.example.test"
     let customDnsRetries = 5
     let customDnsRetryTime = 2.seconds
     let customAcmeRetries = 15
@@ -65,7 +66,7 @@ suite "AutoTLS Configuration Tests":
       issueRetries = customIssueRetries,
       issueRetryTime = customIssueRetryTime,
       registrationURL = customRegistrationURL,
-      dnsServerURL = customDnsServerURL,
+      domainSuffix = customDomainSuffix,
       dnsRetries = customDnsRetries,
       dnsRetryTime = customDnsRetryTime,
       acmeRetries = customAcmeRetries,
@@ -84,7 +85,7 @@ suite "AutoTLS Configuration Tests":
       config.issueRetries == customIssueRetries
       config.issueRetryTime == customIssueRetryTime
       config.registrationURL == customRegistrationURL
-      config.dnsServerURL == customDnsServerURL
+      config.domainSuffix == customDomainSuffix
       config.dnsRetries == customDnsRetries
       config.dnsRetryTime == customDnsRetryTime
       config.acmeRetries == customAcmeRetries

--- a/tests/libp2p/autotls/test_service.nim
+++ b/tests/libp2p/autotls/test_service.nim
@@ -28,7 +28,7 @@ suite "AutoTLS certificate issuance and renewal":
     RenewBufferTime = 1.hours
     ChallengeToken = "some-token"
     NodeIP = "127.0.0.1"
-    DnsServerURL = "example.test"
+    DomainSuffix = "example.test"
 
   # RSA generation dominates the runtime of every test here, so one key pair each.
   let
@@ -174,7 +174,7 @@ suite "AutoTLS certificate issuance and renewal":
     service = newService(
       AutotlsConfig.new(
         ipAddress = Opt.some(parseIpAddress(NodeIP)),
-        dnsServerURL = DnsServerURL,
+        domainSuffix = DomainSuffix,
         issueRetries = 3,
         issueRetryTime = 0.seconds,
       )
@@ -189,7 +189,7 @@ suite "AutoTLS certificate issuance and renewal":
     # Nothing signals a round that ended, so wait out a three retries window.
     await sleepAsync(50.milliseconds)
 
-    let baseDomain = encodePeerId(switch.peerInfo.peerId) & "." & DnsServerURL
+    let baseDomain = encodePeerId(switch.peerInfo.peerId) & "." & DomainSuffix
     check:
       # One round is 8 requests, so more would be a second attempt.
       acmeApi.requestedUris.len == 8


### PR DESCRIPTION
## Summary

`AutotlsConfig.dnsServerURL` is the domain every peer's certificate name sits under. `issueCertificate` joins it as `encodePeerId(peerId) & "." & dnsServerURL`, names the result `baseDomain`, and asks the ACME server for a certificate covering `*.<peerID>.libp2p.direct`.

The name is wrong in two ways. The value is a bare domain, `libp2p.direct`, with no scheme and no path. And nothing ever connects to it, resolution goes through the separate `nameResolver` field.

## Affected Areas

- [x] Other
  AutoTLS service configuration.

## Impact on Library Users

Breaking change to `AutotlsConfig`, which is the type `withAutotls` takes.

| Old | New |
| --- | --- |
| `AutotlsConfig.dnsServerURL` | `AutotlsConfig.domainSuffix` |
| `AutotlsConfig.new(dnsServerURL = ...)` | `AutotlsConfig.new(domainSuffix = ...)` |
| `AutoTLSDNSServer` | `DefaultDomainSuffix` |

Values and behaviour are unchanged. Only code that names the field or the constant needs updating, so anyone on the default is unaffected.

## Risk Assessment

Nothing changes at runtime. The default value, the `baseDomain` built from it, and the code paths around them are untouched. The only risk is that callers naming the old field or constant stop compiling.

## References

- [p2p-forge](https://github.com/ipshipyard/p2p-forge) documents `FORGE_DOMAIN` as "the domain suffix of the forge"
- Kubo, the Go IPFS implementation, exposes the client-side setting as [`AutoTLS.DomainSuffix`](https://github.com/ipfs/kubo/blob/master/docs/config.md#autotlsdomainsuffix)
- #2997, the previous rename of `acmeServerURL` and `brokerURL` on `AutotlsConfig`

## Additional Notes

The defaults test in `test_autotls_config.nim` also gains an assertion on `nameResolver`, so it now covers every field of the config. Unrelated to the rename, included here rather than as a separate change.