### PR TITLE
fix(dialer): retain lookup results across suspended dials

### DIFF
--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -388,8 +388,11 @@ proc dialInOrder(
       return nil
 
     let advertised = DialCandidate(address: rawAddress, peerId: peerId)
-    for expanded in await self.expandCandidate(advertised, deadline):
-      for candidate in await self.resolveCandidate(expanded, deadline):
+    # Retain lookup results across awaits in the loop bodies.
+    let expandedCandidates = await self.expandCandidate(advertised, deadline)
+    for expanded in expandedCandidates:
+      let resolvedCandidates = await self.resolveCandidate(expanded, deadline)
+      for candidate in resolvedCandidates:
         let mux = await self.dialAndUpgrade(
           candidate.peerId, candidate.hostname, candidate.address, dir, deadline,
           forceDial, reach,


### PR DESCRIPTION
## Summary

Fix a regression introduced in #2992 where sequential dialing can raise “the length of the seq changed while iterating over it” after a suspended dial fails. The candidate loops borrowed results from temporary lookup futures that could be reclaimed during a later `await`.

Store the expanded and resolved candidates in local variables so their sequences remain alive throughout iteration. This also resolves the resulting service discovery cleanup failures.
