### PR TITLE
chore(perf): rename uploadSize to responseSize

### DIFF
--- a/libp2p/protocols/perf/server.nim
+++ b/libp2p/protocols/perf/server.nim
@@ -23,9 +23,9 @@ proc new*(T: typedesc[Perf]): T =
     try:
       trace "Received benchmark performance check", stream
 
-      var uploadSizeBuffer: array[8, byte]
-      await stream.readExactly(addr uploadSizeBuffer[0], 8)
-      var uploadSize = uint64.fromBytesBE(uploadSizeBuffer)
+      var sizeBuffer: array[8, byte]
+      await stream.readExactly(addr sizeBuffer[0], 8)
+      var responseSize = uint64.fromBytesBE(sizeBuffer)
 
       var readBuffer: array[PerfSize, byte]
       while not stream.atEof:
@@ -37,10 +37,10 @@ proc new*(T: typedesc[Perf]): T =
           break
 
       var writeBuffer: array[PerfSize, byte]
-      while uploadSize > 0:
-        let toWrite = min(uploadSize, PerfSize)
+      while responseSize > 0:
+        let toWrite = min(responseSize, PerfSize)
         await stream.write(writeBuffer[0 ..< toWrite])
-        uploadSize -= toWrite
+        responseSize -= toWrite
     except CancelledError as exc:
       trace "cancelled perf handler"
       raise exc


### PR DESCRIPTION
The `/perf/1.0.0` server handler reads an 8-byte big-endian size field and sends that many bytes back. The variable held that count but was named `uploadSize`, which names the wrong direction: it is the size of the server's response, not of the client's upload.

This renames it to `responseSize`, and renames `uploadSizeBuffer` to `sizeBuffer`. No behaviour changes.

An earlier version of this PR also capped the size to a configurable maximum. That is wrong: the spec gives the client the size, up to max uint64, and a server-side cap makes the server send a short response with no error, which produces a wrong throughput number for the client. Dropped.

Perf spec: https://github.com/libp2p/specs/blob/master/perf/perf.md
