### PR TITLE
fix(service-disco): cache the advertisement bytes so rotations keep the seqNo

### DIFF
--- a/libp2p/protocols/service_discovery/advertiser.nim
+++ b/libp2p/protocols/service_discovery/advertiser.nim
@@ -50,7 +50,7 @@ proc getAdvertBytes(disco: ServiceDiscovery, explicit: Opt[seq[byte]]): Opt[seq[
   Opt.some(extRecord.encode())
 
 proc advertFor(disco: ServiceDiscovery, serviceId: ServiceId): seq[byte] =
-  ## The caller's own bytes when it supplied them, this node's record otherwise.
+  ## The bytes stored when the service was added, a fresh record only after a clear().
   disco.advertiser.providedAdverts.withValue(serviceId, stored):
     return stored[]
 
@@ -392,14 +392,12 @@ proc addProvidedService*(
     disco.undoProvidedService(service, serviceId)
     return err("routing table missing for service '" & service.id & "'")
 
-  # When a caller supplied an explicit advert we store it so that future
-  # rotations / replacements (maintenance) reuse exactly the same bytes.
-  if advert.isSome():
-    disco.advertiser.providedAdverts[serviceId] = advert.get()
-
   let advertBytes = disco.getAdvertBytes(advert).valueOr:
     disco.undoProvidedService(service, serviceId)
     return err("cannot build the extended peer record to advertise")
+
+  # Rotations reuse these bytes; a later seqNo would duplicate this node in a lookup.
+  disco.advertiser.providedAdverts[serviceId] = advertBytes
 
   debug "added provided service", service = service.id, serviceId
   cd_advertiser_services_added.inc()

--- a/tests/libp2p/service_discovery/test_advertiser.nim
+++ b/tests/libp2p/service_discovery/test_advertiser.nim
@@ -28,6 +28,24 @@ suite "Advertiser - addProvidedService":
 
     check disco.rtManager.hasService(serviceId)
 
+  test "caches this node's record when the caller supplies no advertisement":
+    let disco = setupServiceDiscoveryNode()
+    let service = makeServiceInfo()
+    let serviceId = service.id.hashServiceId()
+
+    disco.populateRoutingTable(1)
+    check disco.addProvidedService(service).isOk()
+
+    let cached = disco.advertiser.providedAdverts[serviceId]
+    let ad = Advertisement.decode(cached).get()
+    check:
+      ad.data.peerId == disco.switch.peerInfo.peerId
+      ad.advertisesService(serviceId)
+
+    disco.switch.peerInfo.addrs = @[makeMultiAddress("10.0.0.2")]
+    check disco.record().get().encode() != cached
+    check disco.advertiser.providedAdverts[serviceId] == cached
+
   test "with empty routing table: creates table but schedules no actions":
     let disco = setupServiceDiscoveryNode()
     let service = makeServiceInfo()


### PR DESCRIPTION
## Summary

`addProvidedService` stored the advert bytes only for an explicit advert, so a node without one rebuilt its record on every rotation, each with a later `seqNo`. Rotation leaves the old record on the previous registrar, and `lookup` merges registrar results into a `HashSet[Advertisement]` that dedupes by value, so the node shows up twice. Storing the encoded bytes for every service pins one record and one `seqNo`.

## Affected Areas

- [x] Peer Management / Discovery: `libp2p/protocols/service_discovery/advertiser.nim`.

## Compatibility & Downstream Validation

N/A. No downstream project consumes service discovery yet.

## Impact on Library Users

`startAdvertising(service)` with no advert now republishes the same record instead of a fresh one. An explicit advert behaves as before.

## Risk Assessment

A pinned record misses a later address change until the service restarts. Re-encoding only on a content change belongs in its own PR.

## References

Split out of #3029.
