### PR TITLE
refactor: simplify error handling with isOkOr

### DIFF
--- a/libp2p/cid.nim
+++ b/libp2p/cid.nim
@@ -149,7 +149,6 @@ proc decode(data: openArray[char]): Result[Cid, CidError] =
 proc validate*(ctype: typedesc[Cid], data: openArray[byte]): bool =
   ## Returns ``true`` is data has valid binary CID representation.
   var version, codec: uint64
-  var res: VarintResult[void]
   if len(data) < 2:
     return false
   let last = data.high
@@ -158,16 +157,14 @@ proc validate*(ctype: typedesc[Cid], data: openArray[byte]): bool =
       return true
   var offset = 0
   var length = 0
-  res = LP.getUVarint(data.toOpenArray(offset, last), length, version)
-  if res.isErr():
+  LP.getUVarint(data.toOpenArray(offset, last), length, version).isOkOr:
     return false
   if version != 1'u64:
     return false
   offset += length
   if offset >= len(data):
     return false
-  res = LP.getUVarint(data.toOpenArray(offset, last), length, codec)
-  if res.isErr():
+  LP.getUVarint(data.toOpenArray(offset, last), length, codec).isOkOr:
     return false
   var mcodec = CodeContentIds.getOrDefault(cast[int](codec), InvalidMultiCodec)
   if mcodec == InvalidMultiCodec:

--- a/libp2p/multihash.nim
+++ b/libp2p/multihash.nim
@@ -543,20 +543,17 @@ proc decode*(
 proc validate*(mhtype: typedesc[MultiHash], data: openArray[byte]): bool =
   ## Returns ``true`` if array of bytes ``data`` has correct MultiHash inside.
   var code, size: uint64
-  var res: VarintResult[void]
   if len(data) < 2:
     return false
   let last = data.high
   var offset = 0
   var length = 0
-  res = LP.getUVarint(data.toOpenArray(offset, last), length, code)
-  if res.isErr():
+  LP.getUVarint(data.toOpenArray(offset, last), length, code).isOkOr:
     return false
   offset += length
   if offset >= len(data):
     return false
-  res = LP.getUVarint(data.toOpenArray(offset, last), length, size)
-  if res.isErr():
+  LP.getUVarint(data.toOpenArray(offset, last), length, size).isOkOr:
     return false
   offset += length
   if size > 0x7FFF_FFFF'u64:

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -271,9 +271,8 @@ proc handleHop*(
       return err(StatusV1.HopNoConnToDst)
     ok(msg)
 
-  let check = checkMsg()
-  if check.isErr:
-    await sendStatus(srcStream, check.error())
+  checkMsg().isOkOr:
+    await sendStatus(srcStream, error)
     return
 
   if r.peerCount[src.peerId] >= r.maxCircuitPerPeer or

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -1210,9 +1210,8 @@ method initPubSub*(g: GossipSub) {.raises: [InitializationError].} =
       "gossipsub: set the overhead rate limit through GossipSubParams, not the inherited FloodSub fields",
     )
 
-  let validationRes = g.parameters.validateParameters()
-  if validationRes.isErr:
-    raise newException(InitializationError, $validationRes.error)
+  g.parameters.validateParameters().isOkOr:
+    raise newException(InitializationError, $error)
 
   # init the floodsub stuff here, we customize timedcache in gossip!
   g.seen =

--- a/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
@@ -361,9 +361,8 @@ proc handlePartialRPC(
     ext.config.updatePeerBehaviorPenalty(peerId, 0.1)
     return
 
-  let validateRes = ext.config.validateRPC(rpc)
-  if validateRes.isErr():
-    debug "RPC rejected by application validation", reason = validateRes.error
+  ext.config.validateRPC(rpc).isOkOr:
+    debug "RPC rejected by application validation", reason = error
     return
 
   ext.recordReceivedMetadata(peerId, rpc)

--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -211,9 +211,8 @@ proc register*[E](
   let ttl = r.ttl.get(rdv.config.minTTL)
   if ttl < rdv.config.minTTL or ttl > rdv.config.maxTTL:
     return stream.sendRegisterResponseError(InvalidTTL)
-  let pr = rdv.peerRecordValidator(peerRecord, r.signedPeerRecord, stream.peerId)
-  if pr.isErr():
-    return stream.sendRegisterResponseError(InvalidSignedPeerRecord, pr.error())
+  rdv.peerRecordValidator(peerRecord, r.signedPeerRecord, stream.peerId).isOkOr:
+    return stream.sendRegisterResponseError(InvalidSignedPeerRecord, error)
   if rdv.countRegister(stream.peerId) >= RegistrationLimitPerPeer:
     return stream.sendRegisterResponseError(NotAuthorized, "Registration limit reached")
 

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -37,9 +37,8 @@ proc refreshSelfSignedPeerRecord(
 
   debug "Publishing Signed XPR", xpr = $extPeerRecord
 
-  let putRes = await disco.putValue(key, encodedSR)
-  if putRes.isErr:
-    debug "Failed to put signed peer record", err = putRes.error
+  (await disco.putValue(key, encodedSR)).isOkOr:
+    debug "Failed to put signed peer record", err = error
 
 proc maintainSelfSignedPeerRecord(
     disco: ServiceDiscovery

--- a/libp2p/services/natservice.nim
+++ b/libp2p/services/natservice.nim
@@ -338,9 +338,8 @@ proc unmapStale(
     if entry in keep:
       continue
     let (port, proto) = entry
-    let r = await self.mapper.unmap(port, proto)
-    if r.isErr:
-      warn "Failed to unmap stale port", port, proto, err = r.error
+    (await self.mapper.unmap(port, proto)).isOkOr:
+      warn "Failed to unmap stale port", port, proto, err = error
 
 proc unmapAll(self: NATService) {.async: (raises: [CancelledError]).} =
   await self.unmapStale(@[])


### PR DESCRIPTION
## Summary
Replace temporary Result variables and explicit error checks with `isOkOr` in CID and multihash validation, protocol handlers, service discovery, and NAT cleanup. This reduces repetitive error-handling code while preserving the existing error paths.
