### PR TITLE
fix(rendezvous): release expired registrations on the deletion heartbeat

### DIFF
--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -258,7 +258,7 @@ proc discover*[E](
       try:
         rdv.namespaces[d.ns.get() & rdv.salt]
       except exceptions.KeyError:
-        await stream.sendDiscoverResponseError(InvalidNamespace)
+        await stream.sendDiscoverResponse(@[], Cookie())
         return
     else:
       toSeq(max(cookie.offset.int, rdv.registered.offset) .. rdv.registered.high())
@@ -598,17 +598,43 @@ proc new*(
   rdv.setup(switch)
   return rdv
 
+func isLive(reg: RegisteredData, n: Moment): bool =
+  reg.expiration >= n
+
+proc clearExpiredRegistrations[E](rdv: GenericRendezVous[E], n: Moment) =
+  rdv.registered.flushIfIt(it.expiration < n)
+
+  # An entry behind a live one keeps its index so the cookies stay valid.
+  for reg in rdv.registered.mitems():
+    if not reg.isLive(n):
+      reg = RegisteredData(expiration: rdv.expiredDT)
+
+proc dropExpiredNamespaces[E](rdv: GenericRendezVous[E], n: Moment) =
+  var emptied: seq[string] = @[]
+
+  for ns, indexes in rdv.namespaces.mpairs():
+    indexes =
+      indexes.filterIt(it >= rdv.registered.offset and rdv.registered[it].isLive(n))
+    if indexes.len == 0:
+      emptied.add(ns)
+
+  for ns in emptied:
+    rdv.namespaces.del(ns)
+
+func liveRegistrations[E](rdv: GenericRendezVous[E]): int =
+  var total = 0
+  for indexes in rdv.namespaces.values():
+    total += indexes.len
+  total
+
 proc deletesRegister*[E](
     rdv: GenericRendezVous[E], interval = 1.minutes
 ) {.async: (raises: [CancelledError]).} =
   heartbeat "Register timeout", interval:
     let n = Moment.now()
-    var total = 0
-    rdv.registered.flushIfIt(it.expiration < n)
-    for data in rdv.namespaces.mvalues():
-      data.keepItIf(it >= rdv.registered.offset)
-      total += data.len
-    libp2p_rendezvous_registered.set(int64(total))
+    rdv.clearExpiredRegistrations(n)
+    rdv.dropExpiredNamespaces(n)
+    libp2p_rendezvous_registered.set(int64(rdv.liveRegistrations()))
     libp2p_rendezvous_namespaces.set(int64(rdv.namespaces.len))
 
 method start*[E](

--- a/libp2p/utils/offsettedseq.nim
+++ b/libp2p/utils/offsettedseq.nim
@@ -58,6 +58,10 @@ iterator items*[T](o: OffsettedSeq[T]): T =
   for e in o.s:
     yield e
 
+iterator mitems*[T](o: var OffsettedSeq[T]): var T =
+  for e in o.s.mitems():
+    yield e
+
 proc high*[T](o: OffsettedSeq[T]): int =
   o.s.high + o.offset
 

--- a/tests/libp2p/discovery/test_rendezvous.nim
+++ b/tests/libp2p/discovery/test_rendezvous.nim
@@ -3,7 +3,8 @@
 
 {.used.}
 
-import sequtils, strformat, sugar, chronos, stew/byteutils, protobuf_serialization
+import
+  sequtils, strformat, sugar, tables, chronos, stew/byteutils, protobuf_serialization
 import
   ../../../libp2p/[
     protocols/rendezvous,
@@ -472,6 +473,32 @@ suite "RendezVous":
           peerNodes[0], Opt.some(namespaceBar), Opt.none(int), Opt.none(seq[PeerId])
         )
       ).len == 5
+
+  asyncTest "Expired registration releases its namespace, its record and its quota":
+    let (rendezvousNode, peerNodes) = setupRendezvousNodeWithPeerNodes(2)
+    startAndDeferStop(rendezvousNode & peerNodes)
+
+    await connectHub(rendezvousNode, peerNodes)
+
+    await peerNodes[0].advertise("keep", Opt.some(5.hours))
+    await peerNodes[1].advertise("drop")
+
+    check:
+      rendezvousNode.namespaces.len == 2
+      rendezvousNode.registered.s.len == 2
+
+    let deletionLoop = rendezvousNode.deletesRegister(1.seconds)
+    defer:
+      await deletionLoop.cancelAndWait()
+
+    rendezvousNode.registered[1].expiration = Moment.now()
+
+    checkUntilTimeout:
+      # The live entry at index 0 blocks the flush, so index 1 stays in place.
+      rendezvousNode.registered.s.len == 2
+      rendezvousNode.registered[1].data.signedPeerRecord.len == 0
+      rendezvousNode.countRegister(peerNodes[1].switch.peerInfo.peerId) == 0
+      rendezvousNode.namespaces.len == 1
 
   asyncTest "Cookie offset is reset to end (returns empty) then new peers are discoverable":
     let (rendezvousNode, peerNodes) = setupRendezvousNodeWithPeerNodes(3)


### PR DESCRIPTION
## Summary

The register deletion heartbeat removed an expired registration only when it sat at the head of `registered`, because `flushIfIt` stops at the first live entry. One registration with a long TTL therefore held every later entry in memory, and the namespace table kept a key for every namespace it had ever seen.

The heartbeat now empties an expired entry that the flush cannot reach, which keeps its index so the discover cookies stay valid. It drops an expired index from the namespace table and deletes the key once that namespace is empty. Both gauges fall as registrations expire, and an expired entry no longer holds its slot in `RegistrationLimitPerPeer`.

`offsettedseq.nim` gains an `mitems` iterator, which is the only change outside the rendezvous protocol.

## Behaviour change to review

`discover` answers an unknown namespace with an empty `Ok` response instead of `InvalidNamespace`, because the server now forgets a namespace whose peers all expired. `InvalidNamespace` still answers a namespace that fails the length check.

## Affected Areas

- [x] Peer Management / Discovery

The wire format, the cookie semantics and the public API are unchanged. A Waku build against this branch is still worth running before merge.

## Not covered

- `discover` builds one `int` per registration for a request with no namespace, before it reads any of them.
- `countRegister` scans every registration on each REGISTER.
- Nothing caps the total number of namespaces or registrations. The heartbeat reclaims them once per interval.
