### PR TITLE
fix(addr-mgr): count the peers which observe an address, not the reports

### DIFF
--- a/libp2p/address_manager.nim
+++ b/libp2p/address_manager.nim
@@ -10,7 +10,7 @@
 
 import std/[sequtils, tables]
 import chronos, chronos/transports/[osnet, ipnet]
-import multiaddress, multicodec, peerinfo, wire, utils/heartbeat
+import multiaddress, multicodec, peerid, peerinfo, wire, utils/heartbeat
 import protocols/connectivity/autonat/types
 
 export NetworkReachability
@@ -60,7 +60,7 @@ type
 
   AddressManagerConfig* = object
     maxSize*: int = DefaultObservedAddrMaxSize
-    minCount*: int = DefaultObservedAddrMinCount
+    minCount*: int = DefaultObservedAddrMinCount ## The peers which must agree.
     verifyInterval*: Duration = DefaultVerifyInterval ## The time between two runs.
     verifyTimeout*: Duration = DefaultVerifyTimeout
       ## The time one run gets; it keeps the verdicts it already collected.
@@ -73,8 +73,12 @@ type
     address: MultiAddress
     runsLeft: int
 
+  Observation = object
+    observer: PeerId
+    address: MultiAddress
+
   AddressManager* = ref object of RootObj
-    observations: seq[MultiAddress]
+    observations: seq[Observation]
     candidates: OrderedTable[MultiAddress, AddrCandidate]
     mappers: seq[SourcedMapper]
     chainAddrs: Table[MultiAddress, set[AddrSource]]
@@ -124,10 +128,10 @@ proc isObservableAddr(ma: MultiAddress): bool =
     return false
   ip.isObservableIp()
 
-proc addObservation*(self: AddressManager, observedAddr: MultiAddress): bool =
-  ## Records the address a remote peer reports for us, evicting the oldest one
-  ## past `maxSize`. False when the manager is stopped, or when no peer can have
-  ## observed us on that address.
+proc addObservation*(
+    self: AddressManager, observer: PeerId, observedAddr: MultiAddress
+): bool =
+  ## Records the address `observer` reports for us; it replaces its previous report.
   if not self.started:
     return false
 
@@ -135,10 +139,15 @@ proc addObservation*(self: AddressManager, observedAddr: MultiAddress): bool =
   if not observedAddr.isObservableAddr():
     return false
 
+  self.observations.keepItIf(it.observer != observer)
   if self.observations.len >= self.maxSize:
     self.observations.delete(0)
-  self.observations.add(observedAddr)
+  self.observations.add(Observation(observer: observer, address: observedAddr))
   true
+
+func observedAddrs(self: AddressManager): seq[MultiAddress] =
+  ## One address per peer, so a count over them counts the peers which agree.
+  self.observations.mapIt(it.address)
 
 func firstProtoCode(ma: MultiAddress): MaResult[MultiCodec] =
   ma[0].flatMap(protoCode)
@@ -158,18 +167,18 @@ func mostObserved(
 func mostObservedIp(self: AddressManager, code: MultiCodec): Opt[MultiAddress] =
   var ips: seq[MultiAddress]
   for observation in self.observations:
-    let ip = observation[0].valueOr:
+    let ip = observation.address[0].valueOr:
       continue
     ips.add(ip)
   self.mostObserved(ips, code)
 
 func mostObservedProtosAndPorts*(self: AddressManager): seq[MultiAddress] =
-  ## The most observed IP4/Port and IP6/Port addresses, empty while no address
-  ## reaches `minCount`.
+  ## The most observed IP4/Port and IP6/Port addresses, empty below `minCount` peers.
+  let observed = self.observedAddrs()
   var res: seq[MultiAddress]
-  self.mostObserved(self.observations, multiCodec("ip4")).withValue(ip4):
+  self.mostObserved(observed, multiCodec("ip4")).withValue(ip4):
     res.add(ip4)
-  self.mostObserved(self.observations, multiCodec("ip6")).withValue(ip6):
+  self.mostObserved(observed, multiCodec("ip6")).withValue(ip6):
     res.add(ip6)
   res
 
@@ -646,7 +655,7 @@ proc stop*(self: AddressManager) =
 
 func `$`*(self: AddressManager): string =
   let addresses = toSeq(self.candidates.keys)
-  "observations: " & $self.observations & ", candidates: " & $addresses
+  "observations: " & $self.observedAddrs() & ", candidates: " & $addresses
 
 proc new*(
     T: typedesc[AddressManager], config: AddressManagerConfig = AddressManagerConfig()

--- a/libp2p/address_manager.nim
+++ b/libp2p/address_manager.nim
@@ -131,7 +131,7 @@ proc isObservableAddr(ma: MultiAddress): bool =
 proc addObservation*(
     self: AddressManager, observer: PeerId, observedAddr: MultiAddress
 ): bool =
-  ## Records the address `observer` reports for us; it replaces its previous report.
+  ## Records the address `observer` reports for us, replacing its previous report and evicting the oldest peer observation past `maxSize`.
   if not self.started:
     return false
 

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -184,7 +184,7 @@ proc identify*(
     peer = remotePeerId
 
   identifyMsg.observedAddr.withValue(observed):
-    if not self.addressManager.addObservation(observed):
+    if not self.addressManager.addObservation(peer, observed):
       trace "Observed address is not valid.", observedAddr = observed
 
   return makeIdentifyInfo(peer, identifyMsg)

--- a/tests/libp2p/kademlia/utils.nim
+++ b/tests/libp2p/kademlia/utils.nim
@@ -8,6 +8,8 @@ import
 import ../../tools/[crypto, unittest, switch_builder, multiaddress]
 import ./mock_kademlia
 
+export crypto
+
 converter toOptSeqByte*(a: seq[byte]): Opt[seq[byte]] =
   Opt.some(a)
 
@@ -209,9 +211,6 @@ proc containsPeer*(providers: HashSet[Peer], node: KadDHT): bool =
 
 proc toPeer*(node: KadDHT): Peer =
   node.switch.peerInfo.toPeer()
-
-proc randomPeerId*(): PeerId =
-  PeerId.random(rng()).get()
 
 proc randomServiceId*(): Key =
   ## Stands in for a `hashServiceId()` result, a key already in the id space.

--- a/tests/libp2p/protocols/test_autonat_v2_service.nim
+++ b/tests/libp2p/protocols/test_autonat_v2_service.nim
@@ -18,6 +18,9 @@ import ../../tools/[unittest, futures, crypto, multiaddress]
 
 const VerifyInterval = 50.milliseconds
 
+proc randomPeerId(): PeerId =
+  PeerId.random(rng()).expect("the rng produces a valid peer id")
+
 proc createSwitch(
     service: AutonatV2Service = nil, minCount = DefaultObservedAddrMinCount
 ): Switch =
@@ -194,7 +197,7 @@ suite "AutonatV2 Service":
 
     let observedAddr = ma("/ip4/8.8.8.8/tcp/4040")
     for _ in 0 ..< 3:
-      check switch.addressManager.addObservation(observedAddr)
+      check switch.addressManager.addObservation(randomPeerId(), observedAddr)
 
     await notified.wait(5.seconds)
 
@@ -215,7 +218,7 @@ suite "AutonatV2 Service":
 
     let observedAddr = ma("/ip4/8.8.8.8/tcp/4040")
     for _ in 0 ..< 3:
-      check switch.addressManager.addObservation(observedAddr)
+      check switch.addressManager.addObservation(randomPeerId(), observedAddr)
 
     await notified.wait(5.seconds)
     await sleepAsync(VerifyInterval * 4)

--- a/tests/libp2p/protocols/test_autonat_v2_service.nim
+++ b/tests/libp2p/protocols/test_autonat_v2_service.nim
@@ -18,9 +18,6 @@ import ../../tools/[unittest, futures, crypto, multiaddress]
 
 const VerifyInterval = 50.milliseconds
 
-proc randomPeerId(): PeerId =
-  PeerId.random(rng()).expect("the rng produces a valid peer id")
-
 proc createSwitch(
     service: AutonatV2Service = nil, minCount = DefaultObservedAddrMinCount
 ): Switch =

--- a/tests/libp2p/pubsub/test_mcache.nim
+++ b/tests/libp2p/pubsub/test_mcache.nim
@@ -4,14 +4,9 @@
 {.used.}
 
 import sequtils, stew/byteutils
-import
-  ../../../libp2p/
-    [peerid, crypto/crypto, protocols/pubsub/mcache, protocols/pubsub/rpc/message]
+import ../../../libp2p/[peerid, protocols/pubsub/mcache, protocols/pubsub/rpc/message]
 import ../../tools/[unittest, crypto]
 import converters
-
-proc randomPeerId(): PeerId =
-  PeerId.init(PrivateKey.random(ECDSA, rng()).get()).get()
 
 const MsgIdGenSuccess = "msg id generation success"
 

--- a/tests/libp2p/pubsub/utils.nim
+++ b/tests/libp2p/pubsub/utils.nim
@@ -29,7 +29,7 @@ import
   ../../tools/[unittest, crypto, bufferstream, futures, switch_builder, multiaddress]
 import ./converters
 
-export switch, converters
+export switch, converters, crypto
 
 randomize()
 
@@ -82,12 +82,6 @@ proc voidPeerHandler*(
     peer: PubSubPeer, data: sink seq[byte]
 ) {.async: (raises: [CancelledError, PeerRateLimitError]).} =
   discard
-
-proc randomPeerId*(): PeerId =
-  try:
-    PeerId.init(PrivateKey.random(ECDSA, rng()).get()).tryGet()
-  except CatchableError as exc:
-    raise newException(Defect, exc.msg)
 
 proc getPubSubPeer*(p: TestGossipSub, peerId: PeerId): PubSubPeer =
   proc getStream(): Future[Stream] {.

--- a/tests/libp2p/service_discovery/test_routing_table_manager.nim
+++ b/tests/libp2p/service_discovery/test_routing_table_manager.nim
@@ -11,7 +11,7 @@ import
   ../../../libp2p/protocols/service_discovery/[types, routing_table_manager]
 import ../../tools/[lifecycle, unittest]
 import ../kademlia/[mock_kademlia, utils]
-import ./utils except randomPeerId
+import ./utils
 
 proc makeKey(x: byte): Key =
   var buf: array[IdLength, byte]

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -22,9 +22,10 @@ import
     routing_record,
     switch,
   ]
-import ../../tools/[crypto, switch_builder, multiaddress]
+import ../../tools/[switch_builder, multiaddress]
+import ../../tools/crypto as testcrypto
 
-export protobuf, registrar, routing_table_manager, types
+export protobuf, registrar, routing_table_manager, types, testcrypto
 
 converter toOptMoment*(a: Moment): Opt[Moment] =
   Opt.some(a)
@@ -40,9 +41,6 @@ converter toOptSeqByte*(a: seq[byte]): Opt[seq[byte]] =
 
 proc randomKey*(): PrivateKey =
   PrivateKey.random(rng()).get()
-
-proc randomPeerId*(): PeerId =
-  PeerId.init(randomKey()).get()
 
 proc makePeerInfo*(
     peerId: PeerId = randomPeerId(), addrs: seq[MultiAddress] = @[]

--- a/tests/libp2p/test_address_manager.nim
+++ b/tests/libp2p/test_address_manager.nim
@@ -13,6 +13,9 @@ import ../tools/[unittest, crypto, switch_builder, multiaddress, lifecycle]
 
 const VerifyInterval = 10.milliseconds
 
+proc randomPeerId(): PeerId =
+  PeerId.random(rng()).expect("the rng produces a valid peer id")
+
 proc makeManager(
     maxSize = DefaultObservedAddrMaxSize,
     minCount = DefaultObservedAddrMinCount,
@@ -116,18 +119,18 @@ suite "AddressManager observations":
     let maIP4 = ma("/ip4/0.0.0.0/tcp/80")
 
     check:
-      manager.addObservation(mostObservedIP4AndPort)
-      manager.addObservation(mostObservedIP4AndPort)
+      manager.addObservation(randomPeerId(), mostObservedIP4AndPort)
+      manager.addObservation(randomPeerId(), mostObservedIP4AndPort)
 
       manager.externalAddrFor(maIP4) == maIP4
 
-      manager.addObservation(ma("/ip4/1.2.3.0/tcp/2"))
-      manager.addObservation(ma("/ip4/1.2.3.1/tcp/1"))
+      manager.addObservation(randomPeerId(), ma("/ip4/1.2.3.0/tcp/2"))
+      manager.addObservation(randomPeerId(), ma("/ip4/1.2.3.1/tcp/1"))
 
       manager.externalAddrFor(maIP4) == ma("/ip4/1.2.3.0/tcp/80")
       manager.mostObservedProtosAndPorts().len == 0
 
-      manager.addObservation(mostObservedIP4AndPort)
+      manager.addObservation(randomPeerId(), mostObservedIP4AndPort)
 
       manager.mostObservedProtosAndPorts() == @[mostObservedIP4AndPort]
 
@@ -135,18 +138,18 @@ suite "AddressManager observations":
     let maIP6 = ma("/ip6/::1/tcp/80")
 
     check:
-      manager.addObservation(mostObservedIP6AndPort)
-      manager.addObservation(mostObservedIP6AndPort)
+      manager.addObservation(randomPeerId(), mostObservedIP6AndPort)
+      manager.addObservation(randomPeerId(), mostObservedIP6AndPort)
 
       manager.externalAddrFor(maIP6) == maIP6
 
-      manager.addObservation(ma("/ip6/::2/tcp/2"))
-      manager.addObservation(ma("/ip6/::3/tcp/1"))
+      manager.addObservation(randomPeerId(), ma("/ip6/::2/tcp/2"))
+      manager.addObservation(randomPeerId(), ma("/ip6/::3/tcp/1"))
 
       manager.externalAddrFor(maIP6) == ma("/ip6/::2/tcp/80")
       manager.mostObservedProtosAndPorts().len == 1
 
-      manager.addObservation(mostObservedIP6AndPort)
+      manager.addObservation(randomPeerId(), mostObservedIP6AndPort)
 
       manager.mostObservedProtosAndPorts() ==
         @[mostObservedIP4AndPort, mostObservedIP6AndPort]
@@ -157,11 +160,60 @@ suite "AddressManager observations":
     let mostObservedIP4AndPort = ma("/ip4/1.2.3.4/tcp/1")
 
     check:
-      manager.addObservation(mostObservedIP4AndPort)
-      manager.addObservation(mostObservedIP4AndPort)
-      manager.addObservation(mostObservedIP4AndPort)
+      manager.addObservation(randomPeerId(), mostObservedIP4AndPort)
+      manager.addObservation(randomPeerId(), mostObservedIP4AndPort)
+      manager.addObservation(randomPeerId(), mostObservedIP4AndPort)
 
       manager.externalAddrFor(ma("/ip4/0.0.0.0")) == ma("/ip4/1.2.3.4")
+
+  asyncTest "one peer counts once, however often it reports":
+    let
+      manager = makeManager(minCount = 3)
+      observer = randomPeerId()
+      observed = ma("/ip4/1.2.3.4/tcp/1")
+
+    startAndDeferStop(manager)
+    for _ in 0 ..< 5:
+      check manager.addObservation(observer, observed)
+
+    check manager.mostObservedProtosAndPorts().len == 0
+
+    for _ in 0 ..< 2:
+      check manager.addObservation(randomPeerId(), observed)
+
+    check manager.mostObservedProtosAndPorts() == @[observed]
+
+  asyncTest "the last report of a peer replaces its previous one":
+    let
+      manager = makeManager(minCount = 2)
+      observer = randomPeerId()
+      first = ma("/ip4/1.2.3.4/tcp/1")
+      last = ma("/ip4/5.6.7.8/tcp/1")
+
+    startAndDeferStop(manager)
+    check:
+      manager.addObservation(randomPeerId(), first)
+      manager.addObservation(observer, first)
+      manager.mostObservedProtosAndPorts() == @[first]
+
+      manager.addObservation(observer, last)
+      manager.mostObservedProtosAndPorts().len == 0
+
+  asyncTest "a peer holds one slot of the window, whatever it reports":
+    let
+      manager = makeManager(maxSize = 3, minCount = 2)
+      noisy = randomPeerId()
+      observed = ma("/ip4/1.2.3.4/tcp/1")
+
+    startAndDeferStop(manager)
+    check manager.addObservation(randomPeerId(), observed)
+
+    for i in 0 ..< 4:
+      check manager.addObservation(noisy, ma("/ip4/9.9.9." & $i & "/tcp/1"))
+
+    check:
+      manager.addObservation(randomPeerId(), observed)
+      manager.mostObservedProtosAndPorts() == @[observed]
 
   asyncTest "an address which is not a direct IP address with a transport is rejected":
     let
@@ -169,14 +221,14 @@ suite "AddressManager observations":
       observed = ma("/ip4/1.2.3.4/tcp/1")
 
     startAndDeferStop(manager)
-    check manager.addObservation(observed)
+    check manager.addObservation(randomPeerId(), observed)
 
     # the window is small: junk must neither be counted nor evict the good entry
     for _ in 0 ..< 4:
       check:
-        not manager.addObservation(ma("/dns4/example.com/tcp/1"))
-        not manager.addObservation(ma("/ip4/1.2.3.4"))
-        not manager.addObservation(ma("/ip4/1.2.3.4/tcp/1/p2p-circuit"))
+        not manager.addObservation(randomPeerId(), ma("/dns4/example.com/tcp/1"))
+        not manager.addObservation(randomPeerId(), ma("/ip4/1.2.3.4"))
+        not manager.addObservation(randomPeerId(), ma("/ip4/1.2.3.4/tcp/1/p2p-circuit"))
 
     check manager.mostObservedProtosAndPorts() == @[observed]
 
@@ -188,8 +240,8 @@ suite "AddressManager observations":
 
     startAndDeferStop(manager)
     check:
-      manager.addObservation(firstObserved)
-      manager.addObservation(lastObserved)
+      manager.addObservation(randomPeerId(), firstObserved)
+      manager.addObservation(randomPeerId(), lastObserved)
       manager.mostObservedProtosAndPorts() == @[lastObserved]
 
   asyncTest "a stopped manager rejects observations until it starts again":
@@ -198,16 +250,16 @@ suite "AddressManager observations":
       observed = ma("/ip4/1.2.3.4/tcp/1")
 
     manager.start()
-    check manager.addObservation(observed)
+    check manager.addObservation(randomPeerId(), observed)
 
     manager.stop()
     check:
-      not manager.addObservation(observed)
+      not manager.addObservation(randomPeerId(), observed)
       manager.mostObservedProtosAndPorts().len == 0
 
     manager.start()
     check:
-      manager.addObservation(observed)
+      manager.addObservation(randomPeerId(), observed)
       manager.mostObservedProtosAndPorts() == @[observed]
 
     manager.stop()
@@ -225,7 +277,7 @@ suite "AddressManager observations":
 
     check:
       manager.isStarted()
-      manager.addObservation(observed)
+      manager.addObservation(randomPeerId(), observed)
       manager.mostObservedProtosAndPorts() == @[observed]
 
     manager.stop()
@@ -242,11 +294,11 @@ suite "AddressManager observations":
 
     check:
       not manager.isStarted()
-      not manager.addObservation(observed)
+      not manager.addObservation(randomPeerId(), observed)
       manager.mostObservedProtosAndPorts().len == 0
 
     manager.start()
-    check manager.addObservation(observed)
+    check manager.addObservation(randomPeerId(), observed)
     manager.stop()
 
 suite "AddressManager wildcard expansion":
@@ -574,7 +626,7 @@ suite "AddressManager verification":
     manager.deriveIdentifyCandidates = true
     startAndDeferStop(manager, peerInfo)
     manager.add(directAddr, AddrSource.Listen)
-    check manager.addObservation(observed)
+    check manager.addObservation(randomPeerId(), observed)
 
     checkUntilTimeout:
       verifier.timesAsked(directAddr) >= 3
@@ -594,7 +646,7 @@ suite "AddressManager verification":
     # with no listen address the guess is the only candidate a dial-back reaches
     manager.deriveIdentifyCandidates = true
     startAndDeferStop(manager, peerInfo)
-    check manager.addObservation(observed)
+    check manager.addObservation(randomPeerId(), observed)
 
     checkUntilTimeout:
       manager.reachability() == NetworkReachability.NotReachable
@@ -619,19 +671,19 @@ suite "AddressManager verification":
     manager.deriveIdentifyCandidates = true
     startAndDeferStop(manager, peerInfo)
 
-    check manager.addObservation(firstIp4)
+    check manager.addObservation(randomPeerId(), firstIp4)
     checkUntilTimeout:
       verifier.timesAsked(firstIp4) == 1
 
     # two newer refutations fill the ring of two and evict the first guess
-    check manager.addObservation(secondIp4)
-    check manager.addObservation(ip6)
+    check manager.addObservation(randomPeerId(), secondIp4)
+    check manager.addObservation(randomPeerId(), ip6)
     checkUntilTimeout:
       secondIp4 in verifier.asked
       ip6 in verifier.asked
 
     # the evicted guess becomes a candidate again on a new observation
-    check manager.addObservation(firstIp4)
+    check manager.addObservation(randomPeerId(), firstIp4)
     checkUntilTimeout:
       verifier.timesAsked(firstIp4) >= 2
 
@@ -649,7 +701,7 @@ suite "AddressManager verification":
     startAndDeferStop(manager, peerInfo)
 
     for _ in 0 ..< 3:
-      check manager.addObservation(observed)
+      check manager.addObservation(randomPeerId(), observed)
 
     checkUntilTimeout:
       manager.candidates().anyIt(
@@ -886,9 +938,9 @@ suite "AddressManager verify and announce":
     manager.addMapper(addingMapper(@[upnpAddr]), AddrSource.Upnp)
     manager.addMapper(addingMapper(@[relayAddr]), AddrSource.Circuit)
 
-    # identify reports: same address three times reaches the quorum
+    # identify reports: three peers on the same address reach the quorum
     for _ in 0 ..< 3:
-      check manager.addObservation(observed)
+      check manager.addObservation(randomPeerId(), observed)
 
     await peerInfo.update()
 
@@ -963,13 +1015,13 @@ suite "Switch-owned AddressManager":
 
     # minCount is 1, so a single observation is enough
     check:
-      switch.addressManager.addObservation(firstObserved)
+      switch.addressManager.addObservation(randomPeerId(), firstObserved)
       switch.addressManager.mostObservedProtosAndPorts() == @[firstObserved]
 
     # maxSize is 2, so the third observation drops the first one
     check:
-      switch.addressManager.addObservation(lastObserved)
-      switch.addressManager.addObservation(lastObserved)
+      switch.addressManager.addObservation(randomPeerId(), lastObserved)
+      switch.addressManager.addObservation(randomPeerId(), lastObserved)
       switch.addressManager.mostObservedProtosAndPorts() == @[lastObserved]
 
   asyncTest "the switch starts and stops the manager":
@@ -992,7 +1044,7 @@ suite "Switch-owned AddressManager":
     await switch.start()
 
     for _ in 0 ..< 3:
-      check switch.addressManager.addObservation(observed)
+      check switch.addressManager.addObservation(randomPeerId(), observed)
 
     check:
       switch.addressManager.mostObservedProtosAndPorts() == @[observed]

--- a/tests/libp2p/test_address_manager.nim
+++ b/tests/libp2p/test_address_manager.nim
@@ -13,9 +13,6 @@ import ../tools/[unittest, crypto, switch_builder, multiaddress, lifecycle]
 
 const VerifyInterval = 10.milliseconds
 
-proc randomPeerId(): PeerId =
-  PeerId.random(rng()).expect("the rng produces a valid peer id")
-
 proc makeManager(
     maxSize = DefaultObservedAddrMaxSize,
     minCount = DefaultObservedAddrMinCount,

--- a/tests/tools/crypto.nim
+++ b/tests/tools/crypto.nim
@@ -2,7 +2,7 @@
 # Copyright (c) Status Research & Development GmbH
 
 import chronos/streams/tlsstream, stew/byteutils
-import ../../libp2p/[crypto/crypto, transports/tls/certificate]
+import ../../libp2p/[crypto/crypto, peerid, transports/tls/certificate]
 
 var rngSingleton {.threadvar.}: Rng
 rngSingleton = newRng()
@@ -12,6 +12,9 @@ proc getRng(): Rng =
 
 template rng*(): Rng =
   getRng()
+
+proc randomPeerId*(r: Rng = rng()): PeerId =
+  PeerId.random(r).expect("the rng produces a valid peer id")
 
 proc tlsCertGenerator*(
     kp: Opt[KeyPair] = Opt.none(KeyPair)


### PR DESCRIPTION


`AddressManager` picks the external address by a count over the observation window. The window stored bare `MultiAddress` values, so `minCount` counted identify messages and not the peers behind them: one peer which reported the same address three times reached the threshold alone.

The window now stores one entry per observer peer id. A new report from a peer replaces the previous report of that peer, so a peer holds one slot of `maxSize` and contributes one vote. `mostObservedProtosAndPorts` and `externalAddrFor` are unchanged, and the count they run is now a count of peers.

