### PR TITLE
fix(floodsub): punish nodes sending malformed messages

### DIFF
--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -99,11 +99,10 @@ method unsubscribePeer*(f: FloodSub, peer: PeerId) =
 
   procCall PubSub(f).unsubscribePeer(peer)
 
-proc punishIfOverBudget(
-    f: FloodSub, peer: PubSubPeer, overhead: int
-) {.async: (raises: [PeerRateLimitError]).} =
+template chargeOverhead(f: FloodSub, peer: PubSubPeer, overhead: int) =
+  # a template, so that a peer within its budget allocates no future
   if not peer.tryCharge(overhead):
-    await f.punishOverBudget(peer, overhead, f.disconnectPeerAboveRateLimit)
+    f.punishOverBudget(peer, overhead, f.disconnectPeerAboveRateLimit)
 
 method rpcHandler*(
     f: FloodSub, peer: PubSubPeer, data: sink seq[byte]
@@ -111,7 +110,7 @@ method rpcHandler*(
   let msgSize = data.len
   var rpcMsg = RPCMsg.decode(move(data)).valueOr:
     debug "failed to decode msg from peer", peer, err = error
-    await f.punishIfOverBudget(peer, msgSize)
+    f.chargeOverhead(peer, msgSize)
     raise newException(PeerMessageDecodeError, "Peer msg couldn't be decoded")
 
   trace "decoded msg from peer", peer, rpcMsg = rpcMsg.shortLog
@@ -124,12 +123,13 @@ method rpcHandler*(
 
     f.handleSubscribe(peer, sub.topic.get(), sub.isSubscribe)
 
+  var invalidBytesSent = 0
   for msg in rpcMsg.messages: # for every message
     let msgIdResult = f.msgIdProvider(msg)
     if msgIdResult.isErr:
       debug "Dropping message due to failed message id generation",
         error = msgIdResult.error
-      await f.punishIfOverBudget(peer, msg.data.len)
+      invalidBytesSent += msg.data.len
       continue
 
     let
@@ -144,13 +144,13 @@ method rpcHandler*(
     if (msg.signature.len > 0 or f.verifySignature) and not msg.verify():
       # always validate if signature is present or required
       debug "Dropping message due to failed signature verification", msgId, peer
-      await f.punishIfOverBudget(peer, msg.data.len)
+      invalidBytesSent += msg.data.len
       continue
 
     if msg.seqno.len > 0 and msg.seqno.len != 8:
       # if we have seqno should be 8 bytes long
       debug "Dropping message due to invalid seqno length", msgId, peer
-      await f.punishIfOverBudget(peer, msg.data.len)
+      invalidBytesSent += msg.data.len
       continue
 
     if f.addSeen(saltedId):
@@ -184,6 +184,7 @@ method rpcHandler*(
     trace "Forwared message to peers", peers = toSendPeers.len
 
   f.updateMetrics(rpcMsg)
+  f.chargeOverhead(peer, invalidBytesSent)
 
 method init*(f: FloodSub) =
   proc handler(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -29,11 +29,11 @@ const FloodSubCodec* = "/floodsub/1.0.0"
 type FloodSub* = ref object of PubSub
   floodsub*: PeerTable # topic to remote peer map
   seen*: TimedCache[SaltedId]
-    # Early filter for messages recently observed on the network
-    # We use a salted id because the messages in this cache have not yet
-    # been validated meaning that an attacker has greater control over the
-    # hash key and therefore could poison the table
+    # salted: these ids are unvalidated, so a plain key lets an attacker poison the table
   seenSalt: array[32, byte] # random data used as salt
+  # gossipsub rejects these two at init and reads GossipSubParams instead
+  overheadRateLimit*: Opt[RateLimit]
+  disconnectPeerAboveRateLimit*: bool
 
 proc salt*(f: FloodSub, msgId: MessageId): SaltedId =
   var hash: sha256
@@ -99,11 +99,19 @@ method unsubscribePeer*(f: FloodSub, peer: PeerId) =
 
   procCall PubSub(f).unsubscribePeer(peer)
 
+proc punishIfOverBudget(
+    f: FloodSub, peer: PubSubPeer, overhead: int
+) {.async: (raises: [PeerRateLimitError]).} =
+  if not peer.tryCharge(overhead):
+    await f.punishOverBudget(peer, overhead, f.disconnectPeerAboveRateLimit)
+
 method rpcHandler*(
     f: FloodSub, peer: PubSubPeer, data: sink seq[byte]
 ) {.async: (raises: [CancelledError, PeerMessageDecodeError, PeerRateLimitError]).} =
+  let msgSize = data.len
   var rpcMsg = RPCMsg.decode(move(data)).valueOr:
     debug "failed to decode msg from peer", peer, err = error
+    await f.punishIfOverBudget(peer, msgSize)
     raise newException(PeerMessageDecodeError, "Peer msg couldn't be decoded")
 
   trace "decoded msg from peer", peer, rpcMsg = rpcMsg.shortLog
@@ -121,7 +129,7 @@ method rpcHandler*(
     if msgIdResult.isErr:
       debug "Dropping message due to failed message id generation",
         error = msgIdResult.error
-      # TODO: descore peers due to error during message validation (malicious?)
+      await f.punishIfOverBudget(peer, msg.data.len)
       continue
 
     let
@@ -136,11 +144,13 @@ method rpcHandler*(
     if (msg.signature.len > 0 or f.verifySignature) and not msg.verify():
       # always validate if signature is present or required
       debug "Dropping message due to failed signature verification", msgId, peer
+      await f.punishIfOverBudget(peer, msg.data.len)
       continue
 
     if msg.seqno.len > 0 and msg.seqno.len != 8:
       # if we have seqno should be 8 bytes long
       debug "Dropping message due to invalid seqno length", msgId, peer
+      await f.punishIfOverBudget(peer, msg.data.len)
       continue
 
     if f.addSeen(saltedId):
@@ -247,8 +257,33 @@ method publish*(
 
   return peers.len
 
+func validateOverheadRateLimit(f: FloodSub): Result[void, cstring] =
+  let limit = f.overheadRateLimit.valueOr:
+    if f.disconnectPeerAboveRateLimit:
+      return err(
+        "floodsub: disconnectPeerAboveRateLimit parameter error, Requires overheadRateLimit"
+      )
+    return ok()
+  if limit.bytes <= 0:
+    return err("floodsub: overheadRateLimit.bytes parameter error, Must be > 0")
+  if limit.interval <= ZeroDuration:
+    return err("floodsub: overheadRateLimit.interval parameter error, Must be > 0")
+  ok()
+
+method getOrCreatePeer*(
+    f: FloodSub, peerId: PeerId, protosToDial: seq[string], protoNegotiated: string = ""
+): PubSubPeer =
+  let peer = procCall PubSub(f).getOrCreatePeer(peerId, protosToDial, protoNegotiated)
+  peer.overheadRateLimitOpt = newOverheadBucket(f.overheadRateLimit)
+
+  peer
+
 method initPubSub*(f: FloodSub) {.raises: [InitializationError].} =
   procCall PubSub(f).initPubSub()
+
+  f.validateOverheadRateLimit().isOkOr:
+    raise newException(InitializationError, $error)
+
   f.seen = TimedCache[SaltedId].init(2.minutes)
   f.rng.generate(f.seenSalt)
 

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -123,13 +123,12 @@ method rpcHandler*(
 
     f.handleSubscribe(peer, sub.topic.get(), sub.isSubscribe)
 
-  var invalidBytesSent = 0
   for msg in rpcMsg.messages: # for every message
     let msgIdResult = f.msgIdProvider(msg)
     if msgIdResult.isErr:
       debug "Dropping message due to failed message id generation",
         error = msgIdResult.error
-      invalidBytesSent += msg.data.len
+      f.chargeOverhead(peer, msg.byteSize())
       continue
 
     let
@@ -144,13 +143,13 @@ method rpcHandler*(
     if (msg.signature.len > 0 or f.verifySignature) and not msg.verify():
       # always validate if signature is present or required
       debug "Dropping message due to failed signature verification", msgId, peer
-      invalidBytesSent += msg.data.len
+      f.chargeOverhead(peer, msg.byteSize())
       continue
 
     if msg.seqno.len > 0 and msg.seqno.len != 8:
       # if we have seqno should be 8 bytes long
       debug "Dropping message due to invalid seqno length", msgId, peer
-      invalidBytesSent += msg.data.len
+      f.chargeOverhead(peer, msg.byteSize())
       continue
 
     if f.addSeen(saltedId):
@@ -184,7 +183,6 @@ method rpcHandler*(
     trace "Forwared message to peers", peers = toSendPeers.len
 
   f.updateMetrics(rpcMsg)
-  f.chargeOverhead(peer, invalidBytesSent)
 
 method init*(f: FloodSub) =
   proc handler(stream: Stream, proto: string) {.async: (raises: [CancelledError]).} =
@@ -275,7 +273,9 @@ method getOrCreatePeer*(
     f: FloodSub, peerId: PeerId, protosToDial: seq[string], protoNegotiated: string = ""
 ): PubSubPeer =
   let peer = procCall PubSub(f).getOrCreatePeer(peerId, protosToDial, protoNegotiated)
-  peer.overheadRateLimitOpt = newOverheadBucket(f.overheadRateLimit)
+  # a returning peer keeps its bucket, so a new stream is no way to refill it
+  if peer.overheadRateLimitOpt.isNone():
+    peer.overheadRateLimitOpt = newOverheadBucket(f.overheadRateLimit)
 
   peer
 

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -685,14 +685,14 @@ proc recordOverheadMetrics(g: GossipSub, peer: PubSubPeer, overhead: int) =
 
 proc rateLimit*(
     g: GossipSub, peer: PubSubPeer, overhead: int
-) {.async: (raises: [PeerRateLimitError]).} =
+) {.async: (raises: [CancelledError, PeerRateLimitError]).} =
   g.recordOverheadMetrics(peer, overhead)
   if peer.tryCharge(overhead):
     return
 
   # counted before the disconnect below, which raises
   libp2p_gossipsub_peers_rate_limit_hits.inc(labelValues = [peer.getAgent()])
-  await g.punishOverBudget(peer, overhead, g.parameters.disconnectPeerAboveRateLimit)
+  g.punishOverBudget(peer, overhead, g.parameters.disconnectPeerAboveRateLimit)
 
 method rpcHandler*(
     g: GossipSub, peer: PubSubPeer, data: sink seq[byte]

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -687,17 +687,12 @@ proc rateLimit*(
     g: GossipSub, peer: PubSubPeer, overhead: int
 ) {.async: (raises: [PeerRateLimitError]).} =
   g.recordOverheadMetrics(peer, overhead)
-  peer.overheadRateLimitOpt.withValue(overheadRateLimit):
-    if not overheadRateLimit.tryConsume(overhead):
-      libp2p_gossipsub_peers_rate_limit_hits.inc(labelValues = [peer.getAgent()])
-        # let's just measure at the beginning for test purposes.
-      debug "Peer sent too much useless application data and it's above rate limit.",
-        peer, overhead
-      if g.parameters.disconnectPeerAboveRateLimit:
-        await g.disconnectPeer(peer)
-        raise newException(
-          PeerRateLimitError, "Peer disconnected because it's above rate limit."
-        )
+  if peer.tryCharge(overhead):
+    return
+
+  # counted before the disconnect below, which raises
+  libp2p_gossipsub_peers_rate_limit_hits.inc(labelValues = [peer.getAgent()])
+  await g.punishOverBudget(peer, overhead, g.parameters.disconnectPeerAboveRateLimit)
 
 method rpcHandler*(
     g: GossipSub, peer: PubSubPeer, data: sink seq[byte]
@@ -1195,6 +1190,12 @@ method initPubSub*(g: GossipSub) {.raises: [InitializationError].} =
   if not g.parameters.explicit:
     g.parameters = GossipSubParams.init()
 
+  if g.overheadRateLimit.isSome() or g.disconnectPeerAboveRateLimit:
+    raise newException(
+      InitializationError,
+      "gossipsub: set the overhead rate limit through GossipSubParams, not the inherited FloodSub fields",
+    )
+
   let validationRes = g.parameters.validateParameters()
   if validationRes.isErr:
     raise newException(InitializationError, $validationRes.error)
@@ -1215,9 +1216,7 @@ method getOrCreatePeer*(
     protoNegotiated: string = "",
 ): PubSubPeer =
   let peer = procCall PubSub(g).getOrCreatePeer(peerId, protosToDial, protoNegotiated)
-  g.parameters.overheadRateLimit.withValue(overheadRateLimit):
-    peer.overheadRateLimitOpt =
-      Opt.some(TokenBucket.new(overheadRateLimit.bytes, overheadRateLimit.interval))
+  peer.overheadRateLimitOpt = newOverheadBucket(g.parameters.overheadRateLimit)
   peer.maxHighPriorityQueueLen = g.parameters.maxHighPriorityQueueLen
   peer.maxMediumPriorityQueueLen = g.parameters.maxMediumPriorityQueueLen
   peer.maxLowPriorityQueueLen = g.parameters.maxLowPriorityQueueLen

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -1216,7 +1216,9 @@ method getOrCreatePeer*(
     protoNegotiated: string = "",
 ): PubSubPeer =
   let peer = procCall PubSub(g).getOrCreatePeer(peerId, protosToDial, protoNegotiated)
-  peer.overheadRateLimitOpt = newOverheadBucket(g.parameters.overheadRateLimit)
+  # a returning peer keeps its bucket, so a new stream is no way to refill it
+  if peer.overheadRateLimitOpt.isNone():
+    peer.overheadRateLimitOpt = newOverheadBucket(g.parameters.overheadRateLimit)
   peer.maxHighPriorityQueueLen = g.parameters.maxHighPriorityQueueLen
   peer.maxMediumPriorityQueueLen = g.parameters.maxMediumPriorityQueueLen
   peer.maxLowPriorityQueueLen = g.parameters.maxLowPriorityQueueLen

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -336,13 +336,11 @@ proc scoringHeartbeat*(g: GossipSub) {.async: (raises: [CancelledError]).} =
 
 proc punishInvalidMessage*(
     g: GossipSub, peer: PubSubPeer, msg: Message
-) {.async: (raises: [PeerRateLimitError]).} =
+) {.async: (raises: [CancelledError, PeerRateLimitError]).} =
   if not peer.tryCharge(msg.data.len):
     # counted before the disconnect below, which raises
     libp2p_gossipsub_peers_rate_limit_hits.inc(labelValues = [peer.getAgent()])
-    await g.punishOverBudget(
-      peer, msg.data.len, g.parameters.disconnectPeerAboveRateLimit
-    )
+    g.punishOverBudget(peer, msg.data.len, g.parameters.disconnectPeerAboveRateLimit)
 
   if msg.topic notin g.topics:
     return

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -130,12 +130,6 @@ proc colocationFactor(g: GossipSub, peer: PubSubPeer): float64 =
   else:
     0.0
 
-proc disconnectPeer*(g: GossipSub, peer: PubSubPeer) {.async: (raises: []).} =
-  try:
-    await g.switch.disconnect(peer.peerId)
-  except CatchableError as exc: # Never cancelled
-    trace "Failed to close connection", peer, errName = exc.name, description = exc.msg
-
 proc disconnectIfBadScorePeer*(g: GossipSub, peer: PubSubPeer, score: float64) =
   if g.parameters.disconnectBadPeers and score < g.parameters.graylistThreshold and
       peer.peerId notin g.parameters.directPeers:
@@ -343,18 +337,12 @@ proc scoringHeartbeat*(g: GossipSub) {.async: (raises: [CancelledError]).} =
 proc punishInvalidMessage*(
     g: GossipSub, peer: PubSubPeer, msg: Message
 ) {.async: (raises: [PeerRateLimitError]).} =
-  peer.overheadRateLimitOpt.withValue(overheadRateLimit):
-    let uselessAppBytesNum = msg.data.len
-    if not overheadRateLimit.tryConsume(uselessAppBytesNum):
-      debug "Peer sent invalid message and it's above rate limit",
-        peer, uselessAppBytesNum
-      libp2p_gossipsub_peers_rate_limit_hits.inc(labelValues = [peer.getAgent()])
-        # let's just measure at the beginning for test purposes.
-      if g.parameters.disconnectPeerAboveRateLimit:
-        await g.disconnectPeer(peer)
-        raise newException(
-          PeerRateLimitError, "Peer disconnected because it's above rate limit."
-        )
+  if not peer.tryCharge(msg.data.len):
+    # counted before the disconnect below, which raises
+    libp2p_gossipsub_peers_rate_limit_hits.inc(labelValues = [peer.getAgent()])
+    await g.punishOverBudget(
+      peer, msg.data.len, g.parameters.disconnectPeerAboveRateLimit
+    )
 
   if msg.topic notin g.topics:
     return

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -102,10 +102,6 @@ type
     slowPeerPenalty*: float64 # penalty from repeated medium/low queue overflow drops
     behaviourPenalty*: float64 # the eventual penalty score
 
-  RateLimit* = object
-    bytes*: int
-    interval*: Duration
-
   GossipSubParams* = object
     # explicit is used to check if the GossipSubParams instance was created by the user either passing params to GossipSubParams(...)
     # or GossipSubParams.init(...). In the first case explicit should be set to true when calling the Nim constructor.

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -12,6 +12,7 @@ import results
 import extensions, preamblestore
 
 export results, tables, sets
+export RateLimit # downstream code names it through this module
 
 const
   GossipSubCodec_13* = "/meshsub/1.3.0"

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -26,7 +26,7 @@ import
   ../../utils/future
 
 export tables, sets, results, chronicles
-export PubSubPeer, PubSubObserver, protocol, pubsub_errors
+export PubSubPeer, PubSubObserver, RateLimit, protocol, pubsub_errors
 
 logScope:
   topics = "libp2p pubsub"
@@ -451,6 +451,24 @@ method getOrCreatePeer*(
     p.unsubscribePeer(peerId)
 
   return pubSubPeer
+
+proc disconnectPeer*(p: PubSub, peer: PubSubPeer) {.async: (raises: []).} =
+  try:
+    await p.switch.disconnect(peer.peerId)
+  except CatchableError as e:
+    trace "Failed to close connection", peer, errName = e.name, description = e.msg
+
+proc punishOverBudget*(
+    p: PubSub, peer: PubSubPeer, overhead: int, disconnectAboveLimit: bool
+) {.async: (raises: [PeerRateLimitError]).} =
+  debug "Peer sent too much useless application data and it's above rate limit.",
+    peer, overhead
+  if not disconnectAboveLimit:
+    return
+
+  await p.disconnectPeer(peer)
+  raise
+    newException(PeerRateLimitError, "Peer disconnected because it's above rate limit.")
 
 proc handleData*(
     p: PubSub, topic: string, data: seq[byte]

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -452,23 +452,22 @@ method getOrCreatePeer*(
 
   return pubSubPeer
 
-proc disconnectPeer*(p: PubSub, peer: PubSubPeer) {.async: (raises: []).} =
-  try:
-    await p.switch.disconnect(peer.peerId)
-  except CatchableError as e:
-    trace "Failed to close connection", peer, errName = e.name, description = e.msg
+proc disconnectPeer*(
+    p: PubSub, peer: PubSubPeer
+) {.async: (raises: [CancelledError]).} =
+  await p.switch.disconnect(peer.peerId)
 
-proc punishOverBudget*(
-    p: PubSub, peer: PubSubPeer, overhead: int, disconnectAboveLimit: bool
-) {.async: (raises: [PeerRateLimitError]).} =
+template punishOverBudget*(
+    p: PubSub, punished: PubSubPeer, invalidBytesSent: int, disconnectAboveLimit: bool
+) =
+  # a template, so that only the disconnect path allocates a future
   debug "Peer sent too much useless application data and it's above rate limit.",
-    peer, overhead
-  if not disconnectAboveLimit:
-    return
-
-  await p.disconnectPeer(peer)
-  raise
-    newException(PeerRateLimitError, "Peer disconnected because it's above rate limit.")
+    peer = punished, overhead = invalidBytesSent
+  if disconnectAboveLimit:
+    await p.disconnectPeer(punished)
+    raise newException(
+      PeerRateLimitError, "Peer disconnected because it's above rate limit."
+    )
 
 proc handleData*(
     p: PubSub, topic: string, data: seq[byte]

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -148,6 +148,10 @@ type
     customStreamCreationCB*: CustomStreamCreationProc
     customPeerSelectionCB*: CustomPeerSelectionProc
 
+  RateLimit* = object
+    bytes*: int
+    interval*: Duration
+
   PubSubPeer* = ref object of RootObj
     getStream*: GetStream # callback to establish a new send stream
     onEvent*: OnEvent # Connectivity updates for peer
@@ -201,6 +205,24 @@ proc getAgent*(peer: PubSubPeer): string =
       if peer.shortAgent.len > 0: peer.shortAgent else: "unknown"
     else:
       "unknown"
+
+proc newOverheadBucket*(overheadRateLimit: Opt[RateLimit]): Opt[TokenBucket] =
+  overheadRateLimit.withValue(limit):
+    if limit.bytes <= 0 or limit.interval <= ZeroDuration:
+      # such a bucket refuses every charge, which would disconnect every peer
+      warn "ignoring an unusable overhead rate limit", limit
+      return Opt.none(TokenBucket)
+
+    return Opt.some(TokenBucket.new(limit.bytes, limit.interval))
+
+  Opt.none(TokenBucket)
+
+proc tryCharge*(peer: PubSubPeer, overhead: int): bool =
+  ## Charges `overhead` bytes of useless data to the peer, false when it cannot pay.
+  peer.overheadRateLimitOpt.withValue(overheadRateLimit):
+    return overheadRateLimit.tryConsume(overhead)
+
+  true
 
 proc `$`*(p: PubSubPeer): string =
   $p.peerId

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -219,6 +219,9 @@ proc newOverheadBucket*(overheadRateLimit: Opt[RateLimit]): Opt[TokenBucket] =
 
 proc tryCharge*(peer: PubSubPeer, overhead: int): bool =
   ## Charges `overhead` bytes of useless data to the peer, false when it cannot pay.
+  if overhead <= 0:
+    return true
+
   peer.overheadRateLimitOpt.withValue(overheadRateLimit):
     return overheadRateLimit.tryConsume(overhead)
 

--- a/tests/libp2p/pubsub/component/test_floodsub.nim
+++ b/tests/libp2p/pubsub/component/test_floodsub.nim
@@ -4,6 +4,7 @@
 {.used.}
 
 import sequtils, tables, sets, chronos, stew/byteutils
+import chronos/ratelimit
 import
   ../utils,
   ../../../../libp2p/[
@@ -11,6 +12,7 @@ import
     stream/connection,
     protocols/pubsub/pubsub,
     protocols/pubsub/floodsub,
+    protocols/pubsub/rpc/message,
     protocols/pubsub/rpc/messages,
     protocols/pubsub/rpc/protobuf,
     protocols/pubsub/peertable,
@@ -18,6 +20,23 @@ import
   ]
 import ../../../../libp2p/protocols/pubsub/errors as pubsub_errors
 import ../../../tools/[lifecycle, topology, unittest, futures]
+
+proc addRateLimitedPeer(f: FloodSub, bucket: TokenBucket): PubSubPeer =
+  let peerId = randomPeerId()
+  proc getStream(): Future[Stream] {.
+      async: (raises: [CancelledError, GetStreamDialError])
+  .} =
+    raise (ref GetStreamDialError)(msg: "unused")
+
+  let peer =
+    PubSubPeer.new(peerId, getStream, nil, FloodSubCodec, 1024 * 1024, voidPeerHandler)
+  peer.overheadRateLimitOpt = Opt.some(bucket)
+  f.peers[peerId] = peer
+
+  peer
+
+func failingMsgIdProvider(m: Message): Result[MessageId, ValidationResult] =
+  err(ValidationResult.Reject)
 
 suite "FloodSub Component":
   const topic = "foobar"
@@ -346,3 +365,46 @@ suite "FloodSub Component":
 
     node.unsubscribePeer(peerId)
     check node.floodsub.len == 0
+
+  asyncTest "FloodSub charges the overhead budget when message id generation fails":
+    const bytes = 10
+
+    let
+      node = generateNodes(1).toFloodSub()[0]
+      peer = node.addRateLimitedPeer(TokenBucket.new(bytes, 1.hours))
+
+    node.msgIdProvider = failingMsgIdProvider
+
+    let msg = Message.init(peer.peerId, "bar".toBytes(), topic, Opt.some(1'u64))
+    await node.rpcHandler(peer, RPCMsg.withMessages(msg).encode(false))
+
+    check not peer.overheadRateLimitOpt.get().tryConsume(bytes)
+
+  asyncTest "FloodSub disconnects a peer above the overhead budget":
+    let
+      node = generateNodes(1).toFloodSub()[0]
+      peer = node.addRateLimitedPeer(TokenBucket.new(1, 1.millis))
+
+    node.msgIdProvider = failingMsgIdProvider
+    node.disconnectPeerAboveRateLimit = true
+
+    let msg = Message.init(peer.peerId, "bar".toBytes(), topic, Opt.some(1'u64))
+
+    expect PeerRateLimitError:
+      await node.rpcHandler(peer, RPCMsg.withMessages(msg).encode(false))
+
+  asyncTest "FloodSub gives a new peer a bucket built from overheadRateLimit":
+    let node = generateNodes(1).toFloodSub()[0]
+    node.overheadRateLimit = Opt.some(RateLimit(bytes: 10, interval: 1.hours))
+
+    let peer = node.getOrCreatePeer(randomPeerId(), @[FloodSubCodec])
+    check peer.overheadRateLimitOpt.isSome()
+
+  asyncTest "FloodSub ignores an overheadRateLimit that refuses every charge":
+    let node = generateNodes(1).toFloodSub()[0]
+    node.overheadRateLimit = Opt.some(RateLimit(bytes: 0, interval: 1.hours))
+
+    let peer = node.getOrCreatePeer(randomPeerId(), @[FloodSubCodec])
+    check:
+      peer.overheadRateLimitOpt.isNone()
+      peer.tryCharge(1024)

--- a/tests/libp2p/pubsub/component/test_floodsub.nim
+++ b/tests/libp2p/pubsub/component/test_floodsub.nim
@@ -367,18 +367,18 @@ suite "FloodSub Component":
     check node.floodsub.len == 0
 
   asyncTest "FloodSub charges the overhead budget when message id generation fails":
-    const bytes = 10
+    const budget = 10
 
     let
       node = generateNodes(1).toFloodSub()[0]
-      peer = node.addRateLimitedPeer(TokenBucket.new(bytes, 1.hours))
+      peer = node.addRateLimitedPeer(TokenBucket.new(budget, 1.hours))
 
     node.msgIdProvider = failingMsgIdProvider
 
     let msg = Message.init(peer.peerId, "bar".toBytes(), topic, Opt.some(1'u64))
     await node.rpcHandler(peer, RPCMsg.withMessages(msg).encode(false))
 
-    check not peer.overheadRateLimitOpt.get().tryConsume(bytes)
+    check not peer.overheadRateLimitOpt.get().tryConsume(budget)
 
   asyncTest "FloodSub disconnects a peer above the overhead budget":
     let

--- a/tests/libp2p/pubsub/component/test_floodsub.nim
+++ b/tests/libp2p/pubsub/component/test_floodsub.nim
@@ -367,7 +367,7 @@ suite "FloodSub Component":
     check node.floodsub.len == 0
 
   asyncTest "FloodSub charges the overhead budget when message id generation fails":
-    const budget = 10
+    const budget = 1024
 
     let
       node = generateNodes(1).toFloodSub()[0]
@@ -378,7 +378,10 @@ suite "FloodSub Component":
     let msg = Message.init(peer.peerId, "bar".toBytes(), topic, Opt.some(1'u64))
     await node.rpcHandler(peer, RPCMsg.withMessages(msg).encode(false))
 
-    check not peer.overheadRateLimitOpt.get().tryConsume(budget)
+    let bucket = peer.overheadRateLimitOpt.get()
+    check:
+      bucket.tryConsume(budget - msg.byteSize())
+      not bucket.tryConsume(1)
 
   asyncTest "FloodSub disconnects a peer above the overhead budget":
     let
@@ -399,6 +402,17 @@ suite "FloodSub Component":
 
     let peer = node.getOrCreatePeer(randomPeerId(), @[FloodSubCodec])
     check peer.overheadRateLimitOpt.isSome()
+
+  asyncTest "FloodSub keeps the bucket a known peer already spent":
+    let
+      node = generateNodes(1).toFloodSub()[0]
+      peer = node.addRateLimitedPeer(TokenBucket.new(10, 1.hours))
+    node.overheadRateLimit = Opt.some(RateLimit(bytes: 10, interval: 1.hours))
+
+    check peer.tryCharge(10)
+    discard node.getOrCreatePeer(peer.peerId, @[FloodSubCodec])
+
+    check not peer.tryCharge(1)
 
   asyncTest "FloodSub ignores an overheadRateLimit that refuses every charge":
     let node = generateNodes(1).toFloodSub()[0]


### PR DESCRIPTION
## Summary

Closes the FloodSub half of #692.

`3b718baa9` ("feat: allow msgIdProvider to fail (#688)") made message id generation fallible and left the same TODO in both protocols: `# TODO: descore peers due to error during message validation (malicious?)`. `0911cb20f` ("chore(gossipsub): cleanups (#1096)") satisfied the GossipSub half with `punishInvalidMessage`. FloodSub kept the TODO because `punishInvalidMessage` is a GossipSub proc: it needs `peerStats`, `TopicInfo` and the v1.1 score, none of which FloodSub has.

A score does not fit FloodSub. Four of the seven v1.1 terms (P1 time in mesh, P3 mesh delivery rate, P3b mesh failure penalty, P7 behaviour penalty) are mesh-relative, and FloodSub has no mesh. Every score consumer in GossipSub is a mesh or gossip decision (`behavior.nim:198`, `:285`, `:296`, `:336`, `:542`, `:688`, `scoring.nim:140`), so the only reachable consumer in FloodSub is disconnect. That is a rate limiter, not a score.

So this PR gives FloodSub the overhead token bucket instead. A peer that sends messages we decode but cannot hash now burns its byte budget, and gets disconnected when `disconnectPeerAboveRateLimit` is set.

The shared machinery moves to `PubSub`, where it removes three existing duplications:

- `disconnectPeer` was defined on `GossipSub` in `gossipsub/scoring.nim`; one copy on `PubSub` now serves both.
- The bucket check and the punishment were written twice, in `gossipsub.nim:rateLimit` and in `scoring.nim:punishInvalidMessage`. Both now call `overBudget` and `punishOverBudget`.
- The `Opt[RateLimit]` to `Opt[TokenBucket]` conversion was inline in GossipSub's `getOrCreatePeer`; it is now `newOverheadBucket`.

`RateLimit` moves from `gossipsub/types.nim` to `pubsub.nim` so both protocols can name it.

## Affected Areas

- [x] Gossipsub
  Pure refactor. `rateLimit` and `punishInvalidMessage` call the shared procs. Order of the metric, the log and the disconnect is preserved, and `libp2p_gossipsub_peers_rate_limit_hits` still fires before the disconnect raises.

- [ ] Transports

- [ ] Peer Management / Discovery

- [x] Protocol Logic
  FloodSub gains `overheadRateLimit` and `disconnectPeerAboveRateLimit`, a `getOrCreatePeer` override that builds the peer's token bucket, and validation of both fields in `initPubSub`.

- [ ] Build / Tooling

- [ ] Other

## Compatibility & Downstream Validation

Reference PRs / branches / commits demonstrating successful integration:

- **Nimbus:**
- **Waku:**
- **Codex:**

## Impact on Library Users

GossipSub behaviour is unchanged. `GossipSubParams` keeps both fields and stays the only place a GossipSub user configures them, including mutation after `initPubSub`, which several tests rely on.

FloodSub users get two new public fields on the `FloodSub` object, both off by default. Set them before `start` and `initPubSub` validates them: a limit with `bytes <= 0` or a non-positive `interval` raises `InitializationError`, as does `disconnectPeerAboveRateLimit` without a limit. This mirrors `validateOverheadRateLimit` in `gossipsub.nim`.

New public API on `PubSub`: `disconnectPeer`, `newOverheadBucket`, `overBudget`, `punishOverBudget`. `RateLimit` keeps its old import path for anyone importing `gossipsub`, because `gossipsub.nim` re-exports `pubsub`.

## Risk Assessment

Low for GossipSub, which keeps reading `g.parameters` at the point of use rather than a cached copy. An earlier version of this change mirrored the two fields into `PubSub` at init time; that silently breaks post-init mutation of `parameters`, which seven in-tree tests do (`test_gossipsub.nim:597`, `:630`, `:659` and `test_gossipsub_scoring.nim:83`, `:122`, `:168`, `:222`). `punishOverBudget` therefore takes the disconnect flag as an argument instead of reading a field.

New behaviour for FloodSub only, and only when a user opts in by setting `overheadRateLimit`. With the field unset, `newOverheadBucket` returns `Opt.none`, `overBudget` is a no-op and the code path is identical to today, minus the TODO.

The FloodSub `getOrCreatePeer` override is not reached from GossipSub: `GossipSub.getOrCreatePeer` calls `procCall PubSub(g).getOrCreatePeer`, which skips it. No peer gets two buckets.

## References

- Issue: #692, "feat: descore peers for which message id generation fails"
- Origin of the TODO: `3b718baa9`, "feat: allow msgIdProvider to fail (#688)"
- GossipSub half: `0911cb20f`, "chore(gossipsub): cleanups (#1096)"
