### PR TITLE
chore(logs): add logs with rate limit

### DIFF
--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -384,7 +384,7 @@ proc dialInOrder(
 
   for rawAddress in addrs:
     if deadline.timeLeft().isZero():
-      debug "Peer dial timed out", peerId, addresses = addrs
+      debug "Peer dial timed out", peerId, addresses = addrs.shortLog
       return nil
 
     let advertised = DialCandidate(address: rawAddress, peerId: peerId)
@@ -521,7 +521,7 @@ proc dialAndUpgrade*(
   ## Dial the addresses, sharing one `deadline`. Nil when all of them fail.
 
   let dialAddrs = normalizedDialAddrs(peerId, addrs)
-  debug "Peer dial started", peerId, addresses = dialAddrs
+  debug "Peer dial started", peerId, addresses = dialAddrs.shortLog
 
   if self.dialRanking:
     await self.dialRanked(peerId, dialAddrs, dir, deadline, forceDial, reach)
@@ -636,7 +636,7 @@ proc establishConnection(
     raise newException(
       DialFailedError,
       "Unable to establish outgoing link in establishConnection: peer_id=" &
-        shortLog(peerId) & " addrs=" & $dialAddrs,
+        shortLog(peerId) & " addrs=" & dialAddrs.shortLog,
     )
 
   slot.trackMuxer(muxed)
@@ -757,7 +757,7 @@ proc tryDial*(
   ## Returns the observed address when the probe succeeds.
   ##
 
-  trace "Peer reachability probe started", peerId, address = addrs
+  trace "Peer reachability probe started", peerId, addresses = addrs.shortLog
   try:
     let mux = await self.dialAndUpgrade(Opt.some(peerId), addrs)
     if mux.isNil():
@@ -818,7 +818,7 @@ method dial*(
       await stream.reset()
 
   try:
-    trace "Peer dial started", peerId, addresses = dialAddrs
+    trace "Peer dial started", peerId, addresses = dialAddrs.shortLog
     conn = await self.internalConnect(Opt.some(peerId), dialAddrs, forceDial)
     trace "Protocol stream opening started", peerId, protocols = protos, conn
     stream = await self.connManager.getStream(conn)
@@ -837,12 +837,12 @@ method dial*(
     raise exc
   except CatchableError as exc:
     debug "Protocol stream establishment failed",
-      err = exc.msg, peerId, protocols = protos, addresses = dialAddrs, conn
+      err = exc.msg, peerId, protocols = protos, addresses = dialAddrs.shortLog, conn
     await cleanup()
     raise newException(
       DialFailedError,
-      "failed new dial: peer_id=" & shortLog(peerId) & " protos=" & $protos & " addrs=" &
-        $dialAddrs & ": " & exc.msg,
+      "failed new dial: peer_id=" & shortLog(peerId) & " protos=" & protos.shortLog &
+        " addrs=" & dialAddrs.shortLog & ": " & exc.msg,
       exc,
     )
 

--- a/libp2p/logging.nim
+++ b/libp2p/logging.nim
@@ -3,7 +3,7 @@
 
 import pkg/[chronicles, chronos]
 
-const logFrequency = 1.minutes 
+const logFrequency = 1.minutes
 
 type LogRateLimit* = object
   initialized: bool

--- a/libp2p/logging.nim
+++ b/libp2p/logging.nim
@@ -3,6 +3,8 @@
 
 import pkg/[chronicles, chronos]
 
+const logFrequency = 1.minutes 
+
 type LogRateLimit* = object
   initialized: bool
   nextAllowed: Moment
@@ -12,7 +14,7 @@ proc allowLog*(limit: var LogRateLimit, now = Moment.now()): bool {.raises: [].}
   if limit.initialized and now < limit.nextAllowed:
     return false
   limit.initialized = true
-  limit.nextAllowed = now + 1.minutes
+  limit.nextAllowed = now + logFrequency
   true
 
 export LogLevel

--- a/libp2p/logging.nim
+++ b/libp2p/logging.nim
@@ -1,7 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import pkg/chronicles
+import pkg/[chronicles, chronos]
+
+type LogRateLimit* = object
+  initialized: bool
+  nextAllowed: Moment
+
+proc allowLog*(limit: var LogRateLimit, now = Moment.now()): bool {.raises: [].} =
+  ## Bound repeated operational warnings without retaining per-peer state.
+  if limit.initialized and now < limit.nextAllowed:
+    return false
+  limit.initialized = true
+  limit.nextAllowed = now + 1.minutes
+  true
 
 export LogLevel
 

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -1365,7 +1365,7 @@ proc replaceIp*(ma: MultiAddress, ip: IpAddress): MaResult[MultiAddress] =
 
 const AvgMultiAddressStringLength = 32
 
-func shortLog*(addrs: seq[MultiAddress], maxAddrs: int): string =
+func shortLog*(addrs: seq[MultiAddress], maxAddrs = ShortCollectionMax): string =
   let limit = min(addrs.len, maxAddrs)
   var res = newStringOfCap(limit * AvgMultiAddressStringLength)
   for i in 0 ..< limit:

--- a/libp2p/protocols/connectivity/autonat/client.nim
+++ b/libp2p/protocols/connectivity/autonat/client.nim
@@ -70,7 +70,7 @@ method dialMe*(
         debug "Unexpected error", err = e.msg
 
   try:
-    trace "sending Dial", addresses = switch.peerInfo.addrs
+    trace "sending Dial", addresses = switch.peerInfo.addrs.shortLog
     await stream.sendDial(switch.peerInfo.peerId, switch.peerInfo.addrs)
   except CancelledError as e:
     raise e

--- a/libp2p/protocols/connectivity/autonat/server.nim
+++ b/libp2p/protocols/connectivity/autonat/server.nim
@@ -92,10 +92,10 @@ proc tryDial(
   except CancelledError as exc:
     raise exc
   except AllFuturesFailedError as exc:
-    debug "All dial attempts failed", addrs, err = exc.msg
+    debug "All dial attempts failed", err = exc.msg, addresses = addrs.shortLog
     await stream.sendResponseError(DialError, "All dial attempts failed")
   except AsyncTimeoutError as exc:
-    debug "Dial timeout", addrs, err = exc.msg
+    debug "Dial timeout", err = exc.msg, addresses = addrs.shortLog
     await stream.sendResponseError(DialError, "Dial timeout")
   finally:
     try:
@@ -128,7 +128,7 @@ proc handleDial(autonat: Autonat, stream: Stream, msg: AutonatMsg): Future[void]
     return stream.sendResponseError(InternalError, "Expected an IP address")
   var addrs = initHashSet[MultiAddress]()
   addrs.incl(observedAddr)
-  trace "addrs received", addresses = peerInfo.addrs
+  trace "addrs received", addresses = peerInfo.addrs.shortLog
   for ma in peerInfo.addrs:
     isRelayed = ma.contains(multiCodec("p2p-circuit")).valueOr:
       continue
@@ -154,7 +154,7 @@ proc handleDial(autonat: Autonat, stream: Stream, msg: AutonatMsg): Future[void]
   if len(addrs) == 0:
     return stream.sendResponseError(DialRefused, "No dialable address")
   let addrsSeq = toSeq(addrs)
-  trace "trying to dial", addresses = addrsSeq
+  trace "trying to dial", addresses = addrsSeq.shortLog
   return autonat.tryDial(stream, addrsSeq)
 
 proc new*(

--- a/libp2p/protocols/connectivity/autonatv2/server.nim
+++ b/libp2p/protocols/connectivity/autonatv2/server.nim
@@ -182,7 +182,7 @@ proc canDial(self: AutonatV2, addrs: MultiAddress): bool =
       if not self.config.allowPrivateAddresses and isPrivate($addrIp):
         return false
     except ValueError:
-      trace "Unable to parse IP address, skipping", addresses = $addrIp
+      trace "Unable to parse IP address, skipping", address = $addrs
       return false
   for t in self.switch.transports:
     if t.handles(addrs):

--- a/libp2p/protocols/connectivity/dcutr/client.nim
+++ b/libp2p/protocols/connectivity/dcutr/client.nim
@@ -39,7 +39,7 @@ proc startSync*(
     var ourDialableAddrs = getHolePunchableAddrs(addrs)
     if ourDialableAddrs.len == 0:
       trace "Dcutr initiator has no supported dialable addresses. Aborting Dcutr.",
-        addrs
+        addresses = addrs.shortLog
       return
 
     stream = await switch.dial(remotePeerId, DcutrCodec)
@@ -52,11 +52,12 @@ proc startSync*(
     peerDialableAddrs = getHolePunchableAddrs(connectAnswer.addrs)
     if peerDialableAddrs.len == 0:
       trace "Dcutr receiver has no supported dialable addresses to connect to. Aborting Dcutr.",
-        addresses = connectAnswer.addrs
+        addresses = connectAnswer.addrs.shortLog
       return
 
     let rttEnd = Moment.now()
-    trace "Dcutr initiator has received a Connect message back.", connectAnswer
+    trace "Dcutr initiator has received a Connect message back.",
+      connectAnswer = connectAnswer.shortLog
     let halfRtt = (rttEnd - rttStart) div 2'i64
 
     # Expected DCUtR connections bypass ConnManager limits.
@@ -73,7 +74,7 @@ proc startSync*(
     if peerDialableAddrs.len > self.maxDialableAddrs:
       peerDialableAddrs = peerDialableAddrs[0 ..< self.maxDialableAddrs]
     trace "Dcutr initiator starting direct dial attempts",
-      peerDialableAddrs, connectTimeout = self.connectTimeout
+      addresses = peerDialableAddrs.shortLog, connectTimeout = self.connectTimeout
     let dialFuts = peerDialableAddrs.mapIt(
       switch.connect(
         stream.peerId,
@@ -104,7 +105,7 @@ proc startSync*(
     raise err
   except AllFuturesFailedError as err:
     trace "Dcutr initiator could not connect to the remote peer, all connect attempts failed",
-      peerDialableAddrs, err = err.msg
+      err = err.msg, addresses = peerDialableAddrs.shortLog
     raise newException(
       DcutrError,
       "Dcutr initiator could not connect to the remote peer, all connect attempts failed",
@@ -112,7 +113,7 @@ proc startSync*(
     )
   except AsyncTimeoutError as err:
     trace "Dcutr initiator could not connect to the remote peer, all connect attempts timed out",
-      peerDialableAddrs, err = err.msg
+      err = err.msg, addresses = peerDialableAddrs.shortLog
     raise newException(
       DcutrError,
       "Dcutr initiator could not connect to the remote peer, all connect attempts timed out",

--- a/libp2p/protocols/connectivity/dcutr/core.nim
+++ b/libp2p/protocols/connectivity/dcutr/core.nim
@@ -36,6 +36,9 @@ type
 
   DcutrError* = object of LPError
 
+func shortLog*(msg: DcutrMsg): auto =
+  (msgType: msg.msgType, addresses: msg.addrs.shortLog)
+
 Protobuf.serializerFor([DcutrMsg], withMetrics = true, domain = "dcutr")
 
 proc expectDcutrConnection*(

--- a/libp2p/protocols/connectivity/dcutr/server.nim
+++ b/libp2p/protocols/connectivity/dcutr/server.nim
@@ -32,7 +32,8 @@ proc new*(
       let connectMsg = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
         raise newException(DcutrError, error)
 
-      trace "Dcutr receiver received a Connect message.", connectMsg
+      trace "Dcutr receiver received a Connect message.",
+        connectMsg = connectMsg.shortLog
 
       var ourAddrs = switch.addressManager.mostObservedProtosAndPorts()
         # likely empty when the peer is reachable
@@ -48,7 +49,7 @@ proc new*(
       var ourDialableAddrs = getHolePunchableAddrs(ourAddrs)
       if ourDialableAddrs.len == 0:
         trace "Dcutr receiver has no supported dialable addresses. Aborting Dcutr.",
-          ourAddrs
+          addresses = ourAddrs.shortLog
         return
 
       peerDialableAddrs = getHolePunchableAddrs(connectMsg.addrs)
@@ -57,9 +58,9 @@ proc new*(
         trace "Dcutr receiver has sent a Connect message back."
         let syncMsg = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
           raise newException(DcutrError, error)
-        trace "Dcutr receiver has received a Sync message.", syncMsg
+        trace "Dcutr receiver has received a Sync message.", syncMsg = syncMsg.shortLog
         trace "Dcutr initiator has no supported dialable addresses to connect to. Aborting Dcutr.",
-          addresses = connectMsg.addrs
+          addresses = connectMsg.addrs.shortLog
         return
 
       # Expected DCUtR connections bypass ConnManager limits.
@@ -80,12 +81,12 @@ proc new*(
       trace "Dcutr receiver has sent a Connect message back."
       let syncMsg = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
         raise newException(DcutrError, error)
-      trace "Dcutr receiver has received a Sync message.", syncMsg
+      trace "Dcutr receiver has received a Sync message.", syncMsg = syncMsg.shortLog
 
       if peerDialableAddrs.len > maxDialableAddrs:
         peerDialableAddrs = peerDialableAddrs[0 ..< maxDialableAddrs]
       trace "Dcutr receiver starting direct dial attempts",
-        peerDialableAddrs, connectTimeout
+        addresses = peerDialableAddrs.shortLog, connectTimeout
       let dialFuts = peerDialableAddrs.mapIt(
         switch.connect(
           stream.peerId,
@@ -115,10 +116,12 @@ proc new*(
       raise err
     except AllFuturesFailedError as err:
       trace "Dcutr receiver could not connect to the remote peer, " &
-        "all connect attempts failed", peerDialableAddrs, err = err.msg
+        "all connect attempts failed",
+        err = err.msg, addresses = peerDialableAddrs.shortLog
     except AsyncTimeoutError as err:
       trace "Dcutr receiver could not connect to the remote peer, " &
-        "all connect attempts timed out", peerDialableAddrs, err = err.msg
+        "all connect attempts timed out",
+        err = err.msg, addresses = peerDialableAddrs.shortLog
     except CatchableError as err:
       trace "Unexpected error when Dcutr receiver tried to connect " &
         "to the remote peer", err = err.msg

--- a/libp2p/protocols/connectivity/relay/client.nim
+++ b/libp2p/protocols/connectivity/relay/client.nim
@@ -144,7 +144,7 @@ proc dialPeerV1*(
     dstPeer: Opt.some(RelayPeer(peerId: dstPeerId, addrs: dstAddrs)),
   )
 
-  trace "Dial peer", msgSend = msg
+  trace "Dial peer", msgSend = msg.shortLog
 
   try:
     await stream.writeLp(encode(msg))
@@ -229,7 +229,7 @@ proc handleStopStreamV2(
   let msg = StopMessage.decode(await stream.readLp(RelayClientMsgSize)).valueOr:
     await sendHopStatus(stream, MalformedMessage)
     return
-  trace "client circuit relay v2 handle stream", msg
+  trace "client circuit relay v2 handle stream", msg = msg.shortLog
 
   if msg.msgType.isSome and msg.msgType.get() == StopMessageType.Connect:
     await cl.handleRelayedConnect(stream, msg)
@@ -272,7 +272,7 @@ proc handleStreamV1(
   let msg = RelayMessage.decode(await stream.readLp(RelayClientMsgSize)).valueOr:
     await sendStatus(stream, StatusV1.MalformedMessage)
     return
-  trace "client circuit relay v1 handle stream", msg
+  trace "client circuit relay v1 handle stream", msg = msg.shortLog
 
   let typ = msg.msgType.valueOr:
     trace "Message type not set"

--- a/libp2p/protocols/connectivity/relay/messages.nim
+++ b/libp2p/protocols/connectivity/relay/messages.nim
@@ -10,7 +10,7 @@ import
   protobuf_serialization/std/enums,
   ../../../peerinfo,
   ../../../signed_envelope,
-  ../../../utils/protobuf
+  ../../../utils/[protobuf, shortlog]
 
 # Circuit Relay V1 Message
 
@@ -104,6 +104,34 @@ type
     peer* {.fieldNumber: 2.}: Opt[Peer]
     limit* {.fieldNumber: 3.}: Opt[Limit]
     status* {.fieldNumber: 4, ext.}: Opt[StatusV2]
+
+func shortLog*(peer: RelayPeer): auto =
+  (peerId: peer.peerId.shortLog, addresses: peer.addrs.shortLog)
+
+func shortLog*(msg: RelayMessage): auto =
+  (
+    messageType: msg.msgType,
+    hasSourcePeer: msg.srcPeer.isSome,
+    hasDestinationPeer: msg.dstPeer.isSome,
+    status: msg.status,
+  )
+
+func shortLog*(msg: HopMessage): auto =
+  (
+    messageType: msg.msgType,
+    hasPeer: msg.peer.isSome,
+    hasReservation: msg.reservation.isSome,
+    hasLimit: msg.limit.isSome,
+    status: msg.status,
+  )
+
+func shortLog*(msg: StopMessage): auto =
+  (
+    messageType: msg.msgType,
+    hasPeer: msg.peer.isSome,
+    hasLimit: msg.limit.isSome,
+    status: msg.status,
+  )
 
 Protobuf.serializerFor([Voucher])
 Protobuf.serializerFor(

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -226,7 +226,7 @@ proc handleHopStreamV2*(
   let msg = HopMessage.decode(await stream.readLp(r.msgSize)).valueOr:
     await sendHopStatus(stream, MalformedMessage)
     return
-  trace "relayv2 handle stream", hopMsg = msg
+  trace "relayv2 handle stream", hopMsg = msg.shortLog
 
   if msg.msgType.isNone:
     trace "relayv2 mesage type not set"
@@ -315,13 +315,13 @@ proc handleHop*(
       return
 
   let msgRcvFromDst = msgRcvFromDstOpt.valueOr:
-    trace "error reading stop response", response = msgRcvFromDstOpt
+    trace "error reading stop response", responsePresent = msgRcvFromDstOpt.isOk
     await sendStatus(srcStream, StatusV1.HopCantOpenDstStream)
     return
 
   if msgRcvFromDst.msgType.get(RelayType.Stop) != RelayType.Status or
       msgRcvFromDst.status.get(StatusV1.StopRelayRefused) != StatusV1.Success:
-    trace "unexcepted relay stop response", msgRcvFromDst
+    trace "Unexpected relay stop response", response = msgRcvFromDst.shortLog
     await sendStatus(srcStream, StatusV1.HopCantOpenDstStream)
     return
 
@@ -335,7 +335,7 @@ proc handleStreamV1(
   let msg = RelayMessage.decode(await stream.readLp(r.msgSize)).valueOr:
     await sendStatus(stream, StatusV1.MalformedMessage)
     return
-  trace "relay handle stream", msg
+  trace "relay handle stream", msg = msg.shortLog
 
   let typ = msg.msgType.valueOr:
     trace "Message type not set"

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -4,6 +4,7 @@
 import std/[sequtils, tables]
 import chronos, chronicles, results
 import ../utils/[heartbeat, future]
+import ../logging
 import ../[peerid, switch, multihash]
 import ./protocol
 import
@@ -266,10 +267,19 @@ proc bootstrap*(
   debug "Bootstrap complete"
 
 proc maintainBuckets(kad: KadDHT) {.async: (raises: [CancelledError]).} =
+  var timedOut = false
+  var warnings: LogRateLimit
+  
   heartbeat "Refreshing buckets", kad.config.bucketRefreshTime, sleepFirst = true:
     let refresh = kad.refreshTable(kad.rtable, false)
     if not await refresh.withTimeout(kad.config.bucketRefreshTime):
       await noCancel refresh.cancelAndWait()
+      if timedOut and warnings.allowLog():
+        warn "Routing table refresh repeatedly timed out",
+          timeout = kad.config.bucketRefreshTime, peers = kad.rtable.peerCount()
+      timedOut = true
+    else:
+      timedOut = false
 
 proc connectedPeerInfos(kad: KadDHT): seq[PeerInfo] {.raises: [].} =
   ## Currently connected peers that we know an address for.
@@ -302,11 +312,38 @@ proc fixLowPeers*(kad: KadDHT) {.async: (raises: [CancelledError]).} =
   await kad.refreshTable(kad.rtable, forceRefresh = true)
 
 proc maintainMinPeers(kad: KadDHT) {.async.} =
+  var
+    timedOut = false
+    previouslyLow = false
+    reportedLow = false
+    timeoutWarnings: LogRateLimit
+    lowPeerWarnings: LogRateLimit
+  
   heartbeat "Checking routing table size",
     kad.config.fixLowPeersInterval, sleepFirst = true:
+    
+    let peers = kad.rtable.peerCount()
+    let lowPeers =
+      not kad.config.disableBootstrapping and peers < kad.config.minRoutingTableSize
+    if lowPeers and previouslyLow and lowPeerWarnings.allowLog():
+      warn "Routing table remains below minimum",
+        peers, minimum = kad.config.minRoutingTableSize
+      reportedLow = true
+    elif not lowPeers and reportedLow:
+      info "Routing table recovered", peers, minimum = kad.config.minRoutingTableSize
+      reportedLow = false
+    previouslyLow = lowPeers
     let fix = kad.fixLowPeers()
     if not await fix.withTimeout(kad.config.fixLowPeersInterval):
       await noCancel fix.cancelAndWait()
+      if timedOut and timeoutWarnings.allowLog():
+        warn "Minimum peer maintenance repeatedly timed out",
+          timeout = kad.config.fixLowPeersInterval,
+          peers = kad.rtable.peerCount(),
+          minimum = kad.config.minRoutingTableSize
+      timedOut = true
+    else:
+      timedOut = false
 
 proc initKadBase*(
     kad: KadDHT,
@@ -428,7 +465,7 @@ proc changeMode*(kad: KadDHT, isServer: bool): Future[bool] {.async: (raises: []
   kad.isServer = isServer
   if not isServer:
     await kad.resetServerStreams()
-  debug "Kad DHT changed mode", isServer
+  info "Kad DHT changed mode", previousIsServer = not isServer, isServer
   true
 
 method start*(kad: KadDHT) {.async: (raises: [CancelledError]).} =

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -269,7 +269,7 @@ proc bootstrap*(
 proc maintainBuckets(kad: KadDHT) {.async: (raises: [CancelledError]).} =
   var timedOut = false
   var warnings: LogRateLimit
-  
+
   heartbeat "Refreshing buckets", kad.config.bucketRefreshTime, sleepFirst = true:
     let refresh = kad.refreshTable(kad.rtable, false)
     if not await refresh.withTimeout(kad.config.bucketRefreshTime):
@@ -318,10 +318,9 @@ proc maintainMinPeers(kad: KadDHT) {.async.} =
     reportedLow = false
     timeoutWarnings: LogRateLimit
     lowPeerWarnings: LogRateLimit
-  
+
   heartbeat "Checking routing table size",
     kad.config.fixLowPeersInterval, sleepFirst = true:
-    
     let peers = kad.rtable.peerCount()
     let lowPeers =
       not kad.config.disableBootstrapping and peers < kad.config.minRoutingTableSize

--- a/libp2p/protocols/kademlia/protobuf.nim
+++ b/libp2p/protocols/kademlia/protobuf.nim
@@ -3,7 +3,7 @@
 
 import std/hashes
 import chronos
-import ../../utils/opt
+import ../../utils/[opt, shortlog]
 import results
 import ../../multiaddress
 import stew/endians2
@@ -88,6 +88,35 @@ type
     providerStatus* {.fieldNumber: 11, ext.}: Opt[AddProviderStatus]
     register* {.fieldNumber: 21.}: Opt[RegisterMessage]
     getAds* {.fieldNumber: 22.}: Opt[GetAdsMessage]
+
+func shortLog*(record: Record): auto =
+  (
+    key: record.key.get(@[]).shortLog,
+    value: record.value.get(@[]).shortLog,
+    timeReceived: record.timeReceived.get("").shortLog,
+  )
+
+func shortLog*(peer: Peer): auto =
+  (
+    id: peer.id.get(@[]).shortLog,
+    addresses: peer.addrs.shortLog,
+    connection: peer.connection,
+  )
+
+func shortLog*(msg: Message): auto =
+  (
+    messageType: msg.msgType,
+    key: msg.key.get(@[]).shortLog,
+    record: msg.record.get(Record()).shortLog,
+    closerPeers: msg.closerPeers.shortLog,
+    providerPeers: msg.providerPeers.shortLog,
+    hasRegistration: msg.register.isSome,
+    advertisementCount:
+      if msg.getAds.isSome:
+        msg.getAds.get().advertisements.len
+      else:
+        0,
+  )
 
 func hide(c: Opt[ConnectionStatus], hideConnectionStatus: bool): Opt[ConnectionStatus] =
   if hideConnectionStatus:

--- a/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
@@ -416,7 +416,7 @@ proc publishPartialToPeer(
         )
         if unionRes.isErr:
           debug "failed to create union from the two parts metadata",
-            msg = unionRes.error
+            err = unionRes.error
           # technically should never happen since materializeParts was successful
         else:
           peerState.receivedPartsMetadata = Opt.some(unionRes.get())

--- a/libp2p/protocols/pubsub/rpc/message.nim
+++ b/libp2p/protocols/pubsub/rpc/message.nim
@@ -60,7 +60,7 @@ proc verify*(m: Message): bool =
 
     var remote: Signature
     let key = m.extractPublicKey().valueOr:
-      trace "could not extract public key", msg = m
+      trace "could not extract public key", msg = m.shortLog
       return false
 
     if remote.init(m.signature):

--- a/libp2p/protocols/rendezvous/protobuf.nim
+++ b/libp2p/protocols/rendezvous/protobuf.nim
@@ -8,7 +8,7 @@ import
   protobuf_serialization,
   protobuf_serialization/pkg/results,
   protobuf_serialization/std/enums,
-  ../../utils/protobuf
+  ../../utils/[protobuf, shortlog]
 
 export results
 
@@ -67,6 +67,29 @@ type
     unregister* {.fieldNumber: 4.}: Opt[Unregister]
     discover* {.fieldNumber: 5.}: Opt[Discover]
     discoverResponse* {.fieldNumber: 6.}: Opt[DiscoverResponse]
+
+func shortLog*(response: RegisterResponse): auto =
+  (status: response.status, text: response.text.get("").shortLog, ttl: response.ttl)
+
+func shortLog*(response: Opt[RegisterResponse]): string =
+  if response.isSome:
+    $response.get().shortLog
+  else:
+    "<unset>"
+
+func shortLog*(response: DiscoverResponse): auto =
+  (
+    status: response.status,
+    registrationCount: response.registrations.len,
+    cookie: response.cookie.get(@[]).shortLog,
+    text: response.text.get("").shortLog,
+  )
+
+func shortLog*(response: Opt[DiscoverResponse]): string =
+  if response.isSome:
+    $response.get().shortLog
+  else:
+    "<unset>"
 
 Protobuf.serializerFor(
   [Cookie, Register, RegisterResponse, Unregister, Discover, DiscoverResponse]

--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -323,9 +323,10 @@ proc advertisePeer[E](
       if msgRecv.msgType != MessageType.RegisterResponse:
         trace "Unexpected register response", peer, msgType = msgRecv.msgType
       elif msgRecv.registerResponse.tryGet().status != ResponseStatus.Ok:
-        trace "Refuse to register", peer, response = msgRecv.registerResponse
+        trace "Refuse to register", peer, response = msgRecv.registerResponse.shortLog
       else:
-        trace "Successfully registered", peer, response = msgRecv.registerResponse
+        trace "Successfully registered",
+          peer, response = msgRecv.registerResponse.shortLog
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
@@ -593,13 +594,15 @@ proc new*(
           stream, msg.register.tryGet(), rdv.switch.peerInfo.signedPeerRecord.data
         )
       of MessageType.RegisterResponse:
-        trace "Got an unexpected Register Response", response = msg.registerResponse
+        trace "Got an unexpected Register Response",
+          response = msg.registerResponse.shortLog
       of MessageType.Unregister:
         rdv.unregister(stream, msg.unregister.tryGet())
       of MessageType.Discover:
         await rdv.discover(stream, msg.discover.tryGet())
       of MessageType.DiscoverResponse:
-        trace "Got an unexpected Discover Response", response = msg.discoverResponse
+        trace "Got an unexpected Discover Response",
+          response = msg.discoverResponse.get(DiscoverResponse()).shortLog
     except CancelledError as exc:
       trace "Cancelled rendezvous handler"
       raise exc

--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -269,7 +269,7 @@ proc registration*(
     connectionIps: seq[IpAddress] = @[],
 ): Message =
   let serviceId = inMsg.key.valueOr:
-    trace "Key not set: registration", msg = inMsg
+    trace "Key not set: registration", msg = inMsg.shortLog
     return
 
   discard disco.rtable.insert(peerId)
@@ -375,7 +375,7 @@ proc getAdvertisements*(
     disco: ServiceDiscovery, peerId: PeerId, msg: Message
 ): Message =
   let serviceId = msg.key.valueOr:
-    trace "Key not set: getAdvertisements", msg = msg
+    trace "Key not set: getAdvertisements", msg = msg.shortLog
     return
 
   discard disco.rtable.insert(peerId)

--- a/libp2p/services/autorelayservice.nim
+++ b/libp2p/services/autorelayservice.nim
@@ -4,6 +4,7 @@
 {.push raises: [].}
 
 import chronos, chronicles, times, tables, sequtils
+import ../logging
 import ../switch, ../protocols/connectivity/relay/[client, utils]
 
 logScope:
@@ -24,6 +25,9 @@ type
     onReservation: OnReservationHandler
     addressMapper: AddressMapper
     rng: Rng
+    reservationWarnings: LogRateLimit
+    lifetimeWarnings: LogRateLimit
+    availabilityWarnings: LogRateLimit
 
 proc isRunning*(self: AutoRelayService): bool =
   return self.running
@@ -45,12 +49,17 @@ proc reserveAndUpdate(
       relayedAddr = rsvp.addrs.mapIt(MultiAddress.init($it & "/p2p-circuit").tryGet())
       ttl = rsvp.expire.int64 - times.now().utc.toTime.toUnix
     if ttl <= 60:
+      if self.lifetimeWarnings.allowLog():
+        warn "Relay reservation lifetime too short", relayPid, ttl, minimumTtl = 61
       # A reservation under a minute is basically useless
       break
     if relayPid notin self.relayAddresses or self.relayAddresses[relayPid] != relayedAddr:
+      let hadAddresses = self.relayAddresses.values.toSeq().anyIt(it.len > 0)
       self.relayAddresses[relayPid] = relayedAddr
       await switch.peerInfo.update()
       debug "Updated relay addresses", relayPid, relayedAddr
+      if not hadAddresses and relayedAddr.len > 0:
+        info "Relay connectivity established", relayPid, addresses = relayedAddr.len
       if self.running and not self.onReservation.isNil():
         self.onReservation(concat(toSeq(self.relayAddresses.values)))
     await sleepAsync chronos.seconds(ttl - 30)
@@ -94,8 +103,25 @@ proc innerRun(
     for k in peers:
       try:
         if self.relayPeers[k].finished():
+          let
+            future = self.relayPeers[k]
+            hadReservation = self.relayAddresses.hasKey(k)
+            hadAddresses = self.relayAddresses.values.toSeq().anyIt(it.len > 0)
           self.relayPeers.del(k)
           self.relayAddresses.del(k)
+          let remainingRelays = self.relayAddresses.len
+          if future.failed() and self.reservationWarnings.allowLog():
+            let exc = future.error()
+            warn "Relay reservation task failed",
+              err = exc.msg,
+              errType = exc.name,
+              relayPid = k,
+              hadReservation,
+              remainingRelays
+          if self.running and hadAddresses and
+              not self.relayAddresses.values.toSeq().anyIt(it.len > 0) and
+              self.availabilityWarnings.allowLog():
+            warn "Last usable relay reservation lost", relayPid = k, remainingRelays
           if self.running and not self.onReservation.isNil():
             self.onReservation(concat(toSeq(self.relayAddresses.values)))
           # To avoid ddosing our peers in certain conditions

--- a/libp2p/transports/memorytransport.nim
+++ b/libp2p/transports/memorytransport.nim
@@ -48,7 +48,7 @@ method start*(
   if self.running:
     return
 
-  info "Starting memory transport on addrs", address = $addrs
+  info "Starting memory transport on addrs", address = addrs.shortLog
 
   self.addrs = addrs.mapIt(self.listenAddress(it))
   self.running = true
@@ -58,7 +58,7 @@ method stop*(self: MemoryTransport) {.async: (raises: []).} =
   if not self.running:
     return
 
-  info "Stopping memory transport", address = $self.addrs
+  info "Stopping memory transport", address = self.addrs.shortLog
   self.running = false
   self.onStop.fire()
 

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -63,7 +63,7 @@ proc connHandler*(
   proc onClose() {.async: (raises: []).} =
     await noCancel client.join()
 
-    trace "Cleaning up client", addresses = $client.remoteAddress, conn
+    trace "Cleaning up client", addresses = ($client.remoteAddress).shortLog, conn
 
     self.clients[dir].keepItIf(it != client)
 
@@ -76,7 +76,7 @@ proc connHandler*(
 
     await conn.close()
 
-    trace "Cleaned up client", addresses = $client.remoteAddress, conn
+    trace "Cleaned up client", addresses = ($client.remoteAddress).shortLog, conn
 
   self.clients[dir].add(client)
 

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -5,6 +5,7 @@
 
 {.push raises: [].}
 
+import ../logging
 import std/[sequtils]
 import chronos, chronicles, results
 import
@@ -34,6 +35,7 @@ type
     acceptFuts: seq[AcceptFuture]
     connectionsTimeout: Duration
     stopping: bool
+    descriptorWarnings: LogRateLimit
     closeFuts: seq[Future[void]]
 
   TcpTransportError* = object of transport.TransportError
@@ -241,7 +243,9 @@ method accept*(
     try:
       await finished
     except TransportTooManyError as exc:
-      debug "Too many files opened", err = exc.msg
+      if self.descriptorWarnings.allowLog():
+        warn "Connection acceptance limited by file descriptor exhaustion",
+          err = exc.msg, errType = exc.name, transport = "tcp"
       return nil
     except TransportAbortedError as exc:
       debug "Transport connection aborted", err = exc.msg

--- a/libp2p/transports/transport.nim
+++ b/libp2p/transports/transport.nim
@@ -48,7 +48,7 @@ method start*(
   ## start the transport
   ##
 
-  info "Transport starting", addresses = addrs
+  info "Transport starting", addresses = addrs.shortLog
   self.addrs = addrs
   self.running = true
   self.onRunning.fire()
@@ -58,7 +58,7 @@ method stop*(self: Transport) {.base, async: (raises: []).} =
   ## including all outstanding connections
   ##
 
-  info "Transport stopping", addresses = self.addrs
+  info "Transport stopping", addresses = self.addrs.shortLog
   self.running = false
   self.onStop.fire()
 

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -414,7 +414,7 @@ method start*(
   await procCall Transport(self).start(resolvedAddrs)
   self.acceptLoop = self.wsAcceptDispatcher()
 
-  trace "Listening on", addresses = self.addrs
+  trace "Listening on", addresses = self.addrs.shortLog
 
 method stop*(self: WsTransport) {.async: (raises: []).} =
   ## stop the transport

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -5,6 +5,7 @@
 
 {.push raises: [].}
 
+import ../logging
 import std/[sequtils]
 import chronos, chronicles, results, metrics, stew/byteutils
 import
@@ -135,6 +136,7 @@ method getWrapped*(s: WsStream): Connection =
   nil
 
 type WsTransport* = ref object of Transport
+  descriptorWarnings: LogRateLimit
   httpservers: seq[HttpServer]
   wsserver: WSServer
   connections: array[Direction, seq[WsStream]]
@@ -276,7 +278,9 @@ proc wsAcceptDispatcher(self: WsTransport) {.async: (raises: []).} =
           if exc of TransportUseClosedError:
             debug "Server was closed", err = exc.msg
           elif exc of TransportTooManyError:
-            debug "Too many files opened", err = exc.msg
+            if self.descriptorWarnings.allowLog():
+              warn "Connection acceptance limited by file descriptor exhaustion",
+                err = exc.msg, errType = exc.name, transport = "websocket"
           elif exc of TransportAbortedError:
             debug "Transport connection aborted", err = exc.msg
           elif exc of TransportOsError:

--- a/libp2p/utils/shortlog.nim
+++ b/libp2p/utils/shortlog.nim
@@ -50,7 +50,7 @@ func shortLog*(item: string): string =
 func shortLog*[T](items: openArray[T], maxItems = ShortCollectionMax): string =
   ## Render a bounded collection preview without falling back to an unbounded
   ## ``$items`` representation. Elements with their own ``shortLog`` overload
-  ## retain a useful preview; all other elements are deliberately summarized.
+  ## retain a useful preview.
   let limit = min(items.len, maxItems)
   var res = newStringOfCap(limit * ShortDumpMax)
   res.add('[')

--- a/libp2p/utils/shortlog.nim
+++ b/libp2p/utils/shortlog.nim
@@ -6,6 +6,7 @@
 import stew/byteutils
 
 const ShortDumpMax = 12
+const ShortCollectionMax* = 3
 
 func shortLog*(item: seq[byte]): string =
   if item.len <= ShortDumpMax:
@@ -45,3 +46,24 @@ func shortLog*(item: string): string =
     s &= "..."
     s &= item[(item.len - split) .. item.high]
     s
+
+func shortLog*[T](items: openArray[T], maxItems = ShortCollectionMax): string =
+  ## Render a bounded collection preview without falling back to an unbounded
+  ## ``$items`` representation. Elements with their own ``shortLog`` overload
+  ## retain a useful preview; all other elements are deliberately summarized.
+  let limit = min(items.len, maxItems)
+  var res = newStringOfCap(limit * ShortDumpMax)
+  res.add('[')
+  for i in 0 ..< limit:
+    if i > 0:
+      res.add(", ")
+    when compiles(shortLog(items[i])):
+      res.add($shortLog(items[i]))
+    else:
+      res.add($items[i])
+  res.add(']')
+  if items.len > maxItems:
+    res.add("...(+")
+    res.add($(items.len - maxItems))
+    res.add(" more)")
+  res

--- a/tests/libp2p/test_logging.nim
+++ b/tests/libp2p/test_logging.nim
@@ -3,7 +3,9 @@
 
 {.used.}
 
-import chronicles
+import chronicles, chronos
+import ../../libp2p/logging as libp2p_logging
+import ../tools/unittest
 
 {.push raises: [].}
 
@@ -20,8 +22,6 @@ const canCaptureLogs = dynamicSink >= 0 and chronicles.runtimeFilteringEnabled
 
 when canCaptureLogs:
   import std/strutils
-  import ../../libp2p/logging as libp2p_logging
-  import ../tools/unittest
 
   # The writer stays installed for the whole test binary, so only this test's records may count.
   const logMarker = "test_logging:"
@@ -61,3 +61,19 @@ else:
       "test_logging is not compiled: it needs a dynamic chronicles sink and " &
       "'-d:chronicles_runtime_filtering:on'."
   .}
+
+suite "Operational log rate limiting":
+  test "first event and boundary pass, intervening events are suppressed":
+    var limit: LogRateLimit
+    let start = Moment.now()
+    check limit.allowLog(start)
+    check not limit.allowLog(start)
+    check not limit.allowLog(start + 59.seconds)
+    check limit.allowLog(start + 1.minutes)
+    check not limit.allowLog(start + 61.seconds)
+
+  test "instances do not suppress each other":
+    var first, second: LogRateLimit
+    let start = Moment.now()
+    check first.allowLog(start)
+    check second.allowLog(start)

--- a/tools/audit_log_fields.py
+++ b/tools/audit_log_fields.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""Reject deprecated Chronicle error fields, unsafe elevated payload logs and
-log fields whose names are too short to be useful (single/two characters)."""
+"""Reject unsafe Chronicle log fields and unhelpfully short field names."""
 
 from pathlib import Path
 import re
@@ -15,6 +14,11 @@ EXCEPTION_ALIAS = re.compile(
 PAYLOAD_FIELD = re.compile(
     r"\b(?:msg|message|buffer|record|reply|response|rpcMsg|data|encoded|"
     r"certificate|ticket|key)\s*="
+)
+UNBOUNDED_FIELD = re.compile(
+    r"\b(?:data|buffer|payload|encoded|certificate|ticket|signature|"
+    r"advertisement|msg|message|request|response|record|addresses|addrs)\s*="
+    r"\s*([^,\n]+)"
 )
 FIELD_ASSIGNMENT = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*=")
 FIELD_NAME = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)")
@@ -131,6 +135,15 @@ def main() -> int:
                 violations.append(
                     f"{path.relative_to(ROOT)}:{line}: elevated log contains payload field"
                 )
+            # Payloads and collections must be bounded even at trace/debug:
+            # peers can otherwise make a single event arbitrarily large. This
+            # is intentionally structural; it only checks field names that
+            # conventionally carry byte arrays or unbounded protocol objects.
+            for value in UNBOUNDED_FIELD.findall(block):
+                if "shortLog" not in value and ".len" not in value:
+                    violations.append(
+                        f"{path.relative_to(ROOT)}:{line}: potentially unbounded log field must use shortLog"
+                    )
             # Structured `name = value` fields ...
             for field_name in FIELD_ASSIGNMENT.findall(block):
                 if len(field_name) < 3 and field_name not in SHORT_FIELD_EXCEPTIONS:


### PR DESCRIPTION
added `LogRateLimit` object that will prevent many logs of same kind - like when log is used in heartbeat to be reported on every heartbeat