### PR TITLE
fix(wstransport): report closed transport without retrying

### DIFF
--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -31,7 +31,6 @@ const
   DefaultConcurrentAccepts = 200
   DefaultAcceptFailureBackoff = 100.millis
   DefaultAutotlsWaitTimeout = 3.seconds
-  DefaultAutotlsRetries = 3
 
 type
   WsStream = ref object of Connection
@@ -498,13 +497,6 @@ proc connHandler(
 method accept*(
     self: WsTransport
 ): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =
-  # wstransport can only start accepting connections after autotls is done
-  # if autotls is not present, self.running is true after listener setup completes
-  var retries = 0
-  while not self.running and retries < DefaultAutotlsRetries:
-    retries += 1
-    await sleepAsync(DefaultAutotlsWaitTimeout)
-
   if not self.running:
     raise newTransportClosedError()
 

--- a/tests/libp2p/transports/basic_tests.nim
+++ b/tests/libp2p/transports/basic_tests.nim
@@ -83,13 +83,16 @@ template basicTransportTest*(
       await server.stop()
 
       let acceptFut = server.accept()
-      if isWsTransport(maddr):
-        # TODO: vacp2p/nim-libp2p#2961
-        check not (await acceptFut.withTimeout(200.milliseconds))
-      else:
-        check:
-          await acceptFut.withTimeout(200.milliseconds)
-          acceptFut.failed()
+      check:
+        await acceptFut.withTimeout(200.milliseconds)
+        acceptFut.failed()
+
+    asyncTest "accept on a never-started transport reports it closed without waiting":
+      let server = transportProvider()
+      let acceptFut = server.accept()
+      check:
+        await acceptFut.withTimeout(200.milliseconds)
+        acceptFut.failed()
 
     asyncTest "transport start/stop events":
       let transport = transportProvider()

--- a/tests/libp2p/transports/test_ws.nim
+++ b/tests/libp2p/transports/test_ws.nim
@@ -331,6 +331,11 @@ suite "WebSocket transport with autotls":
       not wstransport.running
       wstransport.addrs.len == 0
 
+    let acceptFut = wstransport.accept()
+    check await acceptFut.withTimeout(200.milliseconds)
+    expect TransportClosedError:
+      discard await acceptFut
+
   asyncTest "start never returns when the autotls certificate never arrives":
     # TODO: vacp2p/nim-libp2p#2957
     let autotls = AutotlsService(certReady: newAsyncEvent(), running: newAsyncEvent())


### PR DESCRIPTION
## Summary

Make WebSocket `accept()` raise `TransportClosedError` immediately when the transport is not running, removing the redundant AutoTLS retry loop that delayed the error by up to nine seconds.

Enforce the shared 200 ms accept deadline for stopped WS/WSS transports and add regression coverage for never-started transports and failed AutoTLS startup.

## Impact on Library Users

Direct callers must await `start()` before calling `accept()`: accepting while startup is pending now reports the transport closed immediately. AutoTLS certificate readiness is already awaited by `start()`.

## References

Fixes #2961.
