### PR TITLE
fix(transports): harden SOCKS5 handling and simplify transport cleanup

### DIFF
--- a/libp2p/transports/memorymanager.nim
+++ b/libp2p/transports/memorymanager.nim
@@ -52,7 +52,6 @@ proc dial*(self: MemoryListener): Future[RawConn] {.gcsafe, raises: [].} =
 
 type memoryConnManager = ref object
   listeners: Table[string, MemoryListener]
-  connections: Table[string, RawConn]
   lock: Lock
 
 proc init(_: type[memoryConnManager]): memoryConnManager =

--- a/libp2p/transports/tortransport.nim
+++ b/libp2p/transports/tortransport.nim
@@ -90,28 +90,23 @@ proc handlesDial(address: MultiAddress): bool {.gcsafe.} =
 proc handlesStart(address: MultiAddress): bool {.gcsafe.} =
   return TcpOnion3.match(address)
 
-proc connectToTorServer(
-    transportAddress: TransportAddress
-): Future[StreamTransport] {.
+proc authenticate(
+    transp: StreamTransport
+) {.
     async: (
       raises: [
-        Socks5VersionError, Socks5AuthFailedError, Socks5ServerReplyError, LPError,
-        common.TransportError, CancelledError,
+        Socks5VersionError, Socks5AuthFailedError, common.TransportError, CancelledError
       ]
     )
 .} =
-  let transp = await connect(transportAddress)
   discard
     await transp.write(@[Socks5ProtocolVersion, NMethods, Socks5AuthMethod.NoAuth.byte])
-  let
-    serverReply = await transp.read(2)
-    socks5ProtocolVersion = serverReply[0]
-    serverSelectedMethod = serverReply[1]
-  if socks5ProtocolVersion != Socks5ProtocolVersion:
+  var serverReply: array[2, byte]
+  await transp.readExactly(addr serverReply[0], serverReply.len)
+  if serverReply[0] != Socks5ProtocolVersion:
     raise newException(Socks5VersionError, "Unsupported socks version")
-  if serverSelectedMethod != Socks5AuthMethod.NoAuth.byte:
+  if serverReply[1] != Socks5AuthMethod.NoAuth.byte:
     raise newException(Socks5AuthFailedError, "Unsupported auth method")
-  return transp
 
 proc readServerReply(
     transp: StreamTransport
@@ -126,11 +121,9 @@ proc readServerReply(
   ## The specification for this code is defined on
   ## [link text](https://www.rfc-editor.org/rfc/rfc1928#section-5)
   ## and [link text](https://www.rfc-editor.org/rfc/rfc1928#section-6).
+  var firstFourOctets: array[4, byte]
+  await transp.readExactly(addr firstFourOctets[0], firstFourOctets.len)
   let
-    portNumOctets = 2
-    ipV4NumOctets = 4
-    ipV6NumOctets = 16
-    firstFourOctets = await transp.read(4)
     socks5ProtocolVersion = firstFourOctets[0]
     serverReply = firstFourOctets[1]
   if socks5ProtocolVersion != Socks5ProtocolVersion:
@@ -141,17 +134,20 @@ proc readServerReply(
       raise newException(Socks5ServerReplyError, "Server reply error")
     else:
       raise newException(LPError, "Unexpected server reply")
-  let atyp = firstFourOctets[3]
-  case atyp
-  of Socks5AddressType.IPv4.byte:
-    discard await transp.read(ipV4NumOctets + portNumOctets)
-  of Socks5AddressType.FQDN.byte:
-    let fqdnNumOctets = await transp.read(1)
-    discard await transp.read(int(uint8.fromBytes(fqdnNumOctets)) + portNumOctets)
-  of Socks5AddressType.IPv6.byte:
-    discard await transp.read(ipV6NumOctets + portNumOctets)
-  else:
-    raise newException(LPError, "Address not supported")
+  let addressLength =
+    case firstFourOctets[3]
+    of Socks5AddressType.IPv4.byte:
+      4
+    of Socks5AddressType.FQDN.byte:
+      var length: byte
+      await transp.readExactly(addr length, 1)
+      int(length)
+    of Socks5AddressType.IPv6.byte:
+      16
+    else:
+      raise newException(LPError, "Address not supported")
+  var addressAndPort = newSeqUninit[byte](addressLength + 2)
+  await transp.readExactly(addr addressAndPort[0], addressAndPort.len)
 
 proc parseOnion3(
     address: MultiAddress
@@ -235,7 +231,8 @@ method dial*(
   var transp: StreamTransport
 
   try:
-    transp = await connectToTorServer(self.transportAddress)
+    transp = await connect(self.transportAddress)
+    await authenticate(transp)
     await dialPeer(transp, address)
     return self.tcpTransport.connHandler(
       transp, Opt.none(MultiAddress), Opt.none(MultiAddress), Direction.Out

--- a/libp2p/transports/transport.nim
+++ b/libp2p/transports/transport.nim
@@ -4,7 +4,6 @@
 
 {.push raises: [].}
 
-import sequtils
 import chronos, chronicles, results
 import
   ../stream/connection,
@@ -105,7 +104,7 @@ method handles*(
   let protocols = address.protocols.valueOr:
     return false
 
-  protocols.filterIt(it == multiCodec("p2p-circuit")).len == 0
+  multiCodec("p2p-circuit") notin protocols
 
 template safeCloseWait*(stream: untyped) =
   if not isNil(stream):

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -479,8 +479,7 @@ proc connHandler(
       )
     except CatchableError as e:
       trace "WebSocket connection address extraction failed", err = e.msg
-      if not (isNil(stream) and stream.stream.reader.closed):
-        safeClose(stream)
+      safeClose(stream)
       raise e
 
   let conn = WsStream.new(stream, dir, Opt.some(observedAddr), Opt.some(localAddr))

--- a/tests/libp2p/transports/test_tor.nim
+++ b/tests/libp2p/transports/test_tor.nim
@@ -242,3 +242,47 @@ suite "Tor authentication cleanup":
     await peer.shutdownWait()
     expect TransportDialError:
       discard await dialing
+
+suite "Tor CONNECT reply cleanup":
+  teardown:
+    checkTrackers()
+
+  proc checkTruncatedReply(response: seq[byte]) {.async.} =
+    let server = createStreamServer(initTAddress("127.0.0.1:0"))
+    let transport = TorTransport.new(server.localAddress, upgrade = Upgrade())
+    let dialing = transport.dial("", ma("/ip4/127.0.0.1/tcp/1234"))
+    let peer = await server.accept()
+    defer:
+      await peer.closeWait()
+      await server.closeWait()
+      await transport.stop()
+    var greeting: array[3, byte]
+    await peer.readExactly(addr greeting[0], greeting.len)
+    discard await peer.write(@[5'u8, 0])
+    var request: array[10, byte]
+    await peer.readExactly(addr request[0], request.len)
+    discard await peer.write(response)
+    # Signal EOF while keeping the read side open to observe client cleanup.
+    await peer.shutdownWait()
+    expect TransportDialError:
+      discard await dialing
+    var reply: array[1, byte]
+    check (await peer.readOnce(addr reply[0], 1).wait(100.millis)) == 0
+
+  asyncTest "truncated CONNECT header closes the proxy socket":
+    await checkTruncatedReply(@[5'u8, 0, 0])
+
+  asyncTest "missing CONNECT FQDN length closes the proxy socket":
+    await checkTruncatedReply(@[5'u8, 0, 0, 3])
+
+  asyncTest "truncated CONNECT IPv4 address closes the proxy socket":
+    await checkTruncatedReply(@[5'u8, 0, 0, 1, 127, 0, 0])
+
+  asyncTest "truncated CONNECT IPv4 port closes the proxy socket":
+    await checkTruncatedReply(@[5'u8, 0, 0, 1, 127, 0, 0, 1, 0])
+
+  asyncTest "truncated CONNECT IPv6 port closes the proxy socket":
+    await checkTruncatedReply(@[5'u8, 0, 0, 4] & newSeq[byte](17))
+
+  asyncTest "truncated CONNECT FQDN port closes the proxy socket":
+    await checkTruncatedReply(@[5'u8, 0, 0, 3, 3, 97, 98, 99, 0])

--- a/tests/libp2p/transports/test_tor.nim
+++ b/tests/libp2p/transports/test_tor.nim
@@ -243,7 +243,7 @@ suite "Tor authentication":
     expect TransportDialError:
       discard await dialing
 
-suite "Tor CONNECT reply cleanup":
+suite "Tor CONNECT reply":
   teardown:
     checkTrackers()
 

--- a/tests/libp2p/transports/test_tor.nim
+++ b/tests/libp2p/transports/test_tor.nim
@@ -191,7 +191,7 @@ suite "Tor transport":
       torSwitch.addTransport(TcpTransport.new(upgrade = Upgrade()))
     waitFor torSwitch.stop()
 
-suite "Tor authentication cleanup":
+suite "Tor authentication":
   teardown:
     checkTrackers()
 

--- a/tests/libp2p/transports/test_tor.nim
+++ b/tests/libp2p/transports/test_tor.nim
@@ -190,3 +190,55 @@ suite "Tor transport":
     expect(AssertionDefect):
       torSwitch.addTransport(TcpTransport.new(upgrade = Upgrade()))
     waitFor torSwitch.stop()
+
+suite "Tor authentication cleanup":
+  teardown:
+    checkTrackers()
+
+  asyncTest "rejected authentication closes the proxy socket":
+    let server = createStreamServer(initTAddress("127.0.0.1:0"))
+    let transport = TorTransport.new(server.localAddress, upgrade = Upgrade())
+    let dialing = transport.dial("", ma("/ip4/127.0.0.1/tcp/1234"))
+    let peer = await server.accept()
+    defer:
+      await peer.closeWait()
+      await server.closeWait()
+      await transport.stop()
+    var greeting: array[3, byte]
+    await peer.readExactly(addr greeting[0], greeting.len)
+    discard await peer.write(@[5'u8, 255])
+    expect TransportDialError:
+      discard await dialing
+    var reply: array[1, byte]
+    check (await peer.readOnce(addr reply[0], 1).wait(100.millis)) == 0
+
+  asyncTest "cancelled authentication closes the proxy socket":
+    let server = createStreamServer(initTAddress("127.0.0.1:0"))
+    let transport = TorTransport.new(server.localAddress, upgrade = Upgrade())
+    let dialing = transport.dial("", ma("/ip4/127.0.0.1/tcp/1234"))
+    let peer = await server.accept()
+    defer:
+      await peer.closeWait()
+      await server.closeWait()
+      await transport.stop()
+    var greeting: array[3, byte]
+    await peer.readExactly(addr greeting[0], greeting.len)
+    await dialing.cancelAndWait()
+    var reply: array[1, byte]
+    check (await peer.readOnce(addr reply[0], 1).wait(100.millis)) == 0
+
+  asyncTest "truncated authentication is a dial error":
+    let server = createStreamServer(initTAddress("127.0.0.1:0"))
+    let transport = TorTransport.new(server.localAddress, upgrade = Upgrade())
+    let dialing = transport.dial("", ma("/ip4/127.0.0.1/tcp/1234"))
+    let peer = await server.accept()
+    defer:
+      await peer.closeWait()
+      await server.closeWait()
+      await transport.stop()
+    var greeting: array[3, byte]
+    await peer.readExactly(addr greeting[0], greeting.len)
+    discard await peer.write(@[5'u8])
+    await peer.shutdownWait()
+    expect TransportDialError:
+      discard await dialing


### PR DESCRIPTION
## Summary

Close the Tor proxy socket when SOCKS5 authentication fails or is cancelled, and reject truncated authentication and CONNECT replies. Read fixed response headers into arrays and consume the complete bound address and port before returning the connection.

Remove a redundant WebSocket cleanup guard, an unused memory-transport table, and a temporary sequence used to check for relay addresses.


