### PR TITLE
fix(cbind): exit examples safely on timeout and use local dependency paths

### DIFF
--- a/cbind/cbind.nimble
+++ b/cbind/cbind.nimble
@@ -33,6 +33,8 @@ proc findInstalledPkgDir(prefix: string): string =
   )
 
 proc ffiDepPaths(): string =
+  if fileExists("nimble.paths"):
+    return ""
   # A global install writes no nimble.paths; point the compiler at the installed
   # copies.
   " --path:" & findInstalledPkgDir("ffi-") & " --path:" &

--- a/cbind/examples/common.h
+++ b/cbind/examples/common.h
@@ -8,6 +8,7 @@
 #include <stdatomic.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #if defined(__STDC_NO_ATOMICS__)
@@ -25,12 +26,14 @@ static inline void sleep_ms(unsigned ms) {
 }
 #endif
 
-// Poll up to ~10s for a callback to fire; false means it never did, so the
-// caller can report a stuck call instead of treating it as an empty success.
-static inline bool wait_done(atomic_int *done) {
+// A timeout must not unwind stack waiters that a late callback still owns.
+static inline void wait_done(atomic_int *done) {
   for (int i = 0; i < 1000 && !atomic_load(done); i++)
     sleep_ms(10);
-  return atomic_load(done) != 0;
+  if (!atomic_load(done)) {
+    fprintf(stderr, "Timed out waiting for callback or event\n");
+    exit(EXIT_FAILURE);
+  }
 }
 
 // start/stop/connect/mount/subscribe/write/release/close all reply with just a
@@ -52,10 +55,7 @@ static inline void on_bool(int ec, const bool *reply, const char *em,
 }
 
 static inline bool await_bool(BoolWaiter *w, const char *label) {
-  if (!wait_done(&w->done)) {
-    fprintf(stderr, "%s: call did not complete\n", label);
-    return false;
-  }
+  wait_done(&w->done);
   if (w->err_code != 0) {
     fprintf(stderr, "%s: %s\n", label, w->err[0] ? w->err : "unknown");
     return false;
@@ -96,7 +96,8 @@ static inline LibP2PCtx *await_create(const Libp2pConfig *cfg,
   CreateWaiter w;
   memset(&w, 0, sizeof(w));
   libp2p_ctx_create(cfg, on_created, &w);
-  if (!wait_done(&w.done) || w.err_code != 0 || !w.ctx) {
+  wait_done(&w.done);
+  if (w.err_code != 0 || !w.ctx) {
     fprintf(stderr, "create %s: %s\n", label, w.err[0] ? w.err : "unknown");
     return NULL;
   }
@@ -139,7 +140,8 @@ static inline bool await_peerinfo(LibP2PCtx *ctx, PeerInfoWaiter *w,
                                   const char *label) {
   memset(w, 0, sizeof(*w));
   libp2p_ctx_peer_info(ctx, on_peerinfo, w);
-  if (!wait_done(&w->done) || w->err_code != 0) {
+  wait_done(&w->done);
+  if (w->err_code != 0) {
     fprintf(stderr, "%s: %s\n", label, w->err[0] ? w->err : "unknown");
     return false;
   }

--- a/cbind/examples/echo.c
+++ b/cbind/examples/echo.c
@@ -45,10 +45,7 @@ static void on_read(int ec, const ReadResponse *reply, const char *em,
 
 // Reads the request off the accepted stream, echoes it back and releases it.
 static bool serveEcho(LibP2PCtx *server) {
-  if (!wait_done(&g_have_stream)) {
-    fprintf(stderr, "server: no incoming stream\n");
-    return false;
-  }
+  wait_done(&g_have_stream);
   uint64_t streamId = g_stream_id;
   atomic_store(&g_have_stream, 0);
 
@@ -56,7 +53,8 @@ static bool serveEcho(LibP2PCtx *server) {
   memset(&rw, 0, sizeof(rw));
   StreamReadLpRequest readReq = {streamId, EchoMaxSize};
   libp2p_ctx_stream_read_lp(server, &readReq, on_read, &rw);
-  if (!wait_done(&rw.done) || rw.err_code != 0) {
+  wait_done(&rw.done);
+  if (rw.err_code != 0) {
     fprintf(stderr, "server read: %s\n", rw.err[0] ? rw.err : "unknown");
     return false;
   }
@@ -97,7 +95,8 @@ static bool echoRoundTrip(LibP2PCtx *client, LibP2PCtx *server,
   DialWaiter dw;
   memset(&dw, 0, sizeof(dw));
   libp2p_ctx_dial(client, dialReq, on_dial, &dw);
-  if (!wait_done(&dw.done) || dw.err_code != 0) {
+  wait_done(&dw.done);
+  if (dw.err_code != 0) {
     fprintf(stderr, "dial: %s\n", dw.err[0] ? dw.err : "unknown");
     return false;
   }
@@ -121,7 +120,8 @@ static bool echoRoundTrip(LibP2PCtx *client, LibP2PCtx *server,
   memset(&rw, 0, sizeof(rw));
   StreamReadLpRequest readReq = {streamId, EchoMaxSize};
   libp2p_ctx_stream_read_lp(client, &readReq, on_read, &rw);
-  if (!wait_done(&rw.done) || rw.err_code != 0) {
+  wait_done(&rw.done);
+  if (rw.err_code != 0) {
     fprintf(stderr, "stream_read_lp: %s\n", rw.err[0] ? rw.err : "unknown");
     return false;
   }

--- a/cbind/examples/gossipsub.c
+++ b/cbind/examples/gossipsub.c
@@ -109,18 +109,16 @@ int main(void) {
   PublishWaiter pubw;
   memset(&pubw, 0, sizeof(pubw));
   libp2p_ctx_gossipsub_publish(publisher, &pubReq, on_publish, &pubw);
-  if (!wait_done(&pubw.done) || pubw.err_code != 0) {
+  wait_done(&pubw.done);
+  if (pubw.err_code != 0) {
     fprintf(stderr, "publish: %s\n", pubw.err[0] ? pubw.err : "unknown");
     goto cleanup;
   }
   printf("Published to %lld peer(s)\n", (long long)pubw.peerCount);
 
-  if (wait_done(&g_got)) {
-    printf("Subscriber received: %s\n", g_received);
-    status = strcmp(g_received, message) == 0 ? 0 : 1;
-  } else {
-    fprintf(stderr, "Error: timed out waiting for the message\n");
-  }
+  wait_done(&g_got);
+  printf("Subscriber received: %s\n", g_received);
+  status = strcmp(g_received, message) == 0 ? 0 : 1;
 
 cleanup:
   AWAIT_BOOL(bw, libp2p_ctx_stop(publisher, on_bool, &bw), "stop publisher");

--- a/cbind/examples/kad.c
+++ b/cbind/examples/kad.c
@@ -148,7 +148,8 @@ int main(void) {
   // which this topology can never reach; 0 is rejected by the binding.
   KadGetValueRequest getReq = {key, 1};
   libp2p_ctx_kad_get_value(client, &getReq, on_value, &vw);
-  if (!wait_done(&vw.done) || vw.err_code != 0) {
+  wait_done(&vw.done);
+  if (vw.err_code != 0) {
     fprintf(stderr, "get_value: %s\n", vw.err[0] ? vw.err : "unknown");
     goto cleanup_client;
   }
@@ -168,7 +169,8 @@ int main(void) {
                              {(uint8_t *)cidData, strlen(cidData)}};
   // create_cid is context-independent ({.ffiStatic.}), so it takes no ctx.
   libp2p_static_create_cid(&cidReq, on_cid, &cw);
-  if (!wait_done(&cw.done) || cw.err_code != 0) {
+  wait_done(&cw.done);
+  if (cw.err_code != 0) {
     fprintf(stderr, "create_cid: %s\n", cw.err[0] ? cw.err : "unknown");
     goto cleanup_client;
   }
@@ -184,7 +186,8 @@ int main(void) {
   ProvidersWaiter pw;
   memset(&pw, 0, sizeof(pw));
   libp2p_ctx_kad_get_providers(client, nimffi_str(cw.cid), on_providers, &pw);
-  if (!wait_done(&pw.done) || pw.err_code != 0) {
+  wait_done(&pw.done);
+  if (pw.err_code != 0) {
     fprintf(stderr, "get_providers: %s\n", pw.err[0] ? pw.err : "unknown");
     goto cleanup_client;
   }

--- a/cbind/examples/libp2p_mobile_check.c
+++ b/cbind/examples/libp2p_mobile_check.c
@@ -89,7 +89,7 @@ static int wait_for_callback(CallbackWait *wait, const char *op) {
   struct timespec deadline;
   if (clock_gettime(CLOCK_REALTIME, &deadline) != 0) {
     fprintf(stderr, "%s: clock_gettime failed: %s\n", op, strerror(errno));
-    return 1;
+    exit(EXIT_FAILURE);
   }
   deadline.tv_sec += CALLBACK_TIMEOUT_SECONDS;
 
@@ -107,12 +107,13 @@ static int wait_for_callback(CallbackWait *wait, const char *op) {
   if (rc == ETIMEDOUT) {
     fprintf(stderr, "%s: timed out after %d seconds\n", op,
             CALLBACK_TIMEOUT_SECONDS);
-    return 1;
+    // A late callback still owns the stack waiter and its synchronization state.
+    exit(EXIT_FAILURE);
   }
   if (rc != 0) {
     fprintf(stderr, "%s: pthread_cond_timedwait failed: %s\n", op,
             strerror(rc));
-    return 1;
+    exit(EXIT_FAILURE);
   }
   if (err_code != NIMFFI_RET_OK) {
     fprintf(stderr, "%s: %s\n", op,

--- a/cbind/examples/libp2p_mobile_check.c
+++ b/cbind/examples/libp2p_mobile_check.c
@@ -107,7 +107,8 @@ static int wait_for_callback(CallbackWait *wait, const char *op) {
   if (rc == ETIMEDOUT) {
     fprintf(stderr, "%s: timed out after %d seconds\n", op,
             CALLBACK_TIMEOUT_SECONDS);
-    // A late callback still owns the stack waiter and its synchronization state.
+    // A late callback still owns the stack waiter and its synchronization
+    // state.
     exit(EXIT_FAILURE);
   }
   if (rc != 0) {

--- a/cbind/examples/metrics.c
+++ b/cbind/examples/metrics.c
@@ -49,7 +49,8 @@ int main(void) {
   MetricsWaiter mw;
   memset(&mw, 0, sizeof(mw));
   libp2p_static_collect_metrics(on_metrics, &mw);
-  if (!wait_done(&mw.done) || mw.err_code != 0) {
+  wait_done(&mw.done);
+  if (mw.err_code != 0) {
     fprintf(stderr, "collect_metrics: %s\n", mw.err[0] ? mw.err : "unknown");
     goto cleanup;
   }

--- a/cbind/examples/peerstore.c
+++ b/cbind/examples/peerstore.c
@@ -34,7 +34,8 @@ static void on_peers(int ec, const PeersResponse *reply, const char *em,
 static bool get_peers(LibP2PCtx *ctx, PeersWaiter *w) {
   memset(w, 0, sizeof(*w));
   libp2p_ctx_peerstore_get_peers(ctx, on_peers, w);
-  if (!wait_done(&w->done) || w->err_code != 0) {
+  wait_done(&w->done);
+  if (w->err_code != 0) {
     fprintf(stderr, "get_peers: %s\n", w->err[0] ? w->err : "unknown");
     return false;
   }
@@ -122,7 +123,8 @@ int main(void) {
   memset(&entry, 0, sizeof(entry));
   libp2p_ctx_peerstore_get_peer_info(local, nimffi_str(oi.peerId), on_entry,
                                      &entry);
-  if (!wait_done(&entry.done) || entry.err_code != 0) {
+  wait_done(&entry.done);
+  if (entry.err_code != 0) {
     fprintf(stderr, "get_peer_info: %s\n",
             entry.err[0] ? entry.err : "unknown");
     goto cleanup;

--- a/cbind/examples/relay.c
+++ b/cbind/examples/relay.c
@@ -141,7 +141,8 @@ int main(void) {
   DialCircuitRelayRequest dialReq = {nimffi_str(dstInfo.peerId),
                                      nimffi_str(circuit), nimffi_str(Proto), 0};
   libp2p_ctx_dial_circuit_relay(src, &dialReq, on_dial, &dw);
-  if (!wait_done(&dw.done) || dw.err_code != 0) {
+  wait_done(&dw.done);
+  if (dw.err_code != 0) {
     fprintf(stderr, "dial_circuit_relay: %s\n", dw.err[0] ? dw.err : "unknown");
     goto cleanup;
   }
@@ -155,15 +156,13 @@ int main(void) {
     goto cleanup;
 
   // Dst serves its relayed stream from this thread: read and verify.
-  if (!wait_done(&g_have_stream)) {
-    fprintf(stderr, "dst: no incoming stream\n");
-    goto cleanup;
-  }
+  wait_done(&g_have_stream);
   ReadWaiter rw;
   memset(&rw, 0, sizeof(rw));
   StreamReadLpRequest rd = {g_stream_id, 4096};
   libp2p_ctx_stream_read_lp(dst, &rd, on_read, &rw);
-  if (!wait_done(&rw.done) || rw.err_code != 0) {
+  wait_done(&rw.done);
+  if (rw.err_code != 0) {
     fprintf(stderr, "dst read: %s\n", rw.err[0] ? rw.err : "unknown");
     goto cleanup;
   }

--- a/cbind/examples/service_disco.c
+++ b/cbind/examples/service_disco.c
@@ -89,10 +89,7 @@ static bool lookupProvider(LibP2PCtx *seeker, const char *providerId) {
     RecordsWaiter rw;
     memset(&rw, 0, sizeof(rw));
     libp2p_ctx_service_disco_lookup(seeker, &req, on_records, &rw);
-    if (!wait_done(&rw.done)) {
-      fprintf(stderr, "lookup: call did not complete\n");
-      return false;
-    }
+    wait_done(&rw.done);
     if (rw.err_code != 0) {
       fprintf(stderr, "lookup: %s\n", rw.err[0] ? rw.err : "unknown");
       return false;
@@ -119,10 +116,7 @@ static bool rejectsDiscoBeforeStart(LibP2PCtx *ctx) {
   BoolWaiter bw;
   memset(&bw, 0, sizeof(bw));
   libp2p_ctx_service_disco_start(ctx, on_bool, &bw);
-  if (!wait_done(&bw.done)) {
-    fprintf(stderr, "service_disco_start: call did not complete\n");
-    return false;
-  }
+  wait_done(&bw.done);
   if (bw.err_code == 0) {
     fprintf(stderr, "Error: service_disco_start succeeded before ctx_start\n");
     return false;


### PR DESCRIPTION
## Summary

Exit the C examples on callback timeouts instead of returning while a late callback can still access stack variables or destroyed synchronization objects. Update the shared helper and its callers, and apply the same behavior to the mobile check.

Use the dependency paths supplied by `nimble.paths` when present, keeping installed-package lookup as the fallback for global installations.
