### PR TITLE
fix(autonatv2): bound dial backs

### DIFF
--- a/libp2p/protocols/connectivity/autonatv2/server.nim
+++ b/libp2p/protocols/connectivity/autonatv2/server.nim
@@ -4,7 +4,7 @@
 {.push raises: [].}
 
 import results
-import chronos, chronicles
+import chronos, chronicles, metrics
 import
   ../../../../libp2p/[
     switch,
@@ -22,15 +22,28 @@ import
 logScope:
   topics = "libp2p autonat v2 server"
 
+declareCounter(
+  libp2p_autonatv2_dial_back_refusals_total,
+  "dial requests refused because no dial back permit was free",
+)
+
 type AutonatV2Config* = object
   dialTimeout: Duration
   dialDataSize: uint64
   amplificationAttackTimeout: Duration
   allowPrivateAddresses: bool
+  maxConcurrentDialBacks: int
+  maxConcurrentRequestsPerPeer: int
+  maxConcurrentRequestsTotal: int
 
 type AutonatV2* = ref object of LPProtocol
   switch*: Switch
   config: AutonatV2Config
+  dialBackSem: AsyncSemaphore
+
+type DialBackConn = object
+  mux: Muxer
+  stream: Stream
 
 proc new*(
     T: typedesc[AutonatV2Config],
@@ -38,12 +51,18 @@ proc new*(
     dialDataSize: uint64 = DefaultDialDataSize,
     amplificationAttackTimeout: Duration = DefaultAmplificationAttackDialTimeout,
     allowPrivateAddresses: bool = false,
+    maxConcurrentDialBacks: int = DefaultMaxConcurrentDialBacks,
+    maxConcurrentRequestsPerPeer: int = DefaultMaxConcurrentRequestsPerPeer,
+    maxConcurrentRequestsTotal: int = DefaultMaxConcurrentRequestsTotal,
 ): T =
   T(
     dialTimeout: dialTimeout,
     dialDataSize: dialDataSize,
     amplificationAttackTimeout: amplificationAttackTimeout,
     allowPrivateAddresses: allowPrivateAddresses,
+    maxConcurrentDialBacks: maxConcurrentDialBacks,
+    maxConcurrentRequestsPerPeer: maxConcurrentRequestsPerPeer,
+    maxConcurrentRequestsTotal: maxConcurrentRequestsTotal,
   )
 
 proc sendDialResponse(
@@ -172,17 +191,17 @@ proc canDial(self: AutonatV2, addrs: MultiAddress): bool =
 
 proc forceNewConnection(
     self: AutonatV2, pid: PeerId, addrs: seq[MultiAddress]
-): Future[Opt[(Muxer, Stream)]] {.async: (raises: [CancelledError]).} =
+): Future[Opt[DialBackConn]] {.async: (raises: [CancelledError]).} =
   ## Bypasses connManager to force a new connection to ``pid``
   ## instead of reusing a preexistent one
   try:
     let mux = await self.switch.dialer.dialAndUpgrade(Opt.some(pid), addrs)
     if mux.isNil():
-      return Opt.none((Muxer, Stream))
+      return Opt.none(DialBackConn)
     return Opt.some(
-      (
-        mux,
-        await self.switch.dialer.negotiateStream(
+      DialBackConn(
+        mux: mux,
+        stream: await self.switch.dialer.negotiateStream(
           await mux.newStream(), @[$AutonatV2Codec.DialBack]
         ),
       )
@@ -190,27 +209,23 @@ proc forceNewConnection(
   except CancelledError as exc:
     raise exc
   except CatchableError:
-    return Opt.none((Muxer, Stream))
+    return Opt.none(DialBackConn)
 
-proc chooseDialAddr(
-    self: AutonatV2, pid: PeerId, addrs: seq[MultiAddress]
-): Future[(Opt[(Muxer, Stream)], Opt[AddrIdx])] {.async: (raises: [CancelledError]).} =
+proc selectDialAddr(self: AutonatV2, addrs: seq[MultiAddress]): Opt[AddrIdx] =
   for i, ma in addrs:
     if self.canDial(ma):
-      trace "Trying to dial", chosenAddrs = ma, addrIdx = i
-      let (mux, stream) =
-        try:
-          (await (self.forceNewConnection(pid, @[ma]).wait(self.config.dialTimeout))).valueOr:
-            # canDial is true, which means the dial was attempted but failed.
-            # Opt.some(i.AddrIdx) is returned so the response is EDialError, which
-            # triggers NotReachable, and not EDialRefused, which triggers Unknown
-            # and would never be updated.
-            return (Opt.none((Muxer, Stream)), Opt.some(i.AddrIdx))
-        except AsyncTimeoutError:
-          trace "Dial timed out"
-          return (Opt.none((Muxer, Stream)), Opt.some(i.AddrIdx))
-      return (Opt.some((mux, stream)), Opt.some(i.AddrIdx))
-  return (Opt.none((Muxer, Stream)), Opt.none(AddrIdx))
+      return Opt.some(i.AddrIdx)
+  Opt.none(AddrIdx)
+
+proc dialBackConnection(
+    self: AutonatV2, pid: PeerId, ma: MultiAddress
+): Future[Opt[DialBackConn]] {.async: (raises: [CancelledError]).} =
+  trace "Trying to dial", address = ma
+  try:
+    await self.forceNewConnection(pid, @[ma]).wait(self.config.dialTimeout)
+  except AsyncTimeoutError:
+    trace "Dial timed out", timeout = self.config.dialTimeout
+    Opt.none(DialBackConn)
 
 proc handleDialRequest(
     self: AutonatV2, stream: Stream, req: DialRequest
@@ -220,23 +235,21 @@ proc handleDialRequest(
     await stream.sendDialResponse(ResponseStatus.ERequestRejected)
     return
 
-  let (dialBackConnOpt, addrIdxOpt) =
-    await self.chooseDialAddr(stream.peerId, req.addrs)
-  let addrIdx = addrIdxOpt.valueOr:
+  let addrIdx = self.selectDialAddr(req.addrs).valueOr:
     trace "No dialable addresses found"
     await stream.sendDialResponse(ResponseStatus.EDialRefused)
     return
-  let (dialBackMux, dialBackConn) = dialBackConnOpt.valueOr:
-    trace "Dial failed"
-    await stream.sendDialResponse(
-      ResponseStatus.Ok,
-      addrIdx = Opt.some(addrIdx),
-      dialStatus = Opt.some(DialStatus.EDialError),
-    )
+
+  if not self.dialBackSem.tryAcquire():
+    libp2p_autonatv2_dial_back_refusals_total.inc()
+    debug "Too many concurrent dial backs, refusing request", peerId = stream.peerId
+    await stream.sendDialResponse(ResponseStatus.EDialRefused)
     return
   defer:
-    await dialBackConn.close()
-    await dialBackMux.close()
+    try:
+      self.dialBackSem.release()
+    except AsyncSemaphoreError:
+      raiseAssert "semaphore released without acquire"
 
   # the spec exempts only a selected addr whose IP equals the observed IP
   if not ipAddrMatches(observedIPAddr, [req.addrs[addrIdx]]):
@@ -251,12 +264,24 @@ proc handleDialRequest(
       await stream.sendDialResponse(ResponseStatus.EDialRefused)
       return
 
+  let dialBack = (await self.dialBackConnection(stream.peerId, req.addrs[addrIdx])).valueOr:
+    trace "Dial failed"
+    await stream.sendDialResponse(
+      ResponseStatus.Ok,
+      addrIdx = Opt.some(addrIdx),
+      dialStatus = Opt.some(DialStatus.EDialError),
+    )
+    return
+  defer:
+    await dialBack.stream.close()
+    await dialBack.mux.close()
+
   trace "Sending DialBack",
     nonce = req.nonce, addrIdx = addrIdx, addr = req.addrs[addrIdx]
 
   try:
     let dialStatus =
-      await dialBackConn.dialBack(req.nonce).wait(self.config.dialTimeout)
+      await dialBack.stream.dialBack(req.nonce).wait(self.config.dialTimeout)
     await stream.sendDialResponse(
       ResponseStatus.Ok, addrIdx = Opt.some(addrIdx), dialStatus = Opt.some(dialStatus)
     )
@@ -281,7 +306,16 @@ proc new*(
     config: AutonatV2Config = AutonatV2Config.new(),
 ): Self =
   # Self instead of T to avoid clashing with withValue[T]'s type param under --lineDir:on
-  let autonatV2 = Self(switch: switch, config: config)
+  let autonatV2 = Self(
+    switch: switch,
+    config: config,
+    dialBackSem: newAsyncSemaphore(config.maxConcurrentDialBacks),
+  )
+  autonatV2.setStreamLimits(
+    maxIncomingStreamsTotal = config.maxConcurrentRequestsTotal,
+    maxIncomingStreamsPerPeer = config.maxConcurrentRequestsPerPeer,
+  )
+
   proc handleStream(
       stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =

--- a/libp2p/protocols/connectivity/autonatv2/types.nim
+++ b/libp2p/protocols/connectivity/autonatv2/types.nim
@@ -19,6 +19,9 @@ const
   DefaultDialTimeout*: Duration = 15.seconds
   DefaultAmplificationAttackDialTimeout*: Duration = 3.seconds
   DefaultDialDataSize*: uint64 = 50 * 1024 # 50 KiB > 50 KB
+  DefaultMaxConcurrentDialBacks*: int = 8
+  DefaultMaxConcurrentRequestsPerPeer*: int = 2
+  DefaultMaxConcurrentRequestsTotal*: int = 16
   AutonatV2MsgLpSize*: int = 1024
   DialBackLpSize*: int = 1024
   # readLp needs to receive more than 4096 bytes (since it's a DialDataResponse) + overhead

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -86,6 +86,29 @@ template `handler`*(p: LPProtocol, stream: Stream, proto: string): Future[void] 
 func `handler=`*(p: LPProtocol, handler: LPProtoHandler) =
   p.handlerImpl = handler
 
+func setStreamLimits*(
+    p: LPProtocol,
+    maxIncomingStreamsTotal: Opt[int] | int = Opt.none(int),
+    maxIncomingStreamsPerPeer: Opt[int] | int = Opt.none(int),
+    maxOutgoingStreamsTotal: Opt[int] | int = Opt.none(int),
+    maxOutgoingStreamsPerPeer: Opt[int] | int = Opt.none(int),
+) =
+  ## Sets the stream budgets of a protocol built without `LPProtocol.new`.
+  doAssert(not p.started, "stream limits must be set before the protocol starts")
+
+  p.maxIncomingStreamsTotal = toOpt(maxIncomingStreamsTotal)
+  p.maxIncomingStreamsPerPeer = toOpt(maxIncomingStreamsPerPeer)
+  p.maxOutgoingStreamsTotal = toOpt(maxOutgoingStreamsTotal)
+  p.maxOutgoingStreamsPerPeer = toOpt(maxOutgoingStreamsPerPeer)
+
+  # keeping streamBudget uninitialized makes `reserve` and `release` return early (fast path).
+  p.streamBudget =
+    if p.maxIncomingStreamsTotal.isSome or p.maxIncomingStreamsPerPeer.isSome or
+        p.maxOutgoingStreamsTotal.isSome or p.maxOutgoingStreamsPerPeer.isSome:
+      StreamBudgetState()
+    else:
+      nil
+
 proc new*(
     T: type LPProtocol,
     codecs: seq[string],
@@ -98,20 +121,11 @@ proc new*(
   doAssert(codecs.len > 0, "codecs sequence must not be empty")
   doAssert(not handler.isNil, "handler must be set")
 
-  var proto = T(
-    codecs: codecs,
-    handlerImpl: handler,
-    maxIncomingStreamsTotal: toOpt(maxIncomingStreamsTotal),
-    maxIncomingStreamsPerPeer: toOpt(maxIncomingStreamsPerPeer),
-    maxOutgoingStreamsTotal: toOpt(maxOutgoingStreamsTotal),
-    maxOutgoingStreamsPerPeer: toOpt(maxOutgoingStreamsPerPeer),
+  let proto = T(codecs: codecs, handlerImpl: handler)
+  proto.setStreamLimits(
+    maxIncomingStreamsTotal, maxIncomingStreamsPerPeer, maxOutgoingStreamsTotal,
+    maxOutgoingStreamsPerPeer,
   )
-
-  # initialize streamBudget only when there is some limit used.
-  # keeping streamBudget uninitialized makes `reserve` and `release` return early (fast path).
-  if proto.maxIncomingStreamsTotal.isSome or proto.maxIncomingStreamsPerPeer.isSome or
-      proto.maxOutgoingStreamsTotal.isSome or proto.maxOutgoingStreamsPerPeer.isSome:
-    proto.streamBudget = StreamBudgetState()
 
   proto
 

--- a/tests/libp2p/protocols/test_autonat_v2.nim
+++ b/tests/libp2p/protocols/test_autonat_v2.nim
@@ -19,6 +19,13 @@ import
   ]
 import ../../tools/[unittest, crypto, switch_builder, multiaddress]
 
+proc startAndConnect(src, dst: Switch, client: AutonatV2Client) {.async.} =
+  client.setup(src)
+  src.mount(client)
+  await src.start()
+  await dst.start()
+  await src.connect(dst.peerInfo.peerId, dst.peerInfo.addrs)
+
 proc setupAutonat(
     srcAddrs: seq[MultiAddress] = @[TcpAutoAddress],
     dstAddrs: seq[MultiAddress] = @[TcpAutoAddress],
@@ -29,12 +36,7 @@ proc setupAutonat(
     dst = makeStandardSwitchBuilder(dstAddrs).withAutonatV2Server(config).build()
     client = AutonatV2Client.new(rng())
 
-  client.setup(src)
-  src.mount(client)
-  await src.start()
-  await dst.start()
-
-  await src.connect(dst.peerInfo.peerId, dst.peerInfo.addrs)
+  await startAndConnect(src, dst, client)
   (src, dst, client)
 
 proc checkedGetIPAddress(): string =
@@ -308,6 +310,91 @@ suite "AutonatV2":
         ),
         addrs: Opt.some(src.peerInfo.addrs[0]),
       )
+
+  asyncTest "Amplification attack prevention runs before the dial back":
+    # the client refuses to pay dial data, so the server must not dial it back
+    let
+      listenAddrs = @[
+        ma("/ip4/" & checkedGetIPAddress() & "/tcp/4040"), ma("/ip4/127.0.0.1/tcp/4040")
+      ]
+      reqAddrs = @[listenAddrs[0]]
+      (src, dst, client) = await setupAutonat(
+        srcAddrs = listenAddrs,
+        config =
+          AutonatV2Config.new(dialDataSize = (MaxAcceptedDialDataRequest + 1).uint64),
+      )
+    defer:
+      await allFutures(src.stop(), dst.stop())
+
+    expect(AutonatV2Error):
+      discard await client.sendDialRequest(dst.peerInfo.peerId, reqAddrs)
+
+    check src.connManager.connCount(dst.peerInfo.peerId) == 1
+
+  asyncTest "DialRequest refused when every dial back permit is taken":
+    let (src, dst, client) = await setupAutonat(
+      config = AutonatV2Config.new(
+        maxConcurrentDialBacks = 1,
+        maxConcurrentRequestsPerPeer = 2,
+        allowPrivateAddresses = true,
+        amplificationAttackTimeout = 1.minutes,
+      )
+    )
+    defer:
+      await allFutures(src.stop(), dst.stop())
+
+    # the server holds its only permit while it waits for dial data that never comes
+    let holdingStream =
+      await src.dialer.dial(dst.peerInfo.peerId, @[$AutonatV2Codec.DialRequest])
+    defer:
+      await holdingStream.close()
+
+    await holdingStream.writeLp(
+      AutonatV2Msg(
+        oneof: AutonatV2MsgOneof(
+          kind: MsgKind.DialRequest,
+          dialRequest:
+            DialRequest(addrs: @[ma("/ip4/1.1.1.1/tcp/4040")], nonce: 0.Nonce),
+        )
+      ).encode()
+    )
+    let held = AutonatV2Msg.decode(await holdingStream.readLp(AutonatV2MsgLpSize)).valueOr:
+      raiseAssert "expected a DialDataRequest: " & error
+    check held.oneof.kind == MsgKind.DialDataRequest
+
+    check (await client.sendDialRequest(dst.peerInfo.peerId, src.peerInfo.addrs)) ==
+      AutonatV2Response(
+        reachability: Unknown,
+        dialResp: DialResponse(
+          status: EDialRefused,
+          addrIdx: Opt.none(AddrIdx),
+          dialStatus: Opt.none(DialStatus),
+        ),
+        addrs: Opt.none(MultiAddress),
+      )
+    check src.connManager.connCount(dst.peerInfo.peerId) == 1
+
+  test "Concurrent DialRequests are capped per peer and in total":
+    let
+      dst = makeStandardSwitch()
+      autonatServer = server.AutonatV2.new(
+        dst,
+        AutonatV2Config.new(
+          maxConcurrentRequestsPerPeer = 1, maxConcurrentRequestsTotal = 2
+        ),
+      )
+      peerA = PeerId.random(rng()).get()
+      peerB = PeerId.random(rng()).get()
+      peerC = PeerId.random(rng()).get()
+
+    check:
+      autonatServer.reserveIncoming(peerA)
+      not autonatServer.reserveIncoming(peerA)
+      autonatServer.reserveIncoming(peerB)
+      not autonatServer.reserveIncoming(peerC)
+
+    autonatServer.releaseIncoming(peerA)
+    check autonatServer.canAcceptIncoming(peerA)
 
   asyncTest "Server responding with invalid messages":
     let


### PR DESCRIPTION


The AutoNAT v2 server dialed back before it charged the requester, and it served any number of requests at once. The dial back now runs after the DialData exchange, a semaphore admits it (`maxConcurrentDialBacks`, default 8), and the protocol carries an inbound stream budget (2 per peer, 16 total).
