### PR TITLE
fix(gossipsub): ignore RPCs from graylisted peers

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -698,6 +698,14 @@ method rpcHandler*(
     g: GossipSub, peer: PubSubPeer, data: sink seq[byte]
 ) {.async: (raises: [CancelledError, PeerMessageDecodeError, PeerRateLimitError]).} =
   let msgSize = data.len
+
+  if g.isGraylisted(peer, peer.score):
+    await rateLimit(g, peer, msgSize)
+    trace "PubSub RPC ignored",
+      peerId = peer.peerId, reason = "graylisted", score = peer.score
+    libp2p_gossipsub_graylisted_rpcs.inc(labelValues = [peer.getAgent()])
+    return
+
   var rpcMsg = RPCMsg.decode(move(data)).valueOr:
     trace "PubSub RPC decode failed",
       err = error, peerId = peer.peerId, messageType = "rpc", messageSize = msgSize
@@ -716,12 +724,6 @@ method rpcHandler*(
   trace "PubSub RPC decoded",
     peerId = peer.peerId, messageType = "rpc", messageSize = msgSize
   await rateLimit(g, peer, g.messageOverhead(rpcMsg, msgSize))
-
-  if g.isGraylisted(peer, peer.score):
-    trace "PubSub RPC ignored",
-      peerId = peer.peerId, reason = "graylisted", score = peer.score
-    libp2p_gossipsub_graylisted_rpcs.inc(labelValues = [peer.getAgent()])
-    return
 
   # trigger hooks - these may modify the message
   peer.recvObservers(rpcMsg)

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -717,6 +717,12 @@ method rpcHandler*(
     peerId = peer.peerId, messageType = "rpc", messageSize = msgSize
   await rateLimit(g, peer, g.messageOverhead(rpcMsg, msgSize))
 
+  if g.isGraylisted(peer, peer.score):
+    trace "PubSub RPC ignored",
+      peerId = peer.peerId, reason = "graylisted", score = peer.score
+    libp2p_gossipsub_graylisted_rpcs.inc(labelValues = [peer.getAgent()])
+    return
+
   # trigger hooks - these may modify the message
   peer.recvObservers(rpcMsg)
 

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -70,6 +70,11 @@ declarePublicCounter(
   "The number of times peers were above their rate limit",
   labels = ["agent"],
 )
+declarePublicCounter(
+  libp2p_gossipsub_graylisted_rpcs,
+  "The number of RPCs ignored because the sender is graylisted",
+  labels = ["agent"],
+)
 
 proc init*(_: type[TopicParams]): TopicParams =
   TopicParams(
@@ -130,9 +135,11 @@ proc colocationFactor(g: GossipSub, peer: PubSubPeer): float64 =
   else:
     0.0
 
+func isGraylisted*(g: GossipSub, peer: PubSubPeer, score: float64): bool =
+  score < g.parameters.graylistThreshold and peer.peerId notin g.parameters.directPeers
+
 proc disconnectIfBadScorePeer*(g: GossipSub, peer: PubSubPeer, score: float64) =
-  if g.parameters.disconnectBadPeers and score < g.parameters.graylistThreshold and
-      peer.peerId notin g.parameters.directPeers:
+  if g.parameters.disconnectBadPeers and g.isGraylisted(peer, score):
     debug "disconnecting bad score peer", peer, score = peer.score
     g.pendingTasks.trackFut(g.disconnectPeer(peer))
     libp2p_gossipsub_bad_score_disconnection.inc(labelValues = [peer.getAgent()])

--- a/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_scoring.nim
@@ -259,6 +259,65 @@ suite "GossipSub Component - Scoring":
     checkUntilTimeout:
       handlerFut.finished() == true
 
+  asyncTest "Graylisted peers: RPC is ignored":
+    let nodes = generateNodes(2, gossip = true).toGossipSub()
+
+    startAndDeferStop(nodes)
+    await connectStar(nodes)
+
+    let (handlerFut, handler) = createCompleteHandler()
+    nodes[0].subscribe(topic, voidTopicHandler)
+    nodes[1].subscribe(topic, handler)
+    waitSubscribeStar(nodes, topic)
+
+    let node0Id = nodes[0].peerInfo.peerId
+    checkUntilTimeout:
+      nodes[1].mesh.hasPeerId(topic, node0Id)
+
+    # raise the threshold instead of lowering the score, which would also prune the mesh
+    nodes[1].parameters.graylistThreshold = 100000.0
+    check nodes[1].getPeerScore(node0Id) < nodes[1].parameters.graylistThreshold
+
+    var ignored = currentGraylistedRpcs()
+    let peer = nodes[0].getPeerByPeerId(topic, nodes[1].peerInfo.peerId)
+    peer.send(
+      RPCMsg(control: Opt.some(ControlMessage(prune: @[ControlPrune(topicID: topic)]))),
+      false,
+      MessagePriority.High,
+    )
+
+    checkUntilTimeout:
+      currentGraylistedRpcs() > ignored
+    check nodes[1].mesh.hasPeerId(topic, node0Id)
+
+    ignored = currentGraylistedRpcs()
+    tryPublish await nodes[0].publish(topic, toBytes("hellow")), 1
+
+    checkUntilTimeout:
+      currentGraylistedRpcs() > ignored
+    check not handlerFut.finished()
+
+  asyncTest "Graylisted peers: RPC of a direct peer is processed":
+    let nodes = generateNodes(2, gossip = true).toGossipSub()
+
+    startAndDeferStop(nodes)
+    await nodes.addDirectPeerStar()
+
+    let (handlerFut, handler) = createCompleteHandler()
+    nodes[0].subscribe(topic, voidTopicHandler)
+    nodes[1].subscribe(topic, handler)
+    waitSubscribe(nodes[0], nodes[1], topic)
+
+    nodes[1].parameters.graylistThreshold = 100000.0
+    check nodes[1].getPeerScore(nodes[0].peerInfo.peerId) <
+      nodes[1].parameters.graylistThreshold
+
+    tryPublish await nodes[0].publish(topic, toBytes("hellow")), 1
+
+    # without directPeers, the graylist gate would drop this
+    checkUntilTimeout:
+      handlerFut.finished() == true
+
   asyncTest "Slow peer penalty can prune a peer on heartbeat":
     let nodes = generateNodes(
         2,

--- a/tests/libp2p/pubsub/utils.nim
+++ b/tests/libp2p/pubsub/utils.nim
@@ -563,6 +563,14 @@ proc currentRateLimitHits*(label: string = "nim-libp2p"): float64 =
   except KeyError:
     0
 
+proc currentGraylistedRpcs*(label: string = "nim-libp2p"): float64 =
+  try:
+    libp2p_gossipsub_graylisted_rpcs.valueByName(
+      "libp2p_gossipsub_graylisted_rpcs_total", @[label]
+    )
+  except KeyError:
+    0
+
 proc addDirectPeer*[T: PubSub](node: T, target: T) {.async.} =
   doAssert node.switch.peerInfo.peerId != target.switch.peerInfo.peerId,
     "Could not add same peer"


### PR DESCRIPTION
## Summary

`graylistThreshold` had one consumer, `disconnectIfBadScorePeer`, and that one sits behind `disconnectBadPeers`, which defaults to `false`. A graylisted peer therefore kept full access to `rpcHandler`. This adds the gate the spec asks for: `rpcHandler` returns early when `g.isGraylisted(peer, peer.score)`, placed after the decode and after `rateLimit` so the sender still pays the decode penalty and still pays for its bytes.

An ignored RPC includes its subscriptions. go-libp2p still processes those; this does not.

## Affected Areas

- [x] Gossipsub — the `rpcHandler` gate, `isGraylisted` extracted in `scoring.nim` so the predicate has one definition, and the counter `libp2p_gossipsub_graylisted_rpcs{agent}`.

## Compatibility & Downstream Validation

N/A. The default `graylistThreshold` is `-10000.0` and neither Nimbus nor Waku raise it, so the gate is a no-op for the shipped parameters.

## Impact on Library Users

No API change. A peer below `graylistThreshold` stops having its RPCs handled. The gate reads `peer.score`, which `updateScores` refreshes once per `decayInterval`, so it is not instant.

## Risk Assessment

Low. One float compare per RPC on the receive path. Recv observers no longer see traffic from a graylisted peer.

## References

Closes #1141. [Spec: score thresholds](https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#score-thresholds).
