### PR TITLE
fix(cid): correct validation offset and hash equivalent CIDs consistently

### DIFF
--- a/libp2p/cid.nim
+++ b/libp2p/cid.nim
@@ -172,6 +172,7 @@ proc validate*(ctype: typedesc[Cid], data: openArray[byte]): bool =
   var mcodec = CodeContentIds.getOrDefault(cast[int](codec), InvalidMultiCodec)
   if mcodec == InvalidMultiCodec:
     return false
+  offset += length
   if not MultiHash.validate(data.toOpenArray(offset, last)):
     return false
   true
@@ -275,7 +276,7 @@ proc write*(vb: var VBuffer, cid: Cid) =
   vb.writeArray(cid.data.buffer)
 
 proc hash*(cid: Cid): Hash =
-  hash(cid.data.buffer)
+  !$(hash(cid.mcodec) !& hash(cid.data.buffer.toOpenArray(cid.hpos, cid.data.high)))
 
 proc `$`*(cid: Cid): string =
   ## Return official string representation of content identifier ``cid``.

--- a/tests/libp2p/multiformat/test_cid.nim
+++ b/tests/libp2p/multiformat/test_cid.nim
@@ -3,6 +3,7 @@
 
 {.used.}
 
+import std/sets
 import ../../../libp2p/[cid, multihash, multicodec]
 import ../../tools/[unittest]
 
@@ -53,6 +54,8 @@ suite "Content identifier CID test suite":
       .tryGet()
     check:
       cid0 == cid1
+      hash(cid0) == hash(cid1)
+      cid1 in [cid0].toHashSet()
       cid1 == cid2
       cid2 == cid3
       cid3 == cid0
@@ -60,3 +63,15 @@ suite "Content identifier CID test suite":
       cid1 != cid5
       cid2 != cid4
       cid3 != cid6
+
+  test "Binary validation agrees with decoding":
+    let digest = MultiHash.digest("sha2-256", [byte 1, 2, 3]).get()
+    for version in [CIDv0, CIDv1]:
+      let encoded = Cid.init(version, multiCodec("dag-pb"), digest).get().data.buffer
+      check Cid.validate(encoded)
+      check not Cid.validate(encoded[0 ..< encoded.high])
+      check not Cid.validate(encoded & @[0.byte])
+    check not Cid.validate([])
+    check not Cid.validate([1.byte])
+    check not Cid.validate([1.byte, 0xff])
+    check not Cid.validate([1.byte, 0x70])


### PR DESCRIPTION
## Summary

Advance past the content codec before validating the multihash so valid CIDv1 values are accepted. Preserve allocation-free binary validation.

Hash the content codec and multihash without the version header so equivalent CIDv0 and CIDv1 values produce the same hash, consistent with equality. This fixes missed lookups in hash-based collections when mixing equivalent representations.

Add regression coverage for binary validation, equal hashes, and hash-set lookup across CID versions.
