### PR TITLE
chore(tools): fix logs fields lint

### DIFF
--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -73,7 +73,7 @@ chronicles.formatIt(LPChannel):
   shortLog(it)
 
 proc open*(s: LPChannel) {.async: (raises: [CancelledError, LPStreamError]).} =
-  trace "Opening channel", s, conn = s.conn
+  trace "Opening channel", channel = s, conn = s.conn
   if s.conn.isClosed:
     return
   try:
@@ -96,7 +96,7 @@ proc closeUnderlying(s: LPChannel): Future[void] {.async: (raises: []).} =
 
 proc resetChannel*(s: LPChannel, isLocal: bool) {.async: (raises: []).} =
   if s.localReset or s.remoteReset:
-    trace "Already reset", s
+    trace "Already reset", channel = s
     return
 
   s.isClosed = true
@@ -104,23 +104,23 @@ proc resetChannel*(s: LPChannel, isLocal: bool) {.async: (raises: []).} =
   s.localReset = isLocal
   s.remoteReset = not isLocal
 
-  trace "Resetting channel", s, len = s.len
+  trace "Resetting channel", channel = s, len = s.len
 
   if isLocal and s.isOpen and not s.conn.isClosed:
     # If the connection is still active, notify the other end
     proc resetMessage() {.async: (raises: []).} =
       try:
-        trace "Sending reset message", s, conn = s.conn
+        trace "Sending reset message", channel = s, conn = s.conn
         await noCancel s.conn.writeMsg(s.id, s.resetCode) # write reset
       except LPStreamError as exc:
-        trace "Can't send reset message", err = exc.msg, s, conn = s.conn
+        trace "Can't send reset message", err = exc.msg, channel = s, conn = s.conn
         await s.conn.close()
 
     s.resetMessageFut = resetMessage()
 
   await s.closeImpl()
 
-  trace "Channel reset", s
+  trace "Channel reset", channel = s
 
 method resetImpl*(s: LPChannel) {.async: (raises: []).} =
   await s.resetChannel(isLocal = true)
@@ -130,11 +130,11 @@ method close*(s: LPChannel) {.async: (raises: []).} =
   ## informing them that the channel is closed and that we're waiting for
   ## their acknowledgement.
   if s.closedLocal:
-    trace "Already closed", s
+    trace "Already closed", channel = s
     return
   s.closedLocal = true
 
-  trace "Closing channel", s, conn = s.conn, len = s.len
+  trace "Closing channel", channel = s, conn = s.conn, len = s.len
 
   if s.isOpen and not s.conn.isClosed:
     try:
@@ -145,11 +145,11 @@ method close*(s: LPChannel) {.async: (raises: []).} =
       # It's harmless that close message cannot be sent - the connection is
       # likely down already
       await s.conn.close()
-      trace "Cannot send close message", s, id = s.id, err = exc.msg
+      trace "Cannot send close message", channel = s, id = s.id, err = exc.msg
 
   await s.closeUnderlying() # maybe already eofed
 
-  trace "Closed channel", s, len = s.len
+  trace "Closed channel", channel = s, len = s.len
 
 method closeWrite*(s: LPChannel) {.async: (raises: []).} =
   ## For mplex, closeWrite is the same as close - it implements half-close
@@ -160,7 +160,7 @@ method initStream*(s: LPChannel) =
     s.objName = LPChannelTrackerName
 
   s.timeoutHandler = proc(): Future[void] {.async: (raises: [], raw: true).} =
-    trace "Idle timeout expired, resetting LPChannel", s
+    trace "Idle timeout expired, resetting LPChannel", channel = s
     s.reset()
 
   procCall BufferStream(s).initStream()
@@ -173,7 +173,7 @@ method readOnce*(
   ## channel must not be done from within a callback / read handler of another
   ## or the reads will lock each other.
   if s.remoteReset:
-    trace "Reset stream in readOnce", s
+    trace "Reset stream in readOnce", channel = s
     raise newLPStreamResetError()
   if s.localReset:
     raise newLPStreamClosedError()
@@ -193,7 +193,7 @@ method readOnce*(
       if s.protocol.len > 0:
         libp2p_protocols_bytes.inc(bytes.int64, labelValues = [s.protocol, "in"])
 
-    trace "readOnce", s, bytes
+    trace "readOnce", channel = s, bytes
     if bytes == 0:
       await s.closeUnderlying()
     return bytes
@@ -212,7 +212,7 @@ proc prepareWrite(
   # prepareWrite is the slow path of writing a message - see conditions in
   # write
   if s.remoteReset:
-    trace "Stream is reset when prepareWrite", s
+    trace "Stream is reset when prepareWrite", channel = s
     raise newLPStreamResetError()
   if s.closedLocal:
     raise newLPStreamClosedError()
@@ -224,7 +224,7 @@ proc prepareWrite(
 
   if s.writes >= MaxWrites:
     trace "Closing connection, too many in-flight writes on channel",
-      s, conn = s.conn, writes = s.writes
+      channel = s, conn = s.conn, writes = s.writes
     when defined(libp2p_mplex_metrics):
       libp2p_mplex_qlenclose.inc()
     await s.reset()
@@ -268,7 +268,7 @@ proc completeWrite(
   except LPStreamEOFError as exc:
     raise exc
   except LPStreamError as exc:
-    trace "Exception in lpchannel write handler", err = exc.msg, s
+    trace "Exception in lpchannel write handler", err = exc.msg, channel = s
     await s.reset()
     await s.conn.close()
     raise newLPStreamConnDownError(exc)

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -79,7 +79,7 @@ proc cleanupChann(m: Mplex, chann: LPChannel) {.async: (raises: []).} =
   try:
     await chann.join()
     m.channels[chann.initiator].del(chann.id)
-    trace "Cleaned up channel", m, chann
+    trace "Cleaned up channel", muxer = m, chann
 
     when defined(libp2p_expensive_metrics):
       libp2p_mplex_channels.set(
@@ -117,7 +117,7 @@ proc newStreamInternal*(
   when defined(libp2p_agents_metrics):
     channel.shortAgent = m.connection.shortAgent
 
-  trace "Creating new channel", m, channel = channel, id, initiator, name
+  trace "Creating new channel", muxer = m, channel = channel, id, initiator, name
 
   m.channels[initiator][id] = channel
 
@@ -142,7 +142,7 @@ method handle*(m: Mplex) {.async: (raises: []).} =
   trace "Mplex handler started", muxer = m
   try:
     while not m.connection.atEof:
-      trace "Waiting for data", m
+      trace "Waiting for data", muxer = m
       let
         (id, msgType, data) = await m.connection.readMsg()
         initiator = bool(ord(msgType) and 1)
@@ -153,31 +153,31 @@ method handle*(m: Mplex) {.async: (raises: []).} =
         msgType = msgType
         size = data.len
 
-      trace "Read message from connection", m, data = data.shortLog
+      trace "Read message from connection", muxer = m, data = data.shortLog
 
       var channel =
         if MessageType(msgType) != MessageType.New:
           let tmp = m.channels[initiator].getOrDefault(id, nil)
           if tmp == nil:
-            trace "Channel not found, skipping", m
+            trace "Channel not found, skipping", muxer = m
             continue
 
           tmp
         else:
           if m.channels[false].len > m.maxChannCount - 1:
             trace "Too many channels created by remote peer",
-              allowedMax = m.maxChannCount, m
+              allowedMax = m.maxChannCount, muxer = m
             raise newTooManyChannels()
 
           # Stream names are only for debugging and retaining them lets peers
           # multiply the frame-size limit by the channel limit.
           m.newStreamInternal(false, id, timeout = m.outChannTimeout)
 
-      trace "Processing channel message", m, channel, data = data.shortLog
+      trace "Processing channel message", muxer = m, channel, data = data.shortLog
 
       case msgType
       of MessageType.New:
-        trace "Created channel", m, channel
+        trace "Created channel", muxer = m, channel
 
         if m.streamHandler != nil:
           # Launch handler task
@@ -201,10 +201,10 @@ method handle*(m: Mplex) {.async: (raises: []).} =
             await channel.reset()
             continue
 
-        trace "Pushing data to channel", m, channel, len = data.len
+        trace "Pushing data to channel", muxer = m, channel, len = data.len
         try:
           await channel.pushData(data)
-          trace "Pushed data to channel", m, channel, len = data.len
+          trace "Pushed data to channel", muxer = m, channel, len = data.len
         except LPStreamClosedError as exc:
           # Channel is being closed, but `cleanupChann` was not yet triggered.
           trace "Channel data delivery failed",
@@ -217,11 +217,11 @@ method handle*(m: Mplex) {.async: (raises: []).} =
   except CancelledError:
     trace "Mplex handler canceled", muxer = m
   except LPStreamEOFError as exc:
-    trace "Stream EOF", err = exc.msg, m
+    trace "Stream EOF", err = exc.msg, muxer = m
   except LPStreamError as exc:
-    trace "Unexpected stream exception in mplex read loop", err = exc.msg, m
+    trace "Unexpected stream exception in mplex read loop", err = exc.msg, muxer = m
   except MuxerError as exc:
-    debug "Unexpected muxer exception in mplex read loop", err = exc.msg, m
+    debug "Unexpected muxer exception in mplex read loop", err = exc.msg, muxer = m
   finally:
     await m.close()
   trace "Mplex handler stopped", muxer = m
@@ -255,11 +255,11 @@ method newStream*(
 
 method close*(m: Mplex) {.async: (raises: []).} =
   if m.isClosed:
-    trace "Already closed", m
+    trace "Already closed", muxer = m
     return
   m.isClosed = true
 
-  trace "Closing mplex", m
+  trace "Closing mplex", muxer = m
 
   var channs = toSeq(m.channels[false].values) & toSeq(m.channels[true].values)
 
@@ -281,7 +281,7 @@ method close*(m: Mplex) {.async: (raises: []).} =
   m.channels[false].clear()
   m.channels[true].clear()
 
-  trace "Closed mplex", m
+  trace "Closed mplex", muxer = m
 
 method getStreams*(m: Mplex): seq[MuxedStream] {.gcsafe.} =
   var streams: seq[MuxedStream]

--- a/libp2p/protocols/connectivity/relay/client.nim
+++ b/libp2p/protocols/connectivity/relay/client.nim
@@ -198,7 +198,7 @@ proc dialPeerV2*(
 ): Future[RawConn] {.async: (raises: [RelayV2DialError, CancelledError]).} =
   let p = Peer(peerId: Opt.some(dstPeerId), addrs: dstAddrs)
 
-  trace "Dial peer", p
+  trace "Dial peer", peer = p
 
   let msgRcvFromRelay =
     try:

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -179,7 +179,7 @@ proc updateScores*(g: GossipSub) = # avoid async
           var p1 = info.meshTime / topicParams.timeInMeshQuantum
           if p1 > topicParams.timeInMeshCap:
             p1 = topicParams.timeInMeshCap
-          trace "p1", peer, p1, topic, topicScore
+          trace "p1", peer, timeInMeshCapped = p1, topic, topicScore
           topicScore += p1 * topicParams.timeInMeshWeight
         else:
           info.meshMessageDeliveriesActive = false
@@ -194,7 +194,7 @@ proc updateScores*(g: GossipSub) = # avoid async
             let deficit =
               topicParams.meshMessageDeliveriesThreshold - info.meshMessageDeliveries
             let p3 = deficit * deficit
-            trace "p3", peer, p3, topic, topicScore
+            trace "p3", peer, deficitSquared = p3, topic, topicScore
             topicScore += p3 * topicParams.meshMessageDeliveriesWeight
 
         topicScore += info.meshFailurePenalty * topicParams.meshFailurePenaltyWeight

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -363,7 +363,7 @@ proc closeSendStream(
     p: PubSubPeer, event: PubSubPeerEventKind
 ) {.async: (raises: [CancelledError]).} =
   if p.sendStream != nil:
-    trace "Removing send stream", p, stream = p.sendStream
+    trace "Removing send stream", peer = p, stream = p.sendStream
     await p.sendStream.close()
     p.sendStream = nil
 
@@ -395,7 +395,7 @@ proc connectOnce(
     # remote peer - if we had multiple channels up and one goes down, all
     # stop working so we make an effort to only keep a single channel alive
 
-    trace "Get new send stream", p, newStream
+    trace "Get new send stream", peer = p, newStream
 
     # Careful to race conditions here.
     # Topic subscription relies on either connectedFut
@@ -499,7 +499,7 @@ proc sendMsgSlow(
 
   var stream = p.sendStream
   if stream == nil or stream.closed():
-    trace "No send stream", p, encoded = shortLog(msg)
+    trace "No send stream", peer = p, encoded = shortLog(msg)
     return
 
   trace "sending encoded msg to peer", stream, encoded = shortLog(msg)
@@ -584,11 +584,11 @@ proc dropNonHighPriorityMessage(
   of MessagePriority.Medium:
     when defined(pubsubpeer_queue_metrics):
       libp2p_pubsub_medium_priority_queue_drops.inc()
-    trace "medium priority queue full, dropping message", p
+    trace "medium priority queue full, dropping message", peer = p
   of MessagePriority.Low:
     when defined(pubsubpeer_queue_metrics):
       libp2p_pubsub_low_priority_queue_drops.inc()
-    trace "low priority queue full, dropping message", p
+    trace "low priority queue full, dropping message", peer = p
   of MessagePriority.High:
     raiseAssert "high-priority messages are not dropped via queue overflow scoring"
   return newFutureCompleted[void]()
@@ -617,7 +617,7 @@ proc sendEncoded*(
   p.clearSendPriorityQueue()
 
   if msg.len <= 0:
-    debug "empty message, skipping", p, encoded = shortLog(msg)
+    debug "empty message, skipping", peer = p, encoded = shortLog(msg)
     newFutureCompleted[void]()
   elif msg.len > p.maxMessageSize:
     warn "trying to send a msg too big for pubsub",
@@ -809,7 +809,7 @@ proc sendNonHighPriorityTask(p: PubSubPeer) {.async: (raises: [CancelledError]).
     await p.sendMsg(move(msg.data), useCustomStream)
 
 proc startSendNonHighPriorityTask(p: PubSubPeer) =
-  trace "starting sendNonHighPriorityTask", p
+  trace "starting sendNonHighPriorityTask", peer = p
   if p.rpcmessagequeue.sendNonHighPriorityTask.isNil:
     p.rpcmessagequeue.sendNonHighPriorityTask = p.sendNonHighPriorityTask()
 
@@ -823,7 +823,7 @@ proc stopTasks*(p: PubSubPeer) =
     fut.cancelSoon()
   p.sendFuts = @[]
   if not p.rpcmessagequeue.sendNonHighPriorityTask.isNil():
-    trace "stopping sendNonHighPriorityTask", p
+    trace "stopping sendNonHighPriorityTask", peer = p
     p.rpcmessagequeue.sendNonHighPriorityTask.cancelSoon()
     p.rpcmessagequeue.sendNonHighPriorityTask = nil
     for fut in p.rpcmessagequeue.sendPriorityQueue:

--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -376,7 +376,7 @@ proc advertise*[E](
 
   let futs = collect(newSeq()):
     for peer in peers:
-      trace "Send Advertise", peerId = peer, ns
+      trace "Send Advertise", peerId = peer, namespace = ns
       rdv.advertisePeer(peer, msg).withTimeout(5.seconds)
 
   await allFutures(futs)
@@ -438,7 +438,7 @@ proc requestPeer[E](
     trace "Discover response is empty"
     return @[]
   if resp.status != ResponseStatus.Ok:
-    trace "Cannot discover", ns, status = resp.status, text = resp.text
+    trace "Cannot discover", namespace = ns, status = resp.status, text = resp.text
     return @[]
   resp.cookie.withValue(cookie):
     if ns.isSome:
@@ -472,7 +472,7 @@ proc request*[E](
     if rdv.codec notin rdv.switch.peerStore[ProtoBook][peer]:
       continue
     try:
-      trace "Send Request", peerId = peer, ns
+      trace "Send Request", peerId = peer, namespace = ns
       let registrations = await rdv.requestPeer(limit, ns, peer)
       for r in registrations:
         if limit == 0:

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -68,7 +68,7 @@ method initStream*(s: SecureConn) =
   procCall Connection(s).initStream()
 
 method closeImpl*(s: SecureConn) {.async: (raises: []).} =
-  trace "Closing secure conn", s, dir = s.dir
+  trace "Closing secure conn", conn = s, dir = s.dir
   if not s.cleanupFut.isNil():
     s.cleanupFut.cancelSoon()
   if s.stream != nil:
@@ -77,7 +77,7 @@ method closeImpl*(s: SecureConn) {.async: (raises: []).} =
   await procCall Connection(s).closeImpl()
 
 method resetImpl*(s: SecureConn) {.async: (raises: []).} =
-  trace "Resetting secure conn", s, dir = s.dir
+  trace "Resetting secure conn", conn = s, dir = s.dir
   if not s.cleanupFut.isNil():
     s.cleanupFut.cancelSoon()
   if s.stream != nil:

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -48,7 +48,7 @@ method initStream*(s: BufferStream) =
 
   s.readQueue = newAsyncQueue[seq[byte]](1)
 
-  trace "BufferStream created", s
+  trace "BufferStream created", stream = s
 
 proc new*(T: typedesc[BufferStream], timeout: Duration = DefaultConnectionTimeout): T =
   let bufferStream = T(timeout: timeout)
@@ -76,7 +76,7 @@ method pushData*(
   # processed
   try:
     s.pushing = true
-    trace "Pushing data", s, data = data.len
+    trace "Pushing data", stream = s, data = data.len
     await s.readQueue.addLast(data)
   finally:
     s.pushing = false
@@ -95,7 +95,7 @@ method pushEof*(
   # processed
   try:
     s.pushing = true
-    trace "Pushing EOF", s
+    trace "Pushing EOF", stream = s
     await s.readQueue.addLast(Eof)
   finally:
     s.pushing = false
@@ -133,7 +133,7 @@ method readOnce*(
 
     if buf.len == 0:
       # No more data will arrive on read queue
-      trace "EOF", s
+      trace "EOF", stream = s
       s.isEof = true
     else:
       s.readBuf.push(buf)
@@ -151,7 +151,7 @@ method readOnce*(
 
 method closeImpl*(s: BufferStream): Future[void] {.async: (raises: [], raw: true).} =
   ## close the stream and clear the buffer
-  trace "Closing BufferStream", s, len = s.len
+  trace "Closing BufferStream", stream = s, len = s.len
 
   # First, make sure any new calls to `readOnce` and `pushData` etc will fail -
   # there may already be such calls in the event queue however
@@ -194,6 +194,6 @@ method closeImpl*(s: BufferStream): Future[void] {.async: (raises: [], raw: true
   except AsyncQueueEmptyError as e:
     raiseAssert("closeImpl failed queue empty: " & e.msg)
 
-  trace "Closed BufferStream", s
+  trace "Closed BufferStream", stream = s
 
   procCall Connection(s).closeImpl()

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -40,7 +40,7 @@ method initStream*(s: ChronosStream) =
     s.objName = ChronosStreamTrackerName
 
   s.timeoutHandler = proc(): Future[void] {.async: (raises: [], raw: true).} =
-    trace "Idle timeout expired, closing ChronosStream", s
+    trace "Idle timeout expired, closing ChronosStream", conn = s
     s.close()
 
   procCall Connection(s).initStream()
@@ -155,7 +155,7 @@ method closeWrite*(s: ChronosStream) {.async: (raises: []).} =
   if not s.client.closed():
     try:
       await s.client.shutdownWait()
-      trace "Write side closed", address = $s.client.remoteAddress(), s
+      trace "Write side closed", address = $s.client.remoteAddress(), conn = s
     except TransportError:
       # Ignore transport errors during shutdown
       discard
@@ -164,12 +164,11 @@ method closeWrite*(s: ChronosStream) {.async: (raises: []).} =
       discard
 
 method closeImpl*(s: ChronosStream) {.async: (raises: []).} =
-  trace "Shutting down chronos stream", address = $s.client.remoteAddress(), s
+  trace "Shutting down chronos stream", address = $s.client.remoteAddress(), conn = s
 
   if not s.client.closed():
     await s.client.closeWait()
-
-  trace "Shutdown chronos stream", address = $s.client.remoteAddress(), s
+  trace "Shutdown chronos stream", address = $s.client.remoteAddress(), conn = s
 
   when defined(libp2p_agents_metrics):
     # do this after closing!

--- a/libp2p/stream/connection.nim
+++ b/libp2p/stream/connection.nim
@@ -78,17 +78,17 @@ method initStream*(s: Connection) =
   doAssert(s.timerTaskFut == nil)
 
   if s.timeout > 0.millis:
-    trace "Monitoring for timeout", s, timeout = s.timeout
+    trace "Monitoring for timeout", conn = s, timeout = s.timeout
 
     s.timerTaskFut = s.timeoutMonitor()
     if s.timeoutHandler == nil:
       s.timeoutHandler = proc(): Future[void] {.async: (raises: [], raw: true).} =
-        trace "Idle timeout expired, closing connection", s
+        trace "Idle timeout expired, closing connection", conn = s
         s.close()
 
 method closeImpl*(s: Connection): Future[void] {.async: (raises: []).} =
   # Cleanup timeout timer
-  trace "Closing connection", s
+  trace "Closing connection", conn = s
 
   if s.timerTaskFut != nil and not s.timerTaskFut.finished:
     # Don't `cancelAndWait` here to avoid risking deadlock in this scenario:
@@ -98,7 +98,7 @@ method closeImpl*(s: Connection): Future[void] {.async: (raises: []).} =
     s.timerTaskFut.cancelSoon()
     s.timerTaskFut = nil
 
-  trace "Closed connection", s
+  trace "Closed connection", conn = s
 
   procCall LPStream(s).closeImpl()
 
@@ -115,10 +115,10 @@ proc pollActivity(s: Connection): Future[bool] {.async: (raises: []).} =
 
   # Inactivity timeout happened, call timeout monitor
 
-  trace "Connection timed out", s
+  trace "Connection timed out", conn = s
   libp2p_stream_timeouts.inc(labelValues = [s.objName, metricLabel(s.dir)])
   if s.timeoutHandler != nil:
-    trace "Calling timeout handler", s
+    trace "Calling timeout handler", conn = s
     await s.timeoutHandler()
 
   return false

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -169,9 +169,9 @@ method readExactly*(
     trace "Read twice while at EOF"
     raise newLPStreamEOFError()
 
-if read < nbytes:
-  trace "Couldn't read all bytes, incomplete data", stream = s, nbytes, read
-  raise newLPStreamIncompleteError()
+  if read < nbytes:
+    trace "Couldn't read all bytes, incomplete data", stream = s, nbytes, read
+    raise newLPStreamIncompleteError()
 
 method readLine*(
     s: LPStream, limit = 0, sep = "\r\n"

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -112,7 +112,7 @@ method initStream*(s: LPStream) {.base.} =
 
   libp2p_open_streams.inc(labelValues = [s.objName, metricLabel(s.dir)])
   trackCounter(s.objName)
-  trace "Stream created", s, objName = s.objName, dir = $s.dir
+  trace "Stream created", stream = s, objName = s.objName, dir = $s.dir
 
 method join*(
     s: LPStream
@@ -162,15 +162,15 @@ method readExactly*(
 
   if read == 0:
     doAssert s.atEof()
-    trace "Couldn't read all bytes, stream EOF", s, nbytes, read
+    trace "Couldn't read all bytes, stream EOF", stream = s, nbytes, read
     # Re-readOnce to raise a more specific error than EOF
     # Raise EOF if it doesn't raise anything(shouldn't happen)
     discard await s.readOnce(addr pbuffer[read], nbytes - read)
     trace "Read twice while at EOF"
     raise newLPStreamEOFError()
 
-  if read < nbytes:
-    trace "Couldn't read all bytes, incomplete data", s, nbytes, read
+if read < nbytes:
+    trace "Couldn't read all bytes, incomplete data", stream = s, nbytes, read
     raise newLPStreamIncompleteError()
 
 method readLine*(
@@ -268,11 +268,11 @@ proc write*(
 
 method closeImpl*(s: LPStream): Future[void] {.async: (raises: [], raw: true), base.} =
   ## Implementation of close - called only once
-  trace "Closing stream", s, objName = s.objName, dir = $s.dir
+  trace "Closing stream", stream = s, objName = s.objName, dir = $s.dir
   libp2p_open_streams.dec(labelValues = [s.objName, metricLabel(s.dir)])
   untrackCounter(s.objName)
   s.closeEvent.fire()
-  trace "Closed stream", s, objName = s.objName, dir = $s.dir
+  trace "Closed stream", stream = s, objName = s.objName, dir = $s.dir
   newFutureCompleted[void]()
 
 method resetImpl*(s: LPStream): Future[void] {.async: (raises: [], raw: true), base.} =
@@ -283,7 +283,7 @@ method close*(s: LPStream): Future[void] {.async: (raises: [], raw: true), base.
   ## close the stream - this may block, but will not raise exceptions
   ##
   if s.isClosed:
-    trace "Already closed", s
+    trace "Already closed", stream = s
     return newFutureCompleted[void]()
 
   s.isClosed = true # Set flag before performing virtual close
@@ -296,7 +296,7 @@ method close*(s: LPStream): Future[void] {.async: (raises: [], raw: true), base.
 proc resetStream(s: LPStream): Future[void] {.async: (raises: [], raw: true).} =
   ## Abort the stream and best-effort notify the remote peer, if supported.
   if s.isClosed:
-    trace "Already closed", s
+    trace "Already closed", stream = s
     return newFutureCompleted[void]()
 
   s.isClosed = true
@@ -319,7 +319,7 @@ proc closeWithEOF*(s: LPStream): Future[void] {.async: (raises: []).} =
   ## ongoing (which may be the case during cancellations)!
   ##
 
-  trace "Closing with EOF", s
+  trace "Closing with EOF", stream = s
   if s.closedWithEOF:
     trace "Already closed"
     return
@@ -335,10 +335,10 @@ proc closeWithEOF*(s: LPStream): Future[void] {.async: (raises: []).} =
   try:
     var buf: array[8, byte]
     if (await readOnce(s, addr buf[0], buf.len)) != 0:
-      debug "Unexpected bytes while waiting for EOF", s
+      debug "Unexpected bytes while waiting for EOF", stream = s
   except CancelledError:
     discard
   except LPStreamEOFError as e:
-    trace "Expected EOF came", err = e.msg, s
+    trace "Expected EOF came", err = e.msg, stream = s
   except LPStreamError as exc:
-    debug "Unexpected error while waiting for EOF", err = exc.msg, s
+    debug "Unexpected error while waiting for EOF", err = exc.msg, stream = s

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -170,8 +170,8 @@ method readExactly*(
     raise newLPStreamEOFError()
 
 if read < nbytes:
-    trace "Couldn't read all bytes, incomplete data", stream = s, nbytes, read
-    raise newLPStreamIncompleteError()
+  trace "Couldn't read all bytes, incomplete data", stream = s, nbytes, read
+  raise newLPStreamIncompleteError()
 
 method readLine*(
     s: LPStream, limit = 0, sep = "\r\n"

--- a/tools/audit_log_fields.py
+++ b/tools/audit_log_fields.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Reject deprecated Chronicle error fields and unsafe elevated payload logs."""
+"""Reject deprecated Chronicle error fields, unsafe elevated payload logs and
+log fields whose names are too short to be useful (single/two characters)."""
 
 from pathlib import Path
 import re
@@ -16,9 +17,10 @@ PAYLOAD_FIELD = re.compile(
     r"certificate|ticket|key)\s*="
 )
 FIELD_ASSIGNMENT = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*=")
+FIELD_NAME = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)")
 
 # These established identifiers are clearer than a longer expansion in their
-# logging contexts. Every other structured field name must be at least three
+# logging contexts. Every other log field name must be at least three
 # characters long.
 SHORT_FIELD_EXCEPTIONS = {"id", "ip"}
 
@@ -45,6 +47,78 @@ def log_blocks(path: Path):
         line = end
 
 
+def short_positional_fields(block: str):
+    """Field names that chronicles derives from bare (positional) selectors,
+    e.g. the ``s`` in ``trace "...", s``.
+
+    Bare selectors have no ``name = value`` pair, so they are invisible to the
+    FIELD_ASSIGNMENT check above and need dedicated handling. We take the text
+    after the quoted event message, keep only selectors that sit at the top
+    nesting level and treat the plain identifiers (no ``=``) as field names.
+    """
+    # A single chronicles statement may wrap over several lines.
+    text = re.sub(r"\s#.*$", "", block)
+    text = re.sub(r"\s+", " ", text)
+    text = re.sub(r"\s*,\s*", ",", text)
+    # Drop the leading log level and the quoted event message.
+    body = re.sub(
+        r"^\s*(?:trace|debug|info|notice|warn|error|fatal)\s+\"(?:\\.|[^\"])*\"",
+        "",
+        text,
+        count=1,
+    )
+
+    names = []
+    depth = 0
+    in_str = False
+    i = 0
+    start = -1
+    while i < len(body):
+        ch = body[i]
+        if in_str:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == '"':
+                in_str = False
+            i += 1
+            continue
+        if ch == '"':
+            in_str = True
+            i += 1
+            continue
+        if ch in "([{":
+            depth += 1
+            start = -1
+            i += 1
+            continue
+        if ch in ")]}":
+            depth -= 1
+            start = -1
+            i += 1
+            continue
+        if ch == ",":
+            if depth == 0 and start >= 0:
+                names.append(body[start:i])
+            start = -1
+            i += 1
+            continue
+        if depth == 0:
+            if start < 0:
+                start = i
+        i += 1
+    if depth == 0 and start >= 0:
+        names.append(body[start:])
+
+    for selector in names:
+        if "=" in selector:
+            # `name = value` selectors are handled by FIELD_ASSIGNMENT above.
+            continue
+        name = selector.strip()
+        if FIELD_NAME.fullmatch(name) and len(name) < 3:
+            yield name
+
+
 def main() -> int:
     violations = []
     for path in ROOT.joinpath("libp2p").rglob("*.nim"):
@@ -57,10 +131,17 @@ def main() -> int:
                 violations.append(
                     f"{path.relative_to(ROOT)}:{line}: elevated log contains payload field"
                 )
+            # Structured `name = value` fields ...
             for field_name in FIELD_ASSIGNMENT.findall(block):
                 if len(field_name) < 3 and field_name not in SHORT_FIELD_EXCEPTIONS:
                     violations.append(
                         f"{path.relative_to(ROOT)}:{line}: field '{field_name}' is too short (needs to be at least 3 characters long)"
+                    )
+            # ... and chronicles fields passed as bare/positional selectors.
+            for field_name in short_positional_fields(block):
+                if field_name not in SHORT_FIELD_EXCEPTIONS:
+                    violations.append(
+                        f"{path.relative_to(ROOT)}:{line}: bare field '{field_name}' is too short (needs to be at least 3 characters long)"
                     )
     if violations:
         print("\n".join(violations), file=sys.stderr)


### PR DESCRIPTION
currently lint for checking filed length only works with `name = value` fields cases, but with this fix it works for cases were field names are not defined (bare fields).

fixed cases with short field names - since lint works now (for all cases) it must be fixed to pass ci.