### PR TITLE
chore(perf): improve ChaChaPoly and remove byte-at-a-time frame copies

### DIFF
--- a/libp2p/crypto/chacha20poly1305.nim
+++ b/libp2p/crypto/chacha20poly1305.nim
@@ -1,17 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-## This module integrates BearSSL ChaCha20+Poly1305
-##
-## This module uses unmodified parts of code from
-## BearSSL library <https://bearssl.org/>
-## Copyright(C) 2018 Thomas Pornin <pornin@bolet.org>.
+## This module integrates BoringSSL ChaCha20+Poly1305
 
 # RFC @ https://tools.ietf.org/html/rfc7539
 
 {.push raises: [].}
 
-import bearssl/blockx
+import boringssl
 from stew/assign2 import assign
 from stew/ptrops import baseAddr
 
@@ -44,9 +40,23 @@ proc intoChaChaPolyTag*(s: openArray[byte]): ChaChaPolyTag =
   assign(tag, s)
   tag
 
-# bearssl allows us to use optimized versions
-# this is reconciled at runtime
-# we do this in the global scope / module init
+template withAeadCtx(key: ChaChaPolyKey, body: untyped) =
+  # This AEAD keeps no heap state, so a per-call context is cheaper than caching one.
+  block:
+    var ctx {.inject.}: EVP_AEAD_CTX
+    if EVP_AEAD_CTX_init(
+      addr ctx,
+      EVP_aead_chacha20_poly1305(),
+      addr key[0],
+      csize_t(ChaChaPolyKeySize),
+      csize_t(ChaChaPolyTagSize),
+      nil,
+    ) != 1:
+      raiseAssert "EVP_AEAD_CTX_init failed for ChaChaPoly"
+    defer:
+      EVP_AEAD_CTX_cleanup(addr ctx)
+
+    body
 
 proc encrypt*(
     _: type[ChaChaPoly],
@@ -56,48 +66,62 @@ proc encrypt*(
     data: var openArray[byte],
     aad: openArray[byte],
 ) =
+  ## Encrypts `data` in place, writing its tag to `tag`, which must not alias `data`.
   let ad =
     if aad.len > 0:
       addr aad[0]
     else:
       nil
 
-  poly1305CtmulRun(
-    addr key[0],
-    addr nonce[0],
-    baseAddr(data),
-    uint(data.len),
-    ad,
-    uint(aad.len),
-    baseAddr(tag),
-    # cast is required to workaround https://github.com/nim-lang/Nim/issues/13905
-    cast[Chacha20Run](chacha20CtRun), #[encrypt]#
-    1.cint,
-  )
+  var tagLen: csize_t
+  withAeadCtx(key):
+    if EVP_AEAD_CTX_seal_scatter(
+      addr ctx,
+      baseAddr(data),
+      addr tag[0],
+      addr tagLen,
+      csize_t(ChaChaPolyTagSize),
+      addr nonce[0],
+      csize_t(ChaChaPolyNonceSize),
+      baseAddr(data),
+      csize_t(data.len),
+      nil,
+      0,
+      ad,
+      csize_t(aad.len),
+    ) != 1:
+      raiseAssert "EVP_AEAD_CTX_seal_scatter failed for ChaChaPoly"
+    doAssert tagLen == csize_t(ChaChaPolyTagSize)
 
 proc decrypt*(
     _: type[ChaChaPoly],
     key: ChaChaPolyKey,
     nonce: ChaChaPolyNonce,
-    tag: var ChaChaPolyTag,
+    tag: ChaChaPolyTag,
     data: var openArray[byte],
     aad: openArray[byte],
-) =
+): bool =
+  ## Decrypts `data` in place, returning false and zeroing it when `tag` fails.
   let ad =
     if aad.len > 0:
       addr aad[0]
     else:
       nil
 
-  poly1305CtmulRun(
-    addr key[0],
-    addr nonce[0],
-    baseAddr(data),
-    uint(data.len),
-    ad,
-    uint(aad.len),
-    baseAddr(tag),
-    # cast is required to workaround https://github.com/nim-lang/Nim/issues/13905
-    cast[Chacha20Run](chacha20CtRun), #[decrypt]#
-    0.cint,
-  )
+  var authenticated = false
+  withAeadCtx(key):
+    authenticated =
+      EVP_AEAD_CTX_open_gather(
+        addr ctx,
+        baseAddr(data),
+        addr nonce[0],
+        csize_t(ChaChaPolyNonceSize),
+        baseAddr(data),
+        csize_t(data.len),
+        addr tag[0],
+        csize_t(ChaChaPolyTagSize),
+        ad,
+        csize_t(aad.len),
+      ) == 1
+
+  authenticated

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -65,13 +65,13 @@ proc readHeader(
 
   var hdr: YamuxHeader
   hdr.version = buffer[0]
-  let flags = fromBytesBE(uint16, buffer[2 .. 3])
+  let flags = fromBytesBE(uint16, buffer.toOpenArray(2, 3))
   if hdr.version != YamuxVersion or not hdr.msgType.checkedEnumAssign(buffer[1]) or
       flags notin 0'u16 .. 15'u16:
     raise newException(YamuxError, "Wrong header")
   hdr.flags = cast[set[MsgFlags]](flags)
-  hdr.streamId = fromBytesBE(uint32, buffer[4 .. 7])
-  hdr.length = fromBytesBE(uint32, buffer[8 .. 11])
+  hdr.streamId = fromBytesBE(uint32, buffer.toOpenArray(4, 7))
+  hdr.length = fromBytesBE(uint32, buffer.toOpenArray(8, 11))
   hdr
 
 proc `$`(header: YamuxHeader): string =

--- a/libp2p/protocols/perf/client.nim
+++ b/libp2p/protocols/perf/client.nim
@@ -33,16 +33,14 @@ proc perf*(
   p.stats = Stats()
 
   try:
-    var
-      size = sizeToWrite
-      buf: array[PerfSize, byte]
+    var size = sizeToWrite
 
     let start = Moment.now()
 
     await stream.write(toSeq(toBytesBE(sizeToRead)))
     while size > 0:
       let toWrite = min(size, PerfSize)
-      await stream.write(buf[0 ..< toWrite])
+      await stream.write(newSeq[byte](toWrite))
       size -= toWrite.uint
 
       # set stats using copy value to avoid race condition
@@ -55,6 +53,7 @@ proc perf*(
     await stream.closeWrite()
 
     size = sizeToRead
+    var buf: array[PerfSize, byte]
 
     while size > 0:
       let toRead = min(size, PerfSize)

--- a/libp2p/protocols/perf/server.nim
+++ b/libp2p/protocols/perf/server.nim
@@ -36,10 +36,9 @@ proc new*(T: typedesc[Perf]): T =
         except LPStreamEOFError:
           break
 
-      var writeBuffer: array[PerfSize, byte]
       while uploadSize > 0:
         let toWrite = min(uploadSize, PerfSize)
-        await stream.write(writeBuffer[0 ..< toWrite])
+        await stream.write(newSeq[byte](toWrite))
         uploadSize -= toWrite
     except CancelledError as exc:
       trace "cancelled perf handler"

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -159,24 +159,29 @@ proc encryptWithAd(
     tag = byteutils.toHex(tag), data = buf.shortLog, nonce = state.n - 1
   buf
 
-proc decryptWithAd(
-    state: var CipherState, ad, data: openArray[byte]
-): seq[byte] {.raises: [NoiseDecryptTagError, NoiseNonceMaxError].} =
-  var
-    tagIn = data.toOpenArray(data.len - ChaChaPolyTag.len, data.high).intoChaChaPolyTag
-    tagOut: ChaChaPolyTag
-    nonce: ChaChaPolyNonce
-    buf = data[0 .. (data.high - ChaChaPolyTag.len)]
+proc decryptInPlaceWithAd(
+    state: var CipherState, ad: openArray[byte], data: var seq[byte]
+) {.raises: [NoiseDecryptTagError, NoiseNonceMaxError].} =
+  ## Replaces the ciphertext frame in `data` with its plaintext.
+  let tag = data.toOpenArray(data.len - ChaChaPolyTag.len, data.high).intoChaChaPolyTag
+  var nonce: ChaChaPolyNonce
   nonce[4 ..< 12] = toBytesLE(state.n)
-  ChaChaPoly.decrypt(state.k, nonce, tagOut, buf, ad)
-  trace "decryptWithAd",
-    tagIn = tagIn.shortLog, tagOut = tagOut.shortLog, nonce = state.n
-  if tagIn != tagOut:
-    debug "decryptWithAd failed", data = shortLog(data)
+
+  data.setLen(data.len - ChaChaPolyTag.len)
+  if not ChaChaPoly.decrypt(state.k, nonce, tag, data, ad):
+    debug "decryptWithAd failed", tag = tag.shortLog, nonce = state.n, len = data.len
     raise (ref NoiseDecryptTagError)(msg: "decryptWithAd failed tag authentication.")
+
+  trace "decryptWithAd", tag = tag.shortLog, nonce = state.n
   inc state.n
   if state.n > NonceMax:
     raise (ref NoiseNonceMaxError)(msg: "Noise max nonce value reached")
+
+proc decryptWithAd(
+    state: var CipherState, ad, data: openArray[byte]
+): seq[byte] {.raises: [NoiseDecryptTagError, NoiseNonceMaxError].} =
+  var buf = @data
+  state.decryptInPlaceWithAd(ad, buf)
   buf
 
 # Symmetricstate
@@ -429,14 +434,14 @@ method readMessage*(
     sconn: NoiseConnection
 ): Future[seq[byte]] {.async: (raises: [CancelledError, LPStreamError]).} =
   while true: # Discard 0-length payloads
-    let frame = await sconn.stream.readFrame()
+    var frame = await sconn.stream.readFrame()
     sconn.activity = true
     if frame.len > ChaChaPolyTag.len:
-      let res = sconn.readCs.decryptWithAd([], frame)
-      if res.len > 0:
+      sconn.readCs.decryptInPlaceWithAd([], frame)
+      if frame.len > 0:
         when defined(libp2p_dump):
-          dumpMessage(sconn, FlowDirection.Incoming, res)
-        return res
+          dumpMessage(sconn, FlowDirection.Incoming, frame)
+        return frame
 
     when defined(libp2p_dump):
       dumpMessage(sconn, FlowDirection.Incoming, [])

--- a/tests/libp2p/crypto/test_chacha20poly1305_speed.nim
+++ b/tests/libp2p/crypto/test_chacha20poly1305_speed.nim
@@ -1,0 +1,94 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+{.used.}
+
+import std/[monotimes, times]
+import bearssl/blockx
+from stew/ptrops import baseAddr
+import ../../../libp2p/crypto/chacha20poly1305
+import ../../tools/unittest
+
+const
+  ChunkSize = 1 shl 20
+  Chunks = 64
+  WarmupChunks = 4
+  MinSpeedup = 2.0
+
+type BearSslAead = object
+  poly: Poly1305Run
+  chacha: Chacha20Run
+
+proc bestBearSslAead(): BearSslAead =
+  ## The fastest ChaChaPoly BearSSL offers here; a `Get` returns nil when unsupported.
+  var aead = BearSslAead(
+    # cast is required to workaround https://github.com/nim-lang/Nim/issues/13905
+    poly: cast[Poly1305Run](poly1305CtmulRun),
+    chacha: cast[Chacha20Run](chacha20CtRun),
+  )
+
+  let poly = poly1305CtmulqGet()
+  if not poly.isNil():
+    aead.poly = poly
+
+  let chacha = chacha20Sse2Get()
+  if not chacha.isNil():
+    aead.chacha = chacha
+
+  aead
+
+proc encrypt(
+    aead: BearSslAead,
+    key: ChaChaPolyKey,
+    nonce: ChaChaPolyNonce,
+    tag: var ChaChaPolyTag,
+    data: var openArray[byte],
+) =
+  aead.poly(
+    addr key[0],
+    addr nonce[0],
+    baseAddr(data),
+    csize_t(data.len),
+    nil,
+    0,
+    baseAddr(tag),
+    aead.chacha,
+    1.cint,
+  )
+
+template elapsedSeconds(body: untyped): float =
+  block:
+    let start = getMonoTime()
+    body
+    float(inNanoseconds(getMonoTime() - start)) / 1e9
+
+suite "ChaChaPoly throughput":
+  test "the AEAD backend outruns the best BearSSL path":
+    var
+      key: ChaChaPolyKey
+      nonce: ChaChaPolyNonce
+      tag: ChaChaPolyTag
+      noaad: array[0, byte]
+      data = newSeq[byte](ChunkSize)
+    for i in 0 ..< key.len:
+      key[i] = byte(i)
+
+    let bear = bestBearSslAead()
+
+    for _ in 0 ..< WarmupChunks:
+      ChaChaPoly.encrypt(key, nonce, tag, data, noaad)
+      bear.encrypt(key, nonce, tag, data)
+
+    let libp2pSeconds = elapsedSeconds:
+      for _ in 0 ..< Chunks:
+        ChaChaPoly.encrypt(key, nonce, tag, data, noaad)
+
+    let bearSeconds = elapsedSeconds:
+      for _ in 0 ..< Chunks:
+        bear.encrypt(key, nonce, tag, data)
+
+    let megabytes = float(ChunkSize) * float(Chunks) / 1048576.0
+    echo "    libp2p ChaChaPoly: ", int(megabytes / libp2pSeconds), " MiB/s"
+    echo "    BearSSL, best available path: ", int(megabytes / bearSeconds), " MiB/s"
+
+    # BearSSL has no AVX2 or NEON ChaCha20 and no Poly1305 assembly on any target.
+    check libp2pSeconds * MinSpeedup < bearSeconds

--- a/tests/libp2p/crypto/test_crypto.nim
+++ b/tests/libp2p/crypto/test_crypto.nim
@@ -507,19 +507,27 @@ suite "Key interface test suite":
     ChaChaPoly.encrypt(key, nonce, ntag, text, aed)
     check text.toHex == cipher.toHex
     check ntag.toHex == tag.toHex
-    ChaChaPoly.decrypt(key, nonce, ntag, text, aed)
+    check ChaChaPoly.decrypt(key, nonce, ntag, text, aed)
     check text.toHex == plain.toHex
-    check ntag.toHex == tag.toHex
+
+    # a flipped tag bit must not authenticate, and must zero the output
+    block:
+      var
+        forged = plain
+        forgedTag: ChaChaPolyTag
+      ChaChaPoly.encrypt(key, nonce, forgedTag, forged, aed)
+      forgedTag[0] = forgedTag[0] xor 1
+      check not ChaChaPoly.decrypt(key, nonce, forgedTag, forged, aed)
+      check forged == newSeq[byte](plain.len)
 
     # ensure even a 2 byte array works
     var
-      smallPlain: array[2, byte]
+      smallPlain = [0x11.byte, 0x22]
       btag: ChaChaPolyTag
       noaed: array[0, byte]
     ChaChaPoly.encrypt(key, nonce, btag, smallPlain, noaed)
-    ntag = btag
-    ChaChaPoly.decrypt(key, nonce, btag, smallPlain, noaed)
-    check ntag.toHex == btag.toHex
+    check ChaChaPoly.decrypt(key, nonce, btag, smallPlain, noaed)
+    check smallPlain == [0x11.byte, 0x22]
 
     # ensure even a 0 byte array works
     block:
@@ -528,9 +536,7 @@ suite "Key interface test suite":
         btag: ChaChaPolyTag
         noaed: array[0, byte]
       ChaChaPoly.encrypt(key, nonce, btag, emptyPlain, noaed)
-      ntag = btag
-      ChaChaPoly.decrypt(key, nonce, btag, emptyPlain, noaed)
-      check ntag.toHex == btag.toHex
+      check ChaChaPoly.decrypt(key, nonce, btag, emptyPlain, noaed)
 
   test "Curve25519":
     # from bearssl test_crypto.c


### PR DESCRIPTION
## Summary

The perf protocol ran 12-17x slower than go-libp2p (#1484). On loopback, TCP + noise, 2 GiB in each direction, throughput goes from 292 MiB/s to 1053 MiB/s.

Both endpoints were profiled with gprof (`nim c --debugger:native --passC:-pg --passL:-pg`). The suspects named in the issue thread are not on the throughput path: `readLine` runs once per stream during multistream negotiation, and ref10 ed25519 plus BearSSL RSA/EC run only during the handshake. Two other things account for almost all of the time.

**1. The AEAD used BearSSL's portable C code.** `chacha20poly1305.nim` called `poly1305CtmulRun` and `chacha20CtRun` directly, which measure 615 MiB/s here. The file carried a comment claiming the optimized versions were selected at runtime; no such code existed. BoringSSL's `EVP_aead_chacha20_poly1305` measures 2960 MiB/s, a factor of 4.8. The case for that backend is in the next section.

`decrypt` now takes the expected tag and returns whether it authenticates, instead of writing out a computed tag for the caller to compare. BoringSSL verifies it in constant time inside `EVP_AEAD_CTX_open_gather`; the old call site compared two arrays with `!=`.

**2. Nim compiles `array[a..b]` and `openArray[a..b]` into an element-wise loop.** Slicing a 64 KB buffer copied it one byte at a time, on every frame, in two places:

- `noise.decryptWithAd` did `buf = data[0 .. data.high - ChaChaPolyTag.len]`. gprof attributes 52% of receive-side CPU to that expression. `readMessage` now decrypts in place through `decryptInPlaceWithAd`, which shrinks the frame with `setLen`. The handshake keeps the copying variant, because `decryptAndHash` mixes the original ciphertext into the hash; it runs four times per connection on tens of bytes.
- `perf/client.nim` and `perf/server.nim` did `buf[0 ..< toWrite]` on an `array[PerfSize, byte]` that was never written to. gprof attributes 52% of send-side CPU to that expression. Both now use `newSeq[byte](toWrite)`: same allocation the slice already made, without the byte loop.

`yamux.readHeader` rides along and was **not** measured. It allocated three seqs to parse 12 header bytes and now uses `toOpenArray`. One header per frame, frames up to 256 KB, so it never showed up in the profile and earns no part of the numbers below.

## Why BoringSSL and not BearSSL for this primitive

**It is not a new dependency.** `libp2p.nimble` already declares `nim-boringssl >= 0.0.8`, and `transports/tls/certificate_ffi.nim` already imports it. Tag v0.0.8, the declared minimum, already exports `EVP_aead_chacha20_poly1305`, `EVP_AEAD_CTX_seal_scatter` and `EVP_AEAD_CTX_open_gather`, and already compiles `chacha-x86_64-linux.S` and `chacha20_poly1305_x86_64-linux.S`. The assembly this PR reaches is object code every current build links and never calls. No constraint changes.

**It is the direction the repo already chose.** Issue #2474, "Replace BearSSL in phases by BoringSSL", names ChaCha20-Poly1305 in Phase 2. Phase 1 is complete. The issue is iceboxed "unless priorities change"; a 12-17x deficit against go-libp2p is that change. This PR does the ChaCha20-Poly1305 third of Phase 2 and leaves HKDF and X25519, which are handshake-only and absent from the profile.

**BearSSL cannot reach these numbers at its best.** The vendored csources ship two ChaCha20 implementations, `chacha20_ct.c` and `chacha20_sse2.c`, and four Poly1305 implementations, all C. No AVX2, no AVX-512, no NEON, and no Poly1305 assembly on any target. Switching to BearSSL's best x86-64 pair, `chacha20Sse2Get()` plus `poly1305CtmulqGet()`, is worth about 7%. BoringSSL ships a fused kernel that interleaves both halves in one pass, with AVX2 on x86-64 and NEON on armv8.

aarch64 is worse: BearSSL has no ARM code for either half, so its best there is portable C twice over. nim-boringssl already compiles `chacha-armv8-linux.S` and `chacha20_poly1305_armv8-linux.S`. ARM nodes gain more from this than the benchmark machine did.

`tests/libp2p/crypto/test_chacha20poly1305_speed.nim` turns that into a check. It encrypts 64 MiB through `ChaChaPoly.encrypt` and 64 MiB through the fastest ChaChaPoly BearSSL offers on the same machine in the same process, selected at runtime with a fall back to the portable pair, and requires the first to be at least twice as fast. A ratio, not a threshold, so it needs no tuning on a slow CI runner or an ARM builder. It fails on every BearSSL backend, passes on BoringSSL, and prints both figures.

**BearSSL has no releases, and that costs something visible here.** No tagged release since 0.6 on 2018-08-14; fixes land in the git tree and stay there. Its vendored `README.txt` still says "BearSSL is considered beta-level software" and "Using BearSSL for production purposes would be a relatively bold but not utterly crazy move."

Follow one fix through the chain. Upstream commit `7bea48e5` of 2026-04-06: "Fixed bug in handling incoming records with invalid length (impacted CBC encryption with 3DES or with the aes_small or aes_big AES implementations)", credited to Thai Duong at Calif.io. No release carries it, no CVE, no advisory. nim-bearssl v0.2.7 and v0.2.8 pin the parent tree `79c060ee` of 2023-02-21; v0.2.9 and later pin `7bea48e5`. `libp2p.nimble` says `bearssl >= 0.2.7`, so both pre-fix tags satisfy it, and a lock file resolved to either ships pre-fix code while reading as compliant. The constraint cannot express the difference, because the pinned thing has no version number. That bug is **not** reachable from nim-libp2p: it is in BearSSL's TLS record layer, and this repo uses BearSSL only for RNG, HKDF, EC, RSA and PEM. The point is the reporting chain, not this repo's exposure.

BoringSSL sits on the Chromium security process and carries Project Wycheproof vectors for this exact primitive in tree (`third_party/wycheproof_testvectors/chacha20_poly1305_test.json`). Both libraries are in OSS-Fuzz, so fuzzing is not a difference between them. Release engineering is.

**Constant-time behavior is preserved.** ChaCha20 and Poly1305 are add-rotate-xor and a field multiply, with no table lookup or secret-dependent branch in any implementation of either library. The tag comparison is the part that must be constant time, and it improves here: `EVP_AEAD_CTX_open_gather` compares inside BoringSSL, where the removed Nim code compared two `array[16, byte]` with `!=`.

**It reduces backend mixing.** One fewer BearSSL module links. BearSSL stays for RNG, HKDF, X25519, RSA, ECNIST and PEM, exactly as Phases 1 and 3 through 5 of #2474 describe.

The cost on the other side of the ledger is in Risk Assessment: a wrong-parameter path in BoringSSL now aborts, where the old code could not fail at all.

## Affected Areas

- [x] Transports
  <!-- Noise: the ChaCha20-Poly1305 backend and the frame decrypt path. Yamux: header parsing only. -->

- [x] Protocol Logic
  <!-- The perf client and server write path. -->

## Compatibility & Downstream Validation

The wire format does not change. Noise frames, yamux headers and the perf protocol are byte for byte what they were, so a patched node interoperates with an unpatched one and with go-libp2p.

- **Nimbus:** not run
- **Waku:** not run
- **Codex:** not run

## Impact on Library Users

`ChaChaPoly.decrypt` changes signature. It took `tag: var ChaChaPolyTag` and filled it with the computed tag; it now takes `tag: ChaChaPolyTag` and returns a `bool` saying whether that tag authenticates the data. External callers check the return value instead of comparing tags. The result is not `discardable`, so an ignored return is a compile error. `encrypt` is unchanged. Everything else is internal.

Builds that reach `chacha20poly1305.nim` now link BoringSSL. Every build already did, through `builders.nim` and the TLS transport.

Throughput on loopback, TCP + noise, 2 GiB per direction, MiB/s:

| muxer | direction | before | after |
| --- | --- | --- | --- |
| yamux | upload | 292 | 1053 |
| yamux | download | 292 | 988 |
| mplex | upload | 344 | 930 |
| mplex | download | 342 | 906 |

The go+go figure in #1484 is 900719925 bytes in 0.8 s, which is 1074 MiB/s.

## Risk Assessment

The backend swap is the real risk, so it was checked against the RFC 7539 vector directly: same ciphertext, same tag, a flipped tag bit rejected, empty and 2-byte plaintexts round-tripping. Full 4 GiB transfers complete over both yamux and mplex.

`test_crypto.nim` is updated for the new signature and gains a forgery case and a check that a failed decrypt zeroes its output. The short-input cases now assert that the plaintext round-trips, where before they only compared tags. `test_chacha20poly1305_speed.nim` is new; it keeps a `bearssl/blockx` import alive in the test tree on purpose, and Phase 5 of #2474 removes it along with BearSSL.

On a failed tag check, `EVP_AEAD_CTX_open_gather` fills the output with zeros (`aead.h:392`), so `decryptInPlaceWithAd` leaves a zeroed, shortened buffer rather than unauthenticated plaintext. Both call sites raise `NoiseDecryptTagError` and never read it. The failure log carries the tag, the nonce counter and the frame length, and no longer dumps the frame body.

`encrypt` has no error channel, so a non-zero return from `EVP_AEAD_CTX_init` or `EVP_AEAD_CTX_seal_scatter` is a `raiseAssert`. Both require a wrong key or tag length, both compile-time constants here, so neither is reachable from network input. The old code could not abort at all, so this is a new, narrow crash surface.

No network behavior changes. No wire compatibility break.

## References

- Fixes #1484
- Implements the ChaCha20-Poly1305 part of Phase 2 of #2474
- RFC 7539
