### PR TITLE
fix(rendezvous): count the registrations of a peer in a table

### DIFF
--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -92,6 +92,8 @@ type
     # the value is the index sequence corresponding to this
     # namespace in the offsettedqueue.
     namespaces*: Table[string, seq[int]]
+    # Number of entries of `registered` per peer.
+    registeredCount*: Table[PeerId, int]
     rng*: Rng
     config*: RendezVousConfig
     salt*: string
@@ -163,8 +165,13 @@ proc sendDiscoverResponseError*(
   )
   await stream.writeLp(msg)
 
-proc countRegister*[E](rdv: GenericRendezVous[E], peerId: PeerId): int =
-  rdv.registered.countIt(it.peerId == peerId)
+func countRegister*[E](rdv: GenericRendezVous[E], peerId: PeerId): int =
+  rdv.registeredCount.getOrDefault(peerId)
+
+proc recountRegistered[E](rdv: GenericRendezVous[E]) =
+  rdv.registeredCount.clear()
+  for reg in rdv.registered.s:
+    rdv.registeredCount.mgetOrPut(reg.peerId, 0).inc()
 
 proc save*[E](
     rdv: GenericRendezVous[E],
@@ -188,6 +195,7 @@ proc save*[E](
         data: r,
       )
     )
+    rdv.registeredCount.mgetOrPut(peerId, 0).inc()
     rdv.namespaces[nsSalted].add(rdv.registered.high)
   #    rdv.registerEvent.fire()
   except exceptions.KeyError as e:
@@ -634,6 +642,7 @@ proc deletesRegister*[E](
     let n = Moment.now()
     rdv.clearExpiredRegistrations(n)
     rdv.dropExpiredNamespaces(n)
+    rdv.recountRegistered()
     libp2p_rendezvous_registered.set(int64(rdv.liveRegistrations()))
     libp2p_rendezvous_namespaces.set(int64(rdv.namespaces.len))
 

--- a/tests/libp2p/discovery/test_rendezvous.nim
+++ b/tests/libp2p/discovery/test_rendezvous.nim
@@ -696,6 +696,35 @@ suite "RendezVous":
     await peerRdv.advertise(namespace)
     check rendezvousNode.registered.s.len == RegistrationLimitPerPeer
 
+  asyncTest "Registration count follows the registrations held for a peer":
+    let (rendezvousNode, peerNodes) = setupRendezvousNodeWithPeerNodes(1)
+    startAndDeferStop(rendezvousNode & peerNodes)
+
+    await connect(peerNodes[0], rendezvousNode)
+
+    const namespace = "foo"
+    let peerId = peerNodes[0].switch.peerInfo.peerId
+
+    await peerNodes[0].advertise(namespace)
+    await peerNodes[0].advertise(namespace)
+    check:
+      rendezvousNode.registered.s.len == 2
+      rendezvousNode.countRegister(peerId) == 2
+
+    # Unregistering expires the entries, it does not delete them
+    await peerNodes[0].unsubscribe(namespace)
+    checkUntilTimeout:
+      rendezvousNode.registered.s.allIt(it.expiration < Moment.now())
+    check rendezvousNode.countRegister(peerId) == 2
+
+    let deletionLoop = rendezvousNode.deletesRegister(1.seconds)
+    defer:
+      await deletionLoop.cancelAndWait()
+
+    checkUntilTimeout:
+      rendezvousNode.registered.s.len == 0
+      rendezvousNode.countRegister(peerId) == 0
+
   asyncTest "Peer can register to and unsubscribe multiple namespaces":
     let (rendezvousNode, peerNodes) = setupRendezvousNodeWithPeerNodes(3)
     startAndDeferStop(rendezvousNode & peerNodes)

--- a/tests/libp2p/discovery/utils.nim
+++ b/tests/libp2p/discovery/utils.nim
@@ -71,6 +71,7 @@ proc populatePeerRegistrations*(
   let record = targetRdv.registered.s[0]
   for i in 0 ..< count - 1:
     targetRdv.registered.s.add(record)
+  targetRdv.registeredCount[record.peerId] = count
 
 proc createCorruptedSignedPeerRecord*(peerId: PeerId): SignedPeerRecord =
   let wrongPrivKey = PrivateKey.random(rng()).tryGet()


### PR DESCRIPTION
## Summary

`countRegister` scanned all of `registered` on every REGISTER, so one registration cost grew with the number the node held. A `Table[PeerId, int]` next to `registered` makes it a lookup. `save` increments it, and the deletion heartbeat rebuilds it after the flush, the only place an entry leaves `registered`. It still counts expired entries that are not flushed yet, so `RegistrationLimitPerPeer` caps the same memory as before.

## Affected Areas

- [x] Peer Management / Discovery

## Impact on Library Users

No behavior change. `countRegister` keeps its signature and becomes O(1). `GenericRendezVous[E]` gains the public field `registeredCount`. Code that writes into `registered` directly must update it too, or wait one heartbeat for the rebuild.

## Risk Assessment

The count duplicates state and can drift; the heartbeat repairs it within one interval. Verified with `nim check`, no new warnings.
