### PR TITLE
fix(tor): reject DNS names exceeding SOCKS5 length limit

### DIFF
--- a/libp2p/transports/tortransport.nim
+++ b/libp2p/transports/tortransport.nim
@@ -25,6 +25,7 @@ const
 
   Socks5ProtocolVersion = byte(5)
   NMethods = byte(1)
+  MaxSocks5DomainLength = high(uint8).int
 
 type
   TorTransport* = ref object of Transport
@@ -183,8 +184,10 @@ proc parseIpTcp(
 proc parseDnsTcp(
     address: MultiAddress
 ): (byte, seq[byte], seq[byte]) {.raises: [LPError].} =
+  let dnsAddress = address[multiCodec("dns")].tryGet().protoArgument().tryGet()
+  if dnsAddress.len > MaxSocks5DomainLength:
+    raise newException(LPError, "DNS address exceeds SOCKS5 domain length limit")
   let
-    dnsAddress = address[multiCodec("dns")].tryGet().protoArgument().tryGet()
     dstAddr = @(uint8(dnsAddress.len).toBytes()) & dnsAddress
     dstPort = address[multiCodec("tcp")].tryGet().protoArgument().tryGet()
   (Socks5AddressType.FQDN.byte, dstAddr, dstPort)

--- a/tests/libp2p/transports/test_tor.nim
+++ b/tests/libp2p/transports/test_tor.nim
@@ -5,6 +5,7 @@
 {.push raises: [].}
 
 import tables, chronos, stew/[byteutils]
+import std/strutils except fromHex
 import
   ../../../libp2p/[
     stream/connection,
@@ -128,6 +129,29 @@ suite "Tor transport":
 
   asyncTest "test start and dial using dns":
     await test("/ip4/127.0.0.1/tcp/8080", "/dns/libp2p.nim/tcp/8080")
+
+  asyncTest "SOCKS5 DNS address length boundary":
+    let
+      maxDnsAddress = repeat('a', 255)
+      oversizedDnsAddress = repeat('a', 256)
+      client = TorTransport.new(transportAddress = torServer, upgrade = Upgrade())
+    stub.registerAddr(maxDnsAddress & ":8080", "/ip4/127.0.0.1/tcp/8080")
+
+    let server = TcpTransport.new({ReuseAddr}, Upgrade())
+    await server.start(@[ma("/ip4/127.0.0.1/tcp/8080")])
+    let acceptFut = server.accept()
+
+    let conn = await client.dial("", ma("/dns/" & maxDnsAddress & "/tcp/8080"))
+    let serverConn = await acceptFut
+    await conn.close()
+    await serverConn.close()
+    await server.stop()
+
+    expect TransportDialError:
+      discard await client.dial(
+        "", ma("/dns/" & oversizedDnsAddress & "/tcp/8080")
+      )
+    await client.stop()
 
   asyncTest "test start and dial usion onion3 and builder":
     const TestCodec = "/test/proto/1.0.0" # custom protocol string identifier

--- a/tests/libp2p/transports/test_tor.nim
+++ b/tests/libp2p/transports/test_tor.nim
@@ -148,9 +148,7 @@ suite "Tor transport":
     await server.stop()
 
     expect TransportDialError:
-      discard await client.dial(
-        "", ma("/dns/" & oversizedDnsAddress & "/tcp/8080")
-      )
+      discard await client.dial("", ma("/dns/" & oversizedDnsAddress & "/tcp/8080"))
     await client.stop()
 
   asyncTest "test start and dial usion onion3 and builder":


### PR DESCRIPTION
Reject DNS destinations longer than the 255-byte limit imposed by the SOCKS5 domain-name field before converting the length to uint8.