### PR TITLE
feat(dns): full DNS message codec

### DIFF
--- a/libp2p/nameresolving/dnsmessage.nim
+++ b/libp2p/nameresolving/dnsmessage.nim
@@ -135,7 +135,7 @@ proc readName(r: var DnsReader): string {.raises: [ValueError].} =
     pos = r.pos
     resume = -1
     jumps = 0
-    consumed = 0
+    consumed = 1 # the root label terminator
 
   while true:
     if pos >= r.data.len:
@@ -360,16 +360,21 @@ proc encodeQuery*(
 
   return query
 
+func sectionCount(n: int, section: string): uint16 {.raises: [ValueError].} =
+  if n > int(uint16.high):
+    raiseErr("Too many " & section & " in DNS message")
+  return n.uint16
+
 proc encodeMessage*(msg: DnsMessage): seq[byte] {.raises: [ValueError].} =
   ## A response is marked authoritative, which is what a responder sends.
   var buf = newSeqOfCap[byte](HeaderSize + 128)
 
   buf.add(toBytesBE(msg.id))
   buf.add(toBytesBE(if msg.response: ResponseFlags else: 0x0000'u16))
-  buf.add(toBytesBE(msg.questions.len.uint16))
-  buf.add(toBytesBE(msg.answers.len.uint16))
+  buf.add(toBytesBE(sectionCount(msg.questions.len, "questions")))
+  buf.add(toBytesBE(sectionCount(msg.answers.len, "answers")))
   buf.add(toBytesBE(0x0000'u16)) # nscount
-  buf.add(toBytesBE(msg.additionals.len.uint16))
+  buf.add(toBytesBE(sectionCount(msg.additionals.len, "additional records")))
 
   for question in msg.questions:
     buf.writeQuestion(question)

--- a/libp2p/nameresolving/dnsmessage.nim
+++ b/libp2p/nameresolving/dnsmessage.nim
@@ -24,6 +24,9 @@ const
   QrMask = 0x8000'u16 # header flags: QR bit (1 = response)
   ResponseFlags = 0x8400'u16 # QR + AA
   ClassIn = 0x0001'u16
+  ClassAny = 0x00FF'u16 # QCLASS ANY, which an mDNS query may carry
+  ClassTopBit = 0x8000'u16 # cache-flush in a record, unicast-reply in a question
+  ClassMask = 0x7FFF'u16
 
 template raiseErr(msg: string) =
   raise newException(ValueError, msg)
@@ -36,19 +39,27 @@ type
     AAAA = 28
     SRV = 33
 
+  DnsName* = seq[string]
+    ## Labels, root excluded. A label can hold a `.`, so `.` never separates.
+
   DnsAnswer* = object
     kind*: DnsRecordKind
     value*: string ## IPv4/IPv6 textual form, or concatenated TXT strings
 
   DnsQuestion* = object
-    name*: string
+    name*: DnsName
     kind*: DnsRecordKind
+    unicastResponse*: bool ## mDNS QU bit, the top bit of the question class
 
   DnsRecord* = object
-    name*: string
+    name*: DnsName
     kind*: DnsRecordKind
     ttl*: uint32
-    value*: string ## IPv4/IPv6 textual form (A/AAAA), or target name (PTR/SRV)
+    cacheFlush*: bool ## mDNS cache-flush bit, the top bit of the record class
+    address*: string ## A/AAAA textual form
+    target*: DnsName ## PTR/SRV
+    priority*: uint16 ## SRV only
+    weight*: uint16 ## SRV only
     port*: uint16 ## SRV only
     strings*: seq[string] ## TXT only, one entry per character-string
 
@@ -128,7 +139,7 @@ proc pointerAt(data: seq[byte], pos: int, first: uint8): int {.raises: [ValueErr
     raiseErr("DNS name pointer out of range")
   return offset
 
-proc readName(r: var DnsReader): string {.raises: [ValueError].} =
+proc readName(r: var DnsReader): DnsName {.raises: [ValueError].} =
   ## The cursor lands after the name in this record, not after a pointer target.
   var
     labels: seq[string]
@@ -169,7 +180,7 @@ proc readName(r: var DnsReader): string {.raises: [ValueError].} =
     inc pos, first.int
 
   r.pos = if resume >= 0: resume else: pos
-  return labels.join(".")
+  return labels
 
 proc readTxt(r: var DnsReader, rdlength: int): seq[string] {.raises: [ValueError].} =
   ## TXT rdata is a sequence of length-prefixed character-strings.
@@ -219,12 +230,11 @@ proc toRecordKind(rrType: uint16): Opt[DnsRecordKind] =
     Opt.none(DnsRecordKind)
 
 proc readRecord(r: var DnsReader): Opt[DnsRecord] {.raises: [ValueError].} =
-  ## Returns `none` for an unmodelled type; the cursor moves past the record.
+  ## Returns `none` for an unmodelled type or class; the cursor moves past it.
   let
     name = r.readName()
     rrType = r.readShort()
-  discard r.readShort() # class
-  let
+    class = r.readShort()
     ttl = r.readLong()
     rdlength = r.readShort().int
     rdataEnd = r.pos + rdlength
@@ -232,62 +242,93 @@ proc readRecord(r: var DnsReader): Opt[DnsRecord] {.raises: [ValueError].} =
   if rdataEnd > r.data.len:
     raiseErr("Truncated resource record")
 
+  if (class and ClassMask) != ClassIn:
+    r.pos = rdataEnd
+    return Opt.none(DnsRecord)
+
   let kind = toRecordKind(rrType).valueOr:
     r.pos = rdataEnd
     return Opt.none(DnsRecord)
 
-  var record = DnsRecord(name: name, kind: kind, ttl: ttl)
+  var record = DnsRecord(
+    name: name, kind: kind, ttl: ttl, cacheFlush: (class and ClassTopBit) != 0
+  )
   case kind
   of A:
-    record.value = ipv4ToString(r.readAddress(rdlength, 4))
+    record.address = ipv4ToString(r.readAddress(rdlength, 4))
   of AAAA:
-    record.value = ipv6ToString(r.readAddress(rdlength, 16))
+    record.address = ipv6ToString(r.readAddress(rdlength, 16))
   of PTR:
-    record.value = r.readName()
+    record.target = r.readName()
   of TXT:
     record.strings = r.readTxt(rdlength)
   of SRV:
-    discard r.readShort() # priority
-    discard r.readShort() # weight
+    record.priority = r.readShort()
+    record.weight = r.readShort()
     record.port = r.readShort()
-    record.value = r.readName()
+    record.target = r.readName()
 
   r.pos = rdataEnd
   return Opt.some(record)
 
 proc readQuestion(r: var DnsReader): Opt[DnsQuestion] {.raises: [ValueError].} =
-  ## Returns `none` for an unmodelled type; the cursor moves past the question.
+  ## Returns `none` for an unmodelled type or class; the cursor moves past it.
   let
     name = r.readName()
     rrType = r.readShort()
-  discard r.readShort() # class, whose top bit is the mDNS unicast-reply flag
+    class = r.readShort()
+    qclass = class and ClassMask
+
+  if qclass != ClassIn and qclass != ClassAny:
+    return Opt.none(DnsQuestion)
 
   let kind = toRecordKind(rrType).valueOr:
     return Opt.none(DnsQuestion)
-  return Opt.some(DnsQuestion(name: name, kind: kind))
+  return Opt.some(
+    DnsQuestion(name: name, kind: kind, unicastResponse: (class and ClassTopBit) != 0)
+  )
 
 proc addString(buf: var seq[byte], text: string) =
   for c in text:
     buf.add(c.byte)
 
-proc writeName(buf: var seq[byte], name: string) {.raises: [ValueError].} =
+func toDnsName*(name: string): DnsName =
+  ## Splits a presentation-format name, where `.` does separate the labels.
+  name.split('.')
+
+proc writeName(buf: var seq[byte], name: DnsName) {.raises: [ValueError].} =
+  if name.len < 1:
+    raiseErr("A DNS name needs at least one label")
+
   var encoded = 1 # the root label terminator
-  for label in name.split('.'):
+  for label in name:
     if label.len < 1:
-      raiseErr(name & " is not a legal name (empty label)")
+      raiseErr("Empty DNS label")
     if label.len > MaxLabelLength:
-      raiseErr(name & " is not a legal name (label too long)")
+      raiseErr("DNS label longer than 63 bytes: " & label)
     encoded += label.len + 1 # label bytes plus the length octet
     if encoded > MaxNameLength:
-      raiseErr(name & " is not a legal name (encoded name too long)")
+      raiseErr("Encoded DNS name longer than 255 bytes")
     buf.add(label.len.uint8)
     buf.addString(label)
   buf.add(0x00'u8) # root label terminator
 
+func questionClass(q: DnsQuestion): uint16 =
+  if q.unicastResponse:
+    ClassIn or ClassTopBit
+  else:
+    ClassIn
+
+func recordClass(rec: DnsRecord): uint16 =
+  if rec.cacheFlush:
+    ClassIn or ClassTopBit
+  else:
+    ClassIn
+
 proc writeQuestion(buf: var seq[byte], q: DnsQuestion) {.raises: [ValueError].} =
   buf.writeName(q.name)
   buf.add(toBytesBE(q.kind.uint16))
-  buf.add(toBytesBE(ClassIn))
+  buf.add(toBytesBE(q.questionClass()))
 
 proc writeIp(
     buf: var seq[byte], text: string, family: IpAddressFamily
@@ -312,23 +353,23 @@ proc writeCharStrings(
 proc writeRdata(buf: var seq[byte], rec: DnsRecord) {.raises: [ValueError].} =
   case rec.kind
   of A:
-    buf.writeIp(rec.value, IpAddressFamily.IPv4)
+    buf.writeIp(rec.address, IpAddressFamily.IPv4)
   of AAAA:
-    buf.writeIp(rec.value, IpAddressFamily.IPv6)
+    buf.writeIp(rec.address, IpAddressFamily.IPv6)
   of PTR:
-    buf.writeName(rec.value)
+    buf.writeName(rec.target)
   of TXT:
     buf.writeCharStrings(rec.strings)
   of SRV:
-    buf.add(toBytesBE(0x0000'u16)) # priority
-    buf.add(toBytesBE(0x0000'u16)) # weight
+    buf.add(toBytesBE(rec.priority))
+    buf.add(toBytesBE(rec.weight))
     buf.add(toBytesBE(rec.port))
-    buf.writeName(rec.value)
+    buf.writeName(rec.target)
 
 proc writeRecord(buf: var seq[byte], rec: DnsRecord) {.raises: [ValueError].} =
   buf.writeName(rec.name)
   buf.add(toBytesBE(rec.kind.uint16))
-  buf.add(toBytesBE(ClassIn))
+  buf.add(toBytesBE(rec.recordClass()))
   buf.add(toBytesBE(rec.ttl))
 
   let lengthPos = buf.len
@@ -356,7 +397,7 @@ proc encodeQuery*(
   query.add([0x00'u8, 0x00'u8]) # nscount = 0
   query.add([0x00'u8, 0x00'u8]) # arcount = 0
 
-  query.writeQuestion(DnsQuestion(name: name, kind: kind))
+  query.writeQuestion(DnsQuestion(name: name.toDnsName(), kind: kind))
 
   return query
 
@@ -440,7 +481,7 @@ proc parseAnswers*(
       continue
     case record.kind
     of A, AAAA:
-      answers.add(DnsAnswer(kind: record.kind, value: record.value))
+      answers.add(DnsAnswer(kind: record.kind, value: record.address))
     of TXT:
       answers.add(DnsAnswer(kind: TXT, value: record.strings.join()))
     else:

--- a/libp2p/nameresolving/dnsmessage.nim
+++ b/libp2p/nameresolving/dnsmessage.nim
@@ -3,24 +3,27 @@
 
 ## Minimal DNS message codec (RFC 1035).
 ##
-## libp2p performs the UDP transport itself (see `dnsresolver`), so this module
-## only deals with the wire format: building a query and decoding the answer
-## records we care about (`A`, `AAAA`, `TXT`). It is pure bytes-in/bytes-out and
-## raises only `ValueError` on malformed input.
+## libp2p performs the UDP transport itself (see `dnsresolver` and the mDNS
+## service), so this module only deals with the wire format. It is pure
+## bytes-in/bytes-out and raises only `ValueError` on malformed input.
 
 {.push raises: [].}
 
-import std/strutils
+import std/[net, strutils]
+import results
 import stew/endians2
-import ../utils/conversion
+import ../utils/[conversion, opt]
 
 const
   MaxLabelLength = 63 # RFC 1035, section 2.3.4
   MaxNameLength = 255 # RFC 1035, section 3.1
   MaxPacketSize = 512 # RFC 1035, section 4.2.1
+  MaxNameJumps = 16 # compression pointers followed before we give up
   HeaderSize = 12
   CompressionMask = 0xC0'u8
   QrMask = 0x8000'u16 # header flags: QR bit (1 = response)
+  ResponseFlags = 0x8400'u16 # QR + AA
+  ClassIn = 0x0001'u16
 
 template raiseErr(msg: string) =
   raise newException(ValueError, msg)
@@ -28,16 +31,48 @@ template raiseErr(msg: string) =
 type
   DnsRecordKind* = enum
     A = 1
+    PTR = 12
     TXT = 16
     AAAA = 28
+    SRV = 33
 
   DnsAnswer* = object
     kind*: DnsRecordKind
     value*: string ## IPv4/IPv6 textual form, or concatenated TXT strings
 
+  DnsQuestion* = object
+    name*: string
+    kind*: DnsRecordKind
+
+  DnsRecord* = object
+    name*: string
+    kind*: DnsRecordKind
+    ttl*: uint32
+    value*: string ## IPv4/IPv6 textual form (A/AAAA), or target name (PTR/SRV)
+    port*: uint16 ## SRV only
+    strings*: seq[string] ## TXT only, one entry per character-string
+
+  DnsMessage* = object
+    id*: uint16
+    response*: bool
+    questions*: seq[DnsQuestion]
+    answers*: seq[DnsRecord]
+    additionals*: seq[DnsRecord]
+
+  DnsHeader = object
+    id: uint16
+    flags: uint16
+    qdcount: int
+    ancount: int
+    nscount: int
+    arcount: int
+
   DnsReader = object
     data: seq[byte]
     pos: int
+
+func isResponse(h: DnsHeader): bool =
+  (h.flags and QrMask) != 0
 
 proc readByte(r: var DnsReader): uint8 {.raises: [ValueError].} =
   if r.pos >= r.data.len:
@@ -53,6 +88,13 @@ proc readShort(r: var DnsReader): uint16 {.raises: [ValueError].} =
   inc r.pos, 2
   return value
 
+proc readLong(r: var DnsReader): uint32 {.raises: [ValueError].} =
+  if r.pos + 4 > r.data.len:
+    raiseErr("Truncated DNS message")
+  let value = fromBytesBE(uint32, r.data.toOpenArray(r.pos, r.pos + 3))
+  inc r.pos, 4
+  return value
+
 proc readBytes(r: var DnsReader, n: int): seq[byte] {.raises: [ValueError].} =
   if n < 0 or r.pos + n > r.data.len:
     raiseErr("Truncated DNS message")
@@ -60,49 +102,251 @@ proc readBytes(r: var DnsReader, n: int): seq[byte] {.raises: [ValueError].} =
   inc r.pos, n
   return value
 
-proc skipName(r: var DnsReader) {.raises: [ValueError].} =
-  ## Advances past a (possibly compressed) domain name. We never need the name's
-  ## value — only to move the cursor to the bytes that follow it.
-  var consumed = 0
+func stringAt(data: seq[byte], pos, length: int): string =
+  var text = newStringOfCap(length)
+  for i in 0 ..< length:
+    text &= char(data[pos + i])
+  return text
+
+proc readString(r: var DnsReader, n: int): string {.raises: [ValueError].} =
+  if n < 0 or r.pos + n > r.data.len:
+    raiseErr("Truncated DNS message")
+  let text = r.data.stringAt(r.pos, n)
+  inc r.pos, n
+  return text
+
+proc labelAt(data: seq[byte], pos, length: int): string {.raises: [ValueError].} =
+  if pos + length > data.len:
+    raiseErr("Truncated DNS name")
+  return data.stringAt(pos, length)
+
+proc pointerAt(data: seq[byte], pos: int, first: uint8): int {.raises: [ValueError].} =
+  if pos >= data.len:
+    raiseErr("Truncated DNS name")
+  let offset = ((first and 0x3F'u8).int shl 8) or data[pos].int
+  if offset >= data.len:
+    raiseErr("DNS name pointer out of range")
+  return offset
+
+proc readName(r: var DnsReader): string {.raises: [ValueError].} =
+  ## The cursor lands after the name in this record, not after a pointer target.
+  var
+    labels: seq[string]
+    pos = r.pos
+    resume = -1
+    jumps = 0
+    consumed = 0
+
   while true:
-    let length = r.readByte()
-    if length == 0:
+    if pos >= r.data.len:
+      raiseErr("Truncated DNS name")
+    let first = r.data[pos]
+    inc pos
+
+    if first == 0:
       break
-    case length and CompressionMask
-    of 0x00'u8:
-      # An ordinary label: the top two bits being clear bounds it to 63 bytes.
-      discard r.readBytes(length.int)
-      inc consumed, length.int + 1
-      if consumed > MaxNameLength:
-        raiseErr("DNS name too long")
-    of CompressionMask:
-      # A compression pointer is 2 bytes and always terminates the name.
-      discard r.readByte()
-      break
-    else:
+
+    if (first and CompressionMask) == CompressionMask:
+      let offset = r.data.pointerAt(pos, first)
+      inc pos
+      if resume < 0:
+        resume = pos
+      inc jumps
+      if jumps > MaxNameJumps:
+        raiseErr("DNS name compression loop")
+      pos = offset
+      continue
+
+    if (first and CompressionMask) != 0:
       # 0x40 / 0x80 are reserved label types (RFC 1035, section 4.1.4).
       raiseErr("Reserved DNS label type")
 
-proc parseTxt(rdata: openArray[byte]): string {.raises: [ValueError].} =
+    # The top two bits being clear limits an ordinary label to 63 bytes.
+    inc consumed, first.int + 1
+    if consumed > MaxNameLength:
+      raiseErr("DNS name too long")
+    labels.add(r.data.labelAt(pos, first.int))
+    inc pos, first.int
+
+  r.pos = if resume >= 0: resume else: pos
+  return labels.join(".")
+
+proc readTxt(r: var DnsReader, rdlength: int): seq[string] {.raises: [ValueError].} =
   ## TXT rdata is a sequence of length-prefixed character-strings.
-  var text: string
-  var i = 0
-  while i < rdata.len:
-    let length = rdata[i].int
-    inc i
-    if i + length > rdata.len:
+  let stop = r.pos + rdlength
+  if stop > r.data.len:
+    raiseErr("Truncated TXT record")
+
+  var strings: seq[string]
+  while r.pos < stop:
+    let length = r.readByte().int
+    if r.pos + length > stop:
       raiseErr("Invalid TXT record")
-    for j in 0 ..< length:
-      text &= char(rdata[i + j])
-    inc i, length
-  return text
+    strings.add(r.readString(length))
+  return strings
+
+proc readAddress(
+    r: var DnsReader, rdlength, size: int
+): seq[byte] {.raises: [ValueError].} =
+  let rdata = r.readBytes(rdlength)
+  if rdata.len != size:
+    raiseErr("Invalid address record")
+  return rdata
+
+proc readHeader(r: var DnsReader): DnsHeader {.raises: [ValueError].} =
+  var h: DnsHeader
+  h.id = r.readShort()
+  h.flags = r.readShort()
+  h.qdcount = r.readShort().int
+  h.ancount = r.readShort().int
+  h.nscount = r.readShort().int
+  h.arcount = r.readShort().int
+  return h
+
+proc toRecordKind(rrType: uint16): Opt[DnsRecordKind] =
+  case rrType
+  of A.uint16:
+    Opt.some(A)
+  of PTR.uint16:
+    Opt.some(PTR)
+  of TXT.uint16:
+    Opt.some(TXT)
+  of AAAA.uint16:
+    Opt.some(AAAA)
+  of SRV.uint16:
+    Opt.some(SRV)
+  else:
+    Opt.none(DnsRecordKind)
+
+proc readRecord(r: var DnsReader): Opt[DnsRecord] {.raises: [ValueError].} =
+  ## Returns `none` for an unmodelled type; the cursor moves past the record.
+  let
+    name = r.readName()
+    rrType = r.readShort()
+  discard r.readShort() # class
+  let
+    ttl = r.readLong()
+    rdlength = r.readShort().int
+    rdataEnd = r.pos + rdlength
+
+  if rdataEnd > r.data.len:
+    raiseErr("Truncated resource record")
+
+  let kind = toRecordKind(rrType).valueOr:
+    r.pos = rdataEnd
+    return Opt.none(DnsRecord)
+
+  var record = DnsRecord(name: name, kind: kind, ttl: ttl)
+  case kind
+  of A:
+    record.value = ipv4ToString(r.readAddress(rdlength, 4))
+  of AAAA:
+    record.value = ipv6ToString(r.readAddress(rdlength, 16))
+  of PTR:
+    record.value = r.readName()
+  of TXT:
+    record.strings = r.readTxt(rdlength)
+  of SRV:
+    discard r.readShort() # priority
+    discard r.readShort() # weight
+    record.port = r.readShort()
+    record.value = r.readName()
+
+  r.pos = rdataEnd
+  return Opt.some(record)
+
+proc readQuestion(r: var DnsReader): Opt[DnsQuestion] {.raises: [ValueError].} =
+  ## Returns `none` for an unmodelled type; the cursor moves past the question.
+  let
+    name = r.readName()
+    rrType = r.readShort()
+  discard r.readShort() # class, whose top bit is the mDNS unicast-reply flag
+
+  let kind = toRecordKind(rrType).valueOr:
+    return Opt.none(DnsQuestion)
+  return Opt.some(DnsQuestion(name: name, kind: kind))
+
+proc addString(buf: var seq[byte], text: string) =
+  for c in text:
+    buf.add(c.byte)
+
+proc writeName(buf: var seq[byte], name: string) {.raises: [ValueError].} =
+  var encoded = 1 # the root label terminator
+  for label in name.split('.'):
+    if label.len < 1:
+      raiseErr(name & " is not a legal name (empty label)")
+    if label.len > MaxLabelLength:
+      raiseErr(name & " is not a legal name (label too long)")
+    encoded += label.len + 1 # label bytes plus the length octet
+    if encoded > MaxNameLength:
+      raiseErr(name & " is not a legal name (encoded name too long)")
+    buf.add(label.len.uint8)
+    buf.addString(label)
+  buf.add(0x00'u8) # root label terminator
+
+proc writeQuestion(buf: var seq[byte], q: DnsQuestion) {.raises: [ValueError].} =
+  buf.writeName(q.name)
+  buf.add(toBytesBE(q.kind.uint16))
+  buf.add(toBytesBE(ClassIn))
+
+proc writeIp(
+    buf: var seq[byte], text: string, family: IpAddressFamily
+) {.raises: [ValueError].} =
+  let ip = parseIpAddress(text)
+  if ip.family != family:
+    raiseErr(text & " does not match the record type")
+  if family == IpAddressFamily.IPv4:
+    buf.add(ip.address_v4)
+  else:
+    buf.add(ip.address_v6)
+
+proc writeCharStrings(
+    buf: var seq[byte], strings: seq[string]
+) {.raises: [ValueError].} =
+  for text in strings:
+    if text.len > 255:
+      raiseErr("TXT character-string longer than 255 bytes")
+    buf.add(text.len.uint8)
+    buf.addString(text)
+
+proc writeRdata(buf: var seq[byte], rec: DnsRecord) {.raises: [ValueError].} =
+  case rec.kind
+  of A:
+    buf.writeIp(rec.value, IpAddressFamily.IPv4)
+  of AAAA:
+    buf.writeIp(rec.value, IpAddressFamily.IPv6)
+  of PTR:
+    buf.writeName(rec.value)
+  of TXT:
+    buf.writeCharStrings(rec.strings)
+  of SRV:
+    buf.add(toBytesBE(0x0000'u16)) # priority
+    buf.add(toBytesBE(0x0000'u16)) # weight
+    buf.add(toBytesBE(rec.port))
+    buf.writeName(rec.value)
+
+proc writeRecord(buf: var seq[byte], rec: DnsRecord) {.raises: [ValueError].} =
+  buf.writeName(rec.name)
+  buf.add(toBytesBE(rec.kind.uint16))
+  buf.add(toBytesBE(ClassIn))
+  buf.add(toBytesBE(rec.ttl))
+
+  let lengthPos = buf.len
+  buf.add(toBytesBE(0x0000'u16)) # rdlength, patched once the rdata is known
+
+  buf.writeRdata(rec)
+
+  let rdlength = buf.len - lengthPos - 2
+  if rdlength > int(uint16.high):
+    raiseErr("Resource record rdata too long")
+  let encoded = toBytesBE(rdlength.uint16)
+  buf[lengthPos] = encoded[0]
+  buf[lengthPos + 1] = encoded[1]
 
 proc encodeQuery*(
     id: uint16, name: string, kind: DnsRecordKind
 ): seq[byte] {.raises: [ValueError].} =
   ## Builds a standard recursive query for `name`/`kind`.
-  ## Raises `ValueError` on an illegal name (empty/oversized label or a name
-  ## whose encoded form exceeds 255 bytes).
   var query = newSeqOfCap[byte](HeaderSize + name.len + 6)
 
   query.add(toBytesBE(id)) # id
@@ -112,78 +356,89 @@ proc encodeQuery*(
   query.add([0x00'u8, 0x00'u8]) # nscount = 0
   query.add([0x00'u8, 0x00'u8]) # arcount = 0
 
-  var encodedNameLength = 1 # the root label terminator
-  for label in name.split('.'):
-    if label.len < 1:
-      raiseErr(name & " is not a legal name (empty label)")
-    if label.len > MaxLabelLength:
-      raiseErr(name & " is not a legal name (label too long)")
-    encodedNameLength += label.len + 1 # label bytes plus the length octet
-    if encodedNameLength > MaxNameLength:
-      raiseErr(name & " is not a legal name (encoded name too long)")
-    query.add(label.len.uint8)
-    for c in label:
-      query.add(c.byte)
-  query.add(0x00'u8) # root label terminator
-
-  query.add(toBytesBE(kind.uint16)) # qtype
-  query.add(toBytesBE(0x0001'u16)) # qclass = IN
+  query.writeQuestion(DnsQuestion(name: name, kind: kind))
 
   return query
+
+proc encodeMessage*(msg: DnsMessage): seq[byte] {.raises: [ValueError].} =
+  ## A response is marked authoritative, which is what a responder sends.
+  var buf = newSeqOfCap[byte](HeaderSize + 128)
+
+  buf.add(toBytesBE(msg.id))
+  buf.add(toBytesBE(if msg.response: ResponseFlags else: 0x0000'u16))
+  buf.add(toBytesBE(msg.questions.len.uint16))
+  buf.add(toBytesBE(msg.answers.len.uint16))
+  buf.add(toBytesBE(0x0000'u16)) # nscount
+  buf.add(toBytesBE(msg.additionals.len.uint16))
+
+  for question in msg.questions:
+    buf.writeQuestion(question)
+  for record in msg.answers:
+    buf.writeRecord(record)
+  for record in msg.additionals:
+    buf.writeRecord(record)
+
+  return buf
+
+proc parseMessage*(data: openArray[byte]): DnsMessage {.raises: [ValueError].} =
+  ## Accepts a query as well as a response, and takes a packet above 512 bytes.
+  if data.len < HeaderSize:
+    raiseErr("DNS message shorter than header")
+
+  var r = DnsReader(data: @data, pos: 0)
+  let header = r.readHeader()
+
+  var msg = DnsMessage(id: header.id, response: header.isResponse())
+
+  for _ in 0 ..< header.qdcount:
+    r.readQuestion().withValue(question):
+      msg.questions.add(question)
+
+  for _ in 0 ..< header.ancount:
+    r.readRecord().withValue(record):
+      msg.answers.add(record)
+
+  for _ in 0 ..< header.nscount:
+    discard r.readRecord()
+
+  for _ in 0 ..< header.arcount:
+    r.readRecord().withValue(record):
+      msg.additionals.add(record)
+
+  return msg
 
 proc parseAnswers*(
     data: openArray[byte], expectedId: uint16
 ): seq[DnsAnswer] {.raises: [ValueError].} =
-  ## Parses the header and question, then decodes the answer section. Only
-  ## `A`/`AAAA`/`TXT` answers are returned; other record types are skipped.
-  ## `expectedId` is the id of the query this is a response to; a mismatch is
-  ## rejected to guard against stale or spoofed datagrams.
+  ## Decodes the `A`/`AAAA`/`TXT` answers of a response to query `expectedId`.
   if data.len < HeaderSize:
     raiseErr("DNS response shorter than header")
   if data.len > MaxPacketSize:
     raiseErr("DNS response exceeds 512 bytes")
 
   var r = DnsReader(data: @data, pos: 0)
+  let header = r.readHeader()
 
-  if r.readShort() != expectedId:
+  if header.id != expectedId:
     raiseErr("DNS response id does not match the query")
-  if (r.readShort() and QrMask) == 0: # flags
+  if not header.isResponse():
     raiseErr("DNS message is not a response")
-  let qdcount = r.readShort()
-  if qdcount == 0:
+  if header.qdcount == 0:
     raiseErr("DNS response has no question")
-  let ancount = r.readShort()
-  discard r.readShort() # nscount
-  discard r.readShort() # arcount
 
-  # Skip the question section.
-  for _ in 0 ..< qdcount.int:
-    r.skipName()
-    discard r.readShort() # qtype
-    discard r.readShort() # qclass
+  for _ in 0 ..< header.qdcount:
+    discard r.readQuestion()
 
   var answers: seq[DnsAnswer]
-  for _ in 0 ..< ancount.int:
-    r.skipName()
-    let rrType = r.readShort()
-    discard r.readShort() # class
-    discard r.readShort() # ttl high
-    discard r.readShort() # ttl low
-    let rdlength = r.readShort().int
-    let rdata = r.readBytes(rdlength)
-
-    case rrType
-    of A.uint16:
-      if rdata.len != 4:
-        raiseErr("Invalid A record")
-      answers.add(DnsAnswer(kind: A, value: ipv4ToString(rdata)))
-    of AAAA.uint16:
-      if rdata.len != 16:
-        raiseErr("Invalid AAAA record")
-      answers.add(DnsAnswer(kind: AAAA, value: ipv6ToString(rdata)))
-    of TXT.uint16:
-      answers.add(DnsAnswer(kind: TXT, value: parseTxt(rdata)))
+  for _ in 0 ..< header.ancount:
+    let record = r.readRecord().valueOr:
+      continue
+    case record.kind
+    of A, AAAA:
+      answers.add(DnsAnswer(kind: record.kind, value: record.value))
+    of TXT:
+      answers.add(DnsAnswer(kind: TXT, value: record.strings.join()))
     else:
-      discard # unsupported record type (e.g. CNAME), already skipped via rdlength
+      discard # PTR/SRV are not part of the resolver's contract
 
   return answers

--- a/libp2p/nameresolving/dnsmessage.nim
+++ b/libp2p/nameresolving/dnsmessage.nim
@@ -263,12 +263,16 @@ proc readRecord(r: var DnsReader): Opt[DnsRecord] {.raises: [ValueError].} =
   of TXT:
     record.strings = r.readTxt(rdlength)
   of SRV:
+    if rdlength < 7: # six fixed bytes plus at least the root label
+      raiseErr("Invalid SRV record")
     record.priority = r.readShort()
     record.weight = r.readShort()
     record.port = r.readShort()
     record.target = r.readName()
 
-  r.pos = rdataEnd
+  if r.pos != rdataEnd:
+    raiseErr("Resource record data does not match its declared length")
+
   return Opt.some(record)
 
 proc readQuestion(r: var DnsReader): Opt[DnsQuestion] {.raises: [ValueError].} =

--- a/tests/libp2p/test_dnsmessage.nim
+++ b/tests/libp2p/test_dnsmessage.nim
@@ -39,24 +39,7 @@ suite "DNS message codec":
       q[4 .. 5] == @[0x00'u8, 0x01] # qdcount=1
       q[6 .. 11] == @[0x00'u8, 0x00, 0x00, 0x00, 0x00, 0x00] # an/ns/ar = 0
       # question: labels "status"."im", root, qtype=A, qclass=IN
-      q[12 .. ^1] ==
-        @[
-          0x06'u8,
-          ord('s').uint8,
-          ord('t').uint8,
-          ord('a').uint8,
-          ord('t').uint8,
-          ord('u').uint8,
-          ord('s').uint8,
-          0x02,
-          ord('i').uint8,
-          ord('m').uint8,
-          0x00,
-          0x00,
-          0x01,
-          0x00,
-          0x01,
-        ]
+      q[12 .. ^1] == "\x06status\x02im\x00\x00\x01\x00\x01".toBytes()
 
   test "encodeQuery rejects illegal names":
     expect ValueError:
@@ -87,52 +70,12 @@ suite "DNS message codec":
       )
 
   test "parseAnswers decodes and concatenates TXT records":
-    # header: id, flags=0x8180, qd=1, an=1; question "x"; answer via 0xc00c pointer
-    let txt = @[
-      0x00'u8,
-      0x01,
-      0x81,
-      0x80,
-      0x00,
-      0x01,
-      0x00,
-      0x01,
-      0x00,
-      0x00,
-      0x00,
-      0x00, # question: "x", TXT, IN
-      0x01,
-      ord('x').uint8,
-      0x00,
-      0x00,
-      0x10,
-      0x00,
-      0x01, # answer: name ptr -> 0x0c, TXT, IN, ttl=0, rdlength=12
-      0xc0,
-      0x0c,
-      0x00,
-      0x10,
-      0x00,
-      0x01,
-      0x00,
-      0x00,
-      0x00,
-      0x00,
-      0x00,
-      0x0c, # rdata: "hello" + "world"
-      0x05,
-      ord('h').uint8,
-      ord('e').uint8,
-      ord('l').uint8,
-      ord('l').uint8,
-      ord('o').uint8,
-      0x05,
-      ord('w').uint8,
-      ord('o').uint8,
-      ord('r').uint8,
-      ord('l').uint8,
-      ord('d').uint8,
-    ]
+    let txt = (
+      "\x00\x01\x81\x80\x00\x01\x00\x01\x00\x00\x00\x00" & # id, flags, qd=1, an=1
+      "\x01x\x00\x00\x10\x00\x01" & # question: "x", TXT, IN
+      "\xc0\x0c\x00\x10\x00\x01\x00\x00\x00\x00\x00\x0c" & # answer: TXT, rdlen=12
+      "\x05hello\x05world"
+    ).toBytes()
     let answers = parseAnswers(txt, 0x0001'u16)
     check answers.len == 1
     check answers[0].kind == TXT
@@ -165,51 +108,17 @@ suite "DNS message codec":
       discard parseAnswers(noQuestion, 0x0001'u16)
 
   test "parseAnswers rejects an A record with the wrong length":
-    let badA = @[
-      0x00'u8,
-      0x01,
-      0x81,
-      0x80,
-      0x00,
-      0x01,
-      0x00,
-      0x01,
-      0x00,
-      0x00,
-      0x00,
-      0x00,
-      0x01,
-      ord('x').uint8,
-      0x00,
-      0x00,
-      0x01,
-      0x00,
-      0x01, # question: "x", A, IN
-      0xc0,
-      0x0c,
-      0x00,
-      0x01,
-      0x00,
-      0x01,
-      0x00,
-      0x00,
-      0x00,
-      0x00,
-      0x00,
-      0x03,
-      0x01,
-      0x02,
-      0x03, # answer: A, IN, rdlength=3 (invalid), 3 bytes rdata
-    ]
+    let badA = (
+      "\x00\x01\x81\x80\x00\x01\x00\x01\x00\x00\x00\x00" & # id, flags, qd=1, an=1
+      "\x01x\x00\x00\x01\x00\x01" & # question: "x", A, IN
+      "\xc0\x0c\x00\x01\x00\x01\x00\x00\x00\x00\x00\x03\x01\x02\x03" # A, rdlen=3
+    ).toBytes()
     expect ValueError:
       discard parseAnswers(badA, 0x0001'u16)
 
   test "parseAnswers rejects a reserved DNS label type":
     # question label starts with 0x40 (reserved label type, top two bits 01)
-    let reserved = @[
-      0x00'u8, 0x01, 0x81, 0x80, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40,
-      0x00,
-    ]
+    let reserved = "\x00\x01\x81\x80\x00\x01\x00\x00\x00\x00\x00\x00\x40\x00".toBytes()
     expect ValueError:
       discard parseAnswers(reserved, 0x0001'u16)
 
@@ -270,109 +179,23 @@ suite "DNS message codec: whole messages":
       parseMessage(encoded).questions[0].name == name
 
   test "parseMessage skips a record whose class is not IN":
-    # an=2: a CH-class A answer for "a", then an IN-class A answer for "a"
-    let message =
-      @[0x00'u8, 0x00, 0x84, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00] &
-      @[
-        0x01'u8,
-        byte('a'),
-        0x00,
-        0x00,
-        0x01,
-        0x00,
-        0x03,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x00,
-        0x04,
-        0x01,
-        0x02,
-        0x03,
-        0x04,
-      ] &
-      @[
-        0x01'u8,
-        byte('a'),
-        0x00,
-        0x00,
-        0x01,
-        0x00,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x00,
-        0x04,
-        0x05,
-        0x06,
-        0x07,
-        0x08,
-      ]
+    let message = (
+      "\x00\x00\x84\x00\x00\x00\x00\x02\x00\x00\x00\x00" & # response, an=2
+      "\x01a\x00\x00\x01\x00\x03\x00\x00\x00\x01\x00\x04\x01\x02\x03\x04" & # A, CH
+      "\x01a\x00\x00\x01\x00\x01\x00\x00\x00\x01\x00\x04\x05\x06\x07\x08" # A, IN
+    ).toBytes()
     let decoded = parseMessage(message)
     check:
       decoded.answers.len == 1
       decoded.answers[0].address == "5.6.7.8"
 
   test "parseMessage keeps the cursor after a compressed name":
-    # PTR answer whose name is the 0xc00c pointer and whose target is
-    # "x" + a pointer back to the question name.
-    let message = @[
-      0x00'u8,
-      0x00,
-      0x84,
-      0x00,
-      0x00,
-      0x01,
-      0x00,
-      0x01,
-      0x00,
-      0x00,
-      0x00,
-      0x01,
-      0x01,
-      ord('a').uint8,
-      0x00,
-      0x00,
-      0x0c,
-      0x00,
-      0x01, # question: "a", PTR, IN
-      0xc0,
-      0x0c,
-      0x00,
-      0x0c,
-      0x00,
-      0x01,
-      0x00,
-      0x00,
-      0x00,
-      0x0a,
-      0x00,
-      0x04,
-      0x01,
-      ord('x').uint8,
-      0xc0,
-      0x0c, # answer: PTR ttl=10 -> "x.a"
-      0x01,
-      ord('x').uint8,
-      0xc0,
-      0x0c,
-      0x00,
-      0x10,
-      0x00,
-      0x01,
-      0x00,
-      0x00,
-      0x00,
-      0x0a,
-      0x00,
-      0x03,
-      0x02,
-      ord('h').uint8,
-      ord('i').uint8, # additional: "x.a" TXT "hi"
-    ]
+    let message = (
+      "\x00\x00\x84\x00\x00\x01\x00\x01\x00\x00\x00\x01" & # response, qd=1, an=1, ar=1
+      "\x01a\x00\x00\x0c\x00\x01" & # question: "a", PTR, IN
+      "\xc0\x0c\x00\x0c\x00\x01\x00\x00\x00\x0a\x00\x04\x01x\xc0\x0c" & # PTR -> "x.a"
+      "\x01x\xc0\x0c\x00\x10\x00\x01\x00\x00\x00\x0a\x00\x03\x02hi" # TXT "hi"
+    ).toBytes()
     let decoded = parseMessage(message)
     check:
       decoded.answers.len == 1
@@ -385,53 +208,11 @@ suite "DNS message codec: whole messages":
       decoded.additionals[0].strings == @["hi"]
 
   test "parseMessage skips an unknown record type":
-    # an=2: a CNAME answer for "a", then a PTR answer for "a" -> "b"
-    let withCname = @[
-      0x00'u8,
-      0x00,
-      0x84,
-      0x00,
-      0x00,
-      0x00,
-      0x00,
-      0x02,
-      0x00,
-      0x00,
-      0x00,
-      0x00,
-      0x01,
-      ord('a').uint8,
-      0x00,
-      0x00,
-      0x05,
-      0x00,
-      0x01,
-      0x00,
-      0x00,
-      0x00,
-      0x01,
-      0x00,
-      0x03,
-      0x01,
-      ord('b').uint8,
-      0x00,
-      0x01,
-      ord('a').uint8,
-      0x00,
-      0x00,
-      0x0c,
-      0x00,
-      0x01,
-      0x00,
-      0x00,
-      0x00,
-      0x01,
-      0x00,
-      0x03,
-      0x01,
-      ord('b').uint8,
-      0x00,
-    ]
+    let withCname = (
+      "\x00\x00\x84\x00\x00\x00\x00\x02\x00\x00\x00\x00" & # response, an=2
+      "\x01a\x00\x00\x05\x00\x01\x00\x00\x00\x01\x00\x03\x01b\x00" & # CNAME "a" -> "b"
+      "\x01a\x00\x00\x0c\x00\x01\x00\x00\x00\x01\x00\x03\x01b\x00" # PTR "a" -> "b"
+    ).toBytes()
     let decoded = parseMessage(withCname)
     check:
       decoded.answers.len == 1
@@ -440,22 +221,8 @@ suite "DNS message codec: whole messages":
       decoded.answers[0].target == @["b"]
 
   test "parseMessage rejects a compression loop":
-    let loop = @[
-      0x00'u8,
-      0x00,
-      0x84,
-      0x00,
-      0x00,
-      0x00,
-      0x00,
-      0x01,
-      0x00,
-      0x00,
-      0x00,
-      0x00,
-      0xc0,
-      0x0c, # answer name points at itself
-    ]
+    # the answer name is a pointer to itself
+    let loop = "\x00\x00\x84\x00\x00\x00\x00\x01\x00\x00\x00\x00\xc0\x0c".toBytes()
     expect ValueError:
       discard parseMessage(loop)
 

--- a/tests/libp2p/test_dnsmessage.nim
+++ b/tests/libp2p/test_dnsmessage.nim
@@ -212,3 +212,200 @@ suite "DNS message codec":
     ]
     expect ValueError:
       discard parseAnswers(reserved, 0x0001'u16)
+
+suite "DNS message codec: whole messages":
+  test "encodeMessage and parseMessage round-trip a query":
+    let query =
+      DnsMessage(questions: @[DnsQuestion(name: "_p2p._udp.local", kind: PTR)])
+    let decoded = parseMessage(encodeMessage(query))
+    check:
+      not decoded.response
+      decoded.questions == query.questions
+      decoded.answers.len == 0
+
+  test "encodeMessage and parseMessage round-trip a DNS-SD response":
+    let response = DnsMessage(
+      response: true,
+      answers: @[
+        DnsRecord(
+          name: "_p2p._udp.local", kind: PTR, ttl: 120, value: "abc._p2p._udp.local"
+        )
+      ],
+      additionals: @[
+        DnsRecord(
+          name: "abc._p2p._udp.local",
+          kind: TXT,
+          ttl: 120,
+          strings: @["dnsaddr=/ip4/1.2.3.4/tcp/1", "dnsaddr=/ip6/::1/tcp/2"],
+        ),
+        DnsRecord(
+          name: "abc._p2p._udp.local",
+          kind: SRV,
+          ttl: 120,
+          port: 4001,
+          value: "abc.local",
+        ),
+        DnsRecord(name: "abc.local", kind: A, ttl: 120, value: "1.2.3.4"),
+        DnsRecord(name: "abc.local", kind: AAAA, ttl: 120, value: "::1"),
+      ],
+    )
+    let decoded = parseMessage(encodeMessage(response))
+    check:
+      decoded.response
+      decoded.answers == response.answers
+      decoded.additionals == response.additionals
+
+  test "parseMessage keeps the cursor after a compressed name":
+    # PTR answer whose name is the 0xc00c pointer and whose target is
+    # "x" + a pointer back to the question name.
+    let message = @[
+      0x00'u8,
+      0x00,
+      0x84,
+      0x00,
+      0x00,
+      0x01,
+      0x00,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      0x01,
+      0x01,
+      ord('a').uint8,
+      0x00,
+      0x00,
+      0x0c,
+      0x00,
+      0x01, # question: "a", PTR, IN
+      0xc0,
+      0x0c,
+      0x00,
+      0x0c,
+      0x00,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      0x0a,
+      0x00,
+      0x04,
+      0x01,
+      ord('x').uint8,
+      0xc0,
+      0x0c, # answer: PTR ttl=10 -> "x.a"
+      0x01,
+      ord('x').uint8,
+      0xc0,
+      0x0c,
+      0x00,
+      0x10,
+      0x00,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      0x0a,
+      0x00,
+      0x03,
+      0x02,
+      ord('h').uint8,
+      ord('i').uint8, # additional: "x.a" TXT "hi"
+    ]
+    let decoded = parseMessage(message)
+    check:
+      decoded.answers.len == 1
+      decoded.answers[0].name == "a"
+      decoded.answers[0].kind == PTR
+      decoded.answers[0].ttl == 10
+      decoded.answers[0].value == "x.a"
+      decoded.additionals.len == 1
+      decoded.additionals[0].name == "x.a"
+      decoded.additionals[0].strings == @["hi"]
+
+  test "parseMessage skips an unknown record type":
+    # an=2: a CNAME answer for "a", then a PTR answer for "a" -> "b"
+    let withCname = @[
+      0x00'u8,
+      0x00,
+      0x84,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x02,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x01,
+      ord('a').uint8,
+      0x00,
+      0x00,
+      0x05,
+      0x00,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      0x01,
+      0x00,
+      0x03,
+      0x01,
+      ord('b').uint8,
+      0x00,
+      0x01,
+      ord('a').uint8,
+      0x00,
+      0x00,
+      0x0c,
+      0x00,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      0x01,
+      0x00,
+      0x03,
+      0x01,
+      ord('b').uint8,
+      0x00,
+    ]
+    let decoded = parseMessage(withCname)
+    check:
+      decoded.answers.len == 1
+      decoded.answers[0].kind == PTR
+      decoded.answers[0].name == "a"
+      decoded.answers[0].value == "b"
+
+  test "parseMessage rejects a compression loop":
+    let loop = @[
+      0x00'u8,
+      0x00,
+      0x84,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0x01,
+      0x00,
+      0x00,
+      0x00,
+      0x00,
+      0xc0,
+      0x0c, # answer name points at itself
+    ]
+    expect ValueError:
+      discard parseMessage(loop)
+
+  test "encodeMessage rejects a TXT string above 255 bytes":
+    let big = DnsMessage(
+      response: true,
+      answers: @[
+        DnsRecord(
+          name: "a.local", kind: TXT, ttl: 1, strings: @[strutils.repeat("x", 256)]
+        )
+      ],
+    )
+    expect ValueError:
+      discard encodeMessage(big)

--- a/tests/libp2p/test_dnsmessage.nim
+++ b/tests/libp2p/test_dnsmessage.nim
@@ -409,3 +409,22 @@ suite "DNS message codec: whole messages":
     )
     expect ValueError:
       discard encodeMessage(big)
+
+  test "parseMessage enforces the 255-byte name limit":
+    let header =
+      @[0x00'u8, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+    let tail = @[0x00'u8, 0x01, 0x00, 0x01] # qtype = A, qclass = IN
+
+    var legal: seq[byte] # 127 one-char labels plus the terminator = 255 bytes
+    for _ in 0 ..< 127:
+      legal.add([0x01'u8, byte('a')])
+    legal.add(0x00'u8)
+
+    var illegal: seq[byte] # one label carries a second char, making it 256
+    for _ in 0 ..< 126:
+      illegal.add([0x01'u8, byte('a')])
+    illegal.add([0x02'u8, byte('a'), byte('a'), 0x00'u8])
+
+    check parseMessage(header & legal & tail).questions.len == 1
+    expect ValueError:
+      discard parseMessage(header & illegal & tail)

--- a/tests/libp2p/test_dnsmessage.nim
+++ b/tests/libp2p/test_dnsmessage.nim
@@ -215,8 +215,12 @@ suite "DNS message codec":
 
 suite "DNS message codec: whole messages":
   test "encodeMessage and parseMessage round-trip a query":
-    let query =
-      DnsMessage(questions: @[DnsQuestion(name: "_p2p._udp.local", kind: PTR)])
+    let query = DnsMessage(
+      questions: @[
+        DnsQuestion(name: @["_p2p", "_udp", "local"], kind: PTR),
+        DnsQuestion(name: @["a", "local"], kind: A, unicastResponse: true),
+      ]
+    )
     let decoded = parseMessage(encodeMessage(query))
     check:
       not decoded.response
@@ -224,29 +228,31 @@ suite "DNS message codec: whole messages":
       decoded.answers.len == 0
 
   test "encodeMessage and parseMessage round-trip a DNS-SD response":
+    let
+      service = @["_p2p", "_udp", "local"]
+      instance = @["abc"] & service
+      host = @["abc", "local"]
     let response = DnsMessage(
       response: true,
-      answers: @[
-        DnsRecord(
-          name: "_p2p._udp.local", kind: PTR, ttl: 120, value: "abc._p2p._udp.local"
-        )
-      ],
+      answers: @[DnsRecord(name: service, kind: PTR, ttl: 120, target: instance)],
       additionals: @[
         DnsRecord(
-          name: "abc._p2p._udp.local",
+          name: instance,
           kind: TXT,
           ttl: 120,
           strings: @["dnsaddr=/ip4/1.2.3.4/tcp/1", "dnsaddr=/ip6/::1/tcp/2"],
         ),
         DnsRecord(
-          name: "abc._p2p._udp.local",
+          name: instance,
           kind: SRV,
           ttl: 120,
+          priority: 3,
+          weight: 7,
           port: 4001,
-          value: "abc.local",
+          target: host,
         ),
-        DnsRecord(name: "abc.local", kind: A, ttl: 120, value: "1.2.3.4"),
-        DnsRecord(name: "abc.local", kind: AAAA, ttl: 120, value: "::1"),
+        DnsRecord(name: host, kind: A, ttl: 120, cacheFlush: true, address: "1.2.3.4"),
+        DnsRecord(name: host, kind: AAAA, ttl: 120, address: "::1"),
       ],
     )
     let decoded = parseMessage(encodeMessage(response))
@@ -254,6 +260,61 @@ suite "DNS message codec: whole messages":
       decoded.response
       decoded.answers == response.answers
       decoded.additionals == response.additionals
+
+  test "a label may contain a dot":
+    let name = @["my.computer", "local"]
+    let query = DnsMessage(questions: @[DnsQuestion(name: name, kind: A)])
+    let encoded = encodeMessage(query)
+    check:
+      encoded[12] == 11'u8 # the length octet of "my.computer", right after the header
+      parseMessage(encoded).questions[0].name == name
+
+  test "parseMessage skips a record whose class is not IN":
+    # an=2: a CH-class A answer for "a", then an IN-class A answer for "a"
+    let message =
+      @[0x00'u8, 0x00, 0x84, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00] &
+      @[
+        0x01'u8,
+        byte('a'),
+        0x00,
+        0x00,
+        0x01,
+        0x00,
+        0x03,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x00,
+        0x04,
+        0x01,
+        0x02,
+        0x03,
+        0x04,
+      ] &
+      @[
+        0x01'u8,
+        byte('a'),
+        0x00,
+        0x00,
+        0x01,
+        0x00,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x00,
+        0x04,
+        0x05,
+        0x06,
+        0x07,
+        0x08,
+      ]
+    let decoded = parseMessage(message)
+    check:
+      decoded.answers.len == 1
+      decoded.answers[0].address == "5.6.7.8"
 
   test "parseMessage keeps the cursor after a compressed name":
     # PTR answer whose name is the 0xc00c pointer and whose target is
@@ -315,12 +376,12 @@ suite "DNS message codec: whole messages":
     let decoded = parseMessage(message)
     check:
       decoded.answers.len == 1
-      decoded.answers[0].name == "a"
+      decoded.answers[0].name == @["a"]
       decoded.answers[0].kind == PTR
       decoded.answers[0].ttl == 10
-      decoded.answers[0].value == "x.a"
+      decoded.answers[0].target == @["x", "a"]
       decoded.additionals.len == 1
-      decoded.additionals[0].name == "x.a"
+      decoded.additionals[0].name == @["x", "a"]
       decoded.additionals[0].strings == @["hi"]
 
   test "parseMessage skips an unknown record type":
@@ -375,8 +436,8 @@ suite "DNS message codec: whole messages":
     check:
       decoded.answers.len == 1
       decoded.answers[0].kind == PTR
-      decoded.answers[0].name == "a"
-      decoded.answers[0].value == "b"
+      decoded.answers[0].name == @["a"]
+      decoded.answers[0].target == @["b"]
 
   test "parseMessage rejects a compression loop":
     let loop = @[
@@ -403,7 +464,10 @@ suite "DNS message codec: whole messages":
       response: true,
       answers: @[
         DnsRecord(
-          name: "a.local", kind: TXT, ttl: 1, strings: @[strutils.repeat("x", 256)]
+          name: @["a", "local"],
+          kind: TXT,
+          ttl: 1,
+          strings: @[strutils.repeat("x", 256)],
         )
       ],
     )


### PR DESCRIPTION


`dnsmessage` encoded a query and parsed A/AAAA/TXT answers, and nothing else. This PR makes it a full DNS message codec. It is the first piece of mDNS peer discovery ([spec](https://github.com/libp2p/specs/blob/master/discovery/mdns.md)).

New in the codec: name decoding through compression pointers, PTR and SRV records, per-character-string TXT records, and `encodeMessage`/`parseMessage` for a whole message with its question and answer sections.

`encodeQuery` and `parseAnswers` keep their signature and their behaviour, so `dnsresolver` needs no change.

