### PR TITLE
fix(gossipsub): track in-flight IWANT requests

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -403,7 +403,7 @@ method unsubscribePeer*(g: GossipSub, peer: PeerId) =
 
   pubSubPeer.stopTasks()
 
-  g.releasePeerIWantRequests(pubSubPeer)
+  g.releasePeerIWantRequests(peer)
 
   g.extensionsState.removePeer(peer)
 

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -133,6 +133,7 @@ proc init*(
     maxHighPriorityQueueLen = DefaultMaxHighPriorityQueueLen,
     maxMediumPriorityQueueLen = DefaultMaxMediumPriorityQueueLen,
     maxLowPriorityQueueLen = DefaultMaxLowPriorityQueueLen,
+    maxIWantsPerMessage = DefaultMaxIWantsPerMessage,
     sendIDontWantOnPublish = false,
     testExtensionConfig = Opt.none(TestExtensionConfig),
     partialMessageExtensionConfig = Opt.none(PartialMessageExtensionConfig),
@@ -180,6 +181,7 @@ proc init*(
     maxHighPriorityQueueLen: maxHighPriorityQueueLen,
     maxMediumPriorityQueueLen: maxMediumPriorityQueueLen,
     maxLowPriorityQueueLen: maxLowPriorityQueueLen,
+    maxIWantsPerMessage: maxIWantsPerMessage,
     sendIDontWantOnPublish: sendIDontWantOnPublish,
     testExtensionConfig: testExtensionConfig,
     partialMessageExtensionConfig: partialMessageExtensionConfig,
@@ -248,6 +250,8 @@ proc validateParameters*(parameters: GossipSubParams): Result[void, cstring] =
     err("gossipsub: maxMediumPriorityQueueLen parameter error, Must be > 0")
   elif parameters.maxLowPriorityQueueLen <= 0:
     err("gossipsub: maxLowPriorityQueueLen parameter error, Must be > 0")
+  elif parameters.maxIWantsPerMessage <= 0:
+    err("gossipsub: maxIWantsPerMessage parameter error, Must be > 0")
   else:
     validateOverheadRateLimit(parameters)
 
@@ -398,6 +402,8 @@ method unsubscribePeer*(g: GossipSub, peer: PeerId) =
       info.firstMessageDeliveries = 0
 
   pubSubPeer.stopTasks()
+
+  g.releasePeerIWantRequests(pubSubPeer)
 
   g.extensionsState.removePeer(peer)
 
@@ -761,6 +767,9 @@ method rpcHandler*(
       trace "Dropping message of topic without subscription",
         msgId = shortLog(msgId), peer
       continue
+
+    # released before validation, so a peer cannot block the retry with a bad message
+    g.forgetIWantRequests(msgId)
 
     if (msg.signature.len > 0 or g.verifySignature) and not msg.verify():
       trace "Message dropped",

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -62,6 +62,9 @@ declareCounter(
   "number of iwant requests avoided by preamble",
   labels = ["topic"],
 )
+declareCounter(
+  libp2p_gossipsub_saved_iwants, "number of iwant requests avoided", labels = ["reason"]
+)
 
 proc grafted*(g: GossipSub, p: PubSubPeer, topic: string) =
   g.withPeerStats(p.peerId) do(stats: var PeerStats):
@@ -289,6 +292,24 @@ proc handlePrune*(g: GossipSub, peer: PubSubPeer, prunes: seq[ControlPrune]) =
       for handler in g.routingRecordsHandler:
         handler(peer.peerId, topic, routingRecords)
 
+proc recordIWantRequest(g: GossipSub, peer: PubSubPeer, msgId: MessageId) =
+  peer.requestedIWants[0].incl(msgId)
+  g.requestedIWants.mgetOrPut(msgId, 0).inc()
+
+proc releaseIWantRequest(g: GossipSub, msgId: MessageId) =
+  g.requestedIWants.withValue(msgId, count):
+    count[].dec()
+    if count[] <= 0:
+      g.requestedIWants.del(msgId)
+
+proc forgetIWantRequests*(g: GossipSub, msgId: MessageId) =
+  g.requestedIWants.del(msgId)
+
+proc releasePeerIWantRequests*(g: GossipSub, peer: PubSubPeer) =
+  for requested in peer.requestedIWants:
+    for msgId in requested:
+      g.releaseIWantRequest(msgId)
+
 proc handleIHave*(
     g: GossipSub, peer: PubSubPeer, ihaves: seq[ControlIHave]
 ): ControlIWant =
@@ -304,18 +325,27 @@ proc handleIHave*(
         trace "topic not set: ihave", peer
         continue
       trace "peer sent ihave", peer, topicID = topic, msgs = ihave.messageIDs
-      if topic in g.topics:
-        for msgId in ihave.messageIDs:
-          if not g.hasSeen(g.salt(msgId)):
-            if peer.iHaveBudget <= 0:
-              break
-            elif msgId notin res.messageIDs:
-              if g.extensionsState.preambleHandleIHave(peer.peerId, msgId):
-                libp2p_gossipsub_preamble_saved_iwants.inc(labelValues = [topic])
-                continue
-              res.messageIDs.add(msgId)
-              dec peer.iHaveBudget
-              trace "requested message via ihave", messageID = msgId
+      if topic notin g.topics:
+        continue
+
+      for msgId in ihave.messageIDs:
+        if g.hasSeen(g.salt(msgId)):
+          continue
+        if peer.iHaveBudget <= 0:
+          break
+        if msgId in res.messageIDs:
+          continue
+        if g.requestedIWants.getOrDefault(msgId) >= g.parameters.maxIWantsPerMessage:
+          libp2p_gossipsub_saved_iwants.inc(labelValues = ["in_flight"])
+          continue
+        if g.extensionsState.preambleHandleIHave(peer.peerId, msgId):
+          libp2p_gossipsub_preamble_saved_iwants.inc(labelValues = [topic])
+          continue
+
+        res.messageIDs.add(msgId)
+        g.recordIWantRequest(peer, msgId)
+        dec peer.iHaveBudget
+        trace "requested message via ihave", messageID = msgId
     # shuffling res.messageIDs before sending it out to increase the likelihood
     # of getting an answer if the peer truncates the list due to internal size restrictions.
     g.rng.shuffle(res.messageIDs)
@@ -723,6 +753,10 @@ proc onHeartbeat(g: GossipSub) =
       peer.iDontWants.addFirst(default(HashSet[SaltedId]))
       if peer.iDontWants.len > g.parameters.historyLength:
         discard peer.iDontWants.popLast()
+      peer.requestedIWants.addFirst(default(HashSet[MessageId]))
+      if peer.requestedIWants.len > IWantHistoryLen:
+        for msgId in peer.requestedIWants.popLast():
+          g.releaseIWantRequest(msgId)
       peer.iHaveBudget = IHavePeerBudget
 
   var meshMetrics = MeshMetrics()

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -293,22 +293,42 @@ proc handlePrune*(g: GossipSub, peer: PubSubPeer, prunes: seq[ControlPrune]) =
         handler(peer.peerId, topic, routingRecords)
 
 proc recordIWantRequest(g: GossipSub, peer: PubSubPeer, msgId: MessageId) =
-  peer.requestedIWants[0].incl(msgId)
-  g.requestedIWants.mgetOrPut(msgId, 0).inc()
+  g.requestedIWants.mgetOrPut(msgId, @[]).add(
+    IWantRequest(peerId: peer.peerId, heartbeat: g.heartbeatCount)
+  )
 
-proc releaseIWantRequest(g: GossipSub, msgId: MessageId) =
-  g.requestedIWants.withValue(msgId, count):
-    count[].dec()
-    if count[] <= 0:
-      g.requestedIWants.del(msgId)
+proc isIWantInFlight(g: GossipSub, peer: PubSubPeer, msgId: MessageId): bool =
+  g.requestedIWants.withValue(msgId, requests):
+    return
+      requests[].len >= g.parameters.maxIWantsPerMessage or
+      requests[].anyIt(it.peerId == peer.peerId)
+
+  false
 
 proc forgetIWantRequests*(g: GossipSub, msgId: MessageId) =
   g.requestedIWants.del(msgId)
 
-proc releasePeerIWantRequests*(g: GossipSub, peer: PubSubPeer) =
-  for requested in peer.requestedIWants:
-    for msgId in requested:
-      g.releaseIWantRequest(msgId)
+proc delEmptyIWantRequests(g: GossipSub, emptied: seq[MessageId]) =
+  for msgId in emptied:
+    g.requestedIWants.del(msgId)
+
+proc releasePeerIWantRequests*(g: GossipSub, peerId: PeerId) =
+  var emptied: seq[MessageId]
+  for msgId, requests in g.requestedIWants.mpairs:
+    requests.keepItIf(it.peerId != peerId)
+    if requests.len == 0:
+      emptied.add(msgId)
+
+  g.delEmptyIWantRequests(emptied)
+
+proc expireIWantRequests(g: GossipSub) =
+  var emptied: seq[MessageId]
+  for msgId, requests in g.requestedIWants.mpairs:
+    requests.keepItIf(g.heartbeatCount - it.heartbeat < IWantHistoryLen)
+    if requests.len == 0:
+      emptied.add(msgId)
+
+  g.delEmptyIWantRequests(emptied)
 
 proc handleIHave*(
     g: GossipSub, peer: PubSubPeer, ihaves: seq[ControlIHave]
@@ -335,7 +355,7 @@ proc handleIHave*(
           break
         if msgId in res.messageIDs:
           continue
-        if g.requestedIWants.getOrDefault(msgId) >= g.parameters.maxIWantsPerMessage:
+        if g.isIWantInFlight(peer, msgId):
           libp2p_gossipsub_saved_iwants.inc(labelValues = ["in_flight"])
           continue
         if g.extensionsState.preambleHandleIHave(peer.peerId, msgId):
@@ -743,6 +763,9 @@ proc makeGossipControlMessages*(g: GossipSub): Table[PubSubPeer, ControlMessage]
 proc onHeartbeat(g: GossipSub) =
   libp2p_gossipsub_seen_cache_size.set(g.seen.len.int64)
 
+  g.heartbeatCount.inc()
+  g.expireIWantRequests()
+
   # reset IWANT budget
   # reset IHAVE cap
   block:
@@ -753,10 +776,6 @@ proc onHeartbeat(g: GossipSub) =
       peer.iDontWants.addFirst(default(HashSet[SaltedId]))
       if peer.iDontWants.len > g.parameters.historyLength:
         discard peer.iDontWants.popLast()
-      peer.requestedIWants.addFirst(default(HashSet[MessageId]))
-      if peer.requestedIWants.len > IWantHistoryLen:
-        for msgId in peer.requestedIWants.popLast():
-          g.releaseIWantRequest(msgId)
       peer.iHaveBudget = IHavePeerBudget
 
   var meshMetrics = MeshMetrics()

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -53,6 +53,9 @@ const
   IDontWantMaxCount* = 1000
     # maximum number of IDontWant messages in one slot of the history
   MaxOpportunisticGraftPeers* = 2
+  IWantHistoryLen* = 3
+    # number of heartbeats an outstanding IWANT request is remembered for
+  DefaultMaxIWantsPerMessage* = 1
 
 type
   TopicInfo* = object # gossip 1.1 related
@@ -166,6 +169,9 @@ type
     # Max number of enqueued low-priority messages. Excess messages are dropped.
     maxLowPriorityQueueLen*: int
 
+    # Max number of peers we send an IWANT to for the same message at the same time.
+    maxIWantsPerMessage*: int
+
     # Broadcast an IDONTWANT message automatically when the message exceeds the IDONTWANT message size threshold
     sendIDontWantOnPublish*: bool
 
@@ -196,6 +202,8 @@ type
     lastFanoutPubSub*: Table[string, Moment] # last publish time for fanout topics
     mcache*: MCache # messages cache
     validationSeen*: ValidationSeenTable # peers who sent us message in validation
+    requestedIWants*: Table[MessageId, int]
+      # number of peers we have an outstanding IWANT request with, per message
     heartbeatFut*: Future[void] # cancellation future for heartbeat interval
     scoringHeartbeatFut*: Future[void]
       # cancellation future for scoring heartbeat interval

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -58,6 +58,10 @@ const
   DefaultMaxIWantsPerMessage* = 1
 
 type
+  IWantRequest* = object
+    peerId*: PeerId
+    heartbeat*: uint64
+
   TopicInfo* = object # gossip 1.1 related
     graftTime*: Moment
     meshTime*: Duration
@@ -202,8 +206,9 @@ type
     lastFanoutPubSub*: Table[string, Moment] # last publish time for fanout topics
     mcache*: MCache # messages cache
     validationSeen*: ValidationSeenTable # peers who sent us message in validation
-    requestedIWants*: Table[MessageId, int]
-      # number of peers we have an outstanding IWANT request with, per message
+    requestedIWants*: Table[MessageId, seq[IWantRequest]]
+      # peers we have an outstanding IWANT request with, per message
+    heartbeatCount*: uint64 # heartbeats since start, used to expire IWANT requests
     heartbeatFut*: Future[void] # cancellation future for heartbeat interval
     scoringHeartbeatFut*: Future[void]
       # cancellation future for scoring heartbeat interval

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -165,8 +165,6 @@ type
     score*: float64
     subscribedTopics*: int # distinct topics this peer is tracked as subscribed to
     sentIHaves*: Deque[HashSet[MessageId]]
-    requestedIWants*: Deque[HashSet[MessageId]]
-      ## message id:s we asked this peer for and have not received yet
     iDontWants*: Deque[HashSet[SaltedId]]
       ## IDONTWANT contains unvalidated message id:s which may be long and/or
       ## expensive to look up, so we apply the same salting to them as during
@@ -885,7 +883,6 @@ proc new*(
     customStreamCallbacks: customStreamCallbacks,
   )
   response.sentIHaves.addFirst(default(HashSet[MessageId]))
-  response.requestedIWants.addFirst(default(HashSet[MessageId]))
   response.iDontWants.addFirst(default(HashSet[SaltedId]))
   response.startSendNonHighPriorityTask()
 

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -165,6 +165,8 @@ type
     score*: float64
     subscribedTopics*: int # distinct topics this peer is tracked as subscribed to
     sentIHaves*: Deque[HashSet[MessageId]]
+    requestedIWants*: Deque[HashSet[MessageId]]
+      ## message id:s we asked this peer for and have not received yet
     iDontWants*: Deque[HashSet[SaltedId]]
       ## IDONTWANT contains unvalidated message id:s which may be long and/or
       ## expensive to look up, so we apply the same salting to them as during
@@ -883,6 +885,7 @@ proc new*(
     customStreamCallbacks: customStreamCallbacks,
   )
   response.sentIHaves.addFirst(default(HashSet[MessageId]))
+  response.requestedIWants.addFirst(default(HashSet[MessageId]))
   response.iDontWants.addFirst(default(HashSet[SaltedId]))
   response.startSendNonHighPriorityTask()
 

--- a/tests/libp2p/pubsub/component/test_gossipsub_heartbeat.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_heartbeat.nim
@@ -314,8 +314,7 @@ suite "GossipSub Component - Heartbeat":
     # Then the request is recorded
     check:
       iWant.messageIDs == @[id]
-      nodes[1].requestedIWants[id] == 1
-      id in peer.requestedIWants[0]
+      nodes[1].requestedIWants[id].mapIt(it.peerId) == @[peer.peerId]
 
     # And it is forgotten once the history moves past it
     checkUntilTimeout:
@@ -323,7 +322,6 @@ suite "GossipSub Component - Heartbeat":
 
     # And the unanswered request carries no penalty
     check:
-      peer.requestedIWants.allIt(id notin it)
       peer.behaviourPenalty == 0.0
 
     # And the message can be requested again

--- a/tests/libp2p/pubsub/component/test_gossipsub_heartbeat.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_heartbeat.nim
@@ -294,6 +294,42 @@ suite "GossipSub Component - Heartbeat":
     checkUntilTimeout:
       peer.iDontWants.allIt(it.len == 0)
 
+  asyncTest "requestedIWants history - last element is pruned during heartbeat":
+    let nodes = generateNodes(2, gossip = true, heartbeatInterval = 300.milliseconds)
+      .toGossipSub()
+
+    startAndDeferStop(nodes)
+
+    await connectChain(nodes)
+    subscribeAllNodes(nodes, topic, voidTopicHandler)
+    waitSubscribeChain(nodes, topic)
+
+    # When Node1 handles an IHave for an unknown message
+    let
+      peer = nodes[1].mesh[topic].toSeq()[0]
+      id = toBytes("never delivered")
+      ihave = ControlIHave(topicID: topic, messageIDs: @[id])
+      iWant = nodes[1].handleIHave(peer, @[ihave])
+
+    # Then the request is recorded
+    check:
+      iWant.messageIDs == @[id]
+      nodes[1].requestedIWants[id] == 1
+      id in peer.requestedIWants[0]
+
+    # And it is forgotten once the history moves past it
+    checkUntilTimeout:
+      id notin nodes[1].requestedIWants
+
+    # And the unanswered request carries no penalty
+    check:
+      peer.requestedIWants.allIt(id notin it)
+      peer.behaviourPenalty == 0.0
+
+    # And the message can be requested again
+    check:
+      nodes[1].handleIHave(peer, @[ihave]).messageIDs == @[id]
+
   asyncTest "sentIHaves history - last element is pruned during heartbeat":
     # 3 Nodes, Node 0 <==> Node 1 and Node 0 <==> Node 2
     # due to DValues: 1 peer in mesh and 1 peer only in gossip of Node 0

--- a/tests/libp2p/pubsub/test_behavior.nim
+++ b/tests/libp2p/pubsub/test_behavior.nim
@@ -269,7 +269,6 @@ suite "GossipSub Behavior":
     check:
       iWant.messageIDs.len == 0
       id notin gossipSub.requestedIWants
-      peer.requestedIWants.allIt(id notin it)
 
   asyncTest "handleIHave - request a message from only one peer at a time":
     # Given a GossipSub instance with two peers
@@ -292,9 +291,7 @@ suite "GossipSub Behavior":
     check:
       firstIWant.messageIDs == @[id]
       secondIWant.messageIDs.len == 0
-      gossipSub.requestedIWants[id] == 1
-      id in firstPeer.requestedIWants[0]
-      secondPeer.requestedIWants.allIt(id notin it)
+      gossipSub.requestedIWants[id].mapIt(it.peerId) == @[firstPeer.peerId]
 
     # And the unanswered request carries no penalty
     check:
@@ -321,7 +318,65 @@ suite "GossipSub Behavior":
       iWants[0].messageIDs == @[id]
       iWants[1].messageIDs == @[id]
       iWants[2].messageIDs.len == 0
-      gossipSub.requestedIWants[id] == 2
+      gossipSub.requestedIWants[id].mapIt(it.peerId) ==
+        @[peers[0].peerId, peers[1].peerId]
+
+  asyncTest "handleIHave - a repeated announcement takes one slot per peer":
+    # Given a GossipSub instance with two peers, asking two peers per message
+    let
+      (gossipSub, conns, peers) = setupGossipSubWithPeers(2, topic)
+      firstPeer = peers[0]
+      secondPeer = peers[1]
+    defer:
+      await teardownGossipSub(gossipSub, conns)
+
+    gossipSub.parameters.maxIWantsPerMessage = 2
+
+    let id = @[0'u8, 1, 2, 3]
+    let msg = ControlIHave(topicID: topic, messageIDs: @[id])
+
+    # When the first peer announces the same message twice
+    let firstIWant = gossipSub.handleIHave(firstPeer, @[msg])
+    let repeatedIWant = gossipSub.handleIHave(firstPeer, @[msg])
+
+    # Then the second announcement is ignored
+    check:
+      firstIWant.messageIDs == @[id]
+      repeatedIWant.messageIDs.len == 0
+      gossipSub.requestedIWants[id].mapIt(it.peerId) == @[firstPeer.peerId]
+
+    # And the free slot still goes to the second peer
+    check:
+      gossipSub.handleIHave(secondPeer, @[msg]).messageIDs == @[id]
+      gossipSub.requestedIWants[id].len == 2
+
+  asyncTest "unsubscribePeer - releases only the requests of that peer":
+    # Given two peers that were both asked for the same message
+    let
+      (gossipSub, conns, peers) = setupGossipSubWithPeers(2, topic)
+      firstPeer = peers[0]
+      secondPeer = peers[1]
+    defer:
+      await teardownGossipSub(gossipSub, conns)
+
+    gossipSub.parameters.maxIWantsPerMessage = 2
+
+    let id = @[0'u8, 1, 2, 3]
+    let msg = ControlIHave(topicID: topic, messageIDs: @[id])
+    discard gossipSub.handleIHave(firstPeer, @[msg])
+    discard gossipSub.handleIHave(secondPeer, @[msg])
+
+    # When the first peer disconnects
+    gossipSub.unsubscribePeer(firstPeer.peerId)
+
+    # Then only its request is released
+    check:
+      gossipSub.requestedIWants[id].mapIt(it.peerId) == @[secondPeer.peerId]
+
+    # And when the second peer disconnects the message is forgotten
+    gossipSub.unsubscribePeer(secondPeer.peerId)
+    check:
+      id notin gossipSub.requestedIWants
 
   asyncTest "handleIHave - iHaveBudget caps the recorded requests":
     # Given a GossipSub instance with one peer
@@ -342,7 +397,6 @@ suite "GossipSub Behavior":
     check:
       iWant.messageIDs.len == IHavePeerBudget
       gossipSub.requestedIWants.len == IHavePeerBudget
-      peer.requestedIWants[0].len == IHavePeerBudget
       peer.iHaveBudget == 0
 
   asyncTest "handleIWant - message is handled when in cache and with sent IHave":

--- a/tests/libp2p/pubsub/test_behavior.nim
+++ b/tests/libp2p/pubsub/test_behavior.nim
@@ -265,9 +265,85 @@ suite "GossipSub Behavior":
     # When IHave is handled
     let iWant = gossipSub.handleIHave(peer, @[msg])
 
-    # Then no IWANT should be generated
+    # Then no IWANT should be generated and no request is recorded
     check:
       iWant.messageIDs.len == 0
+      id notin gossipSub.requestedIWants
+      peer.requestedIWants.allIt(id notin it)
+
+  asyncTest "handleIHave - request a message from only one peer at a time":
+    # Given a GossipSub instance with two peers
+    let
+      (gossipSub, conns, peers) = setupGossipSubWithPeers(2, topic)
+      firstPeer = peers[0]
+      secondPeer = peers[1]
+    defer:
+      await teardownGossipSub(gossipSub, conns)
+
+    # And both peers announce the same message
+    let id = @[0'u8, 1, 2, 3]
+    let msg = ControlIHave(topicID: topic, messageIDs: @[id])
+
+    # When IHave is handled for both peers
+    let firstIWant = gossipSub.handleIHave(firstPeer, @[msg])
+    let secondIWant = gossipSub.handleIHave(secondPeer, @[msg])
+
+    # Then only the first peer is asked for the message
+    check:
+      firstIWant.messageIDs == @[id]
+      secondIWant.messageIDs.len == 0
+      gossipSub.requestedIWants[id] == 1
+      id in firstPeer.requestedIWants[0]
+      secondPeer.requestedIWants.allIt(id notin it)
+
+    # And the unanswered request carries no penalty
+    check:
+      firstPeer.behaviourPenalty == 0.0
+      secondPeer.behaviourPenalty == 0.0
+
+  asyncTest "handleIHave - maxIWantsPerMessage caps the peers asked for a message":
+    # Given a GossipSub instance with three peers, asking two peers per message
+    let (gossipSub, conns, peers) = setupGossipSubWithPeers(3, topic)
+    defer:
+      await teardownGossipSub(gossipSub, conns)
+
+    gossipSub.parameters.maxIWantsPerMessage = 2
+
+    # And all peers announce the same message
+    let id = @[0'u8, 1, 2, 3]
+    let msg = ControlIHave(topicID: topic, messageIDs: @[id])
+
+    # When IHave is handled for every peer
+    let iWants = peers.mapIt(gossipSub.handleIHave(it, @[msg]))
+
+    # Then the first two peers are asked and the third one is not
+    check:
+      iWants[0].messageIDs == @[id]
+      iWants[1].messageIDs == @[id]
+      iWants[2].messageIDs.len == 0
+      gossipSub.requestedIWants[id] == 2
+
+  asyncTest "handleIHave - iHaveBudget caps the recorded requests":
+    # Given a GossipSub instance with one peer
+    let
+      (gossipSub, conns, peers) = setupGossipSubWithPeers(1, topic)
+      peer = peers[0]
+    defer:
+      await teardownGossipSub(gossipSub, conns)
+
+    # And an IHAVE announcing more messages than the peer has budget for
+    let ids = (0 .. IHavePeerBudget).mapIt(("msg_id_" & $it).toBytes())
+    let msg = ControlIHave(topicID: topic, messageIDs: ids)
+
+    # When IHave is handled
+    let iWant = gossipSub.handleIHave(peer, @[msg])
+
+    # Then the budget caps both the IWANT and the recorded requests
+    check:
+      iWant.messageIDs.len == IHavePeerBudget
+      gossipSub.requestedIWants.len == IHavePeerBudget
+      peer.requestedIWants[0].len == IHavePeerBudget
+      peer.iHaveBudget == 0
 
   asyncTest "handleIWant - message is handled when in cache and with sent IHave":
     let

--- a/tests/libp2p/pubsub/test_gossipsub.nim
+++ b/tests/libp2p/pubsub/test_gossipsub.nim
@@ -427,6 +427,31 @@ suite "GossipSub":
 
     check gossipSub.mcache.msgs.len == 0
 
+  asyncTest "rpcHandler - an outstanding IWANT is forgotten when the message arrives":
+    let (gossipSub, conns, peers) = setupGossipSubWithPeers(2, topic)
+    defer:
+      await teardownGossipSub(gossipSub, conns)
+
+    let
+      sender = peers[0]
+      announcer = peers[1]
+      msg = Message.init(conns[0].peerId, "bar".toBytes(), topic, Opt.some(1'u64))
+      msgId = gossipSub.msgIdProvider(msg).get()
+      ihave = ControlIHave(topicID: topic, messageIDs: @[msgId])
+
+    # Given the announcer was asked for the message
+    check:
+      gossipSub.handleIHave(announcer, @[ihave]).messageIDs == @[msgId]
+      gossipSub.requestedIWants[msgId] == 1
+
+    # When the message arrives from another peer
+    await gossipSub.rpcHandler(sender, RPCMsg.withMessages(msg).encode(false))
+
+    # Then the request is forgotten and a new IHAVE is ignored
+    check:
+      msgId notin gossipSub.requestedIWants
+      gossipSub.handleIHave(announcer, @[ihave]).messageIDs.len == 0
+
   test "seen cache uses configured maximum size":
     let
       params = GossipSubParams.init(seenMaxSize = 3)

--- a/tests/libp2p/pubsub/test_gossipsub.nim
+++ b/tests/libp2p/pubsub/test_gossipsub.nim
@@ -432,6 +432,8 @@ suite "GossipSub":
     defer:
       await teardownGossipSub(gossipSub, conns)
 
+    gossipSub.verifySignature = false
+
     let
       sender = peers[0]
       announcer = peers[1]
@@ -447,10 +449,39 @@ suite "GossipSub":
     # When the message arrives from another peer
     await gossipSub.rpcHandler(sender, RPCMsg.withMessages(msg).encode(false))
 
-    # Then the request is forgotten and a new IHAVE is ignored
+    # Then the request is forgotten and the seen message is not requested again
     check:
       msgId notin gossipSub.requestedIWants
       gossipSub.handleIHave(announcer, @[ihave]).messageIDs.len == 0
+
+  asyncTest "rpcHandler - an outstanding IWANT is forgotten when the message is invalid":
+    let (gossipSub, conns, peers) = setupGossipSubWithPeers(3, topic)
+    defer:
+      await teardownGossipSub(gossipSub, conns)
+
+    let
+      sender = peers[0]
+      announcer = peers[1]
+      otherAnnouncer = peers[2]
+      msg = Message.init(conns[0].peerId, "bar".toBytes(), topic, Opt.some(1'u64))
+      msgId = gossipSub.msgIdProvider(msg).get()
+      ihave = ControlIHave(topicID: topic, messageIDs: @[msgId])
+
+    # Given the announcer was asked for the message
+    check:
+      gossipSub.handleIHave(announcer, @[ihave]).messageIDs == @[msgId]
+
+    # When an unsigned copy arrives and fails verification
+    await gossipSub.rpcHandler(sender, RPCMsg.withMessages(msg).encode(false))
+
+    # Then the message is not seen, yet the request is released
+    check:
+      not gossipSub.hasSeen(gossipSub.salt(msgId))
+      msgId notin gossipSub.requestedIWants
+
+    # And another peer can still be asked for it
+    check:
+      gossipSub.handleIHave(otherAnnouncer, @[ihave]).messageIDs == @[msgId]
 
   test "seen cache uses configured maximum size":
     let

--- a/tests/libp2p/pubsub/test_gossipsub.nim
+++ b/tests/libp2p/pubsub/test_gossipsub.nim
@@ -444,7 +444,7 @@ suite "GossipSub":
     # Given the announcer was asked for the message
     check:
       gossipSub.handleIHave(announcer, @[ihave]).messageIDs == @[msgId]
-      gossipSub.requestedIWants[msgId] == 1
+      gossipSub.requestedIWants[msgId].len == 1
 
     # When the message arrives from another peer
     await gossipSub.rpcHandler(sender, RPCMsg.withMessages(msg).encode(false))


### PR DESCRIPTION


A node that receives an IHAVE for a message it lacks sends an IWANT, and nothing records the request. Every peer gossiping the same id gets its own IWANT and the payload arrives from all of them (#1101).

`GossipSub.requestedIWants` now counts outstanding requests and `handleIHave` skips a duplicate while one is in flight. Per-peer state ages in the heartbeat next to `sentIHaves`, so an unanswered request expires after `IWantHistoryLen = 3` heartbeats. `rpcHandler` releases it on arrival, before validation, so a bad answer cannot block the retry.

#943 did this and was reverted by #977. Its three constraints hold: no penalty on an unanswered IWANT (#976), per-peer expiring state, and clearing on delivery from any source.

### References

#1136, #1318, #1101, #943, #977, #976
