### PR TITLE
test(autotls): reuse stub helpers and improve assertions

### DIFF
--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -93,137 +93,102 @@ suite "AutoTLS ACME API":
     check dns01.status == ACMEChallengeStatus.PENDING
 
   asyncTest "challenge completed successful":
-    api.mockedResponses.add(
-      HTTPResponse(
-        body: %*{"url": "http://example.com/some-check-url"}, headers: HttpTable.init()
-      )
-    )
-    discard await api.sendChallengeCompleted(
-      parseUri("http://example.com/some-chal-url"), key, "kid"
-    )
+    api.queueChallengeCompleted()
+    discard await api.sendChallengeCompleted(parseUri(ChallengeURL), key, "kid")
 
-    api.mockedResponses.add(
-      HTTPResponse(
-        body: %*{"status": "valid"}, headers: HttpTable.init(@[("Retry-After", "0")])
-      )
-    )
-    let completed = await api.checkChallengeCompleted(
-      parseUri("http://example.com/some-chal-url"), key, "kid"
-    )
-    check completed == true
+    api.queueStatus("valid")
+    let completed =
+      await api.checkChallengeCompleted(parseUri(ChallengeURL), key, "kid")
+
+    check:
+      completed == true
+      api.requestedUris == @[parseUri(ChallengeURL), parseUri(ChallengeURL)]
 
   asyncTest "challenge completed max retries reached":
-    api.mockedResponses.add(
-      HTTPResponse(
-        body: %*{"url": "http://example.com/some-check-url"}, headers: HttpTable.init()
-      )
-    )
-    discard await api.sendChallengeCompleted(
-      parseUri("http://example.com/some-chal-url"), key, "kid"
-    )
+    api.queueChallengeCompleted()
+    discard await api.sendChallengeCompleted(parseUri(ChallengeURL), key, "kid")
 
-    # add this mocked response a few times since checkChallengeCompleted might get more than once
-    for _ in 0 .. 5:
-      api.mockedResponses.add(
-        HTTPResponse(
-          body: %*{"status": "pending"},
-          headers: HttpTable.init(@[("Retry-After", "0")]),
-        )
-      )
-    let completed = await api.checkChallengeCompleted(
-      parseUri("http://example.com/some-chal-url"), key, "kid", retries = 1
-    )
-    check completed == false
+    # retries is the number of checks after the first one, so two polls
+    api.queueStatus("pending")
+    api.queueStatus("pending")
+    let completed =
+      await api.checkChallengeCompleted(parseUri(ChallengeURL), key, "kid", retries = 1)
+
+    check:
+      completed == false
+      api.requestedUris ==
+        @[parseUri(ChallengeURL), parseUri(ChallengeURL), parseUri(ChallengeURL)]
 
   asyncTest "challenge completed invalid":
-    api.mockedResponses.add(
-      HTTPResponse(
-        body: %*{"url": "http://example.com/some-check-url"}, headers: HttpTable.init()
-      )
-    )
-    discard await api.sendChallengeCompleted(
-      parseUri("http://example.com/some-chal-url"), key, "kid"
-    )
+    api.queueChallengeCompleted()
+    discard await api.sendChallengeCompleted(parseUri(ChallengeURL), key, "kid")
 
-    # add this mocked response a few times since checkChallengeCompleted might get more than once
-    for _ in 0 .. 5:
-      api.mockedResponses.add(
-        HTTPResponse(
-          body: %*{"status": "invalid"},
-          headers: HttpTable.init(@[("Retry-After", "0")]),
-        )
-      )
-
+    api.queueStatus("invalid")
     expect(ACMEError):
-      discard await api.checkChallengeCompleted(
-        parseUri("http://example.com/some-chal-url"), key, "kid"
-      )
+      discard await api.checkChallengeCompleted(parseUri(ChallengeURL), key, "kid")
+
+    # an invalid challenge raises on the first check instead of polling on
+    check api.requestedUris == @[parseUri(ChallengeURL), parseUri(ChallengeURL)]
 
   asyncTest "finalize certificate successful":
-    # first status is processing, then valid
-    api.mockedResponses.add(
-      HTTPResponse(
-        body: %*{"status": "processing"},
-        headers: HttpTable.init(@[("Retry-After", "0")]),
-      )
-    )
-    api.mockedResponses.add(
-      HTTPResponse(
-        body: %*{"status": "valid"}, headers: HttpTable.init(@[("Retry-After", "0")])
-      )
-    )
+    api.queueStatus("valid") # requestFinalize
+    api.queueStatus("valid") # checkCertFinalized
+
     let finalized = await api.certificateFinalized(
-      "some-domain",
-      parseUri("http://example.com/some-finalize-url"),
-      parseUri("http://example.com/some-order-url"),
-      certKey,
-      key,
-      "kid",
+      "some-domain", parseUri(FinalizeURL), parseUri(OrderURL), certKey, key, "kid"
     )
-    check finalized == true
+
+    check:
+      finalized == true
+      api.requestedUris == @[parseUri(FinalizeURL), parseUri(OrderURL)]
+
+  asyncTest "finalize certificate processing then valid":
+    api.queueStatus("valid") # requestFinalize
+    api.queueStatus("processing")
+    api.queueStatus("valid")
+
+    let finalized = await api.certificateFinalized(
+      "some-domain", parseUri(FinalizeURL), parseUri(OrderURL), certKey, key, "kid"
+    )
+
+    check:
+      finalized == true
+      api.requestedUris ==
+        @[parseUri(FinalizeURL), parseUri(OrderURL), parseUri(OrderURL)]
 
   asyncTest "finalize certificate max retries reached":
-    # add this mocked response a few times since checkCertFinalized might get more than once
-    for _ in 0 .. 5:
-      api.mockedResponses.add(
-        HTTPResponse(
-          body: %*{"status": "processing"},
-          headers: HttpTable.init(@[("Retry-After", "0")]),
-        )
-      )
+    api.queueStatus("valid") # requestFinalize
+    # retries is the number of checks after the first one, so two polls
+    api.queueStatus("processing")
+    api.queueStatus("processing")
+
     let finalized = await api.certificateFinalized(
       "some-domain",
-      parseUri("http://example.com/some-finalize-url"),
-      parseUri("http://example.com/some-order-url"),
+      parseUri(FinalizeURL),
+      parseUri(OrderURL),
       certKey,
       key,
       "kid",
       retries = 1,
     )
-    check finalized == false
+
+    check:
+      finalized == false
+      api.requestedUris ==
+        @[parseUri(FinalizeURL), parseUri(OrderURL), parseUri(OrderURL)]
 
   asyncTest "finalize certificate invalid":
-    # first request is processing, then invalid
-    api.mockedResponses.add(
-      HTTPResponse(
-        body: %*{"status": "processing"},
-        headers: HttpTable.init(@[("Retry-After", "0")]),
-      )
-    )
-    api.mockedResponses.add(
-      HTTPResponse(
-        body: %*{"status": "invalid"}, headers: HttpTable.init(@[("Retry-After", "0")])
-      )
-    )
+    api.queueStatus("valid") # requestFinalize
+    api.queueStatus("invalid")
+
     let finalized = await api.certificateFinalized(
-      "some-domain",
-      parseUri("http://example.com/some-finalize-url"),
-      parseUri("http://example.com/some-order-url"),
-      certKey,
-      key,
-      "kid",
+      "some-domain", parseUri(FinalizeURL), parseUri(OrderURL), certKey, key, "kid"
     )
-    check finalized == false
+
+    check:
+      finalized == false
+      # an invalid order ends the poll instead of retrying
+      api.requestedUris == @[parseUri(FinalizeURL), parseUri(OrderURL)]
 
   asyncTest "expect error on invalid JSON response":
     # add a couple invalid responses as they get popped by every get or post call

--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -191,16 +191,11 @@ suite "AutoTLS ACME API":
       api.requestedUris == @[parseUri(FinalizeURL), parseUri(OrderURL)]
 
   asyncTest "expect error on invalid JSON response":
-    # add a couple invalid responses as they get popped by every get or post call
-    for _ in 0 .. 20:
-      api.mockedResponses.add(
-        HTTPResponse(
-          body: %*{"inexistent field": "invalid value"}, headers: HttpTable.init()
-        )
-      )
+    # One response per call below
+    api.queueInvalidBody(10)
 
     expect(ACMEError):
-      # avoid calling overloaded mock method requestNonce here since we want to test the actual thing
+      # The stub overrides requestNonce, so procCall reaches the real one.
       discard await procCall requestNonce(ACMEApi(api))
 
     expect(ACMEError):
@@ -212,80 +207,31 @@ suite "AutoTLS ACME API":
     expect(ACMEError):
       discard await api.requestAuthorizations(@["auth-1", "auth-2"], key, "kid")
 
-    # clear leftover invalid responses so the mixed response is next in queue
-    api.mockedResponses = @[]
-    api.mockedResponses.add(
-      HTTPResponse(
-        body: %*{
-          "identifier": {"type": "dns", "value": "example.com"},
-          "status": "pending",
-          "challenges": [
-            {
-              "type": "dns-persist-01",
-              "url": "http://example.com/unknown-challenge",
-              "status": "pending",
-              "token": "unknown-token",
-            },
-            {
-              "type": "dns-01",
-              "url": "http://example.com/recognized-challenge",
-              "status": "pending",
-              "token": "recognized-token",
-            },
-          ],
-        },
-        headers: HttpTable.init(),
-      )
-    )
-
-    let mixedAuthResp = await api.requestAuthorizations(@["auth-3"], key, "kid")
-    check mixedAuthResp.challenges.len == 2
-
-    # replenish invalid responses for the remaining expect(ACMEError) blocks
-    for _ in 0 .. 5:
-      api.mockedResponses.add(
-        HTTPResponse(
-          body: %*{"inexistent field": "invalid value"}, headers: HttpTable.init()
-        )
-      )
-
     expect(ACMEError):
       discard await api.requestChallenge(@["domain-1", "domain-2"], key, "kid")
 
     expect(ACMEError):
       discard await api.requestCheck(
-        parseUri("http://example.com/some-check-url"),
-        ACMECheckKind.ACMEOrderCheck,
-        key,
-        "kid",
+        parseUri(OrderURL), ACMECheckKind.ACMEOrderCheck, key, "kid"
       )
 
     expect(ACMEError):
       discard await api.requestCheck(
-        parseUri("http://example.com/some-check-url"),
-        ACMECheckKind.ACMEChallengeCheck,
-        key,
-        "kid",
+        parseUri(ChallengeURL), ACMECheckKind.ACMEChallengeCheck, key, "kid"
       )
 
     expect(ACMEError):
-      discard await api.sendChallengeCompleted(
-        parseUri("http://example.com/some-chal-url"), key, "kid"
-      )
+      discard await api.sendChallengeCompleted(parseUri(ChallengeURL), key, "kid")
 
     expect(ACMEError):
       discard await api.requestFinalize(
-        "some-domain",
-        parseUri("http://example.com/some-finalize-url"),
-        certKey,
-        key,
-        "kid",
+        "some-domain", parseUri(FinalizeURL), certKey, key, "kid"
       )
 
     expect(ACMEError):
-      discard await api.requestGetOrder(
-        parseUri("http://example.com/some-order-url"), key, "kid"
-      )
+      discard await api.requestGetOrder(parseUri(OrderURL), key, "kid")
+
+    check api.mockedResponses.len == 0
 
   asyncTest "the directory URL is used as given":
     let acmeApi = ACMEApi.new(parseUri("http://acme.example/dir"))

--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -31,53 +31,30 @@ suite "AutoTLS ACME API":
     api = ACMEApiStub.new()
 
   asyncTest "register to acme server":
-    api.mockedResponses.add(
-      HTTPResponse(
-        body: %*{"status": "valid"},
-        headers: HttpTable.init(@[("location", "some-expected-kid")]),
-      )
-    )
+    api.queueRegister()
 
     let registerResponse = await api.requestRegister(key)
-    check registerResponse.kid == "some-expected-kid"
+    check registerResponse.kid == AccountURL
 
   asyncTest "request challenge for a domain":
-    api.mockedResponses.add(
-      HTTPResponse(
-        body: %*{
-          "status": "pending",
-          "authorizations": ["http://example.com/expected-authorizations-url"],
-          "finalize": "http://example.com/expected-finalize-url",
-        },
-        headers:
-          HttpTable.init(@[("location", "http://example.com/expected-order-url")]),
-      )
-    )
+    api.queueOrder("pending", %*[AuthorizationsURL])
 
     let challengeResponse =
       await api.requestNewOrder(@["some.dummy.domain.com"], key, "kid")
     check challengeResponse.status == ACMEOrderStatus.PENDING
-    check challengeResponse.authorizations ==
-      ["http://example.com/expected-authorizations-url"]
-    check challengeResponse.finalize == "http://example.com/expected-finalize-url"
-    check challengeResponse.order == "http://example.com/expected-order-url"
+    check challengeResponse.authorizations == [AuthorizationsURL]
+    check challengeResponse.finalize == FinalizeURL
+    check challengeResponse.order == OrderURL
 
-    # reset mocked obj for second request
-    api.mockedResponses.add(
-      HTTPResponse(
-        body: %*{
-          "challenges": [
-            {
-              "url": "http://example.com/expected-dns01-url",
-              "type": "dns-01",
-              "status": "pending",
-              "token": "expected-dns01-token",
-            }
-          ]
-        },
-        headers:
-          HttpTable.init(@[("location", "http://example.com/expected-order-url")]),
-      )
+    api.queueChallenges(
+      %*[
+        {
+          "url": ChallengeURL,
+          "type": "dns-01",
+          "status": "pending",
+          "token": "expected-dns01-token",
+        }
+      ]
     )
 
     let authorizationsResponse =
@@ -87,7 +64,7 @@ suite "AutoTLS ACME API":
     let dns01 = authorizationsResponse.challenges.filterIt(
       it.`type` == ACMEChallengeType.DNS01
     )[0]
-    check dns01.url == "http://example.com/expected-dns01-url"
+    check dns01.url == ChallengeURL
     check dns01.`type` == ACMEChallengeType.DNS01
     check dns01.token == ACMEChallengeToken("expected-dns01-token")
     check dns01.status == ACMEChallengeStatus.PENDING
@@ -231,7 +208,7 @@ suite "AutoTLS ACME API":
     expect(ACMEError):
       discard await api.requestGetOrder(parseUri(OrderURL), key, "kid")
 
-    check api.mockedResponses.len == 0
+    check api.requestedUris.len == 10
 
   asyncTest "the directory URL is used as given":
     let acmeApi = ACMEApi.new(parseUri("http://acme.example/dir"))

--- a/tests/libp2p/autotls/test_autotls_config.nim
+++ b/tests/libp2p/autotls/test_autotls_config.nim
@@ -18,7 +18,7 @@ suite "AutoTLS Configuration Tests":
   asyncTeardown:
     checkTrackers()
 
-  asyncTest "AutotlsConfig constructor with default values":
+  test "AutotlsConfig constructor with default values":
     let config = AutotlsConfig.new()
 
     check:
@@ -37,7 +37,7 @@ suite "AutoTLS Configuration Tests":
       config.finalizeRetries == 10
       config.finalizeRetryTime == 1.seconds
 
-  asyncTest "AutotlsConfig constructor with custom values":
+  test "AutotlsConfig constructor with custom values":
     let customIpAddress = parseIpAddress("203.0.113.7")
     let customNameServers =
       @[initTAddress("192.0.2.53:53"), initTAddress("198.51.100.53:53")]

--- a/tests/libp2p/autotls/test_autotls_config.nim
+++ b/tests/libp2p/autotls/test_autotls_config.nim
@@ -15,7 +15,7 @@ import
 import ../../tools/unittest
 
 suite "AutoTLS Configuration Tests":
-  asyncTeardown:
+  teardown:
     checkTrackers()
 
   test "AutotlsConfig constructor with default values":

--- a/tests/libp2p/autotls/test_peer_id_auth.nim
+++ b/tests/libp2p/autotls/test_peer_id_auth.nim
@@ -12,6 +12,8 @@ import ../../tools/[unittest, crypto]
 import ../../stubs/peer_id_auth_client_stub
 
 suite "PeerID Auth Client":
+  const ExampleURL = "https://example.com/some/uri"
+
   # keys from the peer-id-auth spec's handshake examples
   let
     specServerKey = PrivateKey
@@ -47,11 +49,12 @@ suite "PeerID Auth Client":
       async: (raises: [PeerIDAuthError, CancelledError])
   .} =
     client.authenticationInfo = Opt.some(
-      "libp2p-PeerID sig=\"somesig\", bearer=\"somebearer\", expires=\"" & expires & "\""
+      PeerIDAuthPrefix & " sig=\"somesig\", bearer=\"somebearer\", expires=\"" & expires &
+        "\""
     )
     await client.requestAuthorization(
       peerInfo,
-      parseUri("https://example.com/some/uri"),
+      parseUri(ExampleURL),
       "some-challenge-client",
       "some-challenge-server",
       specServerKey.getPublicKey().get(),
@@ -60,16 +63,15 @@ suite "PeerID Auth Client":
     )
 
   asyncTest "request authentication":
-    let serverPrivateKey = PrivateKey.random(PKScheme.RSA, rng()).get()
-    let serverPubkey = serverPrivateKey.getPublicKey().get()
+    let serverPubkey = specServerKey.getPublicKey().get()
     let b64serverPubkey = serverPubkey.pubkeyBytes().encode(safe = true)
     client.wwwAuthenticate = Opt.some(
-      "libp2p-PeerID " & "challenge-client=\"somechallengeclient\", public-key=\"" &
+      PeerIDAuthPrefix & " challenge-client=\"somechallengeclient\", public-key=\"" &
         b64serverPubkey & "\", opaque=\"someopaque\""
     )
 
     let authenticationResponse =
-      await client.requestAuthentication(parseUri("https://example.com/some/uri"))
+      await client.requestAuthentication(parseUri(ExampleURL))
 
     check authenticationResponse.challengeClient ==
       PeerIDAuthChallenge("somechallengeclient")
@@ -80,12 +82,11 @@ suite "PeerID Auth Client":
     let sig = PeerIDAuthSignature("somesig")
     let bearer = BearerToken(token: "somebearer", expires: Opt.none(DateTime))
     client.authenticationInfo = Opt.some(
-      "libp2p-PeerID " & "sig=\"" & sig & "\", " & "bearer=\"" & bearer.token & "\""
+      PeerIDAuthPrefix & " sig=\"" & sig & "\", bearer=\"" & bearer.token & "\""
     )
 
-    let uri = parseUri("https://example.com/some/uri")
-    let serverPrivateKey = PrivateKey.random(PKScheme.RSA, rng()).get()
-    let serverPubkey = serverPrivateKey.getPublicKey().get()
+    let uri = parseUri(ExampleURL)
+    let serverPubkey = specServerKey.getPublicKey().get()
     let authorizationResponse = await client.requestAuthorization(
       peerInfo, uri, "some-challenge-client", "some-challenge-server", serverPubkey,
       "some-opaque", "some-payload",
@@ -96,7 +97,7 @@ suite "PeerID Auth Client":
   asyncTest "client signature matches the peer-id-auth spec vector":
     discard await client.requestAuthorization(
       PeerInfo.new(specClientKey),
-      parseUri("https://example.com/some/uri"),
+      parseUri(ExampleURL),
       "ERERERERERERERERERERERERERERERERERERERERERE=",
       "MzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMz",
       specServerKey.getPublicKey().get(),
@@ -109,7 +110,7 @@ suite "PeerID Auth Client":
       "OrwJPO4buHKJdKXP2av8PFwv3XF_-m5MqndskeVV5UzufYzBCTm7RBaFnBS1sEhuQHZSZPh9RJgN5NmLzrUrBQ=="
 
   asyncTest "each handshake draws a fresh challenge-server":
-    let uri = parseUri("https://example.com/some/uri")
+    let uri = parseUri(ExampleURL)
     discard await client.send(uri, peerInfo, "somepayload")
     discard await client.send(uri, peerInfo, "somepayload")
 
@@ -120,9 +121,7 @@ suite "PeerID Auth Client":
     client.challengeServer = Opt.some("someotherchallenge")
 
     expect PeerIDAuthError:
-      discard await client.send(
-        parseUri("https://example.com/some/uri"), peerInfo, "somepayload"
-      )
+      discard await client.send(parseUri(ExampleURL), peerInfo, "somepayload")
 
   asyncTest "bearer expiry is parsed in local time":
     # TODO: vacp2p/nim-libp2p#2975
@@ -158,7 +157,7 @@ suite "PeerID Auth Client":
     expect(HttpError):
       discard await realClient.post(parseUri(""), "somepayload", "someauthheader")
 
-  asyncTest "checkSignature successful":
+  test "checkSignature successful":
     # example from peer-id-auth spec
     let serverPublicKey = specServerKey.getPublicKey().get()
     let challenge = "ERERERERERERERERERERERERERERERERERERERERERE="
@@ -168,7 +167,7 @@ suite "PeerID Auth Client":
     let clientPublicKey = specClientKey.getPublicKey().get()
     check checkSignature(sig, serverPublicKey, challenge, clientPublicKey, hostname)
 
-  asyncTest "checkSignature failed":
+  test "checkSignature failed":
     # example from peer-id-auth spec (but with sig altered)
     let serverPublicKey = specServerKey.getPublicKey().get()
     let challenge = "ERERERERERERERERERERERERERERERERERERERERERE="

--- a/tests/stubs/acme_api_stub.nim
+++ b/tests/stubs/acme_api_stub.nim
@@ -112,6 +112,16 @@ proc queueGetOrder*(self: ACMEApiStub, certificateURL: string, expires: string) 
     )
   )
 
+proc queueInvalidBody*(self: ACMEApiStub, count: int = 1) =
+  ## Queues `count` responses whose body is well-formed JSON but not the shape
+  ## the caller decodes.
+  for _ in 0 ..< count:
+    self.mockedResponses.add(
+      HTTPResponse(
+        body: %*{"invalid field": "invalid value"}, headers: HttpTable.init()
+      )
+    )
+
 proc scriptChallenge*(self: ACMEApiStub, token: string) =
   ## Queues the three responses `getChallenge` consumes, carrying `token` in the challenge.
   self.queueRegister()

--- a/tests/stubs/acme_api_stub.nim
+++ b/tests/stubs/acme_api_stub.nim
@@ -112,7 +112,7 @@ proc queueGetOrder*(self: ACMEApiStub, certificateURL: string, expires: string) 
     )
   )
 
-proc queueInvalidBody*(self: ACMEApiStub, count: int = 1) =
+proc queueInvalidBody*(self: ACMEApiStub, count: int) =
   ## Queues `count` responses whose body is well-formed JSON but not the shape
   ## the caller decodes.
   for _ in 0 ..< count:


### PR DESCRIPTION
## Summary

A refactor of the existing autotls tests: reuse the helpers the stub already exposes, and strengthen assertions that only checked a return value.

**Reuse**

- `register to acme server`, `request challenge for a domain` and the six `challenge completed` / `finalize certificate` tests now build responses with `queueRegister` / `queueOrder` / `queueChallenges` / `queueChallengeCompleted` / `queueStatus` instead of hand-built `HTTPResponse` literals.
- The same tests assert against the stub's exported URL constants instead of inline `http://example.com/...` strings.
- New `queueInvalidBody` on the stub. It covers the one response with no helper, a body that is well-formed JSON but not what the caller decodes.
- `test_peer_id_auth.nim`: the URL repeated at six call sites becomes a const, and the `libp2p-PeerID` literal becomes `PeerIDAuthPrefix`.

**Assertions**

- The six `challenge completed` / `finalize certificate` tests assert the full `requestedUris` sequence rather than only the boolean. `checkChallengeCompleted` and `checkCertFinalized` both loop `for i in 0 .. retries`, so a loop running one iteration too few or too many returns the same `false`.
- Their queues now hold exactly what the calls consume, replacing `for _ in 0 .. 5` loops that queued more responses than any call would read.
- `expect error on invalid JSON response` queues an exact count and asserts the request count. It queued 21 responses for calls that read 10. The stub raises `ACMEError` on an empty queue and `expect` discards the exception, so a call that stopped making a request, or started making two, still satisfied every block. Nothing defends against the queueing line itself going missing.

**Other changes**

- New test, `finalize certificate processing then valid`. `finalize certificate successful` queued a `processing` response that `requestFinalize` consumed, so the poll saw `valid` on its first look and the loop never ran a second time.
- One assertion removed rather than converted. The mixed-challenge block inside the invalid-JSON test checked that a `dns-persist-01` parses alongside a `dns-01`, but `requestChallenge` filters to `DNS01`, so nothing reads the second entry.
- Two RSA key generations removed from `test_peer_id_auth.nim`. Neither site asserts anything about the key's scheme and `specServerKey` is already in scope. The generation the suite's comment is about stays.
- `test_autotls_config.nim` and the two `checkSignature` tests become plain `test` and `teardown`, since none of those bodies await.