### PR TITLE
fix(connmanager): restore readiness waits and tag decay on restart

### DIFF
--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -104,7 +104,7 @@ type
   .}
 
   ConnManager* = ref object of RootObj
-    closed: bool
+    started: bool
     muxerStore: MuxerStore
     maxConnsPerPeer: int
     maxConnectionsIn: int
@@ -171,7 +171,7 @@ proc new*(
     watermark: Opt[WatermarkPolicy] = Opt.none(WatermarkPolicy),
     scoring: PeerScoring = PeerScoring(),
 ): ConnManager =
-  ## Creates a `ConnManager`.
+  ## Creates a stopped `ConnManager`. Call `start` before using it.
   ##
   ## `maxConnsPerPeer` accepts values ≤0 to mean "use the default value".
   ##
@@ -257,8 +257,8 @@ proc waitForPeerReady*(
     c: ConnManager, peerId: PeerId, timeout = 5.seconds
 ): Future[bool] {.async: (raises: [CancelledError]).} =
   ## Wait until `storeMuxer` has emitted the `Connected` conn event for `peerId`.
-  ## Existing ready peers bypass waiting.
-  if c.closed:
+  ## Existing ready peers bypass waiting. Returns false while stopped.
+  if not c.started:
     return false
 
   if peerId in c.readyPeers:
@@ -700,12 +700,12 @@ proc runDecayLoop(c: ConnManager) {.async: (raises: [CancelledError]).} =
   c.decayLoopFut = nil
 
 proc start*(c: ConnManager) =
-  ## Resume readiness waits and tag decay after a completed shutdown.
-  if not c.closed:
+  ## Enable readiness waits and tag decay, including after a completed stop.
+  if c.started:
+    warn "ConnManager has already been started"
     return
-  c.closed = false
-  if c.decayingTags.len > 0:
-    c.decayLoopFut = c.runDecayLoop()
+  c.started = true
+  c.decayLoopFut = c.runDecayLoop()
 
 proc tagPeerDecaying*(
     c: ConnManager,
@@ -716,7 +716,7 @@ proc tagPeerDecaying*(
     decayFn: DecayFn,
 ) =
   ## Attach an ephemeral tag to `peerId` with an initial `value`.
-  ## A single decay loop runs every `decayResolution`.
+  ## A single decay loop runs every `decayResolution` while the manager is started.
   ## On each run it applies `decayFn` to every tag whose `interval` has elapsed.
   ## A tag therefore decays at most once per `decayResolution`, even with a shorter `interval`.
   ## When the value drops to ≤0 the tag is removed automatically.
@@ -726,7 +726,7 @@ proc tagPeerDecaying*(
   let now = Moment.now()
   c.decayingTags.mgetOrPut(peerId, initTable[string, DecayingTagValue]())[tag] =
     DecayingTagValue(value: value, lastTick: now, interval: interval, decayFn: decayFn)
-  if c.decayLoopFut.isNil or c.decayLoopFut.finished:
+  if c.started and (c.decayLoopFut.isNil or c.decayLoopFut.finished):
     c.decayLoopFut = c.runDecayLoop()
 
 proc bumpDecayingTag*(c: ConnManager, peerId: PeerId, tag: string, delta: int) =
@@ -804,10 +804,10 @@ proc drainOnCloseTasks(c: ConnManager) {.async: (raises: []).} =
   await noCancel allFutures(c.onCloseFuts)
   c.onCloseFuts = @[]
 
-proc close*(c: ConnManager) {.async: (raises: [CancelledError]).} =
-  ## Cleanup resources for the connection manager.
-  trace "Closing ConnManager"
-  c.closed = true
+proc stop*(c: ConnManager) {.async: (raises: [CancelledError]).} =
+  ## Stop background tasks and close all connections. Retain peer tags for restart.
+  trace "Stopping ConnManager"
+  c.started = false
 
   if not c.decayLoopFut.isNil:
     await c.decayLoopFut.cancelAndWait()
@@ -840,4 +840,4 @@ proc close*(c: ConnManager) {.async: (raises: [CancelledError]).} =
 
   await c.drainOnCloseTasks()
 
-  trace "Closed ConnManager"
+  trace "Stopped ConnManager"

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -104,7 +104,7 @@ type
   .}
 
   ConnManager* = ref object of RootObj
-    started: bool
+    closed: bool
     muxerStore: MuxerStore
     maxConnsPerPeer: int
     maxConnectionsIn: int
@@ -171,7 +171,7 @@ proc new*(
     watermark: Opt[WatermarkPolicy] = Opt.none(WatermarkPolicy),
     scoring: PeerScoring = PeerScoring(),
 ): ConnManager =
-  ## Creates a stopped `ConnManager`. Call `start` before using it.
+  ## Creates a usable `ConnManager`; no explicit `start` is needed until after `stop`.
   ##
   ## `maxConnsPerPeer` accepts values ≤0 to mean "use the default value".
   ##
@@ -258,7 +258,7 @@ proc waitForPeerReady*(
 ): Future[bool] {.async: (raises: [CancelledError]).} =
   ## Wait until `storeMuxer` has emitted the `Connected` conn event for `peerId`.
   ## Existing ready peers bypass waiting. Returns false while stopped.
-  if not c.started:
+  if c.closed:
     return false
 
   if peerId in c.readyPeers:
@@ -700,12 +700,12 @@ proc runDecayLoop(c: ConnManager) {.async: (raises: [CancelledError]).} =
   c.decayLoopFut = nil
 
 proc start*(c: ConnManager) =
-  ## Enable readiness waits and tag decay, including after a completed stop.
-  if c.started:
-    warn "ConnManager has already been started"
+  ## Resume readiness waits and tag decay after a completed stop.
+  if not c.closed:
     return
-  c.started = true
-  c.decayLoopFut = c.runDecayLoop()
+  c.closed = false
+  if c.decayingTags.len > 0:
+    c.decayLoopFut = c.runDecayLoop()
 
 proc tagPeerDecaying*(
     c: ConnManager,
@@ -716,7 +716,7 @@ proc tagPeerDecaying*(
     decayFn: DecayFn,
 ) =
   ## Attach an ephemeral tag to `peerId` with an initial `value`.
-  ## A single decay loop runs every `decayResolution` while the manager is started.
+  ## A single decay loop runs every `decayResolution` unless the manager has been stopped.
   ## On each run it applies `decayFn` to every tag whose `interval` has elapsed.
   ## A tag therefore decays at most once per `decayResolution`, even with a shorter `interval`.
   ## When the value drops to ≤0 the tag is removed automatically.
@@ -726,7 +726,7 @@ proc tagPeerDecaying*(
   let now = Moment.now()
   c.decayingTags.mgetOrPut(peerId, initTable[string, DecayingTagValue]())[tag] =
     DecayingTagValue(value: value, lastTick: now, interval: interval, decayFn: decayFn)
-  if c.started and (c.decayLoopFut.isNil or c.decayLoopFut.finished):
+  if not c.closed and (c.decayLoopFut.isNil or c.decayLoopFut.finished):
     c.decayLoopFut = c.runDecayLoop()
 
 proc bumpDecayingTag*(c: ConnManager, peerId: PeerId, tag: string, delta: int) =
@@ -807,7 +807,7 @@ proc drainOnCloseTasks(c: ConnManager) {.async: (raises: []).} =
 proc stop*(c: ConnManager) {.async: (raises: [CancelledError]).} =
   ## Stop background tasks and close all connections. Retain peer tags for restart.
   trace "Stopping ConnManager"
-  c.started = false
+  c.closed = true
 
   if not c.decayLoopFut.isNil:
     await c.decayLoopFut.cancelAndWait()

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -704,8 +704,7 @@ proc start*(c: ConnManager) =
   if not c.closed:
     return
   c.closed = false
-  if c.decayingTags.len > 0:
-    c.decayLoopFut = c.runDecayLoop()
+  c.decayLoopFut = c.runDecayLoop()
 
 proc tagPeerDecaying*(
     c: ConnManager,

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -104,7 +104,7 @@ type
   .}
 
   ConnManager* = ref object of RootObj
-    closed: bool
+    running: bool
     muxerStore: MuxerStore
     maxConnsPerPeer: int
     maxConnectionsIn: int
@@ -209,6 +209,7 @@ proc new*(
     maxOutArg = ConnectionsUnlimited
 
   T(
+    running: true,
     muxerStore: MuxerStore.new(),
     maxConnsPerPeer:
       if maxConnsPerPeer > 0: maxConnsPerPeer else: DefaultMaxConnectionsPerPeer,
@@ -219,6 +220,9 @@ proc new*(
     watermark: watermark,
     scoring: scoring,
   )
+
+proc isRunning*(c: ConnManager): bool =
+  c.running
 
 proc connCount*(c: ConnManager, peerId: PeerId): int =
   c.muxerStore.count(peerId)
@@ -258,7 +262,7 @@ proc waitForPeerReady*(
 ): Future[bool] {.async: (raises: [CancelledError]).} =
   ## Wait until `storeMuxer` has emitted the `Connected` conn event for `peerId`.
   ## Existing ready peers bypass waiting. Returns false while stopped.
-  if c.closed:
+  if not c.running:
     return false
 
   if peerId in c.readyPeers:
@@ -701,9 +705,10 @@ proc runDecayLoop(c: ConnManager) {.async: (raises: [CancelledError]).} =
 
 proc start*(c: ConnManager) =
   ## Resume readiness waits and tag decay after a completed stop.
-  if not c.closed:
+  if c.running:
+    warn "ConnManager is already running"
     return
-  c.closed = false
+  c.running = true
   c.decayLoopFut = c.runDecayLoop()
 
 proc tagPeerDecaying*(
@@ -725,7 +730,7 @@ proc tagPeerDecaying*(
   let now = Moment.now()
   c.decayingTags.mgetOrPut(peerId, initTable[string, DecayingTagValue]())[tag] =
     DecayingTagValue(value: value, lastTick: now, interval: interval, decayFn: decayFn)
-  if not c.closed and (c.decayLoopFut.isNil or c.decayLoopFut.finished):
+  if c.running and (c.decayLoopFut.isNil or c.decayLoopFut.finished):
     c.decayLoopFut = c.runDecayLoop()
 
 proc bumpDecayingTag*(c: ConnManager, peerId: PeerId, tag: string, delta: int) =
@@ -806,7 +811,7 @@ proc drainOnCloseTasks(c: ConnManager) {.async: (raises: []).} =
 proc stop*(c: ConnManager) {.async: (raises: [CancelledError]).} =
   ## Stop background tasks and close all connections. Retain peer tags for restart.
   trace "Stopping ConnManager"
-  c.closed = true
+  c.running = false
 
   if not c.decayLoopFut.isNil:
     await c.decayLoopFut.cancelAndWait()

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -699,6 +699,14 @@ proc runDecayLoop(c: ConnManager) {.async: (raises: [CancelledError]).} =
     c.applyDecay()
   c.decayLoopFut = nil
 
+proc start*(c: ConnManager) =
+  ## Resume readiness waits and tag decay after a completed shutdown.
+  if not c.closed:
+    return
+  c.closed = false
+  if c.decayingTags.len > 0:
+    c.decayLoopFut = c.runDecayLoop()
+
 proc tagPeerDecaying*(
     c: ConnManager,
     peerId: PeerId,

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -392,6 +392,8 @@ proc start*(s: Switch) {.async: (raises: [CancelledError, LPError]).} =
 
   info "Starting switch for peer", peerInfo = s.peerInfo
 
+  s.connManager.start()
+
   # started first, so that it owns the mapper chain before any service adds one
   doAssert not s.addressManager.isNil(), MissingAddressManager
   s.addressManager.setPeerInfo(s.peerInfo)

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -392,7 +392,8 @@ proc start*(s: Switch) {.async: (raises: [CancelledError, LPError]).} =
 
   info "Starting switch for peer", peerInfo = s.peerInfo
 
-  s.connManager.start()
+  if not s.connManager.isRunning():
+    s.connManager.start()
 
   # started first, so that it owns the mapper chain before any service adds one
   doAssert not s.addressManager.isNil(), MissingAddressManager

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -364,7 +364,7 @@ proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
     await service.stop(s)
 
   # close and cleanup all connections
-  await s.connManager.close()
+  await s.connManager.stop()
 
   for transp in s.transports:
     try:

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -431,7 +431,6 @@ suite "Identify":
     ms.addHandler(limitedPing)
 
     let connManager = ConnManager.new()
-    connManager.start()
     defer:
       await connManager.stop()
 

--- a/tests/libp2p/protocols/test_identify.nim
+++ b/tests/libp2p/protocols/test_identify.nim
@@ -430,8 +430,13 @@ suite "Identify":
       LPProtocol.new(@[PingCodec], unusedHandler, maxOutgoingStreamsTotal = 0)
     ms.addHandler(limitedPing)
 
+    let connManager = ConnManager.new()
+    connManager.start()
+    defer:
+      await connManager.stop()
+
     let
-      dialer = Dialer.new(localInfo.peerId, ConnManager.new(), peerStore, @[], ms, nil)
+      dialer = Dialer.new(localInfo.peerId, connManager, peerStore, @[], ms, nil)
       stream = await muxDialer.newStream()
       negotiateFut = dialer.negotiateStream(stream, @[IdentifyCodec])
 

--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -235,6 +235,19 @@ suite "Connection Manager":
     check await readyWaiter
     await connMngr.close()
 
+  asyncTest "restart resumes readiness waits and retained tag decay":
+    let connMngr = newWatermark(1, 2, decayResolution = 1.millis)
+    connMngr.tagPeerDecaying(peerId, "retained", 1, 1.millis, decayFixed(1))
+    await connMngr.close()
+    connMngr.start()
+    defer:
+      await connMngr.close()
+    let readyWaiter = connMngr.waitForPeerReady(peerId, 1.seconds)
+    await connMngr.storeMuxer(makeMuxer(peerId))
+    check await readyWaiter
+    checkUntilTimeoutCustom(1.seconds, 10.millis):
+      connMngr.peerScore(peerId) == 0
+
   asyncTest "waitForPeerReady timeout does not break concurrent waiters":
     let connMngr = newMaxTotal()
 

--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -20,16 +20,18 @@ method newStream*(
   Connection.new(m.peerId, Direction.Out)
 
 proc newMaxTotal(maxConnections = 10, maxConnsPerPeer = 1): ConnManager =
-  ConnManager.new(
+  result = ConnManager.new(
     maxConnsPerPeer = maxConnsPerPeer,
     limits = Opt.some(ConnectionLimits.maxTotal(maxConnections)),
   )
+  result.start()
 
 proc newMaxInOut(maxIn: int, maxOut: int, maxConnsPerPeer = 1): ConnManager =
-  ConnManager.new(
+  result = ConnManager.new(
     maxConnsPerPeer = maxConnsPerPeer,
     limits = Opt.some(ConnectionLimits.maxInOut(maxIn, maxOut)),
   )
+  result.start()
 
 proc newWatermark*(
     lowWater: int,
@@ -47,7 +49,8 @@ proc newWatermark*(
   )
   let scCfg =
     PeerScoring(outboundBonus: outboundBonus, decayResolution: decayResolution)
-  ConnManager.new(watermark = Opt.some(wtCfg), scoring = scCfg)
+  result = ConnManager.new(watermark = Opt.some(wtCfg), scoring = scCfg)
+  result.start()
 
 proc storeMuxers(connMngr: ConnManager, count: uint): Future[seq[PeerId]] {.async.} =
   let peers = PeerId.random(count, rng()).tryGet()
@@ -71,7 +74,7 @@ suite "Connection Manager":
     check peerMux == mux
     check peerMux.connection.dir == Direction.In
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "get all connections":
     let connMngr = newMaxTotal()
@@ -84,7 +87,7 @@ suite "Connection Manager":
     let connsMux = connMngr.getConnections().values.toSeq().mapIt(it[0])
     check unorderedCompare(connsMux, muxs)
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "shouldn't allow a closed connection":
     let connMngr = newMaxTotal()
@@ -94,7 +97,7 @@ suite "Connection Manager":
     expect LPError:
       await connMngr.storeMuxer(mux)
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "shouldn't allow an EOFed connection":
     let connMngr = newMaxTotal()
@@ -105,7 +108,7 @@ suite "Connection Manager":
       await connMngr.storeMuxer(mux)
 
     await mux.close()
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "shouldn't allow a muxer with no connection":
     let connMngr = newMaxTotal()
@@ -118,7 +121,7 @@ suite "Connection Manager":
 
     await conn.close()
     await muxer.close()
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "get conn with direction":
     let connMngr = newMaxTotal(maxConnsPerPeer = 2)
@@ -140,7 +143,7 @@ suite "Connection Manager":
     check outMux.connection.dir == Direction.Out
     check inMux.connection.dir == Direction.In
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "get muxed stream for peer":
     let connMngr = newMaxTotal()
@@ -157,7 +160,7 @@ suite "Connection Manager":
     check not stream.isNil
     check stream.peerId == peerId
 
-    await connMngr.close()
+    await connMngr.stop()
     await connection.close()
     await stream.close()
 
@@ -177,7 +180,7 @@ suite "Connection Manager":
     let stream2 = await connMngr.getStream(peerId, Direction.Out)
     check stream2.isNil
 
-    await connMngr.close()
+    await connMngr.stop()
     await stream1.close()
     await connection.close()
 
@@ -206,7 +209,7 @@ suite "Connection Manager":
     expect TooManyConnectionsError:
       await connMngr.storeMuxer(muxs[1])
 
-    await connMngr.close()
+    await connMngr.stop()
 
     checkUntilTimeout:
       waitedConn3.cancelled()
@@ -224,7 +227,7 @@ suite "Connection Manager":
     checkUntilTimeout:
       muxer notin connMngr
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "waitForPeerReady unblocks when muxer is stored":
     let connMngr = newMaxTotal()
@@ -233,20 +236,50 @@ suite "Connection Manager":
     await connMngr.storeMuxer(makeMuxer(peerId))
 
     check await readyWaiter
-    await connMngr.close()
+    await connMngr.stop()
+
+  asyncTest "readiness waits require start":
+    let connMngr = ConnManager.new()
+    defer:
+      await connMngr.stop()
+    check not (await connMngr.waitForPeerReady(peerId))
+    connMngr.start()
+    let readyWaiter = connMngr.waitForPeerReady(peerId, 1.seconds)
+    await connMngr.storeMuxer(makeMuxer(peerId))
+    check await readyWaiter
+    await connMngr.stop()
+    check not (await connMngr.waitForPeerReady(peerId))
 
   asyncTest "restart resumes readiness waits and retained tag decay":
     let connMngr = newWatermark(1, 2, decayResolution = 1.millis)
     connMngr.tagPeerDecaying(peerId, "retained", 1, 1.millis, decayFixed(1))
-    await connMngr.close()
+    await connMngr.stop()
     connMngr.start()
     defer:
-      await connMngr.close()
+      await connMngr.stop()
     let readyWaiter = connMngr.waitForPeerReady(peerId, 1.seconds)
     await connMngr.storeMuxer(makeMuxer(peerId))
     check await readyWaiter
     checkUntilTimeoutCustom(1.seconds, 10.millis):
       connMngr.peerScore(peerId) == 0
+
+  asyncTest "tags configured while stopped decay only after start":
+    let connMngr = newWatermark(1, 2, decayResolution = 10.millis)
+    defer:
+      connMngr.removeDecayingTag(peerId, "between-starts")
+      await connMngr.stop()
+    await connMngr.stop()
+    connMngr.tagPeerDecaying(peerId, "between-starts", 100, 1.millis, decayFixed(1))
+    await sleepAsync(50.millis)
+    check connMngr.peerScore(peerId) == 100
+    connMngr.start()
+    connMngr.start()
+    checkUntilTimeout:
+      connMngr.peerScore(peerId) < 100
+    await connMngr.stop()
+    let scoreAtStop = connMngr.peerScore(peerId)
+    await sleepAsync(50.millis)
+    check connMngr.peerScore(peerId) == scoreAtStop
 
   asyncTest "waitForPeerReady timeout does not break concurrent waiters":
     let connMngr = newMaxTotal()
@@ -258,7 +291,7 @@ suite "Connection Manager":
     await connMngr.storeMuxer(makeMuxer(peerId))
     check await longWaiter
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "waitForPeerReady cleanup after disconnect":
     let connMngr = newMaxTotal()
@@ -271,12 +304,12 @@ suite "Connection Manager":
       peerId notin connMngr
 
     check (await connMngr.waitForPeerReady(peerId, 10.millis)) == false
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "does not emit Joined when muxer is dropped before connected handlers finish":
     let connMngr = newMaxTotal()
     defer:
-      await connMngr.close()
+      await connMngr.stop()
 
     let
       muxer = makeMuxer(peerId)
@@ -346,7 +379,7 @@ suite "Connection Manager":
     check connMngr.selectMuxer(peerId, Direction.In).isNil
     check connMngr.selectMuxer(peerId, Direction.Out).isNil
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "track total incoming connection limits":
     let connMngr = newMaxTotal(3)
@@ -357,7 +390,7 @@ suite "Connection Manager":
     # should timeout adding a connection over the limit
     check not (await connMngr.getIncomingSlot().withTimeout(10.millis))
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "try incoming connection slot":
     let connMngr = newMaxTotal(1)
@@ -371,7 +404,7 @@ suite "Connection Manager":
     check reacquired.isSome
     reacquired.get().release()
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "track total outgoing connection limits":
     let connMngr = newMaxTotal(3)
@@ -383,7 +416,7 @@ suite "Connection Manager":
     expect TooManyConnectionsError:
       discard connMngr.getOutgoingSlot()
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "track both incoming and outgoing total connections limits - fail on incoming":
     let connMngr = newMaxTotal(3)
@@ -394,7 +427,7 @@ suite "Connection Manager":
     # should timeout adding a connection over the limit
     check not (await connMngr.getIncomingSlot().withTimeout(10.millis))
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "track both incoming and outgoing total connections limits - fail on outgoing":
     let connMngr = newMaxTotal(3)
@@ -406,7 +439,7 @@ suite "Connection Manager":
     expect TooManyConnectionsError:
       discard connMngr.getOutgoingSlot()
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "track max incoming connection limits":
     let connMngr = newMaxInOut(3, 1)
@@ -416,7 +449,7 @@ suite "Connection Manager":
 
     check not (await connMngr.getIncomingSlot().withTimeout(10.millis))
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "track max outgoing connection limits":
     let connMngr = newMaxInOut(1, 3)
@@ -428,7 +461,7 @@ suite "Connection Manager":
     expect TooManyConnectionsError:
       discard connMngr.getOutgoingSlot()
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "track incoming max connections limits - fail on incoming":
     let connMngr = newMaxInOut(1, 3)
@@ -441,7 +474,7 @@ suite "Connection Manager":
     # should timeout adding a connection over the limit
     check not (await connMngr.getIncomingSlot().withTimeout(10.millis))
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "track incoming max connections limits - fail on outgoing":
     let connMngr = newMaxInOut(3, 1)
@@ -455,7 +488,7 @@ suite "Connection Manager":
     expect TooManyConnectionsError:
       discard connMngr.getOutgoingSlot()
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "allow force dial":
     let connMngr = newMaxTotal(2)
@@ -467,7 +500,7 @@ suite "Connection Manager":
     expect TooManyConnectionsError:
       discard connMngr.getOutgoingSlot(false)
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "release slot on connection end":
     let connMngr = newMaxTotal(3)
@@ -489,7 +522,7 @@ suite "Connection Manager":
     await allFuturesRaising(muxs.mapIt(it.close()))
     check await incomingSlot.withTimeout(10.millis)
 
-    await connMngr.close()
+    await connMngr.stop()
 
 suite "Connection Manager maxConnsPerPeer":
   teardown:
@@ -517,7 +550,7 @@ suite "Connection Manager maxConnsPerPeer":
 
     check connMngr.connCount(peerId) == numberOfMuxersToConnect
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "maxConnsPerPeer = -1 uses default":
     await runTest(-1, defaultMaxConnsPerPeer)
@@ -547,7 +580,7 @@ suite "Connection Manager Watermark":
 
     check connMngr.getConnections().len == lowWater
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "grace period protects newly connected peers":
     # long grace period - newly connected peers must not be pruned
@@ -561,7 +594,7 @@ suite "Connection Manager Watermark":
     # all peers are within grace period - none should be pruned
     check connMngr.getConnections().len == peersToConnect
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "protected peers survive trim":
     const peersToConnect = 3
@@ -582,7 +615,7 @@ suite "Connection Manager Watermark":
     check connMngr.contains(peers[0])
     check connMngr.contains(peers[1])
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "unprotect removes tag and allows trimming":
     let connMngr = newWatermark(1, 3)
@@ -597,7 +630,7 @@ suite "Connection Manager Watermark":
     check connMngr.unprotect(peerId, "tag-b") == false # no longer protected
     check not connMngr.isProtected(peerId)
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "silence period throttles back-to-back trims":
     const peersToConnect = 3
@@ -617,7 +650,7 @@ suite "Connection Manager Watermark":
     # silence period still active - count should be >= before
     check connMngr.getConnections().len == connectedPeers + peersToConnect
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "getIncomingSlot does not block in watermark mode":
     let connMngr = newWatermark(1, 5)
@@ -625,7 +658,7 @@ suite "Connection Manager Watermark":
     # should return immediately without semaphore blocking
     check await connMngr.getIncomingSlot().withTimeout(10.millis)
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "getOutgoingSlot does not raise in watermark mode":
     let connMngr = newWatermark(1, 5)
@@ -633,14 +666,14 @@ suite "Connection Manager Watermark":
     for i in 0 ..< 10:
       discard connMngr.getOutgoingSlot()
 
-    await connMngr.close()
+    await connMngr.stop()
 
   asyncTest "lifecycle events stay ordered when trim prunes the new connection":
     # The trim may prune the just-stored connection, but consumers such as
     # pubsub rely on Joined being observed before Left for the same peer.
     let connMngr = newWatermark(1, 2)
     defer:
-      await connMngr.close()
+      await connMngr.stop()
 
     let peers = PeerId.random(3, rng()).tryGet()
     let prunedPeer = peers[2]
@@ -692,7 +725,7 @@ suite "Connection Manager Watermark":
     # A pruned peer must not remain ready after trim removes its only muxer.
     let connMngr = newWatermark(1, 2)
     defer:
-      await connMngr.close()
+      await connMngr.stop()
 
     let peers = PeerId.random(3, rng()).tryGet()
     let prunedPeer = peers[2]
@@ -719,7 +752,7 @@ suite "Connection Manager Scoring":
   asyncTest "peerScore returns 0 for unknown peer":
     let cm = newWatermark(1, 2)
     check cm.peerScore(peerId) == 0
-    await cm.close()
+    await cm.stop()
 
   asyncTest "static tag contributes to peer score":
     let cm = newWatermark(1, 2)
@@ -728,7 +761,7 @@ suite "Connection Manager Scoring":
     check cm.peerScore(peerId) == 50
     cm.tagPeer(peerId, "🕶️", 30)
     check cm.peerScore(peerId) == 80
-    await cm.close()
+    await cm.stop()
 
   asyncTest "untagPeer removes score contribution":
     let cm = newWatermark(1, 2)
@@ -736,27 +769,27 @@ suite "Connection Manager Scoring":
     cm.tagPeer(peerId, tag, 50)
     cm.untagPeer(peerId, tag)
     check cm.peerScore(peerId) == 0
-    await cm.close()
+    await cm.stop()
 
   asyncTest "outbound connection gets outboundBonus":
     const outboundBonus = 2345432
     let cm = newWatermark(1, 2, outboundBonus = outboundBonus)
     await cm.storeMuxer(makeMuxer(peerId, Direction.Out))
     check cm.peerScore(peerId) == outboundBonus
-    await cm.close()
+    await cm.stop()
 
   asyncTest "inbound connection gets no outboundBonus":
     let cm = newWatermark(1, 2)
     await cm.storeMuxer(makeMuxer(peerId, Direction.In))
     check cm.peerScore(peerId) == 0
-    await cm.close()
+    await cm.stop()
 
   asyncTest "decaying tag contributes initial value to score":
     let cm = newWatermark(1, 2)
     await cm.storeMuxer(makeMuxer(peerId))
     cm.tagPeerDecaying(peerId, tag, 100, 1.hours, decayLinear(0.5))
     check cm.peerScore(peerId) == 100
-    await cm.close()
+    await cm.stop()
 
   asyncTest "decaying tag value decreases over interval":
     let cm = newWatermark(1, 2, decayResolution = 20.millis)
@@ -764,7 +797,7 @@ suite "Connection Manager Scoring":
     cm.tagPeerDecaying(peerId, tag, 100, 20.millis, decayFixed(30))
     checkUntilTimeout:
       cm.peerScore(peerId) < 100
-    await cm.close()
+    await cm.stop()
 
   asyncTest "decaying tag auto-removed when value hits zero":
     let cm = newWatermark(1, 2, decayResolution = 20.millis)
@@ -772,7 +805,7 @@ suite "Connection Manager Scoring":
     cm.tagPeerDecaying(peerId, tag, 10, 20.millis, decayFixed(15))
     checkUntilTimeout:
       cm.peerScore(peerId) == 0
-    await cm.close()
+    await cm.stop()
 
   asyncTest "bumpDecayingTag increases tag value":
     let cm = newWatermark(1, 2)
@@ -780,7 +813,7 @@ suite "Connection Manager Scoring":
     cm.tagPeerDecaying(peerId, tag, 50, 1.hours, decayNone())
     cm.bumpDecayingTag(peerId, tag, 25)
     check cm.peerScore(peerId) == 75
-    await cm.close()
+    await cm.stop()
 
   asyncTest "removeDecayingTag removes tag immediately":
     let cm = newWatermark(1, 2)
@@ -788,7 +821,7 @@ suite "Connection Manager Scoring":
     cm.tagPeerDecaying(peerId, tag, 50, 1.hours, decayNone())
     cm.removeDecayingTag(peerId, tag)
     check cm.peerScore(peerId) == 0
-    await cm.close()
+    await cm.stop()
 
   asyncTest "watermark trim prunes lowest-score peer first":
     let cm = newWatermark(1, 2)
@@ -801,7 +834,7 @@ suite "Connection Manager Scoring":
     await cm.storeMuxer(makeMuxer(PeerId.random(rng()).tryGet()))
     check cm.contains(highScorePeer)
     check cm.getConnections().len == 1
-    await cm.close()
+    await cm.stop()
 
   asyncTest "outbound peer survives watermark trim over inbound peers":
     let cm = newWatermark(1, 2, outboundBonus = 500)
@@ -812,7 +845,7 @@ suite "Connection Manager Scoring":
     await cm.storeMuxer(makeMuxer(PeerId.random(rng()).tryGet(), Direction.In))
     check cm.contains(outboundPeer)
     check cm.getConnections().len == 1
-    await cm.close()
+    await cm.stop()
 
 suite "Connection Manager: watermark with connection limiting":
   teardown:
@@ -831,6 +864,8 @@ suite "Connection Manager: watermark with connection limiting":
         )
       ),
     )
+
+    connMngr.start()
 
     # acquire a semaphore slot for each peer, protect it, then register it.
     # protecting before storeMuxer ensures the peer is already shielded when
@@ -853,4 +888,4 @@ suite "Connection Manager: watermark with connection limiting":
     expect TooManyConnectionsError:
       discard connMngr.getOutgoingSlot()
 
-    await connMngr.close()
+    await connMngr.stop()

--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -238,17 +238,23 @@ suite "Connection Manager":
     check await readyWaiter
     await connMngr.stop()
 
-  asyncTest "readiness waits require start":
+  asyncTest "readiness waits work without start until stopped":
     let connMngr = ConnManager.new()
     defer:
       await connMngr.stop()
-    check not (await connMngr.waitForPeerReady(peerId))
-    connMngr.start()
     let readyWaiter = connMngr.waitForPeerReady(peerId, 1.seconds)
     await connMngr.storeMuxer(makeMuxer(peerId))
     check await readyWaiter
     await connMngr.stop()
     check not (await connMngr.waitForPeerReady(peerId))
+
+  asyncTest "new manager decays tags without explicit start":
+    let connMngr = ConnManager.new(scoring = PeerScoring(decayResolution: 1.millis))
+    defer:
+      await connMngr.stop()
+    connMngr.tagPeerDecaying(peerId, "initial", 1, 1.millis, decayFixed(1))
+    checkUntilTimeoutCustom(1.seconds, 10.millis):
+      connMngr.peerScore(peerId) == 0
 
   asyncTest "restart resumes readiness waits and retained tag decay":
     let connMngr = newWatermark(1, 2, decayResolution = 1.millis)

--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -20,13 +20,13 @@ method newStream*(
   Connection.new(m.peerId, Direction.Out)
 
 proc newMaxTotal(maxConnections = 10, maxConnsPerPeer = 1): ConnManager =
-  result = ConnManager.new(
+  return ConnManager.new(
     maxConnsPerPeer = maxConnsPerPeer,
     limits = Opt.some(ConnectionLimits.maxTotal(maxConnections)),
   )
 
 proc newMaxInOut(maxIn: int, maxOut: int, maxConnsPerPeer = 1): ConnManager =
-  result = ConnManager.new(
+  return ConnManager.new(
     maxConnsPerPeer = maxConnsPerPeer,
     limits = Opt.some(ConnectionLimits.maxInOut(maxIn, maxOut)),
   )
@@ -47,7 +47,7 @@ proc newWatermark*(
   )
   let scCfg =
     PeerScoring(outboundBonus: outboundBonus, decayResolution: decayResolution)
-  result = ConnManager.new(watermark = Opt.some(wtCfg), scoring = scCfg)
+  return ConnManager.new(watermark = Opt.some(wtCfg), scoring = scCfg)
 
 proc storeMuxers(connMngr: ConnManager, count: uint): Future[seq[PeerId]] {.async.} =
   let peers = PeerId.random(count, rng()).tryGet()

--- a/tests/libp2p/test_conn_manager.nim
+++ b/tests/libp2p/test_conn_manager.nim
@@ -24,14 +24,12 @@ proc newMaxTotal(maxConnections = 10, maxConnsPerPeer = 1): ConnManager =
     maxConnsPerPeer = maxConnsPerPeer,
     limits = Opt.some(ConnectionLimits.maxTotal(maxConnections)),
   )
-  result.start()
 
 proc newMaxInOut(maxIn: int, maxOut: int, maxConnsPerPeer = 1): ConnManager =
   result = ConnManager.new(
     maxConnsPerPeer = maxConnsPerPeer,
     limits = Opt.some(ConnectionLimits.maxInOut(maxIn, maxOut)),
   )
-  result.start()
 
 proc newWatermark*(
     lowWater: int,
@@ -50,7 +48,6 @@ proc newWatermark*(
   let scCfg =
     PeerScoring(outboundBonus: outboundBonus, decayResolution: decayResolution)
   result = ConnManager.new(watermark = Opt.some(wtCfg), scoring = scCfg)
-  result.start()
 
 proc storeMuxers(connMngr: ConnManager, count: uint): Future[seq[PeerId]] {.async.} =
   let peers = PeerId.random(count, rng()).tryGet()
@@ -240,12 +237,14 @@ suite "Connection Manager":
 
   asyncTest "readiness waits work without start until stopped":
     let connMngr = ConnManager.new()
+    check connMngr.isRunning()
     defer:
       await connMngr.stop()
     let readyWaiter = connMngr.waitForPeerReady(peerId, 1.seconds)
     await connMngr.storeMuxer(makeMuxer(peerId))
     check await readyWaiter
     await connMngr.stop()
+    check not connMngr.isRunning()
     check not (await connMngr.waitForPeerReady(peerId))
 
   asyncTest "new manager decays tags without explicit start":
@@ -261,6 +260,7 @@ suite "Connection Manager":
     connMngr.tagPeerDecaying(peerId, "retained", 1, 1.millis, decayFixed(1))
     await connMngr.stop()
     connMngr.start()
+    check connMngr.isRunning()
     defer:
       await connMngr.stop()
     let readyWaiter = connMngr.waitForPeerReady(peerId, 1.seconds)
@@ -870,8 +870,6 @@ suite "Connection Manager: watermark with connection limiting":
         )
       ),
     )
-
-    connMngr.start()
 
     # acquire a semaphore slot for each peer, protect it, then register it.
     # protecting before storeMuxer ensures the peer is already shielded when

--- a/tests/libp2p/test_switch.nim
+++ b/tests/libp2p/test_switch.nim
@@ -584,6 +584,7 @@ suite "Switch":
     await switches[0].start()
 
     switches.add(makeStandardSwitchBuilder().withPrivateKey(privateKey).build())
+    await switches[1].start()
     await switches[1].connect(switches[0].peerInfo.peerId, switches[0].peerInfo.addrs)
     onConnect.done()
 
@@ -621,6 +622,7 @@ suite "Switch":
       )
       switches[i].addConnEventHandler(hook, ConnEventKind.Connected)
       switches[i].addConnEventHandler(hook, ConnEventKind.Disconnected)
+      await switches[i].start()
       await switches[i].connect(switches[0].peerInfo.peerId, switches[0].peerInfo.addrs)
 
     # Wait until all 5 are connected
@@ -637,7 +639,7 @@ suite "Switch":
       not isCounterLeaked(LPChannelTrackerName)
       not isCounterLeaked(SecureConnTrackerName)
 
-    await allFuturesRaising(switches[0].stop())
+    await allFuturesRaising(switches.mapIt(it.stop()))
 
   asyncTest "e2e drop peer from inside its own stream handler":
     let disconnected = newWaitGroup(1)
@@ -733,6 +735,7 @@ suite "Switch":
     let switch2 = makeStandardSwitch()
 
     await switch1.start()
+    await switch2.start()
 
     let stream =
       await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, TestCodec)
@@ -1065,6 +1068,7 @@ suite "Switch":
       destSwitch = makeStandardSwitch(@[TcpAutoAddress, WsAutoAddress])
 
     await destSwitch.start()
+    await srcTcpSwitch.start()
     await srcWsSwitch.start()
 
     resolver.txtResponses["_dnsaddr.test.io"] = @[

--- a/tests/libp2p/test_switch.nim
+++ b/tests/libp2p/test_switch.nim
@@ -584,7 +584,6 @@ suite "Switch":
     await switches[0].start()
 
     switches.add(makeStandardSwitchBuilder().withPrivateKey(privateKey).build())
-    await switches[1].start()
     await switches[1].connect(switches[0].peerInfo.peerId, switches[0].peerInfo.addrs)
     onConnect.done()
 
@@ -622,7 +621,6 @@ suite "Switch":
       )
       switches[i].addConnEventHandler(hook, ConnEventKind.Connected)
       switches[i].addConnEventHandler(hook, ConnEventKind.Disconnected)
-      await switches[i].start()
       await switches[i].connect(switches[0].peerInfo.peerId, switches[0].peerInfo.addrs)
 
     # Wait until all 5 are connected
@@ -639,7 +637,7 @@ suite "Switch":
       not isCounterLeaked(LPChannelTrackerName)
       not isCounterLeaked(SecureConnTrackerName)
 
-    await allFuturesRaising(switches.mapIt(it.stop()))
+    await allFuturesRaising(switches[0].stop())
 
   asyncTest "e2e drop peer from inside its own stream handler":
     let disconnected = newWaitGroup(1)
@@ -735,7 +733,6 @@ suite "Switch":
     let switch2 = makeStandardSwitch()
 
     await switch1.start()
-    await switch2.start()
 
     let stream =
       await switch2.dial(switch1.peerInfo.peerId, switch1.peerInfo.addrs, TestCodec)
@@ -1068,7 +1065,6 @@ suite "Switch":
       destSwitch = makeStandardSwitch(@[TcpAutoAddress, WsAutoAddress])
 
     await destSwitch.start()
-    await srcTcpSwitch.start()
     await srcWsSwitch.start()
 
     resolver.txtResponses["_dnsaddr.test.io"] = @[

--- a/tests/libp2p/test_switch.nim
+++ b/tests/libp2p/test_switch.nim
@@ -1276,3 +1276,18 @@ suite "Switch :: IdentifyPusher Service":
     # switch1 should receive new address
     checkUntilTimeout:
       extra in switch1.peerStore[AddressBook][switch2.peerInfo.peerId]
+
+  asyncTest "restarted switch accepts identified connections":
+    let listener = makeStandardSwitch(TcpAutoAddress)
+    let dialer = makeStandardSwitch(TcpAutoAddress)
+    await listener.start()
+    await listener.stop()
+    await listener.start()
+    await dialer.start()
+    defer:
+      await allFutures(listener.stop(), dialer.stop())
+    await dialer.connect(listener.peerInfo.peerId, listener.peerInfo.addrs).wait(
+      2.seconds
+    )
+    check listener.isConnected(dialer.peerInfo.peerId)
+    check (await listener.connManager.waitForPeerReady(dialer.peerInfo.peerId))

--- a/tests/libp2p/transports/test_tor.nim
+++ b/tests/libp2p/transports/test_tor.nim
@@ -16,7 +16,6 @@ import
     muxers/muxer,
     muxers/mplex/mplex,
     builders,
-    connmanager,
   ]
 import ../../tools/[unittest, crypto, multiaddress]
 import ../../stubs/torstub
@@ -171,8 +170,6 @@ suite "Tor transport":
       let clientSwitch =
         TorSwitch.new(torServer = torServer, rng = rng(), flags = {ReuseAddr})
 
-      # This dial-only client has no Tor listen address.
-      clientSwitch.connManager.start()
       let conn = await clientSwitch.dial(serverPeerId, serverAddress, TestCodec)
 
       await conn.write("client")

--- a/tests/libp2p/transports/test_tor.nim
+++ b/tests/libp2p/transports/test_tor.nim
@@ -16,6 +16,7 @@ import
     muxers/muxer,
     muxers/mplex/mplex,
     builders,
+    connmanager,
   ]
 import ../../tools/[unittest, crypto, multiaddress]
 import ../../stubs/torstub
@@ -170,6 +171,8 @@ suite "Tor transport":
       let clientSwitch =
         TorSwitch.new(torServer = torServer, rng = rng(), flags = {ReuseAddr})
 
+      # This dial-only client has no Tor listen address.
+      clientSwitch.connManager.start()
       let conn = await clientSwitch.dial(serverPeerId, serverAddress, TestCodec)
 
       await conn.write("client")


### PR DESCRIPTION
## Summary

After a switch is stopped and started again, its connection manager remains marked closed and retained peer tags stop decaying. Restore readiness waits and restart tag decay when the switch starts after shutdown.

Add regression tests for connection-manager restart and for accepting identified connections after a switch restart.
