### PR TITLE
fix: handle disconnect while opening stream

### DIFF
--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -365,6 +365,9 @@ proc connectOnce(
         await p.getStream().wait(5.seconds)
       except AsyncTimeoutError:
         raise newException(GetStreamDialError, "establishing stream timed out")
+    if p.disconnected:
+      await newStream.close()
+      return
 
     # When the send channel goes up, subscriptions need to be sent to the
     # remote peer - if we had multiple channels up and one goes down, all
@@ -386,7 +389,7 @@ proc connectOnce(
       # if codec was not know, it can be retrieved from newly established stream
       p.codec = newStream.protocol
 
-    p.connectedFut.complete()
+    p.connectedFut.completeOnce()
     if p.onEvent != nil:
       p.onEvent(p, PubSubPeerEvent(kind: PubSubPeerEventKind.StreamOpened))
 
@@ -579,7 +582,7 @@ proc sendEncoded*(
   ## Parameters:
   ## - `p`: The `PubSubPeer` instance to which the message is to be sent.
   ## - `msg`: The message to be sent, encoded as a sequence of bytes (`seq[byte]`).
-  ## - `priority`: 
+  ## - `priority`:
   ##   - `High` or any priority when all queues are empty: sent immediately
   ##   - `Medium`: queued in `mediumPriorityQueue`. Dropped when full.
   ##   - `Low`: queued in `lowPriorityQueue`. Dropped when full.


### PR DESCRIPTION
## Summary
<!--
Provide a clear and concise description of the purpose of this PR.

Explain:
- What this PR does
- Why it is needed
- The problem it solves or the improvement it introduces
-->

If peer is disconnected while waiting for stream to be completed (but within the 5 seconds timeout), could end up re-initializing the already-disconnected peer, completing `connectedFut` twice.

## Affected Areas
<!--
Indicate which parts of the codebase are impacted.
Check all that apply and briefly describe the scope of the changes.
-->

- [X] Gossipsub  
  <!-- e.g. scoring changes, message validation, peer handling -->

- [ ] Transports  
  <!-- e.g. TCP, QUIC, WebSockets, Noise, etc. -->

- [ ] Peer Management / Discovery

- [ ] Protocol Logic

- [ ] Build / Tooling

- [ ] Other  
  <!-- Describe below -->


## Compatibility & Downstream Validation
<!--
For PRs affecting behavior on existing features, provide evidence that
dependent projects build and function correctly with these changes.
-->

Pure bugfix

Reference PRs / branches / commits demonstrating successful integration:

- **Nimbus:**  
  n/a <!-- Link PR or branch -->

- **Waku:**  
  n/a <!-- Link PR or branch -->

- **Codex:**  
  n/a <!-- Link PR or branch -->


## Impact on Library Users
<!--
Describe how this affects downstream users of nim-libp2p.

Examples:
- API changes
- Behavior changes
- Performance implications
- Migration requirements
- No impact (internal refactor)
-->

No impact (internal bugfix)


## Risk Assessment
<!--
Identify potential risks introduced by this change.

Consider:
- Backward compatibility
- Network behavior changes
- Performance regressions
- Security implications
-->

Avoids a potential `FutureDefect`.


## References
<!--
Link to related:
- Issues
- Specs
- Design discussions
- Prior PRs
-->
n/a


## Additional Notes
<!--
Optional: any extra context reviewers should be aware of.
-->
n/a