### PR TITLE
fix(autotls): keep ACME requests on the directory origin

### DIFF
--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -186,6 +186,25 @@ template handleError*(msg: string, body: untyped): untyped =
   except CatchableError as exc:
     raise newException(ACMEError, msg & ": Unexpected error", exc)
 
+func origin(uri: Uri): string =
+  let scheme = uri.scheme.toLowerAscii()
+  let port =
+    if uri.port.len > 0:
+      uri.port
+    elif scheme == "http":
+      "80"
+    else:
+      "443"
+  scheme & "://" & uri.hostname.toLowerAscii() & ":" & port
+
+proc checkOrigin*(self: ACMEApi, uri: Uri) {.raises: [ACMEError].} =
+  ## The directory is the only URL the caller chooses; the rest come from the server.
+  if uri.origin != self.directoryURL.origin:
+    raise newException(
+      ACMEError,
+      "ACME URL " & $uri & " is not on the directory origin " & self.directoryURL.origin,
+    )
+
 proc checkAPIError(resp: HTTPResponse) {.raises: [ACMEError].} =
   let respType =
     try:
@@ -273,16 +292,24 @@ proc acmeHeader(
       kid: kid.get(),
     )
 
+proc sendPost(
+    self: ACMEApi, uri: Uri, payload: string
+): Future[HttpClientResponseRef] {.
+    async: (raises: [ACMEError, HttpError, CancelledError])
+.} =
+  self.checkOrigin(uri)
+  let request = HttpClientRequestRef.post(
+    self.session, $uri, body = payload, headers = ACMEHttpHeaders
+  ).valueOr:
+    raiseHttpAddressError(error)
+  await request.send()
+
 method post*(
     self: ACMEApi, uri: Uri, payload: string
 ): Future[HTTPResponse] {.
     async: (raises: [ACMEError, HttpError, CancelledError]), base
 .} =
-  let request = HttpClientRequestRef.post(
-    self.session, $uri, body = payload, headers = ACMEHttpHeaders
-  ).valueOr:
-    raiseHttpAddressError(error)
-  let rawResponse = await request.send()
+  let rawResponse = await self.sendPost(uri, payload)
   let body = await rawResponse.getResponseBody()
   let resp = HTTPResponse(body: body, headers: rawResponse.headers)
   checkAPIError(resp)
@@ -293,6 +320,7 @@ method get*(
 ): Future[HTTPResponse] {.
     async: (raises: [ACMEError, HttpError, CancelledError]), base
 .} =
+  self.checkOrigin(uri)
   let request = HttpClientRequestRef.get(self.session, $uri).valueOr:
     raiseHttpAddressError(error)
   let rawResponse = await request.send()
@@ -555,11 +583,7 @@ proc downloadCertificate*(
 
   handleError("downloadCertificate"):
     # not `self.post` as it reads the response as JSON, and a certificate is PEM
-    let request = HttpClientRequestRef.post(
-      self.session, orderResponse.certificate, body = payload, headers = ACMEHttpHeaders
-    ).valueOr:
-      raiseHttpAddressError(error)
-    let rawResponse = await request.send()
+    let rawResponse = await self.sendPost(certificateURL, payload)
     ACMECertificateResponse(
       rawCertificate: bytesToString(await rawResponse.getBodyBytes()),
       certificateExpiry: parse(orderResponse.expires, "yyyy-MM-dd'T'HH:mm:ss'Z'"),

--- a/tests/libp2p/autotls/test_acme_utils.nim
+++ b/tests/libp2p/autotls/test_acme_utils.nim
@@ -35,7 +35,7 @@ suite "ACME utils":
     let server = startTestHttpServer("")
     defer:
       await server.stop()
-    let acmeApi = ACMEApi.new()
+    let acmeApi = ACMEApi.new(directoryURL = parseUri(server.url))
     defer:
       await acmeApi.close()
 
@@ -45,7 +45,7 @@ suite "ACME utils":
     let server = startTestHttpServer("<html>not json</html>")
     defer:
       await server.stop()
-    let acmeApi = ACMEApi.new()
+    let acmeApi = ACMEApi.new(directoryURL = parseUri(server.url))
     defer:
       await acmeApi.close()
 

--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -182,7 +182,7 @@ suite "AutoTLS ACME API":
       discard await api.requestNewOrder(@["some-domain"], key, "kid")
 
     expect(ACMEError):
-      discard await api.requestAuthorizations(@["auth-1", "auth-2"], key, "kid")
+      discard await api.requestAuthorizations(@[AuthorizationsURL], key, "kid")
 
     expect(ACMEError):
       discard await api.requestChallenge(@["domain-1", "domain-2"], key, "kid")
@@ -323,6 +323,12 @@ suite "AutoTLS ACME API":
     expect(ACMEError):
       discard await api.requestChallenge(@[WildcardDomain], key, AccountURL)
 
+  asyncTest "an order naming an authorization off the directory origin is refused":
+    api.queueOrder("pending", %*["https://elsewhere.example/authz/1"])
+
+    expect(ACMEError):
+      discard await api.requestChallenge(@[WildcardDomain], key, AccountURL)
+
   asyncTest "a register response with no location header is refused":
     api.mockedResponses.add(
       HTTPResponse(body: %*{"status": "valid"}, headers: HttpTable.init())
@@ -389,6 +395,7 @@ suite "AutoTLS ACME API":
     defer:
       await certServer.stop()
 
+    api.directoryURL = parseUri(certServer.url)
     api.queueGetOrder(certServer.url, expires)
     await api.downloadCertificate(parseUri(OrderURL), key, AccountURL)
 
@@ -409,10 +416,14 @@ suite "AutoTLS ACME API":
     expect(ACMEError):
       discard await downloadWithExpires("2026-11-02T14:30:00+00:00")
 
-  asyncTest "an order whose certificate url has no hostname is a network error":
+  asyncTest "an order whose certificate url is off the directory origin is refused":
     api.queueGetOrder("", "2026-11-02T14:30:00Z")
+    api.queueGetOrder("https://elsewhere.example/cert/1", "2026-11-02T14:30:00Z")
 
-    expect(ACMENetworkError):
+    expect(ACMEError):
+      discard await api.downloadCertificate(parseUri(OrderURL), key, AccountURL)
+
+    expect(ACMEError):
       discard await api.downloadCertificate(parseUri(OrderURL), key, AccountURL)
 
 suite "AutoTLS ACME API over HTTP":
@@ -422,7 +433,8 @@ suite "AutoTLS ACME API over HTTP":
     checkTrackers()
 
   asyncTest "a url the session cannot turn into an address is an http error":
-    let api = ACMEApi.new()
+    # an empty directory URL keeps the empty request URL on its origin
+    let api = ACMEApi.new(directoryURL = parseUri(""))
     defer:
       await api.close()
 
@@ -434,14 +446,39 @@ suite "AutoTLS ACME API over HTTP":
 
   asyncTest "a post carries the server's response body back":
     let server = startTestHttpServer($ %*{"status": "valid"})
-    let api = ACMEApi.new()
+    let api = ACMEApi.new(directoryURL = parseUri(server.url))
     defer:
       await api.close()
       await server.stop()
 
     check (await api.post(parseUri(server.url), "{}")).body == %*{"status": "valid"}
 
-  asyncTest "a directory url with no hostname is a network error":
+  asyncTest "a request off the directory origin is refused":
+    let api = ACMEApi.new(parseUri("https://acme.example/directory"))
+    defer:
+      await api.close()
+
+    expect(ACMEError):
+      discard await api.get(parseUri("https://elsewhere.example/new-nonce"))
+
+    expect(ACMEError):
+      discard await api.post(parseUri("http://127.0.0.1:8080/new-order"), "{}")
+
+    # same host, other scheme and port
+    expect(ACMEError):
+      discard await api.get(parseUri("http://acme.example/new-nonce"))
+
+  asyncTest "a request on the directory origin is sent":
+    let server = startTestHttpServer($ %*{"status": "valid"})
+    let api = ACMEApi.new(directoryURL = parseUri(server.url))
+    defer:
+      await api.close()
+      await server.stop()
+
+    check (await api.get(parseUri(server.url & "acme/new-nonce"))).body ==
+      %*{"status": "valid"}
+
+  asyncTest "a directory naming a resource off its origin is refused":
     let server = startTestHttpServer(
       $ %*{"newNonce": "", "newOrder": OrderURL, "newAccount": AccountURL}
     )
@@ -450,7 +487,7 @@ suite "AutoTLS ACME API over HTTP":
       await api.close()
       await server.stop()
 
-    expect(ACMENetworkError):
+    expect(ACMEError):
       discard await api.requestNonce()
 
 suite "AutoTLS ACME Client":

--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -323,12 +323,6 @@ suite "AutoTLS ACME API":
     expect(ACMEError):
       discard await api.requestChallenge(@[WildcardDomain], key, AccountURL)
 
-  asyncTest "an order naming an authorization off the directory origin is refused":
-    api.queueOrder("pending", %*["https://elsewhere.example/authz/1"])
-
-    expect(ACMEError):
-      discard await api.requestChallenge(@[WildcardDomain], key, AccountURL)
-
   asyncTest "a register response with no location header is refused":
     api.mockedResponses.add(
       HTTPResponse(body: %*{"status": "valid"}, headers: HttpTable.init())

--- a/tests/libp2p/autotls/test_service.nim
+++ b/tests/libp2p/autotls/test_service.nim
@@ -167,6 +167,8 @@ suite "AutoTLS certificate issuance and renewal":
     defer:
       await certServer.stop()
 
+    # the certificate download is a real request, so it has to be on the directory origin
+    acmeApi.directoryURL = parseUri(certServer.url)
     acmeApi.scriptChallenge(ChallengeToken)
     acmeApi.scriptCertificate(certServer.url, OrderExpires)
 

--- a/tests/stubs/acme_api_stub.nim
+++ b/tests/stubs/acme_api_stub.nim
@@ -142,6 +142,8 @@ proc scriptCertificate*(self: ACMEApiStub, certificateURL: string, expires: stri
 proc respond(
     self: ACMEApiStub, uri: Uri
 ): Future[HTTPResponse] {.async: (raises: [ACMEError, CancelledError]).} =
+  # the real transport refuses an off-origin URL before it sends anything
+  self.checkOrigin(uri)
   self.requestedUris.add(uri)
   if self.stalls:
     await Future[void].Raising([CancelledError]).init("ACMEApiStub.stall")

--- a/tests/stubs/acme_api_stub.nim
+++ b/tests/stubs/acme_api_stub.nim
@@ -142,8 +142,6 @@ proc scriptCertificate*(self: ACMEApiStub, certificateURL: string, expires: stri
 proc respond(
     self: ACMEApiStub, uri: Uri
 ): Future[HTTPResponse] {.async: (raises: [ACMEError, CancelledError]).} =
-  # the real transport refuses an off-origin URL before it sends anything
-  self.checkOrigin(uri)
   self.requestedUris.add(uri)
   if self.stalls:
     await Future[void].Raising([CancelledError]).init("ACMEApiStub.stall")


### PR DESCRIPTION
The ACME client follows URLs it reads out of server responses: newNonce, newAccount and newOrder from the directory, the authorizations, finalize and the certificate from an order. This PR checks that `scheme`, `host` and `port` match the configured directory URL. Let's Encrypt and Pebble serve all of those from the directory host.

The tests cover an off-origin host, a loopback URL, a scheme change, and an off-origin newNonce, authorization and certificate. A CA that splits its endpoints across hosts would now fail; the check then relaxes to a configured host list.