### PR TITLE
fix(mplex): refine stream setup buffering

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -182,12 +182,16 @@ proc withSignedPeerRecord*(b: SwitchBuilder, sendIt = true): SwitchBuilder =
   b
 
 proc withMplex*(
-    b: SwitchBuilder, inTimeout = 5.minutes, outTimeout = 5.minutes, maxChannCount = 200
+    b: SwitchBuilder,
+    inTimeout = 5.minutes,
+    outTimeout = 5.minutes,
+    maxChannCount = 200,
+    maxBufferedBytes = MaxBufferedBytes,
 ): SwitchBuilder =
   ## Uses `Mplex <https://docs.libp2p.io/concepts/stream-multiplexing/#mplex>`_ as a multiplexer
   ## `Timeout` is the duration after which a inactive connection will be closed
   proc newMuxer(conn: RawConn): Muxer =
-    Mplex.new(conn, inTimeout, outTimeout, maxChannCount)
+    Mplex.new(conn, inTimeout, outTimeout, maxChannCount, maxBufferedBytes)
 
   doAssert b.muxers.countIt(it.codec == MplexCodec) == 0, "Mplex build multiple times"
   b.muxers.add(MuxerProvider.new(newMuxer, MplexCodec))

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -4,7 +4,7 @@
 {.push raises: [].}
 
 import tables, sequtils, oids
-import chronos, chronicles, stew/byteutils, metrics
+import chronos, chronicles, metrics
 import
   ../muxer,
   ../../stream/connection,
@@ -19,9 +19,11 @@ export muxer
 logScope:
   topics = "libp2p mplex"
 
-const MplexCodec* = "/mplex/6.7.0"
-
-const MaxChannelCount = 200
+const
+  MplexCodec* = "/mplex/6.7.0"
+  MaxChannelCount = 200
+  MaxBufferedBytes* = 4 * MaxMsgSize
+    ## Maximum unread data across four fully decoded frames.
 
 when defined(libp2p_expensive_metrics):
   declareGauge(libp2p_mplex_channels, "mplex channels", labels = ["initiator", "peer"])
@@ -37,6 +39,7 @@ type
     isClosed: bool
     oid*: Oid
     maxChannCount: int
+    maxBufferedBytes: int
 
 func shortLog*(m: Mplex): auto =
   shortLog(m.connection)
@@ -49,6 +52,14 @@ proc newTooManyChannels(): ref TooManyChannels =
 
 proc newInvalidChannelIdError(): ref InvalidChannelIdError =
   newException(InvalidChannelIdError, "max allowed channel count exceeded")
+
+proc bufferedBytes(m: Mplex): int =
+  var total = 0
+  for initiator in [false, true]:
+    for channel in m.channels[initiator].values:
+      if channel.protocol.len == 0:
+        total += channel.len
+  total
 
 proc drainChannelTasks(channs: seq[LPChannel]) {.async: (raises: []).} =
   ## Awaits the per-channel tasks so they don't outlive the muxer; callers must
@@ -158,8 +169,9 @@ method handle*(m: Mplex) {.async: (raises: []).} =
               allowedMax = m.maxChannCount, m
             raise newTooManyChannels()
 
-          let name = string.fromBytes(data)
-          m.newStreamInternal(false, id, name, timeout = m.outChannTimeout)
+          # Stream names are only for debugging and retaining them lets peers
+          # multiply the frame-size limit by the channel limit.
+          m.newStreamInternal(false, id, timeout = m.outChannTimeout)
 
       trace "Processing channel message", m, channel, data = data.shortLog
 
@@ -176,6 +188,18 @@ method handle*(m: Mplex) {.async: (raises: []).} =
           warn "attempting to send a packet larger than allowed",
             allowed = MaxMsgSize, channel
           raise newLPStreamLimitError()
+
+        if channel.protocol.len == 0:
+          let bufferedBytes = m.bufferedBytes()
+          if data.len > m.maxBufferedBytes or
+              bufferedBytes > m.maxBufferedBytes - data.len:
+            debug "mplex pre-negotiation buffer limit reached",
+              allowedMax = m.maxBufferedBytes,
+              buffered = bufferedBytes,
+              incoming = data.len,
+              channel
+            await channel.reset()
+            continue
 
         trace "pushing data to channel", m, channel, len = data.len
         try:
@@ -208,6 +232,7 @@ proc new*(
     inTimeout: Duration = DefaultChanTimeout,
     outTimeout: Duration = DefaultChanTimeout,
     maxChannCount: int = MaxChannelCount,
+    maxBufferedBytes: int = MaxBufferedBytes,
 ): Mplex =
   M(
     connection: conn,
@@ -215,6 +240,7 @@ proc new*(
     outChannTimeout: outTimeout,
     oid: genOid(),
     maxChannCount: maxChannCount,
+    maxBufferedBytes: maxBufferedBytes,
   )
 
 method newStream*(

--- a/tests/libp2p/muxers/test_mplex.nim
+++ b/tests/libp2p/muxers/test_mplex.nim
@@ -512,9 +512,7 @@ suite "Mplex":
 
       let stream = LPChannel(mplex.getStreams()[0])
       stream.protocol = "/test/1.0.0"
-      await conn.pushData(
-        encodeMessage(0, MessageType.MsgOut, @[0'u8, 1, 2, 3, 4])
-      )
+      await conn.pushData(encodeMessage(0, MessageType.MsgOut, @[0'u8, 1, 2, 3, 4]))
 
       checkUntilTimeoutCustom(1.seconds, 10.millis):
         stream.len == 5

--- a/tests/libp2p/muxers/test_mplex.nim
+++ b/tests/libp2p/muxers/test_mplex.nim
@@ -26,6 +26,12 @@ proc noopWriteHandler(
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
   discard
 
+proc encodeMessage(id: uint64, msgType: MessageType, data: seq[byte]): seq[byte] =
+  var buf = initVBuffer()
+  buf.writePBVarint(id shl 3 or ord(msgType).uint64)
+  buf.writeSeq(data)
+  buf.buffer
+
 suite "Mplex":
   teardown:
     checkTrackers()
@@ -448,6 +454,75 @@ suite "Mplex":
 
       check await chann.join().withTimeout(1.minutes)
       await conn.close()
+
+  suite "mplex limits":
+    asyncTest "does not retain remote stream names":
+      let
+        conn = TestBufferStream.new(noopWriteHandler)
+        mplex = Mplex.new(conn)
+        handleFut = mplex.handle()
+        remoteName = "attacker-controlled-name"
+
+      await conn.pushData(encodeMessage(0, MessageType.New, remoteName.toBytes()))
+
+      checkUntilTimeoutCustom(1.seconds, 10.millis):
+        mplex.getStreams().len == 1
+
+      check LPChannel(mplex.getStreams()[0]).name != remoteName
+
+      await mplex.close()
+      await handleFut
+
+    asyncTest "resets a stream that exceeds the connection buffer limit":
+      let
+        conn = TestBufferStream.new(noopWriteHandler)
+        mplex = Mplex.new(conn, maxBufferedBytes = 4)
+
+      mplex.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
+        await noCancel stream.join()
+
+      let handleFut = mplex.handle()
+      await conn.pushData(
+        encodeMessage(0, MessageType.New, @[]) &
+          encodeMessage(0, MessageType.MsgOut, @[0'u8, 1, 2, 3]) &
+          encodeMessage(1, MessageType.New, @[]) &
+          encodeMessage(1, MessageType.MsgOut, @[4'u8])
+      )
+
+      checkUntilTimeoutCustom(1.seconds, 10.millis):
+        mplex.getStreams().len == 1
+        LPChannel(mplex.getStreams()[0]).len == 4
+
+      await mplex.close()
+      await handleFut
+
+    asyncTest "does not limit negotiated stream buffers":
+      let
+        conn = TestBufferStream.new(noopWriteHandler)
+        mplex = Mplex.new(conn, maxBufferedBytes = 4)
+
+      mplex.streamHandler = proc(stream: MuxedStream) {.async: (raises: []).} =
+        await noCancel stream.join()
+
+      let handleFut = mplex.handle()
+      await conn.pushData(encodeMessage(0, MessageType.New, @[]))
+
+      checkUntilTimeoutCustom(1.seconds, 10.millis):
+        mplex.getStreams().len == 1
+
+      let stream = LPChannel(mplex.getStreams()[0])
+      stream.protocol = "/test/1.0.0"
+      await conn.pushData(
+        encodeMessage(0, MessageType.MsgOut, @[0'u8, 1, 2, 3, 4])
+      )
+
+      checkUntilTimeoutCustom(1.seconds, 10.millis):
+        stream.len == 5
+
+      check not stream.localReset
+
+      await mplex.close()
+      await handleFut
 
   suite "mplex e2e":
     asyncTest "read/write receiver":


### PR DESCRIPTION
## Summary

Refines incoming mplex stream setup by discarding optional remote labels after parsing and bounding buffering while protocol negotiation is pending. Negotiated streams retain their existing buffering behavior.