### PR TITLE
chore: native hkdf and autotls pem encoding

### DIFF
--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -4,7 +4,6 @@
 {.push raises: [].}
 
 import sequtils
-import bearssl/pem
 import chronos, chronicles, net, results, uri
 import chronos/streams/tlsstream
 from times import DateTime, now, toTime, toUnix

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -3,7 +3,7 @@
 {.push raises: [].}
 
 import chronos, chronicles, strutils
-import stew/base36
+import stew/[base36, base64]
 import
   ../errors,
   ../peerid,
@@ -34,6 +34,22 @@ proc encodePeerId*(peerId: PeerId): string {.raises: [AutoTLSError].} =
     raise newException(AutoTLSError, "Failed to initialize CID from multihash")
 
   return Base36.encode(cidResult.get().data.buffer)
+
+const PemLineWidth = 64
+
+func pemEncode*(data: openArray[byte], banner: string): string =
+  ## RFC 7468: padded base64 in 64-column lines, between BEGIN and END banners.
+  var pem = "-----BEGIN " & banner & "-----\n"
+
+  let body = Base64Pad.encode(data)
+  var i = 0
+  while i < body.len:
+    let stop = min(i + PemLineWidth, body.len)
+    pem.add(body[i ..< stop])
+    pem.add('\n')
+    i = stop
+
+  pem & "-----END " & banner & "-----\n"
 
 func dnsLabel(ipAddress: IpAddress): string =
   ## p2p-forge label: 100.10.10.3 gives 100-10-10-3, ::1 gives 0--1 (RFC 1123).

--- a/libp2p/crypto/hkdf.nim
+++ b/libp2p/crypto/hkdf.nim
@@ -5,43 +5,57 @@
 
 {.push raises: [].}
 
-import nimcrypto
-import bearssl/[kdf, hash]
+import nimcrypto/[hash, hmac, sha2, utils]
 
 type HkdfResult*[len: static int] = array[len, byte]
 
-proc hkdf*[T: sha256, len: static int](
+func extract[T: sha256](salt, ikm: openArray[byte]): MDigest[T.bits] =
+  var ctx: HMAC[T]
+  defer:
+    ctx.clear()
+
+  ctx.init(salt)
+  ctx.update(ikm)
+  ctx.finish()
+
+func hkdf*[T: sha256, len: static int](
     _: type[T],
     salt, ikm, info: openArray[byte],
     outputs: var openArray[HkdfResult[len]],
 ) =
-  var ctx: HkdfContext
-  hkdfInit(
-    ctx,
-    addr sha256Vtable,
-    if salt.len > 0:
-      addr salt[0]
-    else:
-      nil,
-    csize_t(salt.len),
-  )
-  hkdfInject(
-    ctx,
-    if ikm.len > 0:
-      addr ikm[0]
-    else:
-      nil,
-    csize_t(ikm.len),
-  )
-  hkdfFlip(ctx)
-  for i in 0 .. outputs.high:
-    discard hkdfProduce(
-      ctx,
-      if info.len > 0:
-        addr info[0]
-      else:
-        nil,
-      csize_t(info.len),
-      addr outputs[i][0],
-      csize_t(outputs[i].len),
-    )
+  ## `outputs` is one continuous OKM stream: `outputs[1]` continues `outputs[0]`.
+  const hashLen = T.bits div 8
+  doAssert outputs.len * len <= 255 * hashLen, "HKDF output is too long"
+
+  var
+    prk = extract[T](salt, ikm)
+    t: MDigest[T.bits]
+    tLen = 0
+    used = 0
+    counter = 1'u8
+
+  defer:
+    burnMem(prk)
+    burnMem(t)
+
+  for output in outputs.mitems:
+    var filled = 0
+    while filled < len:
+      if used == tLen:
+        var ctx: HMAC[T]
+        ctx.init(prk.data)
+        if tLen > 0:
+          ctx.update(t.data)
+        ctx.update(info)
+        ctx.update([counter])
+        t = ctx.finish()
+        ctx.clear()
+
+        tLen = hashLen
+        used = 0
+        inc counter
+
+      let chunk = min(tLen - used, len - filled)
+      copyMem(addr output[filled], addr t.data[used], chunk)
+      filled += chunk
+      used += chunk

--- a/tests/libp2p/autotls/test_utils.nim
+++ b/tests/libp2p/autotls/test_utils.nim
@@ -214,3 +214,20 @@ suite "AutoTLS peer ID label":
         # RFC 1035 caps a DNS label at 63 octets.
         label.len <= 63
         label.allIt(it in {'0' .. '9', 'a' .. 'z'})
+
+suite "AutoTLS PEM":
+  test "the body wraps at 64 columns between the banners":
+    check pemEncode(toSeq(0 .. 48).mapIt(byte(it)), "PRIVATE KEY") ==
+      "-----BEGIN PRIVATE KEY-----\n" &
+      "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4v\n" & "MA==\n" &
+      "-----END PRIVATE KEY-----\n"
+
+  test "a body that fills the last column adds no blank line":
+    check pemEncode(toSeq(0 .. 47).mapIt(byte(it)), "PRIVATE KEY") ==
+      "-----BEGIN PRIVATE KEY-----\n" &
+      "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4v\n" &
+      "-----END PRIVATE KEY-----\n"
+
+  test "an empty key gives an empty body":
+    check pemEncode(newSeq[byte](), "PRIVATE KEY") ==
+      "-----BEGIN PRIVATE KEY-----\n-----END PRIVATE KEY-----\n"

--- a/tests/libp2p/crypto/test_crypto.nim
+++ b/tests/libp2p/crypto/test_crypto.nim
@@ -4,7 +4,7 @@
 
 from std/strutils import toUpper
 import std/[sequtils, algorithm]
-import bearssl/[hash, rand], nimcrypto/utils
+import nimcrypto/utils
 import ../../../libp2p/crypto/[crypto, chacha20poly1305, curve25519, hkdf]
 import ../../tools/[unittest, crypto]
 
@@ -627,6 +627,20 @@ suite "Key interface test suite":
 
     sha256.hkdf(salt, ikm, info, output)
     check output[0].toHex(true) == truth
+
+  test "HKDF outputs continue one OKM stream":
+    let
+      ikm = fromHex("0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b")
+      salt = fromHex("0x000102030405060708090a0b0c")
+      info = fromHex("0xf0f1f2f3f4f5f6f7f8f9")
+      truth =
+        "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf" &
+        "34007208d5b887185865b4b0a85a993b89b9b65683d60f0106d28fff039d0b6f" &
+        "3408900c0f2a9d4463de83622056be50a881bebf2b983ab43e069912f0a57582"
+    var output: array[3, array[32, byte]]
+
+    sha256.hkdf(salt, ikm, info, output)
+    check output[0].toHex(true) & output[1].toHex(true) & output[2].toHex(true) == truth
 
   test "shuffle":
     var cards = ["Ace", "King", "Queen", "Jack", "Ten"]

--- a/tests/libp2p/crypto/test_crypto.nim
+++ b/tests/libp2p/crypto/test_crypto.nim
@@ -4,7 +4,7 @@
 
 from std/strutils import toUpper
 import std/[sequtils, algorithm]
-import nimcrypto/utils
+import bearssl/[hash, rand], nimcrypto/utils
 import ../../../libp2p/crypto/[crypto, chacha20poly1305, curve25519, hkdf]
 import ../../tools/[unittest, crypto]
 


### PR DESCRIPTION
## Summary

Drops `bearssl/[kdf, hash, pem]` by replacing thin wrappers with the equivalent code over dependencies already in the tree.

`hkdf.nim` becomes RFC 5869 over `nimcrypto` HMAC-SHA256, with the `T(i)` chain written out. `outputs` is one continuous OKM stream, which `noise.nim` relies on and the BearSSL stream API left implicit. A new test locks it. Key material is now zeroed on exit.

`pemEncode` moves to `autotls/utils.nim` over `stew/base64`. The BearSSL wrapper took `unsafeAddr data[0]` with no length check, so an empty key crashed.

## Affected Areas

- [x] Protocol Logic (Noise key derivation; derived keys unchanged)
- [x] Other (`crypto/hkdf.nim`, `crypto/rng.nim`, `autotls/{service,utils}.nim`)

## Impact on Library Users

`pemEncode` wraps at 64 columns per RFC 7468. BearSSL wrapped at 76, because `BR_PEM_LINE64` was never passed. Same key, different line layout; every PEM reader takes both.

`newBearSslRng` is removed. It had no in-tree caller; use `newRng`.

`hkdf.nim` no longer re-exports all of `nimcrypto`.

## Risk Assessment

HKDF returns the same bytes. Covered by the two existing RFC 5869 vectors plus a 3 x 32 expansion. `pemEncode` is covered at two lines, at the exact column boundary, and empty.

## References

RFC 5869, RFC 7468.
