### PR TITLE
fix(floodsub): limit the entry count of the seen cache

### DIFF
--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -24,7 +24,9 @@ import
 logScope:
   topics = "libp2p floodsub"
 
-const FloodSubCodec* = "/floodsub/1.0.0"
+const
+  FloodSubCodec* = "/floodsub/1.0.0"
+  FloodSubSeenMaxSize* = 1_000_000 # ~112 bytes per entry, so a ~120 MB ceiling
 
 type FloodSub* = ref object of PubSub
   floodsub*: PeerTable # topic to remote peer map
@@ -285,7 +287,7 @@ method initPubSub*(f: FloodSub) {.raises: [InitializationError].} =
   f.validateOverheadRateLimit().isOkOr:
     raise newException(InitializationError, $error)
 
-  f.seen = TimedCache[SaltedId].init(2.minutes)
+  f.seen = TimedCache[SaltedId].init(2.minutes, maxSize = FloodSubSeenMaxSize)
   f.rng.generate(f.seenSalt)
 
   f.init()

--- a/libp2p/protocols/pubsub/timedcache.nim
+++ b/libp2p/protocols/pubsub/timedcache.nim
@@ -126,6 +126,10 @@ func len*[K](t: TimedCache[K]): int =
   ## Returns the number of entries in the cache.
   t.entries.len
 
+func maxSize*[K](t: TimedCache[K]): int =
+  ## Returns the entry limit of the cache, 0 meaning unlimited.
+  t.maxSize
+
 func addedAt*[K](t: var TimedCache[K], k: K): Moment =
   let tmp = TimedEntry[K](key: k)
   try:

--- a/tests/libp2p/pubsub/component/test_floodsub.nim
+++ b/tests/libp2p/pubsub/component/test_floodsub.nim
@@ -12,6 +12,7 @@ import
     stream/connection,
     protocols/pubsub/pubsub,
     protocols/pubsub/floodsub,
+    protocols/pubsub/timedcache,
     protocols/pubsub/rpc/message,
     protocols/pubsub/rpc/messages,
     protocols/pubsub/rpc/protobuf,
@@ -422,3 +423,7 @@ suite "FloodSub Component":
     check:
       peer.overheadRateLimitOpt.isNone()
       peer.tryCharge(1024)
+
+  asyncTest "FloodSub caps the entry count of the seen cache":
+    let node = generateNodes(1).toFloodSub()[0]
+    check node.seen.maxSize == FloodSubSeenMaxSize


### PR DESCRIPTION


FloodSub builds its `seen` deduplication cache with a TTL only: `TimedCache[SaltedId].init(2.minutes)`. `TimedCache` reads `maxSize == 0` as unlimited, so the entry count of the cache follows the rate of unique messages with no ceiling. GossipSub already passes a limit (`seenMaxSize`, default `GossipSubSeenMaxSize`) and overrides the cache in its own `initPubSub`, so the gap is FloodSub-only.

This PR gives FloodSub the same treatment: a `FloodSubSeenMaxSize` constant of 1_000_000 entries, passed to `TimedCache.init`. An entry costs about 112 bytes (a 32-byte `SaltedId`, the `TimedEntry` header and its two list pointers, and a `HashSet` slot), so the cache now tops out near 120 MB instead of growing with traffic. The limit sits far above any plausible FloodSub message rate: 1M entries over the 2-minute TTL is about 8300 unique messages per second.

`TimedCache` gains a `maxSize` accessor next to the existing `len`, and the FloodSub component suite gets one test that pins the configuration, so a future edit cannot drop the argument and silently return to unlimited.
