### PR TITLE
fix(dialer): preserve backoff through identify

### DIFF
--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -57,6 +57,9 @@ type
   DialReach* = ref object
     ## Shared by every address of one dial, so the peer answers for a real dial only.
     dialed: bool
+    connected: seq[(Muxer, MultiAddress)]
+    deferBackoffSuccess: bool
+      ## The managed connect clears the winning key only after identify succeeds.
 
   DialLock = ref object
     lock: AsyncLock
@@ -96,10 +99,10 @@ proc dialAndUpgrade*(
   let transport = self.transportFor(addrs).valueOr:
     return nil
 
-  let backoffKey = backoffKey(addrs, peerId)
+  let addressKey = backoffKey(addrs, peerId)
   self.dialBackoff.withValue(backoff):
     # `forceDial` already overrides the connection limits, so it overrides the wait too.
-    if not forceDial and backoff.blocked(backoffKey):
+    if not forceDial and backoff.blocked(addressKey):
       return nil
 
   reach.dialed = true
@@ -121,7 +124,7 @@ proc dialAndUpgrade*(
         (Moment.now() - dialStarted).milliseconds, labelValues = ["failed"]
       )
       self.dialBackoff.withValue(backoff):
-        backoff.recordFailure(backoffKey)
+        backoff.recordFailure(addressKey)
       return nil # Try the next address
 
   libp2p_successful_dials.inc()
@@ -147,7 +150,7 @@ proc dialAndUpgrade*(
         (Moment.now() - dialStarted).milliseconds, labelValues = ["upgrade_failed"]
       )
       self.dialBackoff.withValue(backoff):
-        backoff.recordFailure(backoffKey)
+        backoff.recordFailure(addressKey)
 
       # Try other address
       return nil
@@ -158,8 +161,10 @@ proc dialAndUpgrade*(
     (Moment.now() - dialStarted).milliseconds, labelValues = ["success"]
   )
 
-  self.dialBackoff.withValue(backoff):
-    backoff.recordSuccess(backoffKey)
+  reach.connected.add((mux, addressKey))
+  if not reach.deferBackoffSuccess:
+    self.dialBackoff.withValue(backoff):
+      backoff.recordSuccess(addressKey)
 
   let filtered = self.peerStore.addressPolicy.filterAddrs(@[addrs])
   if filtered.len > 0:
@@ -580,6 +585,12 @@ proc finishUpgrade(
       DialFailedError, "failed finishUpgrade in establishConnection: " & e.msg, e
     )
 
+proc connectedKey(reach: DialReach, muxed: Muxer): MultiAddress =
+  for (connected, key) in reach.connected:
+    if connected == muxed:
+      return key
+  raiseAssert "the selected muxer has no dial backoff key"
+
 proc establishConnection(
     self: Dialer,
     peerId: Opt[PeerId],
@@ -610,7 +621,7 @@ proc establishConnection(
 
   let
     dialAddrs = normalizedDialAddrs(peerId, addrs)
-    reach = DialReach()
+    reach = DialReach(deferBackoffSuccess: true)
   let muxed =
     try:
       await self.dialAndUpgrade(
@@ -630,15 +641,23 @@ proc establishConnection(
         shortLog(peerId) & " addrs=" & $dialAddrs,
     )
 
+  let winningKey = reach.connectedKey(muxed)
+  self.dialBackoff.withValue(backoff):
+    for (connected, key) in reach.connected:
+      if connected != muxed and key != winningKey:
+        backoff.recordSuccess(key)
+
   slot.trackMuxer(muxed)
   try:
     await self.finishUpgrade(muxed, dir)
   except DialFailedError as e:
     self.dialBackoff.withValue(backoff):
+      backoff.recordFailure(winningKey)
       backoff.recordFailure(peerId)
     raise e
 
   self.dialBackoff.withValue(backoff):
+    backoff.recordSuccess(winningKey)
     backoff.recordSuccess(peerId)
   muxed
 

--- a/tests/libp2p/test_dialer.nim
+++ b/tests/libp2p/test_dialer.nim
@@ -593,6 +593,49 @@ suite "Dialer":
 
     check src.connManager.connCount(dst.peerInfo.peerId) == 1
 
+  asyncTest "An address-only identify failure backs the address off":
+    let
+      src = makeStandardSwitch(TcpAutoAddress)
+      dst = makeStandardSwitch(TcpAutoAddress)
+    await src.start()
+    await dst.start()
+    dst.stallIdentify()
+    defer:
+      await allFutures(src.stop(), dst.stop())
+
+    let dialer = Dialer.new(
+      src.peerInfo.peerId,
+      src.connManager,
+      src.peerStore,
+      src.transports,
+      src.ms,
+      dialTimeout = 1.seconds,
+      dialBackoff = Opt.some(
+        DialBackoffConfig(
+          tolerance: 0, base: 100.milliseconds, factor: 4, maxDelay: 1.minutes
+        )
+      ),
+    )
+
+    expect DialFailedError:
+      discard await dialer
+        .connect(dst.peerInfo.addrs[0], allowUnknownPeerId = true)
+        .wait(5.seconds)
+
+    await sleepAsync(110.milliseconds)
+
+    expect DialFailedError:
+      discard await dialer
+        .connect(dst.peerInfo.addrs[0], allowUnknownPeerId = true)
+        .wait(5.seconds)
+
+    await sleepAsync(150.milliseconds)
+
+    expect DialFailedError:
+      discard await dialer
+        .connect(dst.peerInfo.addrs[0], allowUnknownPeerId = true)
+        .wait(100.milliseconds)
+
   asyncTest "Cancelling a dial at any point leaves nothing open":
     let
       src = makeStandardSwitch(TcpAutoAddress)


### PR DESCRIPTION
## Summary

Keep successful dial candidates associated with their backoff keys so ranked dialing applies Identify failures to the selected address. Managed connections now defer clearing successful address backoff until Identify completes, while successful losing candidates are cleared after selection.

This also lets address-only connections record Identify failures and retain consecutive failure counts, so exponential backoff continues across repeated Identify timeouts.

## Affected Areas

- [x] Peer Management / Discovery

## Impact on Library Users

No API changes. Address-only connections that repeatedly fail Identify now observe the configured exponential dial backoff.

## Risk Assessment

The change affects when address backoff entries are cleared around ranked dialing and Identify. Regression coverage checks repeated address-only Identify failures and delayed retries.

## References

- Follow-up to #3011

## Additional Notes

- Formatted with nph.
- Nim semantic checks pass for the modified implementation and test files.
- Tests were not executed.