### PR TITLE
chore(logs): standardize log fields

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Check Nimble lock versions
         run: python3 tools/check-nimble-lock.py
 
+      - name: Audit Chronicle log fields
+        run: python3 tools/audit_log_fields.py
+
       - name: Check License Header
         uses: apache/skywalking-eyes/header@v0.8.0
         with:

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -25,6 +25,29 @@ user. It does not follow the wording of a message, whether code is in an
 | `debug` | Developers troubleshooting one operation | A bounded result or fallback summary. |
 | `trace` | Developers diagnosing traffic; potentially high frequency | Per-peer, per-message, per-stream, packet, retry, cancellation, and expected network detail. |
 
+## Structured fields
+
+Chronicle messages are stable, concise event descriptions. Put variable data in
+structured fields rather than interpolating it into a message string.
+
+| Field | Use |
+| --- | --- |
+| `err` | Human-readable exception or error-result text, normally `exc.msg`. |
+| `errType` | Exception class, normally `exc.name`, only when it changes the diagnostic or operator response. |
+| `peerId` | A local or remote peer identifier; add a separate direction or role field when needed. |
+| `address` / `addresses` | One network or multiaddress value / a collection of them. |
+| `protocol` | A negotiated or requested protocol identifier. |
+| `operation` | A stable operation name when the event otherwise lacks context. |
+| `attempt` / `maxAttempts` | Current and maximum retry counts. |
+| `messageType` | Protocol message kind; never exception text. |
+| `messageSize` | Encoded or payload size in bytes. |
+| `reason` | A bounded validation, rejection, or decision reason when no exception or error result exists. |
+
+Do not use `description`, `error`, `message`, or `msg` for exception text. Do
+not log complete peer-controlled messages, buffers, records, advertisements,
+keys, certificates, or tickets; log bounded metadata such as `messageType`,
+`messageSize`, `peerId`, and `reason` instead.
+
 ## Network, exceptions, cancellation, and retries
 
 Remote-controlled events must not produce `warn` or `error` merely because the

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -48,6 +48,10 @@ not log complete peer-controlled messages, buffers, records, advertisements,
 keys, certificates, or tickets; log bounded metadata such as `messageType`,
 `messageSize`, `peerId`, and `reason` instead.
 
+Use field names of at least three characters. `id` and `ip` are the only
+accepted abbreviations; never use a one-character field name in logs. Log
+fields are operator-facing data, not local code variables.
+
 ## Network, exceptions, cancellation, and retries
 
 Remote-controlled events must not produce `warn` or `error` merely because the

--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -381,7 +381,7 @@ proc requestAuthorizations*(
       try:
         challenges.add(challenge.to(ACMEChallenge))
       except ValueError, JsonKindError:
-        debug "Could not parse challenge", msg = getCurrentExceptionMsg()
+        debug "Could not parse challenge", err = getCurrentExceptionMsg()
 
     if challenges.len == 0:
       raise newException(ACMEError, "No challenges received")

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -226,7 +226,7 @@ proc tryIssueCertificate(self: AutotlsService) {.async: (raises: [CancelledError
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      debug "Failed to issue certificate", err = exc.msg
+      debug "Certificate issuance failed", err = exc.msg, errType = exc.name
   error "Failed to issue certificate"
 
 method start*(

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -70,7 +70,7 @@ proc checkDNSRecords*(
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      debug "Failed to resolve IP", description = exc.msg # retry
+      debug "Failed to resolve IP", err = exc.msg # retry
 
     if txt.len > 0 and txt[0] == keyAuth and resolvedIps.len > 0:
       return true

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -57,7 +57,8 @@ proc checkDNSRecords*(
 ): Future[bool] {.async: (raises: [AutoTLSError, CancelledError]).} =
   let acmeChalDomain = api.Domain("_acme-challenge." & baseDomain)
   let ipDomain = api.Domain(ipAddress.dnsLabel() & "." & baseDomain)
-  debug "Waiting for DNS record to be set", ip = ipDomain, acme = acmeChalDomain
+  debug "Waiting for DNS record to be set",
+    ip = ipDomain, acmeDomain = acmeChalDomain
 
   for attempt in 0 .. retries:
     if attempt > 0:

--- a/libp2p/autotls/utils.nim
+++ b/libp2p/autotls/utils.nim
@@ -57,8 +57,7 @@ proc checkDNSRecords*(
 ): Future[bool] {.async: (raises: [AutoTLSError, CancelledError]).} =
   let acmeChalDomain = api.Domain("_acme-challenge." & baseDomain)
   let ipDomain = api.Domain(ipAddress.dnsLabel() & "." & baseDomain)
-  debug "Waiting for DNS record to be set",
-    ip = ipDomain, acmeDomain = acmeChalDomain
+  debug "Waiting for DNS record to be set", ip = ipDomain, acmeDomain = acmeChalDomain
 
   for attempt in 0 .. retries:
     if attempt > 0:

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -311,9 +311,9 @@ proc triggerConnEvent*(
     c: ConnManager, peerId: PeerId, event: ConnEvent
 ) {.async: (raises: [CancelledError]).} =
   try:
-    trace "About to trigger connection events", peer = peerId
+    trace "About to trigger connection events", peerId = peerId
     if c.connEvents[event.kind].len > 0:
-      trace "triggering connection events", peer = peerId, event = $event.kind
+      trace "triggering connection events", peerId = peerId, event = $event.kind
       var connEvents = newSeqOfCap[Future[void]](c.connEvents[event.kind].len)
       for h in c.connEvents[event.kind]:
         connEvents.add(h(peerId, event))
@@ -322,8 +322,8 @@ proc triggerConnEvent*(
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    warn "Exception in triggerConnEvent",
-      description = exc.msg, peer = peerId, event = $event
+    warn "Connection event callback failed",
+      err = exc.msg, errType = exc.name, peer = peerId, event = $event
 
 proc addPeerEventHandler*(
     c: ConnManager, handler: PeerEventHandler, kind: PeerEventKind
@@ -341,12 +341,12 @@ proc removePeerEventHandler*(
 proc triggerPeerEvents*(
     c: ConnManager, peerId: PeerId, event: PeerEvent
 ) {.async: (raises: [CancelledError]).} =
-  trace "About to trigger peer events", peer = peerId
+  trace "About to trigger peer events", peerId = peerId
   if c.peerEvents[event.kind].len == 0:
     return
 
   try:
-    trace "triggering peer events", peer = peerId, event = $event
+    trace "triggering peer events", peerId = peerId, event = $event
 
     var peerEvents: seq[Future[void]]
     for h in c.peerEvents[event.kind]:
@@ -356,7 +356,7 @@ proc triggerPeerEvents*(
   except CancelledError as exc:
     raise exc
   except CatchableError as exc: # handlers should not raise!
-    warn "Exception in triggerPeerEvents", description = exc.msg, peer = peerId
+    warn "Peer event callback failed", err = exc.msg, errType = exc.name, peer = peerId
 
 proc expectConnection*(
     c: ConnManager, p: PeerId, dir: Direction
@@ -393,7 +393,7 @@ proc closeMuxer(muxer: Muxer) {.async: (raises: [CancelledError]).} =
     try:
       await muxer.handler
     except CatchableError as exc:
-      trace "Exception in close muxer handler", description = exc.msg
+      trace "Exception in close muxer handler", err = exc.msg
   trace "Cleaned up muxer", m = muxer
 
 proc onPeerDisconnected(c: ConnManager, peerId: PeerId) {.async: (raises: []).} =
@@ -419,8 +419,7 @@ proc onClose(c: ConnManager, mux: Muxer) {.async: (raises: []).} =
     await mux.connection.join()
     trace "Connection closed, cleaning up", mux
   except CatchableError as exc:
-    trace "Unexpected exception in connection manager's cleanup",
-      description = exc.msg, mux
+    trace "Unexpected exception in connection manager's cleanup", err = exc.msg, mux
   finally:
     let peerId = mux.connection.peerId
     let removed = c.muxerStore.remove(mux)
@@ -578,7 +577,7 @@ proc trackConnection*(cs: ConnectionSlot, conn: RawConn) =
     try:
       await conn.join()
     except CatchableError as exc:
-      trace "Exception in semaphore monitor, ignoring", description = exc.msg
+      trace "Exception in semaphore monitor, ignoring", err = exc.msg
     finally:
       cs.release()
 

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -386,7 +386,7 @@ proc contains*(c: ConnManager, muxer: Muxer): bool =
   return c.muxerStore.contains(muxer)
 
 proc closeMuxer(muxer: Muxer) {.async: (raises: [CancelledError]).} =
-  trace "Cleaning up muxer", m = muxer
+  trace "Cleaning up muxer", muxer = muxer
 
   await muxer.close()
   if not muxer.handler.isNil:
@@ -394,7 +394,7 @@ proc closeMuxer(muxer: Muxer) {.async: (raises: [CancelledError]).} =
       await muxer.handler
     except CatchableError as exc:
       trace "Exception in close muxer handler", err = exc.msg
-  trace "Cleaned up muxer", m = muxer
+  trace "Cleaned up muxer", muxer = muxer
 
 proc onPeerDisconnected(c: ConnManager, peerId: PeerId) {.async: (raises: []).} =
   if c.muxerStore.count(peerId) > 0:

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -111,11 +111,10 @@ proc dialAndUpgrade*(
       libp2p_total_dial_attempts.inc()
       transport.dial(hostname, addrs, peerId, dir).awaitWithDeadline(deadline)
     except CancelledError as e:
-      trace "Dialing canceled", description = e.msg, peerId
+      trace "Dialing canceled", err = e.msg, peerId
       raise e
     except CatchableError as e:
-      debug "Dialing failed",
-        description = e.msg, peerId = peerId, address = addrs, hostname
+      debug "Dialing failed", err = e.msg, peerId = peerId, address = addrs, hostname
       libp2p_failed_dials.inc()
       libp2p_dial_duration_ms.observe(
         (Moment.now() - dialStarted).milliseconds, labelValues = ["failed"]
@@ -137,8 +136,7 @@ proc dialAndUpgrade*(
     except CatchableError as e:
       # Another transport for the same address fails the same way, so give this one up.
       await dialed.close()
-      debug "Connection upgrade failed",
-        description = e.msg, peerId, address = addrs, hostname
+      debug "Connection upgrade failed", err = e.msg, peerId, address = addrs, hostname
       if dialed.dir == Direction.Out:
         libp2p_failed_upgrades_outgoing.inc()
       else:
@@ -175,7 +173,7 @@ proc expandDnsAddr(
   if not DNS.matchPartial(address):
     return @[(address, peerId)]
   if isNil(self.nameResolver):
-    warn "Can't resolve DNSADDR without NameResolver", ma = address
+    warn "Can't resolve DNSADDR without NameResolver", address = address
     return @[]
 
   trace "Start trying to resolve addresses"
@@ -193,7 +191,7 @@ proc expandDnsAddr(
     try:
       self.nameResolver.resolveDnsAddr(toResolve).awaitWithDeadline(deadline)
     except AsyncTimeoutError:
-      trace "Out of time resolving dnsaddr", ma = toResolve
+      trace "Out of time resolving dnsaddr", address = toResolve
       return @[]
 
   trace "resolved addresses",
@@ -226,7 +224,7 @@ proc resolveWithDeadline(
   try:
     self.nameResolver.resolveMAddress(address).awaitWithDeadline(deadline)
   except AsyncTimeoutError:
-    trace "Out of time resolving address", ma = address
+    trace "Out of time resolving address", address = address
     @[]
 
 proc tryExpandDnsAddr(
@@ -239,7 +237,7 @@ proc tryExpandDnsAddr(
     raise e
   except CatchableError as e:
     trace "Skipping the address, dnsaddr expansion failed",
-      peerId, ma = address, description = e.msg
+      peerId, ma = address, err = e.msg
     @[]
 
 proc tryResolve(
@@ -251,8 +249,7 @@ proc tryResolve(
   except CancelledError as e:
     raise e
   except CatchableError as e:
-    trace "Skipping the address, name resolution failed",
-      ma = address, description = e.msg
+    trace "Skipping the address, name resolution failed", ma = address, err = e.msg
     @[]
 
 proc normalizedDialAddrs(
@@ -368,7 +365,7 @@ proc directCandidates(
     if DNS.matchPartial(address):
       continue
     if self.transportFor(address).isNone():
-      trace "Skipping the address, no transport handles it", peerId, ma = address
+      trace "Skipping the address, no transport handles it", peerId, address = address
       continue
 
     # `wstransport` sends this as the Host header, so a wire address needs it too.
@@ -513,7 +510,7 @@ proc dialAndUpgrade*(
   ## Dial the addresses, sharing one `deadline`. Nil when all of them fail.
 
   let dialAddrs = normalizedDialAddrs(peerId, addrs)
-  debug "Dialing peer", peerId = peerId, addrs = dialAddrs
+  debug "Dialing peer", peerId = peerId, addresses = dialAddrs
 
   if self.dialRanking:
     await self.dialRanked(peerId, dialAddrs, dir, deadline, forceDial, reach)
@@ -574,7 +571,7 @@ proc finishUpgrade(
     await muxed.close()
     raise e
   except CatchableError as e:
-    trace "Failed to finish outgoing upgrade", description = e.msg
+    trace "Failed to finish outgoing upgrade", err = e.msg
     await muxed.close()
     raise newException(
       DialFailedError, "failed finishUpgrade in establishConnection: " & e.msg, e
@@ -778,10 +775,10 @@ method dial*(
       )
     return await self.negotiateStream(stream, protos)
   except CancelledError as exc:
-    trace "Dial canceled", description = exc.msg
+    trace "Dial canceled", err = exc.msg
     raise exc
   except CatchableError as exc:
-    trace "Error dialing", description = exc.msg
+    trace "Error dialing", err = exc.msg
     raise newException(DialFailedError, "failed dial existing: " & exc.msg)
 
 method dial*(
@@ -820,12 +817,11 @@ method dial*(
 
     return await self.negotiateStream(stream, protos)
   except CancelledError as exc:
-    trace "Dial canceled", conn, description = exc.msg
+    trace "Dial canceled", conn, err = exc.msg
     await cleanup()
     raise exc
   except CatchableError as exc:
-    debug "Error dialing",
-      conn, peerId, protos, addrs = dialAddrs, description = exc.msg
+    debug "Error dialing", conn, peerId, protos, addrs = dialAddrs, err = exc.msg
     await cleanup()
     raise newException(
       DialFailedError,

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -236,8 +236,7 @@ proc tryExpandDnsAddr(
   except CancelledError as e:
     raise e
   except CatchableError as e:
-    trace "Skipping the address, dnsaddr expansion failed",
-      peerId, ma = address, err = e.msg
+    trace "Skipping the address, dnsaddr expansion failed", peerId, address, err = e.msg
     @[]
 
 proc tryResolve(
@@ -249,7 +248,7 @@ proc tryResolve(
   except CancelledError as e:
     raise e
   except CatchableError as e:
-    trace "Skipping the address, name resolution failed", ma = address, err = e.msg
+    trace "Skipping the address, name resolution failed", address, err = e.msg
     @[]
 
 proc normalizedDialAddrs(
@@ -336,7 +335,7 @@ proc resolveCandidate(
   for address in resolved:
     if self.transportFor(address).isNone():
       trace "Skipping the address, no transport handles it",
-        peerId = candidate.peerId, ma = address
+        peerId = candidate.peerId, address
       continue
 
     candidates.add(
@@ -821,7 +820,7 @@ method dial*(
     await cleanup()
     raise exc
   except CatchableError as exc:
-    debug "Error dialing", conn, peerId, protos, addrs = dialAddrs, err = exc.msg
+    debug "Error dialing", conn, peerId, protos, addresses = dialAddrs, err = exc.msg
     await cleanup()
     raise newException(
       DialFailedError,

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -236,7 +236,7 @@ proc tryExpandDnsAddr(
   except CancelledError as e:
     raise e
   except CatchableError as e:
-    trace "Skipping the address, dnsaddr expansion failed", peerId, address, err = e.msg
+    trace "Skipping the address, dnsaddr expansion failed", peerId, err = e.msg, address
     @[]
 
 proc tryResolve(
@@ -248,7 +248,7 @@ proc tryResolve(
   except CancelledError as e:
     raise e
   except CatchableError as e:
-    trace "Skipping the address, name resolution failed", address, err = e.msg
+    trace "Skipping the address, name resolution failed", err = e.msg, address
     @[]
 
 proc normalizedDialAddrs(
@@ -816,7 +816,7 @@ method dial*(
 
     return await self.negotiateStream(stream, protos)
   except CancelledError as exc:
-    trace "Dial canceled", conn, err = exc.msg
+    trace "Dial canceled", err = exc.msg, conn
     await cleanup()
     raise exc
   except CatchableError as exc:

--- a/libp2p/errors.nim
+++ b/libp2p/errors.nim
@@ -32,9 +32,9 @@ macro checkFutures*[F](futs: seq[F], exclude: untyped = []): untyped =
         if res.failed:
           let exc = res.error
           # We still don't abort but warn
-          debug "A future has failed, enable trace logging for details",
-            error = exc.name
-          trace "Exception message", description = exc.msg, stack = getStackTrace()
+          debug "Future failed", err = exc.msg, errType = exc.name
+          trace "Future failed",
+            err = exc.msg, errType = exc.name, stack = getStackTrace()
   else:
     quote:
       for res in `futs`:
@@ -43,9 +43,8 @@ macro checkFutures*[F](futs: seq[F], exclude: untyped = []): untyped =
             let exc = res.error
             for i in 0 ..< `nexclude`:
               if exc of `exclude`[i]:
-                trace "A future has failed", error = exc.name, description = exc.msg
+                trace "Future failed", err = exc.msg, errType = exc.name
                 break check
             # We still don't abort but warn
-            debug "A future has failed, enable trace logging for details",
-              error = exc.name
-            trace "Exception details", description = exc.msg
+            debug "Future failed", err = exc.msg, errType = exc.name
+            trace "Future failed", err = exc.msg, errType = exc.name

--- a/libp2p/errors.nim
+++ b/libp2p/errors.nim
@@ -32,7 +32,6 @@ macro checkFutures*[F](futs: seq[F], exclude: untyped = []): untyped =
         if res.failed:
           let exc = res.error
           # We still don't abort but warn
-          debug "Future failed", err = exc.msg, errType = exc.name
           trace "Future failed",
             err = exc.msg, errType = exc.name, stack = getStackTrace()
   else:
@@ -46,5 +45,4 @@ macro checkFutures*[F](futs: seq[F], exclude: untyped = []): untyped =
                 trace "Future failed", err = exc.msg, errType = exc.name
                 break check
             # We still don't abort but warn
-            debug "Future failed", err = exc.msg, errType = exc.name
             trace "Future failed", err = exc.msg, errType = exc.name

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -1225,7 +1225,7 @@ proc getRepeatedField*(
   else:
     for item in items:
       let ma = MultiAddress.init(item).valueOr:
-        debug "Unsupported MultiAddress in blob", ma = item
+        debug "Unsupported MultiAddress in blob", address = item
         continue
 
       value.add(ma)

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -47,7 +47,7 @@ proc select*(
   ## select a remote protocol
   await stream.writeLp(Codec & "\n") # write handshake
   if proto.len() > 0:
-    trace "selecting proto", stream, proto = proto[0]
+    trace "selecting proto", stream, protocol = proto[0]
     await stream.writeLp((proto[0] & "\n")) # select proto
 
   var s = string.fromBytes((await stream.readLp(MsgSize))) # read ms header
@@ -66,15 +66,15 @@ proc select*(
     validateSuffix(s)
     trace "reading first requested proto", stream, s, proto
     if s == proto[0]:
-      trace "successfully selected ", stream, proto = proto[0]
+      trace "successfully selected ", stream, protocol = proto[0]
       stream.protocol = proto[0]
       return proto[0]
     elif proto.len > 1:
       # Try to negotiate alternatives
       let protos = proto[1 ..< proto.len()]
-      trace "selecting one of several protos", stream, protos = protos
+      trace "selecting one of several protos", stream, protocols = protos
       for p in protos:
-        trace "selecting proto", stream, proto = p
+        trace "selecting proto", stream, protocol = p
         await stream.writeLp((p & "\n")) # select proto
         s = string.fromBytes(await stream.readLp(MsgSize)) # read the first proto
         validateSuffix(s)
@@ -202,10 +202,10 @@ proc handle*(
       let (protos, matchers) = m.allProtosAndMatchers()
       await MultistreamSelect.handle(stream, protos, matchers, active)
     except LPStreamError as e:
-      trace "Exception in MultistreamSelect.handle", stream, description = e.msg
+      trace "Exception in MultistreamSelect.handle", stream, err = e.msg
       return
     except MultiStreamError as e:
-      trace "Exception in MultistreamSelect.handle", stream, description = e.msg
+      trace "Exception in MultistreamSelect.handle", stream, err = e.msg
       return
 
   m.lookupProtocol(ms).withValue(p):
@@ -225,7 +225,7 @@ proc handle*(
     trace "no handlers", stream, protocol = ms
 
 proc addHandler*(m: MultistreamSelect, protocol: LPProtocol, matcher: Matcher = nil) =
-  trace "registering protocols", protos = protocol.codecs
+  trace "registering protocols", protocols = protocol.codecs
   m.handlers.add(
     HandlerHolder(protos: protocol.codecs, protocol: protocol, match: matcher)
   )

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -202,10 +202,10 @@ proc handle*(
       let (protos, matchers) = m.allProtosAndMatchers()
       await MultistreamSelect.handle(stream, protos, matchers, active)
     except LPStreamError as e:
-      trace "Exception in MultistreamSelect.handle", stream, err = e.msg
+      trace "Exception in MultistreamSelect.handle", err = e.msg, stream
       return
     except MultiStreamError as e:
-      trace "Exception in MultistreamSelect.handle", stream, err = e.msg
+      trace "Exception in MultistreamSelect.handle", err = e.msg, stream
       return
 
   m.lookupProtocol(ms).withValue(p):

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -113,7 +113,7 @@ proc resetChannel*(s: LPChannel, isLocal: bool) {.async: (raises: []).} =
         trace "sending reset message", s, conn = s.conn
         await noCancel s.conn.writeMsg(s.id, s.resetCode) # write reset
       except LPStreamError as exc:
-        trace "Can't send reset message", s, conn = s.conn, description = exc.msg
+        trace "Can't send reset message", s, conn = s.conn, err = exc.msg
         await s.conn.close()
 
     s.resetMessageFut = resetMessage()
@@ -145,7 +145,7 @@ method close*(s: LPChannel) {.async: (raises: []).} =
       # It's harmless that close message cannot be sent - the connection is
       # likely down already
       await s.conn.close()
-      trace "Cannot send close message", s, id = s.id, description = exc.msg
+      trace "Cannot send close message", s, id = s.id, err = exc.msg
 
   await s.closeUnderlying() # maybe already eofed
 
@@ -268,7 +268,7 @@ proc completeWrite(
   except LPStreamEOFError as exc:
     raise exc
   except LPStreamError as exc:
-    trace "exception in lpchannel write handler", s, description = exc.msg
+    trace "exception in lpchannel write handler", s, err = exc.msg
     await s.reset()
     await s.conn.close()
     raise newLPStreamConnDownError(exc)

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -329,6 +329,6 @@ proc init*(
       else:
         $chann.oid
 
-  trace "Created new lpchannel", s = chann, id, initiator
+  trace "LP channel created", channel = chann, id, initiator
 
   return chann

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -113,7 +113,7 @@ proc resetChannel*(s: LPChannel, isLocal: bool) {.async: (raises: []).} =
         trace "sending reset message", s, conn = s.conn
         await noCancel s.conn.writeMsg(s.id, s.resetCode) # write reset
       except LPStreamError as exc:
-        trace "Can't send reset message", s, conn = s.conn, err = exc.msg
+        trace "Can't send reset message", err = exc.msg, s, conn = s.conn
         await s.conn.close()
 
     s.resetMessageFut = resetMessage()
@@ -268,7 +268,7 @@ proc completeWrite(
   except LPStreamEOFError as exc:
     raise exc
   except LPStreamError as exc:
-    trace "exception in lpchannel write handler", s, err = exc.msg
+    trace "exception in lpchannel write handler", err = exc.msg, s
     await s.reset()
     await s.conn.close()
     raise newLPStreamConnDownError(exc)

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -76,7 +76,7 @@ proc cleanupChann(m: Mplex, chann: LPChannel) {.async: (raises: []).} =
         labelValues = [$chann.initiator, $m.connection.peerId],
       )
   except CancelledError as exc:
-    trace "Error cleaning up mplex channel", m, chann, description = exc.msg
+    trace "Error cleaning up mplex channel", m, chann, err = exc.msg
 
 proc newStreamInternal*(
     m: Mplex,
@@ -184,7 +184,7 @@ method handle*(m: Mplex) {.async: (raises: []).} =
         except LPStreamClosedError as exc:
           # Channel is being closed, but `cleanupChann` was not yet triggered.
           trace "pushing data to channel failed",
-            m, channel, len = data.len, description = exc.msg
+            m, channel, len = data.len, err = exc.msg
           discard # Ignore message, same as if `cleanupChann` had completed.
       of MessageType.CloseIn, MessageType.CloseOut:
         await channel.pushEof()
@@ -193,11 +193,11 @@ method handle*(m: Mplex) {.async: (raises: []).} =
   except CancelledError:
     trace "Unexpected cancellation in mplex handler", m
   except LPStreamEOFError as exc:
-    trace "Stream EOF", m, description = exc.msg
+    trace "Stream EOF", m, err = exc.msg
   except LPStreamError as exc:
-    trace "Unexpected stream exception in mplex read loop", m, description = exc.msg
+    trace "Unexpected stream exception in mplex read loop", m, err = exc.msg
   except MuxerError as exc:
-    debug "Unexpected muxer exception in mplex read loop", m, description = exc.msg
+    debug "Unexpected muxer exception in mplex read loop", m, err = exc.msg
   finally:
     await m.close()
   trace "Stopped mplex handler", m

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -193,11 +193,11 @@ method handle*(m: Mplex) {.async: (raises: []).} =
   except CancelledError:
     trace "Unexpected cancellation in mplex handler", m
   except LPStreamEOFError as exc:
-    trace "Stream EOF", m, err = exc.msg
+    trace "Stream EOF", err = exc.msg, m
   except LPStreamError as exc:
-    trace "Unexpected stream exception in mplex read loop", m, err = exc.msg
+    trace "Unexpected stream exception in mplex read loop", err = exc.msg, m
   except MuxerError as exc:
-    debug "Unexpected muxer exception in mplex read loop", m, err = exc.msg
+    debug "Unexpected muxer exception in mplex read loop", err = exc.msg, m
   finally:
     await m.close()
   trace "Stopped mplex handler", m

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -397,7 +397,7 @@ proc sendLoop(channel: YamuxChannel) {.async: (raises: []).} =
     except CancelledError:
       discard # sendLoopFut is channel-owned and never cancelled from outside
     except LPStreamError as exc:
-      trace "failed to send the buffer", description = exc.msg
+      trace "failed to send the buffer", err = exc.msg
       let connDown = newLPStreamConnDownError(exc)
       for fut in futures:
         fut.fail(connDown)
@@ -589,9 +589,9 @@ method close*(m: Yamux) {.async: (raises: []).} =
   try:
     await m.connection.write(YamuxHeader.goAway(NormalTermination))
   except CancelledError as exc:
-    trace "cancelled sending goAway", description = exc.msg
+    trace "cancelled sending goAway", err = exc.msg
   except LPStreamError as exc:
-    trace "failed to send goAway", description = exc.msg
+    trace "failed to send goAway", err = exc.msg
   await m.connection.close()
 
   await drainChannelTasks(channels)
@@ -703,19 +703,19 @@ method handle*(m: Yamux) {.async: (raises: []).} =
           trace "remote reset channel"
           await channel.reset()
   except CancelledError as exc:
-    trace "Unexpected cancellation in yamux handler", description = exc.msg
+    trace "Unexpected cancellation in yamux handler", err = exc.msg
   except LPStreamEOFError as exc:
-    trace "Stream EOF", description = exc.msg
+    trace "Stream EOF", err = exc.msg
   except LPStreamError as exc:
-    trace "Unexpected stream exception in yamux read loop", description = exc.msg
+    trace "Unexpected stream exception in yamux read loop", err = exc.msg
   except YamuxError as exc:
-    trace "Closing yamux connection", description = exc.msg
+    trace "Closing yamux connection", err = exc.msg
     try:
       await m.connection.write(YamuxHeader.goAway(ProtocolError))
     except CancelledError, LPStreamError:
       discard
   except MuxerError as exc:
-    debug "Unexpected muxer exception in yamux read loop", description = exc.msg
+    debug "Unexpected muxer exception in yamux read loop", err = exc.msg
     try:
       await m.connection.write(YamuxHeader.goAway(ProtocolError))
     except CancelledError, LPStreamError:

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -98,7 +98,7 @@ proc encode(header: YamuxHeader): array[12, byte] =
 proc write(
     conn: LPStream, header: YamuxHeader
 ): Future[void] {.async: (raises: [CancelledError, LPStreamError], raw: true).} =
-  trace "write directly on stream", h = $header
+  trace "Writing directly on stream", header = $header
   var buffer = header.encode()
   conn.write(@buffer)
 
@@ -390,7 +390,7 @@ proc sendLoop(channel: YamuxChannel) {.async: (raises: []).} =
 
       inBuffer.inc(bufferToSend)
 
-    trace "try to send the buffer", h = $header
+    trace "Trying to send buffer", header = $header
     try:
       await channel.conn.write(move(sendBuffer))
       channel.sendWindow.dec(inBuffer)
@@ -607,12 +607,12 @@ proc handleStream(m: Yamux, channel: YamuxChannel) {.async: (raises: []).} =
   doAssert(channel.isClosed, "connection not closed by handler!")
 
 method handle*(m: Yamux) {.async: (raises: []).} =
-  trace "Starting yamux handler", pid = m.connection.peerId
+  trace "Starting yamux handler", peerId = m.connection.peerId
   try:
     while not m.connection.atEof:
       trace "waiting for header"
       let header = await m.connection.readHeader()
-      trace "got message", h = $header
+      trace "Message received", header = $header
 
       case header.msgType
       of Ping:

--- a/libp2p/nameresolving/dnsresolver.nim
+++ b/libp2p/nameresolving/dnsresolver.nim
@@ -82,7 +82,7 @@ method resolveIp*(
       resolvedAddresses: OrderedSet[string]
       resolveFailed = false
     template handleFail(e): untyped =
-      trace "Failed to query DNS", address, error = e.msg
+      trace "Failed to query DNS", address, err = e.msg
       resolveFailed = true
       break
 
@@ -94,7 +94,7 @@ method resolveIp*(
       except CancelledError as e:
         raise e
       except ValueError as e:
-        trace "Invalid DNS query", address, error = e.msg
+        trace "Invalid DNS query", address, err = e.msg
         return @[]
       except IOError as e:
         handleFail(e)
@@ -119,7 +119,7 @@ method resolveTxt*(
   for _ in 0 ..< self.nameServers.len:
     let server = self.nameServers[0]
     template handleFail(e): untyped =
-      trace "Failed to query DNS", address, error = e.msg
+      trace "Failed to query DNS", address, err = e.msg
       self.nameServers.add(self.nameServers[0])
       self.nameServers.delete(0)
       continue

--- a/libp2p/nameresolving/dnsresolver.nim
+++ b/libp2p/nameresolving/dnsresolver.nim
@@ -82,7 +82,7 @@ method resolveIp*(
       resolvedAddresses: OrderedSet[string]
       resolveFailed = false
     template handleFail(e): untyped =
-      trace "Failed to query DNS", address, err = e.msg
+      trace "Failed to query DNS", err = e.msg, address
       resolveFailed = true
       break
 
@@ -94,7 +94,7 @@ method resolveIp*(
       except CancelledError as e:
         raise e
       except ValueError as e:
-        trace "Invalid DNS query", address, err = e.msg
+        trace "Invalid DNS query", err = e.msg, address
         return @[]
       except IOError as e:
         handleFail(e)
@@ -119,7 +119,7 @@ method resolveTxt*(
   for _ in 0 ..< self.nameServers.len:
     let server = self.nameServers[0]
     template handleFail(e): untyped =
-      trace "Failed to query DNS", address, err = e.msg
+      trace "Failed to query DNS", err = e.msg, address
       self.nameServers.add(self.nameServers[0])
       self.nameServers.delete(0)
       continue

--- a/libp2p/protocols/connectivity/autonat/client.nim
+++ b/libp2p/protocols/connectivity/autonat/client.nim
@@ -67,10 +67,10 @@ method dialMe*(
         await (await incomingConnection).connection.close()
       except AlreadyExpectingConnectionError as e:
         # this err is already handled above and could not happen later
-        debug "Unexpected error", description = e.msg
+        debug "Unexpected error", err = e.msg
 
   try:
-    trace "sending Dial", addrs = switch.peerInfo.addrs
+    trace "sending Dial", addresses = switch.peerInfo.addrs
     await stream.sendDial(switch.peerInfo.peerId, switch.peerInfo.addrs)
   except CancelledError as e:
     raise e

--- a/libp2p/protocols/connectivity/autonat/server.nim
+++ b/libp2p/protocols/connectivity/autonat/server.nim
@@ -46,7 +46,7 @@ proc sendResponseError(
   try:
     await stream.writeLp(pb)
   except LPStreamError as exc:
-    trace "autonat failed to send response error", description = exc.msg, stream
+    trace "autonat failed to send response error", err = exc.msg, stream
 
 proc sendResponseOk(
     stream: Stream, ma: MultiAddress
@@ -62,7 +62,7 @@ proc sendResponseOk(
   try:
     await stream.writeLp(pb)
   except LPStreamError as exc:
-    trace "autonat failed to send response ok", description = exc.msg, stream
+    trace "autonat failed to send response ok", err = exc.msg, stream
 
 proc tryDial(
     autonat: Autonat, stream: Stream, addrs: seq[MultiAddress]
@@ -92,10 +92,10 @@ proc tryDial(
   except CancelledError as exc:
     raise exc
   except AllFuturesFailedError as exc:
-    debug "All dial attempts failed", addrs, description = exc.msg
+    debug "All dial attempts failed", addrs, err = exc.msg
     await stream.sendResponseError(DialError, "All dial attempts failed")
   except AsyncTimeoutError as exc:
-    debug "Dial timeout", addrs, description = exc.msg
+    debug "Dial timeout", addrs, err = exc.msg
     await stream.sendResponseError(DialError, "Dial timeout")
   finally:
     try:
@@ -128,7 +128,7 @@ proc handleDial(autonat: Autonat, stream: Stream, msg: AutonatMsg): Future[void]
     return stream.sendResponseError(InternalError, "Expected an IP address")
   var addrs = initHashSet[MultiAddress]()
   addrs.incl(observedAddr)
-  trace "addrs received", addrs = peerInfo.addrs
+  trace "addrs received", addresses = peerInfo.addrs
   for ma in peerInfo.addrs:
     isRelayed = ma.contains(multiCodec("p2p-circuit")).valueOr:
       continue
@@ -154,7 +154,7 @@ proc handleDial(autonat: Autonat, stream: Stream, msg: AutonatMsg): Future[void]
   if len(addrs) == 0:
     return stream.sendResponseError(DialRefused, "No dialable address")
   let addrsSeq = toSeq(addrs)
-  trace "trying to dial", addrs = addrsSeq
+  trace "trying to dial", addresses = addrsSeq
   return autonat.tryDial(stream, addrsSeq)
 
 proc new*(
@@ -175,7 +175,7 @@ proc new*(
       trace "cancelled autonat handler"
       raise exc
     except CatchableError as exc:
-      debug "exception in autonat handler", description = exc.msg, stream
+      debug "exception in autonat handler", err = exc.msg, stream
     finally:
       trace "exiting autonat handler", stream
       await stream.close()

--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -140,15 +140,15 @@ proc askPeer(
       debug "dialMe answer is reachable"
       Reachable
     except AutonatUnreachableError as error:
-      debug "dialMe answer is not reachable", description = error.msg
+      debug "dialMe answer is not reachable", err = error.msg
       NotReachable
     except AsyncTimeoutError as error:
-      debug "dialMe timed out", description = error.msg
+      debug "dialMe timed out", err = error.msg
       Unknown
     except CancelledError as error:
       raise error
     except CatchableError as error:
-      debug "dialMe unexpected error", description = error.msg
+      debug "dialMe unexpected error", err = error.msg
       Unknown
   let hasReachabilityOrConfidenceChanged = await self.handleAnswer(ans)
   if hasReachabilityOrConfidenceChanged:
@@ -194,7 +194,7 @@ proc addressMapper(
         processedMA = addressManager.externalAddrFor(listenAddr)
           # handle manual port forwarding
     except CatchableError as exc:
-      debug "Error while handling address mapper", description = exc.msg
+      debug "Error while handling address mapper", err = exc.msg
     addrs.add(processedMA)
   return addrs
 

--- a/libp2p/protocols/connectivity/autonatv2/client.nim
+++ b/libp2p/protocols/connectivity/autonatv2/client.nim
@@ -62,7 +62,7 @@ proc new*(
   ) {.async: (raises: [CancelledError]).} =
     try:
       let dialBack = DialBack.decode(await stream.readLp(DialBackLpSize)).valueOr:
-        trace "Unable to decode DialBack", error = error
+        trace "Unable to decode DialBack", err = error
         return
       if not await client.handleDialBack(stream, dialBack).withTimeout(
         client.dialBackTimeout
@@ -71,9 +71,9 @@ proc new*(
     except CancelledError as exc:
       raise exc
     except LPStreamRemoteClosedError as exc:
-      trace "Stream closed by peer", description = exc.msg, peer = stream.peerId
+      trace "Stream closed by peer", err = exc.msg, peerId = stream.peerId
     except LPStreamError as exc:
-      trace "Stream closed by peer", description = exc.msg, peer = stream.peerId
+      trace "Stream closed by peer", err = exc.msg, peerId = stream.peerId
 
   client.handler = handleStream
   client.codec = $AutonatV2Codec.DialBack
@@ -191,7 +191,7 @@ method sendDialRequest*(
             AutonatV2Error, "Invalid addrIdx " & $addrIdx & " in DialResponse"
           )
   except LPStreamRemoteClosedError as exc:
-    trace "Stream reset by server", description = exc.msg, peer = pid
+    trace "Stream reset by server", err = exc.msg, peerId = pid
   finally:
     # rollback any changes
     self.expectedNonces.del(nonce)

--- a/libp2p/protocols/connectivity/autonatv2/client.nim
+++ b/libp2p/protocols/connectivity/autonatv2/client.nim
@@ -32,7 +32,7 @@ proc handleDialBack(
     self: AutonatV2Client, stream: Stream, dialBack: DialBack
 ) {.async: (raises: [CancelledError, AutonatV2Error, LPStreamError]).} =
   trace "Handling DialBack",
-    stream = stream, localAddr = stream.localAddr, observedAddr = stream.observedAddr
+    stream, localAddr = stream.localAddr, observedAddr = stream.observedAddr
 
   if not self.expectedNonces.hasKey(dialBack.nonce):
     trace "Not expecting this nonce", nonce = dialBack.nonce

--- a/libp2p/protocols/connectivity/autonatv2/client.nim
+++ b/libp2p/protocols/connectivity/autonatv2/client.nim
@@ -106,7 +106,7 @@ proc handleDialDataRequest*(
     (req.numBytes + MaxDialDataResponsePayload - 1) div MaxDialDataResponsePayload
   for i in 0 ..< messagesToSend:
     await stream.writeLp(msg.encode())
-    trace "Sending DialDataResponse", i = i, messagesToSend = messagesToSend
+    trace "Sending DialDataResponse", index = i, messagesToSend = messagesToSend
 
   # get DialResponse
   msg = AutonatV2Msg.decode(await stream.readLp(AutonatV2MsgLpSize)).valueOr:

--- a/libp2p/protocols/connectivity/autonatv2/server.nim
+++ b/libp2p/protocols/connectivity/autonatv2/server.nim
@@ -97,11 +97,11 @@ proc dialBack(
 
     # receive DialBackResponse
     discard DialBackResponse.decode(await stream.readLp(AutonatV2MsgLpSize)).valueOr:
-      trace "DialBack failed, could not decode DialBackResponse", error = error
+      trace "DialBack failed, could not decode DialBackResponse", err = error
       return DialStatus.EDialBackError
   except LPStreamRemoteClosedError as exc:
     # failed because of nonce error (remote reset the stream): EDialBackError
-    trace "DialBack failed, remote closed the connection", description = exc.msg
+    trace "DialBack failed, remote closed the connection", err = exc.msg
     return DialStatus.EDialBackError
 
   # TODO: failed because of client or server resources: EDialError
@@ -147,7 +147,7 @@ proc amplificationAttackPrevention(
   try:
     await self.handleDialDataResponses(stream)
   except AutonatV2Error as exc:
-    debug "Amplification attack prevention failed", description = exc.msg
+    debug "Amplification attack prevention failed", err = exc.msg
     return false
 
   return true
@@ -163,7 +163,7 @@ proc canDial(self: AutonatV2, addrs: MultiAddress): bool =
       if not self.config.allowPrivateAddresses and isPrivate($addrIp):
         return false
     except ValueError:
-      trace "Unable to parse IP address, skipping", addrs = $addrIp
+      trace "Unable to parse IP address, skipping", addresses = $addrIp
       return false
   for t in self.switch.transports:
     if t.handles(addrs):
@@ -261,7 +261,7 @@ proc handleDialRequest(
       ResponseStatus.Ok, addrIdx = Opt.some(addrIdx), dialStatus = Opt.some(dialStatus)
     )
   except DialFailedError as exc:
-    trace "DialBack failed", description = exc.msg
+    trace "DialBack failed", err = exc.msg
     await stream.sendDialResponse(
       ResponseStatus.Ok,
       addrIdx = Opt.some(addrIdx),
@@ -291,10 +291,10 @@ proc new*(
     let msg =
       try:
         AutonatV2Msg.decode(await stream.readLp(AutonatV2MsgLpSize)).valueOr:
-          trace "Unable to decode AutonatV2Msg", error = error
+          trace "Unable to decode AutonatV2Msg", err = error
           return
       except LPStreamError as exc:
-        trace "Could not receive AutonatV2Msg", description = exc.msg
+        trace "Could not receive AutonatV2Msg", err = exc.msg
         return
 
     trace "Received message", kind = $msg.oneof.kind
@@ -307,9 +307,9 @@ proc new*(
     except CancelledError as exc:
       raise exc
     except LPStreamRemoteClosedError as exc:
-      trace "Stream closed by peer", description = exc.msg, peer = stream.peerId
+      trace "Stream closed by peer", err = exc.msg, peerId = stream.peerId
     except LPStreamError as exc:
-      trace "Stream Error", description = exc.msg
+      trace "Stream Error", err = exc.msg
 
   autonatV2.handler = handleStream
   autonatV2.codec = $AutonatV2Codec.DialRequest

--- a/libp2p/protocols/connectivity/autonatv2/verifier.nim
+++ b/libp2p/protocols/connectivity/autonatv2/verifier.nim
@@ -57,7 +57,7 @@ proc askPeer(
       trace "DialRequest timed out", peerId, address
       return Opt.none(AddrState)
     except LPError as e:
-      trace "DialRequest failed", peerId, address, description = e.msg
+      trace "DialRequest failed", peerId, address, err = e.msg
       return Opt.none(AddrState)
 
   case reachability

--- a/libp2p/protocols/connectivity/autonatv2/verifier.nim
+++ b/libp2p/protocols/connectivity/autonatv2/verifier.nim
@@ -57,7 +57,7 @@ proc askPeer(
       trace "DialRequest timed out", peerId, address
       return Opt.none(AddrState)
     except LPError as e:
-      trace "DialRequest failed", peerId, address, err = e.msg
+      trace "DialRequest failed", peerId, err = e.msg, address
       return Opt.none(AddrState)
 
   case reachability

--- a/libp2p/protocols/connectivity/dcutr/client.nim
+++ b/libp2p/protocols/connectivity/dcutr/client.nim
@@ -104,7 +104,7 @@ proc startSync*(
     raise err
   except AllFuturesFailedError as err:
     trace "Dcutr initiator could not connect to the remote peer, all connect attempts failed",
-      peerDialableAddrs, description = err.msg
+      peerDialableAddrs, err = err.msg
     raise newException(
       DcutrError,
       "Dcutr initiator could not connect to the remote peer, all connect attempts failed",
@@ -112,7 +112,7 @@ proc startSync*(
     )
   except AsyncTimeoutError as err:
     trace "Dcutr initiator could not connect to the remote peer, all connect attempts timed out",
-      peerDialableAddrs, description = err.msg
+      peerDialableAddrs, err = err.msg
     raise newException(
       DcutrError,
       "Dcutr initiator could not connect to the remote peer, all connect attempts timed out",
@@ -120,7 +120,7 @@ proc startSync*(
     )
   except CatchableError as err:
     trace "Unexpected error when Dcutr initiator tried to connect to the remote peer",
-      description = err.msg
+      err = err.msg
     raise newException(
       DcutrError,
       "Unexpected error when Dcutr initiator tried to connect to the remote peer: " &

--- a/libp2p/protocols/connectivity/dcutr/client.nim
+++ b/libp2p/protocols/connectivity/dcutr/client.nim
@@ -52,7 +52,7 @@ proc startSync*(
     peerDialableAddrs = getHolePunchableAddrs(connectAnswer.addrs)
     if peerDialableAddrs.len == 0:
       trace "Dcutr receiver has no supported dialable addresses to connect to. Aborting Dcutr.",
-        addrs = connectAnswer.addrs
+        addresses = connectAnswer.addrs
       return
 
     let rttEnd = Moment.now()

--- a/libp2p/protocols/connectivity/dcutr/server.nim
+++ b/libp2p/protocols/connectivity/dcutr/server.nim
@@ -115,13 +115,13 @@ proc new*(
       raise err
     except AllFuturesFailedError as err:
       trace "Dcutr receiver could not connect to the remote peer, " &
-        "all connect attempts failed", peerDialableAddrs, description = err.msg
+        "all connect attempts failed", peerDialableAddrs, err = err.msg
     except AsyncTimeoutError as err:
       trace "Dcutr receiver could not connect to the remote peer, " &
-        "all connect attempts timed out", peerDialableAddrs, description = err.msg
+        "all connect attempts timed out", peerDialableAddrs, err = err.msg
     except CatchableError as err:
       trace "Unexpected error when Dcutr receiver tried to connect " &
-        "to the remote peer", description = err.msg
+        "to the remote peer", err = err.msg
 
   let self = T()
   self.handler = handleStream

--- a/libp2p/protocols/connectivity/dcutr/server.nim
+++ b/libp2p/protocols/connectivity/dcutr/server.nim
@@ -59,7 +59,7 @@ proc new*(
           raise newException(DcutrError, error)
         trace "Dcutr receiver has received a Sync message.", syncMsg
         trace "Dcutr initiator has no supported dialable addresses to connect to. Aborting Dcutr.",
-          addrs = connectMsg.addrs
+          addresses = connectMsg.addrs
         return
 
       # Expected DCUtR connections bypass ConnManager limits.

--- a/libp2p/protocols/connectivity/relay/client.nim
+++ b/libp2p/protocols/connectivity/relay/client.nim
@@ -52,7 +52,7 @@ proc sendStopError(
   except CancelledError as e:
     raise e
   except LPStreamError as e:
-    trace "failed to send stop status", description = e.msg
+    trace "failed to send stop status", err = e.msg
 
 proc handleRelayedConnect(
     cl: RelayClient, stream: Stream, msg: StopMessage
@@ -99,7 +99,7 @@ proc reserve*(
       except CancelledError as exc:
         raise exc
       except CatchableError as exc:
-        trace "error writing or reading reservation message", description = exc.msg
+        trace "error writing or reading reservation message", err = exc.msg
         raise newException(ReservationError, exc.msg)
 
   if msg.msgType.isNone or msg.msgType.get() != HopMessageType.Status:
@@ -151,7 +151,7 @@ proc dialPeerV1*(
   except CancelledError as exc:
     raise exc
   except LPStreamError as exc:
-    trace "error writing hop request", description = exc.msg
+    trace "error writing hop request", err = exc.msg
     raise newException(RelayV1DialError, "error writing hop request: " & exc.msg, exc)
 
   let msgRcvFromRelayOpt =
@@ -160,7 +160,7 @@ proc dialPeerV1*(
     except CancelledError as exc:
       raise exc
     except LPStreamError as exc:
-      trace "error reading stop response", description = exc.msg
+      trace "error reading stop response", err = exc.msg
       await sendStatus(stream, StatusV1.HopCantOpenDstStream)
       raise
         newException(RelayV1DialError, "error reading stop response: " & exc.msg, exc)
@@ -209,7 +209,7 @@ proc dialPeerV2*(
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "error reading stop response", description = exc.msg
+      trace "error reading stop response", err = exc.msg
       raise
         newException(RelayV2DialError, "Exception decoding HopMessage: " & exc.msg, exc)
 
@@ -332,7 +332,7 @@ proc new*(
       trace "cancelled client handler"
       raise exc
     except CatchableError as exc:
-      trace "exception in client handler", description = exc.msg, stream
+      trace "exception in client handler", err = exc.msg, stream
     finally:
       trace "exiting client handler", stream
       await stream.close()

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -173,7 +173,7 @@ proc handleConnect(
       raise exc
     except DialFailedError as exc:
       libp2p_relay_connections.inc(labelValues = ["dial_failed"])
-      trace "error opening relay stream", dst, description = exc.msg
+      trace "error opening relay stream", dst, err = exc.msg
       await sendHopStatus(srcStream, ConnectionFailed)
       return
   defer:
@@ -203,7 +203,7 @@ proc handleConnect(
     raise exc
   except CatchableError as exc:
     libp2p_relay_connections.inc(labelValues = ["stop_failed"])
-    trace "error sending stop message", description = exc.msg
+    trace "error sending stop message", err = exc.msg
     await sendHopStatus(srcStream, ConnectionFailed)
     return
 
@@ -293,7 +293,7 @@ proc handleHop*(
     except CancelledError as exc:
       raise exc
     except DialFailedError as exc:
-      trace "error opening relay stream", dst, description = exc.msg
+      trace "error opening relay stream", dst, err = exc.msg
       await sendStatus(srcStream, StatusV1.HopCantDialDst)
       return
   defer:
@@ -310,8 +310,7 @@ proc handleHop*(
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "error writing stop handshake or reading stop response",
-        description = exc.msg
+      trace "error writing stop handshake or reading stop response", err = exc.msg
       await sendStatus(srcStream, StatusV1.HopCantOpenDstStream)
       return
 
@@ -396,7 +395,7 @@ proc new*(
       trace "cancelled relayv2 handler"
       raise exc
     except CatchableError as exc:
-      debug "exception in relayv2 handler", description = exc.msg, stream
+      debug "exception in relayv2 handler", err = exc.msg, stream
     finally:
       trace "exiting relayv2 handler", stream
       await stream.close()

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -173,7 +173,7 @@ proc handleConnect(
       raise exc
     except DialFailedError as exc:
       libp2p_relay_connections.inc(labelValues = ["dial_failed"])
-      trace "error opening relay stream", dst, err = exc.msg
+      trace "error opening relay stream", err = exc.msg, dst
       await sendHopStatus(srcStream, ConnectionFailed)
       return
   defer:
@@ -293,7 +293,7 @@ proc handleHop*(
     except CancelledError as exc:
       raise exc
     except DialFailedError as exc:
-      trace "error opening relay stream", dst, err = exc.msg
+      trace "error opening relay stream", err = exc.msg, dst
       await sendStatus(srcStream, StatusV1.HopCantDialDst)
       return
   defer:

--- a/libp2p/protocols/connectivity/relay/utils.nim
+++ b/libp2p/protocols/connectivity/relay/utils.nim
@@ -22,7 +22,7 @@ proc sendStatus*(stream: Stream, code: StatusV1) {.async: (raises: [CancelledErr
   except CancelledError as e:
     raise e
   except LPStreamError as e:
-    trace "error sending relay status", description = e.msg
+    trace "error sending relay status", err = e.msg
 
 proc sendHopStatus*(
     stream: Stream, code: StatusV2
@@ -87,7 +87,7 @@ proc bridge*(
       trace "relay src closed connection", src = srcStream.peerId
     if dstStream.closed() or dstStream.atEof():
       trace "relay dst closed connection", dst = dstStream.peerId
-    trace "relay error", description = exc.msg
+    trace "relay error", err = exc.msg
   trace "end relaying", bytesSentFromSrcToDst, bytesSentFromDstToSrc
   libp2p_relay_bytes.inc(bytesSentFromSrcToDst.int64, labelValues = ["in"])
   libp2p_relay_bytes.inc(bytesSentFromDstToSrc.int64, labelValues = ["out"])

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -145,7 +145,7 @@ method init*(p: Identify) =
       await stream.writeLp(msg.encode())
       trace "identify: info sent", stream, info = p.peerInfo
     except LPError as e:
-      trace "identify handler failed to write message", description = e.msg, stream
+      trace "identify handler failed to write message", err = e.msg, stream
     finally:
       trace "exiting identify handler", stream
       await stream.closeWithEOF()
@@ -206,7 +206,7 @@ proc init*(p: IdentifyPush) =
       try:
         await stream.readLp(maxMsgSize)
       except LPError as e:
-        trace "failed to read message from stream", description = e.msg, stream
+        trace "failed to read message from stream", err = e.msg, stream
         return
 
     let identifyMsg = IdentifyMsg.decode(move message).valueOr:
@@ -235,7 +235,7 @@ proc init*(p: IdentifyPush) =
       except CancelledError as e:
         raise e
       except CatchableError as e:
-        trace "got unexpected error", description = e.msg, stream
+        trace "got unexpected error", err = e.msg, stream
         # compiler reports strange CatchableError error that should never really happen
         discard
 

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -65,7 +65,7 @@ proc checkAndEvictPeer(
   if kad.stopping:
     return
   if not kad.livenessSem.tryAcquire():
-    trace "Liveness probe skipped: no free slot", peer = peerId.shortLog()
+    trace "Liveness probe skipped: no free slot", peerId = peerId.shortLog()
     kad_routing_table_liveness_probes.inc(labelValues = ["skipped"])
     return
   defer:
@@ -84,7 +84,8 @@ proc checkAndEvictPeer(
     if rtable.isReplaceable(peerId, grace, Moment.now()):
       dueTables.add(rtable)
   if dueTables.len == 0:
-    trace "Liveness probe skipped: peer no longer replaceable", peer = peerId.shortLog()
+    trace "Liveness probe skipped: peer no longer replaceable",
+      peerId = peerId.shortLog()
     return
 
   let addrs = kad.dialAddrs(peerId)
@@ -105,9 +106,9 @@ proc checkAndEvictPeer(
         peer = peerId.shortLog()
     return
 
-  trace "Probing peer for liveness", peer = peerId.shortLog(), tables = dueTables.len
+  trace "Probing peer for liveness", peerId = peerId.shortLog(), tables = dueTables.len
   if (await kad.lookupCheck(peerId, addrs)):
-    trace "Liveness probe succeeded", peer = peerId.shortLog()
+    trace "Liveness probe succeeded", peerId = peerId.shortLog()
     # Peer is reachable: one registry write refreshes usefulness for every index.
     kad.rtable.markUseful(peerId)
     kad_routing_table_liveness_probes.inc(labelValues = ["ok"])
@@ -132,11 +133,11 @@ proc checkAndEvictPeer(
 proc launchLivenessProbe(kad: KadDHT, peerId: PeerId) {.raises: [].} =
   ## Starts a liveness probe unless one is already in flight for this peer.
   if kad.livenessProbes.hasKey(peerId):
-    trace "Liveness probe already in flight", peer = peerId.shortLog()
+    trace "Liveness probe already in flight", peerId = peerId.shortLog()
     return
   if kad.stopping:
     return
-  trace "Launching liveness probe", peer = peerId.shortLog()
+  trace "Launching liveness probe", peerId = peerId.shortLog()
   kad.trackLivenessProbe(peerId, kad.checkAndEvictPeer(peerId))
 
 proc probeAndEvictPeers*(
@@ -158,7 +159,7 @@ proc probeAndEvictPeers*(
   var futs = newSeqOfCap[Future[void]](peers.len)
   for peerId in peers:
     kad.livenessProbes.withValue(peerId, existing):
-      trace "Liveness batch reusing in-flight probe", peer = peerId.shortLog()
+      trace "Liveness batch reusing in-flight probe", peerId = peerId.shortLog()
       futs.add(existing[])
       continue
     let fut = kad.checkAndEvictPeer(peerId)

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -374,7 +374,7 @@ proc new*(
         except LPStreamEOFError:
           return
         except LPStreamError as exc:
-          trace "Read error when handling kademlia RPC", stream, err = exc.msg
+          trace "Read error when handling kademlia RPC", err = exc.msg, stream
           return
       let bufLen = buf.len
       let msg = Message.decode(move(buf)).valueOr:

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -374,7 +374,7 @@ proc new*(
         except LPStreamEOFError:
           return
         except LPStreamError as exc:
-          trace "Read error when handling kademlia RPC", stream = stream, err = exc.msg
+          trace "Read error when handling kademlia RPC", stream, err = exc.msg
           return
       let bufLen = buf.len
       let msg = Message.decode(move(buf)).valueOr:

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -286,10 +286,11 @@ proc lookupCheck*(
     await noCancel probe.cancelAndWait()
   discard await probe.withTimeout(kad.config.timeout)
   if not probe.completed():
-    trace "Kad probe timed out", peer = peerId.shortLog(), timeout = kad.config.timeout
+    trace "Kad probe timed out",
+      peerId = peerId.shortLog(), timeout = kad.config.timeout
     return false
   let reply = probe.value().valueOr:
-    trace "Kad probe failed", peer = peerId.shortLog(), description = error
+    trace "Kademlia probe failed", peerId = peerId.shortLog(), err = error
     return false
   reply.msgType == Opt.some(MessageType.findNode)
 
@@ -306,7 +307,7 @@ proc admitPeer(
     except CancelledError:
       return
   if not reachable:
-    trace "Kad admission probe failed, not inserting peer", peer = peerId.shortLog()
+    trace "Kad admission probe failed, not inserting peer", peerId = peerId.shortLog()
     kad.probeRecordFailure(peerId, addrs)
     return
   kad.probeClearFailures(peerId)
@@ -315,7 +316,7 @@ proc admitPeer(
 
   # Table may have been detachAll'd (e.g. service uninterest) while the probe ran.
   if rtable.detached:
-    trace "Kad admission probe abandoned: table detached", peer = peerId.shortLog()
+    trace "Kad admission probe abandoned: table detached", peerId = peerId.shortLog()
     return
   if rtable.insert(peerId) and not onAdmit.isNil():
     onAdmit(peerId)
@@ -351,12 +352,12 @@ proc scheduleAdmissionProbe(
     return false
 
   if kad.probeBackedOff(peerId, addrs):
-    trace "Kad admission probe backed off", peer = peerId.shortLog()
+    trace "Kad admission probe backed off", peerId = peerId.shortLog()
     kad_admission_probes_backed_off.inc()
     return false
 
   if not kad.admissionSem.tryAcquire():
-    trace "Kad admission probe dropped: no free slot", peer = peerId.shortLog()
+    trace "Kad admission probe dropped: no free slot", peerId = peerId.shortLog()
     kad_admission_probes_dropped.inc()
     return false
 
@@ -438,7 +439,7 @@ proc dispatchPeer(
 ): Future[DispatchResult] {.async: (raises: [CancelledError]).} =
   let res = await dispatch(kad, peerId, target)
   if res.isErr():
-    trace "Kad lookup: RPC error", peer = peerId.shortLog(), msg = res.error()
+    trace "Kademlia lookup RPC failed", peerId = peerId.shortLog(), err = res.error()
     return DispatchResult(peer: peerId, outcome: Errored)
   DispatchResult(peer: peerId, outcome: Completed, msg: res.value())
 
@@ -479,7 +480,7 @@ proc fillSlots(
     if peerId in active:
       continue
     state.attempts[peerId] = state.attempts.getOrDefault(peerId, 0) + 1
-    trace "Lookup query", peer = peerId.shortLog()
+    trace "Lookup query", peerId = peerId.shortLog()
     pending.add(
       Attempt(
         peer: peerId,
@@ -740,7 +741,8 @@ method handleFindNode*(
     kad: KadDHT, stream: Stream, msg: Message
 ) {.base, async: (raises: [CancelledError]).} =
   let msgKey = msg.key.valueOr:
-    trace "Key not set: handleFindNode", msg = msg, stream = stream
+    trace "Find-node request rejected",
+      reason = "missingKey", messageType = "findNode", stream = stream
     return
 
   let response = Message(

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -742,7 +742,7 @@ method handleFindNode*(
 ) {.base, async: (raises: [CancelledError]).} =
   let msgKey = msg.key.valueOr:
     trace "Find-node request rejected",
-      reason = "missingKey", messageType = "findNode", stream = stream
+      reason = "missingKey", messageType = "findNode", stream
     return
 
   let response = Message(
@@ -754,8 +754,7 @@ method handleFindNode*(
   try:
     await stream.writeLp(encoded)
   except LPStreamError as exc:
-    trace "Write error when writing kad find-node RPC reply",
-      stream = stream, err = exc.msg
+    trace "Write error when writing kad find-node RPC reply", stream, err = exc.msg
     return
 
   # Only admit senders with known dialable addresses; an inbound connection

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -754,7 +754,7 @@ method handleFindNode*(
   try:
     await stream.writeLp(encoded)
   except LPStreamError as exc:
-    trace "Write error when writing kad find-node RPC reply", stream, err = exc.msg
+    trace "Write error when writing kad find-node RPC reply", err = exc.msg, stream
     return
 
   # Only admit senders with known dialable addresses; an inbound connection

--- a/libp2p/protocols/kademlia/get.nim
+++ b/libp2p/protocols/kademlia/get.nim
@@ -128,7 +128,8 @@ method handleGetValue*(
     kad: KadDHT, stream: Stream, msg: Message
 ) {.base, async: (raises: [CancelledError]).} =
   let key = msg.key.valueOr:
-    trace "Key not set: handleGetValue", msg = msg, stream = stream
+    trace "Get-value request rejected",
+      reason = "missingKey", messageType = "getValue", stream = stream
     return
 
   # Evict the entry eagerly if it has expired so the `valueOr` below treats it

--- a/libp2p/protocols/kademlia/get.nim
+++ b/libp2p/protocols/kademlia/get.nim
@@ -69,7 +69,7 @@ proc getValue*(
       return
 
     let record = reply.record.valueOr:
-      trace "GetValue returned empty record", reply = reply
+      trace "Get-value reply has no record", messageType = "getValue"
       return
 
     if record.key.isNone or record.key.get() != key:
@@ -78,7 +78,7 @@ proc getValue*(
       return
 
     let value = record.value.valueOr:
-      trace "GetValue returned record with no value", reply = reply
+      trace "Get-value reply has no value", messageType = "getValue"
       return
 
     if value.len > kad.config.limits.maxValueSize:
@@ -129,7 +129,7 @@ method handleGetValue*(
 ) {.base, async: (raises: [CancelledError]).} =
   let key = msg.key.valueOr:
     trace "Get-value request rejected",
-      reason = "missingKey", messageType = "getValue", stream = stream
+      reason = "missingKey", messageType = "getValue", stream
     return
 
   # Evict the entry eagerly if it has expired so the `valueOr` below treats it
@@ -152,7 +152,7 @@ method handleGetValue*(
     try:
       await stream.writeLp(encoded)
     except LPStreamError as exc:
-      debug "Failed to send get-value RPC reply", stream = stream, err = exc.msg
+      debug "Failed to send get-value RPC reply", stream, err = exc.msg
     return
 
   let response = Message(
@@ -172,5 +172,5 @@ method handleGetValue*(
   try:
     await stream.writeLp(encoded)
   except LPStreamError as exc:
-    trace "Failed to send get-value RPC reply", stream = stream, err = exc.msg
+    trace "Failed to send get-value RPC reply", stream, err = exc.msg
     return

--- a/libp2p/protocols/kademlia/get.nim
+++ b/libp2p/protocols/kademlia/get.nim
@@ -152,7 +152,7 @@ method handleGetValue*(
     try:
       await stream.writeLp(encoded)
     except LPStreamError as exc:
-      debug "Failed to send get-value RPC reply", stream, err = exc.msg
+      debug "Failed to send get-value RPC reply", err = exc.msg, stream
     return
 
   let response = Message(
@@ -172,5 +172,5 @@ method handleGetValue*(
   try:
     await stream.writeLp(encoded)
   except LPStreamError as exc:
-    trace "Failed to send get-value RPC reply", stream, err = exc.msg
+    trace "Failed to send get-value RPC reply", err = exc.msg, stream
     return

--- a/libp2p/protocols/kademlia/ping.nim
+++ b/libp2p/protocols/kademlia/ping.nim
@@ -41,5 +41,5 @@ proc handlePing*(
   try:
     await stream.writeLp(encoded)
   except LPStreamError as exc:
-    debug "Failed to send ping reply", stream, err = exc.msg
+    debug "Failed to send ping reply", err = exc.msg, stream
     return

--- a/libp2p/protocols/kademlia/ping.nim
+++ b/libp2p/protocols/kademlia/ping.nim
@@ -41,5 +41,5 @@ proc handlePing*(
   try:
     await stream.writeLp(encoded)
   except LPStreamError as exc:
-    debug "Failed to send ping reply", stream = stream, err = exc.msg
+    debug "Failed to send ping reply", stream, err = exc.msg
     return

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -431,7 +431,8 @@ method handleAddProvider*(
     kad: KadDHT, stream: Stream, msg: Message
 ) {.base, async: (raises: [CancelledError]).} =
   let msgKey = msg.key.valueOr:
-    trace "Key not set: handleAddProvider", msg = msg, stream = stream
+    trace "Add-provider request rejected",
+      reason = "missingKey", messageType = "addProvider", stream = stream
     return
 
   if msgKey.len == 0 or msgKey.len > MaxProviderKeyLen:
@@ -460,7 +461,8 @@ method handleAddProvider*(
     let effectiveCount = existingProviders.len - (if senderIsKnown: 1 else: 0)
     if effectiveCount >= limit:
       atCap = true
-      trace "ADD_PROVIDER rejected: per-key limit reached", key = msgKey, limit = limit
+      trace "Add-provider request rejected",
+        reason = "perKeyLimit", keySize = msgKey.len, limit = limit
 
   if not atCap:
     for peer in validPeers:
@@ -491,7 +493,8 @@ proc dispatchGetProviders*(
   let msg = Message(msgType: Opt.some(MessageType.getProviders), key: Opt.some(key))
   let reply = ?await kad.dispatchRpc(peer, msg)
 
-  trace "Received reply for GetProviders", peer = peer, reply = reply
+  trace "Get-providers reply received",
+    peerId = peer, messageType = "getProviders", providerCount = reply.providerPeers.len
 
   ok(reply)
 
@@ -533,7 +536,8 @@ proc handleGetProviders*(
     kad: KadDHT, stream: Stream, msg: Message
 ) {.async: (raises: [CancelledError]).} =
   let msgKey = msg.key.valueOr:
-    trace "Key not set: handleGetProviders", msg = msg, stream = stream
+    trace "Get-providers request rejected",
+      reason = "missingKey", messageType = "getProviders", stream = stream
     return
 
   var providers =

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -424,20 +424,23 @@ proc sendAddProviderResponse(
   try:
     await stream.writeLp(response.encode(kad.config.hideConnectionStatus))
   except LPStreamError as exc:
-    trace "Failed to send add-provider response",
-      stream = stream, err = exc.msg, status = status
+    trace "Failed to send add-provider response", stream, err = exc.msg, status = status
 
 method handleAddProvider*(
     kad: KadDHT, stream: Stream, msg: Message
 ) {.base, async: (raises: [CancelledError]).} =
   let msgKey = msg.key.valueOr:
     trace "Add-provider request rejected",
-      reason = "missingKey", messageType = "addProvider", stream = stream
+      reason = "missingKey", messageType = "addProvider", stream
     return
 
   if msgKey.len == 0 or msgKey.len > MaxProviderKeyLen:
-    trace "ADD_PROVIDER key length out of bounds",
-      msg = msg, stream = stream, keyLen = msgKey.len, maxLen = MaxProviderKeyLen
+    trace "Add-provider request rejected",
+      reason = "invalidKeyLength",
+      stream,
+      messageType = "addProvider",
+      keySize = msgKey.len,
+      maxKeySize = MaxProviderKeyLen
     if kad.config.providerRejection:
       await stream.sendAddProviderResponse(kad, AddProviderStatus.rejected)
     return
@@ -537,7 +540,7 @@ proc handleGetProviders*(
 ) {.async: (raises: [CancelledError]).} =
   let msgKey = msg.key.valueOr:
     trace "Get-providers request rejected",
-      reason = "missingKey", messageType = "getProviders", stream = stream
+      reason = "missingKey", messageType = "getProviders", stream
     return
 
   var providers =
@@ -560,4 +563,4 @@ proc handleGetProviders*(
   try:
     await stream.writeLp(encoded)
   except LPStreamError as exc:
-    trace "Failed to send get-providers RPC reply", stream = stream, err = exc.msg
+    trace "Failed to send get-providers RPC reply", stream, err = exc.msg

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -424,7 +424,7 @@ proc sendAddProviderResponse(
   try:
     await stream.writeLp(response.encode(kad.config.hideConnectionStatus))
   except LPStreamError as exc:
-    trace "Failed to send add-provider response", stream, err = exc.msg, status = status
+    trace "Failed to send add-provider response", err = exc.msg, stream, status = status
 
 method handleAddProvider*(
     kad: KadDHT, stream: Stream, msg: Message
@@ -563,4 +563,4 @@ proc handleGetProviders*(
   try:
     await stream.writeLp(encoded)
   except LPStreamError as exc:
-    trace "Failed to send get-providers RPC reply", stream, err = exc.msg
+    trace "Failed to send get-providers RPC reply", err = exc.msg, stream

--- a/libp2p/protocols/kademlia/put.nim
+++ b/libp2p/protocols/kademlia/put.nim
@@ -45,7 +45,7 @@ proc manageExpiredRecords*(kad: KadDHT) {.async: (raises: [CancelledError]).} =
         toRemove.add(key)
     for key in toRemove:
       kad.dataTable.del(key)
-      trace "Expired record removed", key = key
+      trace "Expired record removed", keySize = key.len
 
 proc dispatchPutVal*(
     kad: KadDHT, peer: PeerId, key: Key, value: seq[byte]
@@ -57,11 +57,12 @@ proc dispatchPutVal*(
   )
   let reply = ?await kad.dispatchRpc(peer, msg)
 
-  trace "Got PutValue reply", msg = msg, reply = reply, peer = peer
+  trace "Put-value reply received",
+    peerId = peer, messageType = "putValue", replyType = $reply.msgType
 
   if reply != msg:
-    trace "Unexpected change between msg and reply: ",
-      msg = msg, reply = reply, peer = peer
+    trace "Put-value reply differed from request",
+      peerId = peer, messageType = "putValue", replyType = $reply.msgType
 
   ok()
 
@@ -106,19 +107,23 @@ proc handlePutValue*(
     kad: KadDHT, stream: Stream, msg: Message
 ) {.async: (raises: [CancelledError]).} =
   let record = msg.record.valueOr:
-    trace "No record in message buffer", msg = msg, stream = stream
+    trace "Put-value request rejected",
+      reason = "missingRecord", messageType = "putValue", stream = stream
     return
 
   let msgKey = msg.key.valueOr:
-    trace "Key not set: handlePutValue", msg = msg, stream = stream
+    trace "Put-value request rejected",
+      reason = "missingKey", messageType = "putValue", stream = stream
     return
 
   if record.key.isNone or record.key.get() != msgKey:
-    trace "Record key is different than Message key", msg = msg, stream = stream
+    trace "Put-value request rejected",
+      reason = "keyMismatch", messageType = "putValue", stream = stream
     return
 
   let value = record.value.valueOr:
-    trace "No value in record", msg = msg, stream = stream
+    trace "Put-value request rejected",
+      reason = "missingValue", messageType = "putValue", stream = stream
     return
 
   if value.len > kad.config.limits.maxValueSize:
@@ -131,7 +136,8 @@ proc handlePutValue*(
 
   # Value sanitisation done. Start insertion process
   if not kad.config.validator.isValid(msgKey, entryRecord):
-    trace "Record is not valid", msg = msg, entryRecord = entryRecord
+    trace "Put-value request rejected",
+      reason = "invalidRecord", messageType = "putValue", stream = stream
     return
 
   if not kad.isBestValue(msgKey, entryRecord):

--- a/libp2p/protocols/kademlia/put.nim
+++ b/libp2p/protocols/kademlia/put.nim
@@ -108,27 +108,27 @@ proc handlePutValue*(
 ) {.async: (raises: [CancelledError]).} =
   let record = msg.record.valueOr:
     trace "Put-value request rejected",
-      reason = "missingRecord", messageType = "putValue", stream = stream
+      reason = "missingRecord", messageType = "putValue", stream
     return
 
   let msgKey = msg.key.valueOr:
     trace "Put-value request rejected",
-      reason = "missingKey", messageType = "putValue", stream = stream
+      reason = "missingKey", messageType = "putValue", stream
     return
 
   if record.key.isNone or record.key.get() != msgKey:
     trace "Put-value request rejected",
-      reason = "keyMismatch", messageType = "putValue", stream = stream
+      reason = "keyMismatch", messageType = "putValue", stream
     return
 
   let value = record.value.valueOr:
     trace "Put-value request rejected",
-      reason = "missingValue", messageType = "putValue", stream = stream
+      reason = "missingValue", messageType = "putValue", stream
     return
 
   if value.len > kad.config.limits.maxValueSize:
     trace "PUT_VALUE dropped: value exceeds maxValueSize",
-      stream = stream, size = value.len, cap = kad.config.limits.maxValueSize
+      stream, size = value.len, cap = kad.config.limits.maxValueSize
     await stream.reset()
     return
 
@@ -137,7 +137,7 @@ proc handlePutValue*(
   # Value sanitisation done. Start insertion process
   if not kad.config.validator.isValid(msgKey, entryRecord):
     trace "Put-value request rejected",
-      reason = "invalidRecord", messageType = "putValue", stream = stream
+      reason = "invalidRecord", messageType = "putValue", stream
     return
 
   if not kad.isBestValue(msgKey, entryRecord):
@@ -146,8 +146,7 @@ proc handlePutValue*(
     return
 
   if not kad.canStoreLocalRecord(msgKey):
-    debug "PutValue: local record limit reached",
-      stream = stream, current = kad.dataTable.len
+    debug "PutValue: local record limit reached", stream, current = kad.dataTable.len
     await stream.reset()
     return
 
@@ -159,5 +158,5 @@ proc handlePutValue*(
   try:
     await stream.writeLp(encoded)
   except LPStreamError as exc:
-    trace "Failed to send find-node RPC reply", stream = stream, err = exc.msg
+    trace "Failed to send find-node RPC reply", stream, err = exc.msg
     return

--- a/libp2p/protocols/kademlia/put.nim
+++ b/libp2p/protocols/kademlia/put.nim
@@ -158,5 +158,5 @@ proc handlePutValue*(
   try:
     await stream.writeLp(encoded)
   except LPStreamError as exc:
-    trace "Failed to send find-node RPC reply", stream, err = exc.msg
+    trace "Failed to send find-node RPC reply", err = exc.msg, stream
     return

--- a/libp2p/protocols/kademlia/put.nim
+++ b/libp2p/protocols/kademlia/put.nim
@@ -45,7 +45,7 @@ proc manageExpiredRecords*(kad: KadDHT) {.async: (raises: [CancelledError]).} =
         toRemove.add(key)
     for key in toRemove:
       kad.dataTable.del(key)
-      trace "Expired record removed", keySize = key.len
+      trace "Expired record removed", key
 
 proc dispatchPutVal*(
     kad: KadDHT, peer: PeerId, key: Key, value: seq[byte]

--- a/libp2p/protocols/perf/server.nim
+++ b/libp2p/protocols/perf/server.nim
@@ -45,7 +45,7 @@ proc new*(T: typedesc[Perf]): T =
       trace "cancelled perf handler"
       raise exc
     except CatchableError as exc:
-      trace "exception in perf handler", description = exc.msg, stream
+      trace "exception in perf handler", err = exc.msg, stream
     finally:
       await stream.close()
 

--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -46,9 +46,9 @@ method init*(p: Ping) =
         if not isNil(p.pingHandler):
           await p.pingHandler(stream.peerId)
     except LPStreamEOFError as exc:
-      trace "ping stream closed", description = exc.msg, stream
+      trace "ping stream closed", err = exc.msg, stream
     except LPStreamError as exc:
-      trace "exception in ping handler", description = exc.msg, stream
+      trace "exception in ping handler", err = exc.msg, stream
 
   p.handler = handle
   p.codec = PingCodec

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -109,11 +109,13 @@ method rpcHandler*(
 ) {.async: (raises: [CancelledError, PeerMessageDecodeError, PeerRateLimitError]).} =
   let msgSize = data.len
   var rpcMsg = RPCMsg.decode(move(data)).valueOr:
-    trace "failed to decode msg from peer", peer, err = error
+    trace "PubSub RPC decode failed",
+      peerId = peer.peerId, err = error, messageType = "rpc", messageSize = msgSize
     f.chargeOverhead(peer, msgSize)
     raise newException(PeerMessageDecodeError, "Peer msg couldn't be decoded")
 
-  trace "decoded msg from peer", peer, rpcMsg = rpcMsg.shortLog
+  trace "PubSub RPC decoded",
+    peerId = peer.peerId, messageType = "rpc", messageSize = msgSize
   # trigger hooks
   peer.recvObservers(rpcMsg)
 
@@ -126,8 +128,7 @@ method rpcHandler*(
   for msg in rpcMsg.messages: # for every message
     let msgIdResult = f.msgIdProvider(msg)
     if msgIdResult.isErr:
-      trace "Dropping message due to failed message id generation",
-        error = msgIdResult.error
+      trace "Message dropped after ID generation failed", err = msgIdResult.error
       f.chargeOverhead(peer, msg.byteSize())
       continue
 
@@ -205,7 +206,7 @@ method publish*(
     data: sink seq[byte],
     publishParams: Opt[PublishParams] = Opt.none(PublishParams),
 ): Future[int] {.async: (raises: []).} =
-  trace "Publishing message on topic", data = data.shortLog, topic
+  trace "Publishing message", messageSize = data.len, topic
 
   if topic.len <= 0: # data could be 0/empty
     debug "Empty topic, skipping publish", topic
@@ -236,10 +237,15 @@ method publish*(
     return 0
 
   let msgId = f.msgIdProvider(msg).valueOr:
-    trace "Error generating message id, skipping publish", error = error
+    trace "Publish skipped after message ID generation failed", err = error
     return 0
 
-  trace "Created new message", message = shortLog(msg), peers = peers.len, topic, msgId
+  trace "Message created",
+    messageType = "publish",
+    messageSize = messageSize,
+    peerCount = peers.len,
+    topic,
+    msgId
 
   if f.addSeen(f.salt(msgId)):
     # custom msgid providers might cause this

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -110,7 +110,7 @@ method rpcHandler*(
   let msgSize = data.len
   var rpcMsg = RPCMsg.decode(move(data)).valueOr:
     trace "PubSub RPC decode failed",
-      peerId = peer.peerId, err = error, messageType = "rpc", messageSize = msgSize
+      err = error, peerId = peer.peerId, messageType = "rpc", messageSize = msgSize
     f.chargeOverhead(peer, msgSize)
     raise newException(PeerMessageDecodeError, "Peer msg couldn't be decoded")
 

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -630,7 +630,7 @@ proc validateAndRelay(
   except CancelledError:
     trace "validateAndRelay cancelled"
   except PeerRateLimitError as exc:
-    trace "validateAndRelay failed", description = exc.msg
+    trace "validateAndRelay failed", err = exc.msg
 
 proc dataAndTopicsIdSize(msgs: seq[Message]): int =
   msgs.mapIt(it.data.len + it.topic.len).foldl(a + b, 0)
@@ -699,7 +699,8 @@ method rpcHandler*(
 ) {.async: (raises: [CancelledError, PeerMessageDecodeError, PeerRateLimitError]).} =
   let msgSize = data.len
   var rpcMsg = RPCMsg.decode(move(data)).valueOr:
-    trace "failed to decode msg from peer", peer, err = error
+    trace "PubSub RPC decode failed",
+      peerId = peer.peerId, err = error, messageType = "rpc", messageSize = msgSize
     await rateLimit(g, peer, msgSize)
     # Raising in the handler closes the gossipsub connection (but doesn't
     # disconnect the peer!)
@@ -712,7 +713,8 @@ method rpcHandler*(
     for m in rpcMsg.messages:
       libp2p_pubsub_received_messages.inc(labelValues = [$peer.peerId, m.topic])
 
-  trace "decoded msg from peer", peer, rpcMsg = rpcMsg.shortLog
+  trace "PubSub RPC decoded",
+    peerId = peer.peerId, messageType = "rpc", messageSize = msgSize
   await rateLimit(g, peer, g.messageOverhead(rpcMsg, msgSize))
 
   # trigger hooks - these may modify the message
@@ -746,8 +748,7 @@ method rpcHandler*(
     let msgIdResult = g.msgIdProvider(msg)
 
     if msgIdResult.isErr:
-      trace "Dropping message due to failed message id generation",
-        error = msgIdResult.error
+      trace "Message dropped after ID generation failed", err = msgIdResult.error
       await g.punishInvalidMessage(peer, msg)
       continue
 
@@ -762,7 +763,8 @@ method rpcHandler*(
       continue
 
     if (msg.signature.len > 0 or g.verifySignature) and not msg.verify():
-      trace "Dropping message due to failed signature verification", msg = msg
+      trace "Message dropped",
+        peerId = peer.peerId, reason = "signatureVerificationFailed"
 
       await g.punishInvalidMessage(peer, msg)
       continue
@@ -950,7 +952,7 @@ method publish*(
 
   g.handleSelfPublishing(topic, data)
 
-  trace "Publishing message on topic", data = data.shortLog
+  trace "Publishing message", messageSize = data.len
 
   let pubParams = publishParams.get(PublishParams())
 
@@ -976,14 +978,15 @@ method publish*(
     return 0
 
   let msgId = g.msgIdProvider(msg).valueOr:
-    trace "Error generating message id, skipping publish", error = error
+    trace "Publish skipped after message ID generation failed", err = error
     libp2p_gossipsub_failed_publish.inc()
     return 0
 
   logScope:
     msgId = shortLog(msgId)
 
-  trace "Created new message", message = shortLog(msg), peers = peers.len
+  trace "Message created",
+    messageType = "publish", messageSize = messageSize, peerCount = peers.len
 
   if g.addSeen(g.salt(msgId)):
     # If the message was received or published recently, don't re-publish it -
@@ -1034,7 +1037,7 @@ proc maintainDirectPeer(
     g: GossipSub, id: PeerId, addrs: seq[MultiAddress]
 ) {.async: (raises: [CancelledError]).} =
   if id notin g.peers:
-    trace "Attempting to dial a direct peer", peer = id
+    trace "Attempting to dial a direct peer", peerId = id
     if g.switch.isConnected(id):
       warn "We are connected to a direct peer, but it isn't a GossipSub peer!", id
       return
@@ -1046,7 +1049,7 @@ proc maintainDirectPeer(
       trace "Direct peer dial canceled"
       raise exc
     except DialFailedError as exc:
-      trace "Direct peer error dialing", description = exc.msg
+      trace "Direct peer error dialing", err = exc.msg
 
 proc addDirectPeer*(
     g: GossipSub, id: PeerId, addrs: seq[MultiAddress]

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -700,7 +700,7 @@ method rpcHandler*(
   let msgSize = data.len
   var rpcMsg = RPCMsg.decode(move(data)).valueOr:
     trace "PubSub RPC decode failed",
-      peerId = peer.peerId, err = error, messageType = "rpc", messageSize = msgSize
+      err = error, peerId = peer.peerId, messageType = "rpc", messageSize = msgSize
     await rateLimit(g, peer, msgSize)
     # Raising in the handler closes the gossipsub connection (but doesn't
     # disconnect the peer!)

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -73,7 +73,7 @@ proc grafted*(g: GossipSub, p: PubSubPeer, topic: string) =
 
     stats.topicInfos[topic] = info
 
-    trace "grafted", peer = p, topic
+    trace "grafted", peerId = p, topic
 
 proc pruned*(
     g: GossipSub,
@@ -101,7 +101,7 @@ proc pruned*(
 
       info.inMesh = false
 
-      trace "pruned", peer = p, topic
+      trace "pruned", peerId = p, topic
 
 proc handleBackingOff*(t: var BackoffTable, topic: string) =
   let now = Moment.now()

--- a/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
@@ -233,7 +233,7 @@ proc unionWithSentPartsMetadata(
       ext.config.unionPartsMetadata(peerState.sentPartsMetadata.get(), newMetadata)
     if unionRes.isErr():
       # union failed, it is safe to use the most recent parts metadata
-      debug "failed to create union from the two parts metadata", msg = unionRes.error
+      debug "Parts metadata union failed", reason = unionRes.error
       hasChanged = true
       peerState.sentPartsMetadata = Opt.some(newMetadata)
     elif unionRes.get() != peerState.sentPartsMetadata.get():
@@ -363,7 +363,7 @@ proc handlePartialRPC(
 
   let validateRes = ext.config.validateRPC(rpc)
   if validateRes.isErr():
-    debug "RPC did not pass application validation", msg = validateRes.error
+    debug "RPC rejected by application validation", reason = validateRes.error
     return
 
   ext.recordReceivedMetadata(peerId, rpc)

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -150,7 +150,7 @@ proc updateScores*(g: GossipSub) = # avoid async
     if isNil(peer) or not (peer.connected):
       if now > stats.expire:
         evicting.add(peerId)
-        trace "evicted peer from memory", peer = peerId
+        trace "evicted peer from memory", peerId = peerId
       continue
 
     trace "updating peer score", peer

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -186,7 +186,8 @@ proc updateScores*(g: GossipSub) = # avoid async
 
         topicScore +=
           info.firstMessageDeliveries * topicParams.firstMessageDeliveriesWeight
-        trace "p2", peer, p2 = info.firstMessageDeliveries, topic, topicScore
+        trace "Score component two",
+          peer, scoreComponent = info.firstMessageDeliveries, topic, topicScore
 
         if info.meshMessageDeliveriesActive:
           if info.meshMessageDeliveries < topicParams.meshMessageDeliveriesThreshold:
@@ -202,9 +203,9 @@ proc updateScores*(g: GossipSub) = # avoid async
         topicScore +=
           info.invalidMessageDeliveries * info.invalidMessageDeliveries *
           topicParams.invalidMessageDeliveriesWeight
-        trace "p4",
+        trace "Score component four",
           peer,
-          p4 = info.invalidMessageDeliveries * info.invalidMessageDeliveries,
+          scoreComponent = info.invalidMessageDeliveries * info.invalidMessageDeliveries,
           topic,
           topicScore
 

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -420,7 +420,7 @@ method getOrCreatePeer*(
     try:
       await p.rpcHandler(peer, move(data))
     except PeerMessageDecodeError as e:
-      trace "failed to decode message in peerHandler", description = e.msg, peer = peer
+      trace "failed to decode message in peerHandler", err = e.msg, peerId = peer
       # loop continues and invalid messages are swallowed
 
   # create new pubsub peer
@@ -496,7 +496,7 @@ proc handleData*(
         for fut in futs:
           if fut.failed:
             let err = fut.error()
-            warn "Error in topic handler", description = err.msg
+            warn "Error in topic handler", err = err.msg
 
       return waiter()
 

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -330,12 +330,12 @@ proc sendObservers(p: PubSubPeer, msg: var RPCMsg) =
 proc runHandleLoop*(
     p: PubSubPeer, stream: Stream
 ) {.async: (raises: [CancelledError]).} =
-  trace "starting pubsub read loop", stream, peer = p, closed = stream.closed
+  trace "starting pubsub read loop", stream, peerId = p, closed = stream.closed
   defer:
-    trace "exiting pubsub read loop", stream, peer = p, closed = stream.closed
+    trace "exiting pubsub read loop", stream, peerId = p, closed = stream.closed
 
   while not stream.atEof:
-    trace "waiting for data", stream, peer = p, closed = stream.closed
+    trace "waiting for data", stream, peerId = p, closed = stream.closed
 
     var data =
       try:
@@ -344,21 +344,20 @@ proc runHandleLoop*(
         return
       except LPStreamError as e:
         trace "Exception occurred reading message PubSubPeer.handle",
-          stream, peer = p, closed = stream.closed, description = e.msg
+          stream, peer = p, closed = stream.closed, err = e.msg
         return
 
     trace "read data from peer",
       stream, peer = p, closed = stream.closed, data = data.shortLog
 
     if p.handler.isNil:
-      trace "Ignoring pubsub message without handler", stream, peer = p
+      trace "Ignoring pubsub message without handler", stream, peerId = p
       continue
 
     try:
       await p.handler(p, move(data))
     except PeerRateLimitError as e:
-      trace "peer rate limit exceeded in peerHandler",
-        description = e.msg, stream, peer = p
+      trace "peer rate limit exceeded in peerHandler", err = e.msg, stream, peer = p
       await stream.closeWithEOF()
       return
 
@@ -433,9 +432,9 @@ proc connectImpl(p: PubSubPeer) {.async: (raises: []).} =
         return
       await connectOnce(p)
   except CancelledError as exc:
-    trace "Could not establish send stream", description = exc.msg
+    trace "Could not establish send stream", err = exc.msg
   except GetStreamDialError as exc:
-    trace "Could not establish send stream", description = exc.msg
+    trace "Could not establish send stream", err = exc.msg
 
 proc connect*(p: PubSubPeer) =
   if p.connected:
@@ -483,10 +482,10 @@ proc sendMsgContinue(
     await msgFut
     trace "sent pubsub message to remote", stream
   except CancelledError as exc:
-    trace "sendMsgContinue cancelled", stream, description = exc.msg
+    trace "sendMsgContinue cancelled", stream, err = exc.msg
     raise exc
   except LPStreamError as exc:
-    trace "Unexpected exception in sendMsgContinue", stream, description = exc.msg
+    trace "Unexpected exception in sendMsgContinue", stream, err = exc.msg
     # Next time sendStream is used, it will be have its close flag set and thus
     # will be recycled
     await stream.close() # This will clean up the send stream
@@ -684,7 +683,8 @@ proc send*(
     warn "message exceeds maximum message size; message will not be sent",
       encodedSize = encoded.len, maxMessageSize = p.maxMessageSize
 
-  trace "sending msg to peer", peer = p, rpcMsg = shortLog(msg)
+  trace "Sending PubSub RPC",
+    peerId = p.peerId, messageType = "rpc", messageSize = encoded.len
   p.trackSend(p.sendEncoded(move(encoded), priority, useCustomStream))
 
 proc sendResponse*(
@@ -706,7 +706,8 @@ proc sendResponse*(
 
   proc send(toSendMsg: RPCMsg) =
     var encoded = encodeRpcMsg(p, toSendMsg, anonymize)
-    trace "sending response msg to peer", peer = p, rpcMsg = shortLog(toSendMsg)
+    trace "Sending PubSub RPC response",
+      peerId = p.peerId, messageType = "rpc", messageSize = encoded.len
     p.trackSend(p.sendEncoded(move(encoded), priority, useCustomStream))
 
   template wireSize(toSizeMsg: RPCMsg): int =

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -533,7 +533,7 @@ proc sendMsg(
 
   if not slowPath:
     trace "sending encoded msg to peer",
-      streamType = $streamType, stream = stream, encoded = shortLog(msg)
+      streamType = $streamType, stream, encoded = shortLog(msg)
     let f = stream.writeLp(msg)
     await sendMsgContinue(stream, f)
   else:

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -482,10 +482,10 @@ proc sendMsgContinue(
     await msgFut
     trace "sent pubsub message to remote", stream
   except CancelledError as exc:
-    trace "sendMsgContinue cancelled", stream, err = exc.msg
+    trace "sendMsgContinue cancelled", err = exc.msg, stream
     raise exc
   except LPStreamError as exc:
-    trace "Unexpected exception in sendMsgContinue", stream, err = exc.msg
+    trace "Unexpected exception in sendMsgContinue", err = exc.msg, stream
     # Next time sendStream is used, it will be have its close flag set and thus
     # will be recycled
     await stream.close() # This will clean up the send stream

--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -301,7 +301,7 @@ proc advertisePeer[E](
       let
         buf = await stream.readLp(4096)
         msgRecv = Message.decode(buf).valueOr:
-          trace "failed to decode Message", error = error
+          trace "failed to decode Message", err = error
           return
       if msgRecv.msgType != MessageType.RegisterResponse:
         trace "Unexpected register response", peer, msgType = msgRecv.msgType
@@ -312,7 +312,7 @@ proc advertisePeer[E](
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "exception in the advertise", description = exc.msg
+      trace "exception in the advertise", err = exc.msg
     finally:
       try:
         rdv.sema.release()
@@ -332,7 +332,7 @@ proc advertise*[E](
   let signedPeerRecord = SignedPayload[E].init(
     rdv.switch.peerInfo.privateKey, customPeerRecord
   ).valueOr:
-    info "Can't create the signed peer record", error = error
+    info "Can't create the signed peer record", err = error
     return
 
   let pBuff = signedPeerRecord.encode()
@@ -412,7 +412,7 @@ proc requestPeer[E](
   let
     buf = await stream.readLp(MaximumMessageLen)
     msgRcv = Message.decode(buf).valueOr:
-      trace "Message undecodable", error = error
+      trace "Message undecodable", err = error
       return @[]
   if msgRcv.msgType != MessageType.DiscoverResponse:
     trace "Unexpected discover response", msgType = msgRcv.msgType
@@ -485,9 +485,9 @@ proc request*[E](
     except CancelledError as e:
       raise e
     except DialFailedError as e:
-      trace "failed to dial a peer", description = e.msg
+      trace "failed to dial a peer", err = e.msg
     except LPStreamError as e:
-      trace "failed to communicate with a peer", description = e.msg
+      trace "failed to communicate with a peer", err = e.msg
   return toSeq(s.values()).mapIt(it[0])
 
 proc unsubscribeLocally*[E](rdv: GenericRendezVous[E], ns: string) =
@@ -518,7 +518,7 @@ proc unsubscribe*[E](
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "exception while unsubscribing", description = exc.msg
+      trace "exception while unsubscribing", err = exc.msg
 
   let futs = collect(newSeq()):
     for peer in peerIds:
@@ -568,7 +568,7 @@ proc new*(
       let
         buf = await stream.readLp(4096)
         msg = Message.decode(buf).valueOr:
-          trace "failed to decode Message", error = error
+          trace "failed to decode Message", err = error
           return
       case msg.msgType
       of MessageType.Register:
@@ -587,7 +587,7 @@ proc new*(
       trace "cancelled rendezvous handler"
       raise exc
     except CatchableError as exc:
-      trace "exception in rendezvous handler", description = exc.msg
+      trace "exception in rendezvous handler", err = exc.msg
     finally:
       await stream.close()
 

--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -204,7 +204,7 @@ proc save*[E](
 proc register*[E](
     rdv: GenericRendezVous[E], stream: Stream, r: Register, peerRecord: E
 ): Future[void] =
-  trace "Received Register", peerId = stream.peerId, ns = r.ns
+  trace "Register received", peerId = stream.peerId, namespace = r.ns
   libp2p_rendezvous_register.inc()
   if r.ns.len < MinimumNamespaceLen or r.ns.len > MaximumNamespaceLen:
     return stream.sendRegisterResponseError(InvalidNamespace)
@@ -223,7 +223,7 @@ proc register*[E](
   stream.sendRegisterResponse(ttl)
 
 proc unregister*[E](rdv: GenericRendezVous[E], stream: Stream, u: Unregister) =
-  trace "Received Unregister", peerId = stream.peerId, ns = u.ns
+  trace "Unregister received", peerId = stream.peerId, namespace = u.ns
   let nsSalted = u.ns & rdv.salt
   try:
     for index in rdv.namespaces[nsSalted]:
@@ -236,7 +236,7 @@ proc unregister*[E](rdv: GenericRendezVous[E], stream: Stream, u: Unregister) =
 proc discover*[E](
     rdv: GenericRendezVous[E], stream: Stream, d: Discover
 ) {.async: (raises: [CancelledError, LPStreamError]).} =
-  trace "Received Discover", peerId = stream.peerId, ns = d.ns
+  trace "Discover received", peerId = stream.peerId, namespace = d.ns
   libp2p_rendezvous_discover.inc()
   if d.ns.isSome() and d.ns.get().len > MaximumNamespaceLen:
     await stream.sendDiscoverResponseError(InvalidNamespace)

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -594,7 +594,7 @@ method handshake*(
     finally:
       burnMem(handshakeRes)
 
-  trace "Noise handshake completed!", initiator, peer = shortLog(secure.peerId)
+  trace "Noise handshake completed!", initiator, peerId = shortLog(secure.peerId)
 
   conn.timeout = timeout
 

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -162,7 +162,7 @@ method init*(s: Secure) =
       trace "securing connection canceled", stream
       raise exc
     except LPStreamError as exc:
-      trace "securing connection failed", description = exc.msg, stream
+      trace "securing connection failed", err = exc.msg, stream
     finally:
       await stream.close()
 
@@ -195,8 +195,8 @@ method readOnce*(
     except CancelledError as exc:
       raise exc
     except LPStreamError as err:
-      debug "Error while reading message from secure connection, closing.",
-        error = err.name, message = err.msg, connection = s
+      debug "Secure connection message read failed",
+        err = err.msg, errType = err.name, connection = s
       await s.close()
       raise newException(LPStreamError, "Secure connection read error: " & err.msg, err)
 

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -131,7 +131,7 @@ proc new*(
         except LPStreamEOFError:
           return
         except LPStreamError as exc:
-          trace "Read error when handling service-discovery RPC", stream, err = exc.msg
+          trace "Read error when handling service-discovery RPC", err = exc.msg, stream
           return
       let msg = Message.decode(buf).valueOr:
         trace "Failed to decode message", err = error

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -131,8 +131,7 @@ proc new*(
         except LPStreamEOFError:
           return
         except LPStreamError as exc:
-          trace "Read error when handling service-discovery RPC",
-            stream = stream, err = exc.msg
+          trace "Read error when handling service-discovery RPC", stream, err = exc.msg
           return
       let msg = Message.decode(buf).valueOr:
         trace "Failed to decode message", err = error

--- a/libp2p/protocols/service_discovery/connection.nim
+++ b/libp2p/protocols/service_discovery/connection.nim
@@ -89,4 +89,4 @@ proc handleMessage*(
   let writeRes = catch:
     await stream.writeLp(bytes)
   if writeRes.isErr:
-    trace "failed to send message response", error = writeRes.error.msg
+    trace "failed to send message response", err = writeRes.error.msg

--- a/libp2p/protocols/service_discovery/random_find.nim
+++ b/libp2p/protocols/service_discovery/random_find.nim
@@ -50,7 +50,7 @@ proc randomRecords(
         raise e
 
     let reply = res.valueOr:
-      trace "kad getValue failed", error = error
+      trace "Kademlia get-value failed", err = error
       continue
 
     let record = reply.record.valueOr:

--- a/libp2p/services/hpservice.nim
+++ b/libp2p/services/hpservice.nim
@@ -69,7 +69,7 @@ proc tryStartingDirectConn(
     except CancelledError as err:
       raise err
     except CatchableError as err:
-      debug "Failed to create direct connection.", description = err.msg
+      debug "Failed to create direct connection.", err = err.msg
       continue
   return false
 
@@ -101,7 +101,7 @@ proc newConnectedPeerHandler(
   except CancelledError as err:
     raise err
   except CatchableError as err:
-    debug "Hole punching failed during dcutr", description = err.msg
+    debug "Hole punching failed during dcutr", err = err.msg
 
 proc reachabilityObservers*(self: HPService): ReachabilityObservers =
   ## The observers of the AutoNAT v1 service that drives hole punching.

--- a/libp2p/services/identify_pusher.nim
+++ b/libp2p/services/identify_pusher.nim
@@ -86,12 +86,11 @@ proc sendOne(p: IdentifyPusher, peerId: PeerId) {.async: (raises: [CancelledErro
   except CancelledError as e:
     raise e
   except MuxerError as e:
-    trace "failed to open stream for identify push", peerId, description = e.msg
+    trace "failed to open stream for identify push", peerId, err = e.msg
   except MultiStreamError as e:
-    trace "multistream negotiation failed for identify push",
-      peerId, description = e.msg
+    trace "multistream negotiation failed for identify push", peerId, err = e.msg
   except LPStreamError as e:
-    trace "stream error during identify push", peerId, description = e.msg
+    trace "stream error during identify push", peerId, err = e.msg
   finally:
     if not stream.isNil:
       if pushCompleted:

--- a/libp2p/services/identify_pusher.nim
+++ b/libp2p/services/identify_pusher.nim
@@ -86,11 +86,11 @@ proc sendOne(p: IdentifyPusher, peerId: PeerId) {.async: (raises: [CancelledErro
   except CancelledError as e:
     raise e
   except MuxerError as e:
-    trace "failed to open stream for identify push", peerId, err = e.msg
+    trace "failed to open stream for identify push", err = e.msg, peerId
   except MultiStreamError as e:
-    trace "multistream negotiation failed for identify push", peerId, err = e.msg
+    trace "multistream negotiation failed for identify push", err = e.msg, peerId
   except LPStreamError as e:
-    trace "stream error during identify push", peerId, err = e.msg
+    trace "stream error during identify push", err = e.msg, peerId
   finally:
     if not stream.isNil:
       if pushCompleted:

--- a/libp2p/services/natservice.nim
+++ b/libp2p/services/natservice.nim
@@ -315,7 +315,7 @@ proc mapOnePort(
 ): Future[Opt[MappedEntry]] {.async: (raises: [CancelledError]).} =
   # libplum returns the external address with the mapping; no separate discovery.
   let mapped = (await self.mapper.map(lp.port, lp.port, lp.proto)).valueOr:
-    warn "NAT port mapping failed", port = lp.port, proto = lp.proto, err = error
+    warn "NAT port mapping failed", port = lp.port, protocol = lp.proto, err = error
     return Opt.none(MappedEntry)
 
   Opt.some(

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -339,6 +339,6 @@ proc closeWithEOF*(s: LPStream): Future[void] {.async: (raises: []).} =
   except CancelledError:
     discard
   except LPStreamEOFError as e:
-    trace "Expected EOF came", s, description = e.msg
+    trace "Expected EOF came", s, err = e.msg
   except LPStreamError as exc:
-    debug "Unexpected error while waiting for EOF", s, description = exc.msg
+    debug "Unexpected error while waiting for EOF", s, err = exc.msg

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -339,6 +339,6 @@ proc closeWithEOF*(s: LPStream): Future[void] {.async: (raises: []).} =
   except CancelledError:
     discard
   except LPStreamEOFError as e:
-    trace "Expected EOF came", s, err = e.msg
+    trace "Expected EOF came", err = e.msg, s
   except LPStreamError as exc:
-    debug "Unexpected error while waiting for EOF", s, err = exc.msg
+    debug "Unexpected error while waiting for EOF", err = exc.msg, s

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -272,7 +272,7 @@ proc upgradeMonitor(
     trace "Connection upgrade timeout", conn
     libp2p_failed_upgrades_incoming.inc()
   except UpgradeError as e:
-    trace "Connection upgrade failed", description = e.msg, conn
+    trace "Connection upgrade failed", err = e.msg, conn
     libp2p_failed_upgrades_incoming.inc()
   finally:
     deadlineFut.cancelSoon()
@@ -329,7 +329,7 @@ proc accept(s: Switch, transport: Transport) {.async: (raises: []).} =
     except CancelledError:
       return
     except CatchableError as exc:
-      error "Exception in accept loop, exiting", description = exc.msg
+      error "Accept loop stopped", err = exc.msg, errType = exc.name
       if not isNil(conn):
         await conn.close()
       return
@@ -352,7 +352,7 @@ proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    debug "Cannot cancel accepts", description = exc.msg
+    debug "Cannot cancel accepts", err = exc.msg
 
   await s.upgradeFuts.cancelAndWait()
   s.upgradeFuts = @[]
@@ -372,7 +372,7 @@ proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      warn "error cleaning up transports", description = exc.msg
+      warn "error cleaning up transports", err = exc.msg
 
   await s.ms.stop()
 
@@ -429,4 +429,4 @@ proc start*(s: Switch) {.async: (raises: [CancelledError, LPError]).} =
 
   s.peerStore.startAddressPruning()
 
-  info "Started libp2p node", peer = s.peerInfo
+  info "Started libp2p node", peerId = s.peerInfo

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -275,7 +275,7 @@ method handle*(m: QuicMuxer): Future[void] {.async: (raises: []).} =
     except ConnectionError as e:
       # keep handling, until connection is closed. 
       # this stream failed but we need to keep handling for other streams.
-      trace "QuicMuxer.handler got error while opening stream", msg = e.msg
+      trace "QuicMuxer.handler got error while opening stream", err = e.msg
 
   if not m.session.isClosed:
     await m.session.close()
@@ -332,7 +332,7 @@ proc parseCertificate(certificatesDer: seq[seq[byte]]): Opt[P2pCertificate] =
     try:
       parse(certificatesDer[0])
     except CertificateParsingError as e:
-      trace "CertificateVerifier: failed to parse certificate", msg = e.msg
+      trace "CertificateVerifier: failed to parse certificate", err = e.msg
       return Opt.none(P2pCertificate)
 
   Opt.some(cert)
@@ -572,13 +572,13 @@ method accept*(
     let conn = await finished
     return self.wrapConnection(conn, Direction.In)
   except QuicError as exc:
-    debug "Quic Error", description = exc.msg
+    debug "Quic Error", err = exc.msg
     raise (ref QuicTransportError)(msg: "QUIC accept failed: " & exc.msg, parent: exc)
   except common.TransportError as exc:
-    debug "Transport Error", description = exc.msg
+    debug "Transport Error", err = exc.msg
     raise newTransportClosedError(exc)
   except TransportOsError as exc:
-    debug "OS Error", description = exc.msg
+    debug "OS Error", err = exc.msg
     raise
       (ref QuicTransportError)(msg: "QUIC OS accept failed: " & exc.msg, parent: exc)
 
@@ -694,7 +694,7 @@ method upgrade*(
     except CancelledError:
       return
     except CatchableError as exc:
-      trace "exception in stream handler", stream, msg = exc.msg
+      trace "exception in stream handler", stream, err = exc.msg
     finally:
       await stream.closeWithEOF()
       trace "Stream handler done", stream

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -694,7 +694,7 @@ method upgrade*(
     except CancelledError:
       return
     except CatchableError as exc:
-      trace "exception in stream handler", stream, err = exc.msg
+      trace "exception in stream handler", err = exc.msg, stream
     finally:
       await stream.closeWithEOF()
       trace "Stream handler done", stream

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -63,7 +63,7 @@ proc connHandler*(
   proc onClose() {.async: (raises: []).} =
     await noCancel client.join()
 
-    trace "Cleaning up client", addrs = $client.remoteAddress, conn
+    trace "Cleaning up client", addresses = $client.remoteAddress, conn
 
     self.clients[dir].keepItIf(it != client)
 
@@ -76,7 +76,7 @@ proc connHandler*(
 
     await conn.close()
 
-    trace "Cleaned up client", addrs = $client.remoteAddress, conn
+    trace "Cleaned up client", addresses = $client.remoteAddress, conn
 
   self.clients[dir].add(client)
 
@@ -241,10 +241,10 @@ method accept*(
     try:
       await finished
     except TransportTooManyError as exc:
-      debug "Too many files opened", description = exc.msg
+      debug "Too many files opened", err = exc.msg
       return nil
     except TransportAbortedError as exc:
-      debug "Connection aborted", description = exc.msg
+      debug "Connection aborted", err = exc.msg
       return nil
     except TransportUseClosedError as exc:
       raise newTransportClosedError(exc)
@@ -277,7 +277,7 @@ method accept*(
     except TransportOsError as exc:
       # The connection had errors / was closed before `await` returned control
       safeCloseWait(transp)
-      debug "Cannot read address", description = exc.msg
+      debug "Cannot read address", err = exc.msg
       return nil
   self.connHandler(transp, Opt.some(observedAddr), Opt.some(localAddr), Direction.In)
 

--- a/libp2p/transports/transport.nim
+++ b/libp2p/transports/transport.nim
@@ -112,14 +112,14 @@ template safeCloseWait*(stream: untyped) =
     try:
       await noCancel stream.closeWait()
     except CatchableError as e:
-      trace "Error closing", description = e.msg
+      trace "Error closing", err = e.msg
 
 template safeClose*(stream: untyped) =
   if not isNil(stream):
     try:
       await noCancel stream.close()
     except CatchableError as e:
-      trace "Error closing", description = e.msg
+      trace "Error closing", err = e.msg
 
 proc toTransportAddress*(
     self: Transport, addrsMa: seq[MultiAddress]

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -185,13 +185,13 @@ proc releaseAcceptSlot(self: WsTransport) {.raises: [].} =
   try:
     self.acceptSem.release()
   except AsyncSemaphoreError as e:
-    trace "Error releasing WS accept semaphore", description = e.msg
+    trace "Error releasing WS accept semaphore", err = e.msg
 
 proc closeHttpStream(stream: AsyncStream) {.async: (raises: []).} =
   try:
     await noCancel stream.closeWait()
   except CatchableError as e:
-    trace "Error closing HTTP stream", description = e.msg
+    trace "Error closing HTTP stream", err = e.msg
 
 proc connHandler(
   self: WsTransport, stream: WSSession, secure: bool, dir: Direction
@@ -216,19 +216,19 @@ proc wsHandshakeWorker(
     await self.acceptResults.addLast(conn)
     accepted = true
   except WebSocketError as e:
-    debug "Websocket Error", description = e.msg
+    debug "Websocket Error", err = e.msg
   except HttpError as e:
-    debug "Http Error", description = e.msg
+    debug "Http Error", err = e.msg
   except AsyncStreamError as e:
-    debug "AsyncStream Error", description = e.msg
+    debug "AsyncStream Error", err = e.msg
   except AsyncTimeoutError as e:
-    debug "Timed out", description = e.msg
+    debug "Timed out", err = e.msg
   except CancelledError as e:
     if not accepted:
       await noCancel closeHttpStream(stream)
     raise e
   except CatchableError as e:
-    debug "Unexpected error accepting websocket connection", description = e.msg
+    debug "Unexpected error accepting websocket connection", err = e.msg
 
   if not accepted:
     await closeHttpStream(stream)
@@ -268,15 +268,15 @@ proc wsAcceptDispatcher(self: WsTransport) {.async: (raises: []).} =
         elif finished.failed():
           let exc = finished.error()
           if exc of TransportUseClosedError:
-            debug "Server was closed", description = exc.msg
+            debug "Server was closed", err = exc.msg
           elif exc of TransportTooManyError:
-            debug "Too many files opened", description = exc.msg
+            debug "Too many files opened", err = exc.msg
           elif exc of TransportAbortedError:
-            debug "Connection aborted", description = exc.msg
+            debug "Connection aborted", err = exc.msg
           elif exc of TransportOsError:
-            debug "OS Error", description = exc.msg
+            debug "OS Error", err = exc.msg
           else:
-            debug "Unexpected error accepting websocket stream", description = exc.msg
+            debug "Unexpected error accepting websocket stream", err = exc.msg
 
           if acquired:
             self.releaseAcceptSlot()
@@ -301,7 +301,7 @@ proc wsAcceptDispatcher(self: WsTransport) {.async: (raises: []).} =
         if acquired:
           self.releaseAcceptSlot()
         if self.running:
-          debug "Unexpected error in websocket accept dispatcher", description = e.msg
+          debug "Unexpected error in websocket accept dispatcher", err = e.msg
         else:
           break
   finally:
@@ -312,7 +312,7 @@ proc wsAcceptDispatcher(self: WsTransport) {.async: (raises: []).} =
         try:
           await closeHttpStream(fut.read())
         except CatchableError as e:
-          trace "Error reading completed WS accept stream", description = e.msg
+          trace "Error reading completed WS accept stream", err = e.msg
 
     if notifyOnClose:
       var toWait: seq[Future[void]]
@@ -324,7 +324,7 @@ proc wsAcceptDispatcher(self: WsTransport) {.async: (raises: []).} =
         try:
           await noCancel allFutures(toWait)
         except CatchableError as e:
-          trace "Error stopping WS handshake workers", description = e.msg
+          trace "Error stopping WS handshake workers", err = e.msg
 
       self.notifyAcceptClosed()
 
@@ -448,7 +448,7 @@ method stop*(self: WsTransport) {.async: (raises: []).} =
     self.acceptLoop = nil
     info "Transport stopped"
   except CatchableError as e:
-    trace "Error shutting down ws transport", description = e.msg
+    trace "Error shutting down ws transport", err = e.msg
   finally:
     self.notifyAcceptClosed()
 
@@ -473,7 +473,7 @@ proc connHandler(
         MultiAddress.init(localAddr).tryGet() & codec.tryGet(),
       )
     except CatchableError as e:
-      trace "Failed to create observedAddr or listenAddr", description = e.msg
+      trace "Failed to create observedAddr or listenAddr", err = e.msg
       if not (isNil(stream) and stream.stream.reader.closed):
         safeClose(stream)
       raise e

--- a/libp2p/utils/ipaddr.nim
+++ b/libp2p/utils/ipaddr.nim
@@ -41,12 +41,12 @@ proc primaryIPAddrTo(probe: IpAddress): Opt[IpAddress] {.raises: [].} =
   try:
     Opt.some(getPrimaryIPAddr(probe))
   except CatchableError as e:
-    debug "Unable to get primary ip address", probe, description = e.msg
+    debug "Unable to get primary ip address", probe, err = e.msg
     Opt.none(IpAddress)
   except Defect as e:
     raise e
   except Exception as e: # on windows getPrimaryIPAddr has untracked effects
-    debug "Unable to get primary ip address", probe, description = e.msg
+    debug "Unable to get primary ip address", probe, err = e.msg
     Opt.none(IpAddress)
 
 func firstGlobalIP*(candidates: openArray[IpAddress]): Opt[IpAddress] =

--- a/tools/audit_log_fields.py
+++ b/tools/audit_log_fields.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Reject deprecated Chronicle error fields and unsafe elevated payload logs."""
+
+from pathlib import Path
+import re
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+LOG_START = re.compile(r"^(\s*)(trace|debug|info|notice|warn|error|fatal)\s+\"")
+EXCEPTION_ALIAS = re.compile(
+    r"\b(?:description|error|message|msg)\s*=\s*"
+    r"(?:getCurrentExceptionMsg\(\)|[A-Za-z_][\w.]*\.msg)"
+)
+PAYLOAD_FIELD = re.compile(
+    r"\b(?:msg|message|buffer|record|reply|response|rpcMsg|data|encoded|"
+    r"certificate|ticket|key)\s*="
+)
+
+
+def log_blocks(path: Path):
+    lines = path.read_text().splitlines()
+    line = 0
+    while line < len(lines):
+        match = LOG_START.match(lines[line])
+        if not match:
+            line += 1
+            continue
+        indent = len(match.group(1).expandtabs(2))
+        end = line + 1
+        while end < len(lines):
+            text = lines[end]
+            if not text.strip():
+                end += 1
+                continue
+            if len(text) - len(text.lstrip(" \t")) <= indent:
+                break
+            end += 1
+        yield line + 1, match.group(2), "\n".join(lines[line:end])
+        line = end
+
+
+def main() -> int:
+    violations = []
+    for path in ROOT.joinpath("libp2p").rglob("*.nim"):
+        for line, level, block in log_blocks(path):
+            if EXCEPTION_ALIAS.search(block):
+                violations.append(
+                    f"{path.relative_to(ROOT)}:{line}: use err for exception text"
+                )
+            if level in {"warn", "error"} and PAYLOAD_FIELD.search(block):
+                violations.append(
+                    f"{path.relative_to(ROOT)}:{line}: elevated log contains payload field"
+                )
+    if violations:
+        print("\n".join(violations), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/audit_log_fields.py
+++ b/tools/audit_log_fields.py
@@ -60,7 +60,7 @@ def main() -> int:
             for field_name in FIELD_ASSIGNMENT.findall(block):
                 if len(field_name) < 3 and field_name not in SHORT_FIELD_EXCEPTIONS:
                     violations.append(
-                        f"{path.relative_to(ROOT)}:{line}: field '{field_name}' is too short"
+                        f"{path.relative_to(ROOT)}:{line}: field '{field_name}' is too short (needs to be at least 3 characters long)"
                     )
     if violations:
         print("\n".join(violations), file=sys.stderr)

--- a/tools/audit_log_fields.py
+++ b/tools/audit_log_fields.py
@@ -15,6 +15,12 @@ PAYLOAD_FIELD = re.compile(
     r"\b(?:msg|message|buffer|record|reply|response|rpcMsg|data|encoded|"
     r"certificate|ticket|key)\s*="
 )
+FIELD_ASSIGNMENT = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*=")
+
+# These established identifiers are clearer than a longer expansion in their
+# logging contexts. Every other structured field name must be at least three
+# characters long.
+SHORT_FIELD_EXCEPTIONS = {"id", "ip"}
 
 
 def log_blocks(path: Path):
@@ -51,6 +57,11 @@ def main() -> int:
                 violations.append(
                     f"{path.relative_to(ROOT)}:{line}: elevated log contains payload field"
                 )
+            for field_name in FIELD_ASSIGNMENT.findall(block):
+                if len(field_name) < 3 and field_name not in SHORT_FIELD_EXCEPTIONS:
+                    violations.append(
+                        f"{path.relative_to(ROOT)}:{line}: field '{field_name}' is too short"
+                    )
     if violations:
         print("\n".join(violations), file=sys.stderr)
         return 1


### PR DESCRIPTION
this pr is standardizing log fileds:
- log filed names should be at least 3 characters (exceptions`ip`, `id`, ..); single letter field name should be always avoided
- standardize on same names: err for error, peerId for peerId, etc... 
- added ci lint script that will enforce some of these rules

 