### PR TITLE
fix(kademlia): track provider RPCs immediately and preserve keys on refresh

### DIFF
--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -205,7 +205,6 @@ type OptimisticState = ref object
   returnThreshold: int ## completed RPCs to wait for before returning
   scheduled: HashSet[PeerId]
   failed: int
-  puts: seq[Future[void]]
   completed: int
   doneEvent: AsyncEvent
 
@@ -229,14 +228,15 @@ proc putProviderRecord(
     os: OptimisticState, pid: PeerId
 ) {.async: (raises: [CancelledError]).} =
   ## A rejected record still counts: the walk only needs the peer to answer.
+  defer:
+    os.completed.inc()
+    os.doneEvent.fire()
   if (await os.kad.dispatchAddProvider(pid, os.key)).isErr():
     os.failed.inc()
-  os.completed.inc()
-  os.doneEvent.fire()
 
 proc schedulePut(os: OptimisticState, pid: PeerId) {.raises: [].} =
   os.scheduled.incl(pid)
-  os.puts.add(os.putProviderRecord(pid))
+  os.kad.provideTasks.trackFut(os.putProviderRecord(pid))
 
 proc maybeTrackNetsize(kad: KadDHT, key: Key, closest: seq[PeerId]) =
   ## Feed a converged lookup's closest-first peers into the estimator, so classic
@@ -275,7 +275,7 @@ proc optimisticStop(
 proc waitForReturn(os: OptimisticState) {.async: (raises: [CancelledError]).} =
   ## Return once ``returnThreshold`` RPCs completed, or all of them if fewer ran.
   ## `completed` only grows and is re-read after each clear, so no wakeup is lost.
-  let target = min(os.returnThreshold, os.puts.len)
+  let target = min(os.returnThreshold, os.scheduled.len)
   while os.completed < target:
     await os.doneEvent.wait()
     os.doneEvent.clear()
@@ -297,10 +297,6 @@ proc optimisticProvide(
 
   await os.waitForReturn()
   kad.maybeTrackNetsize(key, closest)
-
-  # Keep the still-running puts alive and cancellable on `stop`.
-  for fut in os.puts:
-    kad.provideTasks.trackFut(fut)
 
 proc addProvider*(kad: KadDHT, key: Key) {.async: (raises: [CancelledError]), gcsafe.} =
   if kad.config.optimisticProvide:
@@ -324,10 +320,11 @@ proc addProvider*(kad: KadDHT, cid: Cid) {.async: (raises: [CancelledError]), gc
   await addProvider(kad, cid.toKey())
 
 proc startProviding*(kad: KadDHT, c: Cid) {.async: (raises: [CancelledError]).} =
-  if kad.providerManager.providedKeys.isFull():
+  let k = c.toKey()
+  if not kad.providerManager.providedKeys.hasKey(k) and
+      kad.providerManager.providedKeys.isFull():
     kad.providerManager.providedKeys.deleteOldest()
 
-  let k = c.toKey()
   kad.providerManager.providedKeys.provided[k] = chronos.Moment.now()
   await kad.addProvider(k)
 

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -235,6 +235,8 @@ proc putProviderRecord(
     os.failed.inc()
 
 proc schedulePut(os: OptimisticState, pid: PeerId) {.raises: [].} =
+  if os.kad.stopping:
+    return
   os.scheduled.incl(pid)
   os.kad.provideTasks.trackFut(os.putProviderRecord(pid))
 

--- a/tests/libp2p/kademlia/mock_kademlia.nim
+++ b/tests/libp2p/kademlia/mock_kademlia.nim
@@ -12,6 +12,8 @@ type MockKadDHT* = ref object of KadDHT
   findNodeTables*: seq[RoutingTable]
   getValueResponse*: Opt[Message]
   handleAddProviderMessage*: Opt[Message]
+  handleAddProviderDelay*: Duration
+  handleAddProviderCalls*: int
   handleFindNodeDelay*: Duration
   handleFindNodeCalls*: int
   handleFindNodeMalformedResponse*: bool
@@ -60,6 +62,8 @@ method handleGetValue*(
 method handleAddProvider*(
     kad: MockKadDHT, stream: Stream, msg: Message
 ) {.async: (raises: [CancelledError]).} =
+  kad.handleAddProviderCalls.inc()
+  await sleepAsync(kad.handleAddProviderDelay)
   await procCall handleAddProvider(
     KadDHT(kad), stream, kad.handleAddProviderMessage.valueOr(msg)
   )

--- a/tests/libp2p/kademlia/test_add_provider.nim
+++ b/tests/libp2p/kademlia/test_add_provider.nim
@@ -127,6 +127,27 @@ suite "KadDHT - Add Provider":
       kads[1].providerManager.knownKeys.len == 0
       kads[0].providerManager.providedKeys.len == 0
 
+  asyncTest "Refreshing a provided key at capacity preserves other keys":
+    let kad = setupKad()
+    startAndDeferStop(@[kad])
+    let keys = kad.providerManager.providedKeys
+    keys.capacity = 2
+    let first = Cid
+      .init(CIDv1, multiCodec("raw"), MultiHash.digest("sha2-256", @[1.byte]).get())
+      .get()
+    let second = Cid
+      .init(CIDv1, multiCodec("raw"), MultiHash.digest("sha2-256", @[2.byte]).get())
+      .get()
+    keys.provided[first.toKey()] = Moment.now() - 2.seconds
+    keys.provided[second.toKey()] = Moment.now() - 1.seconds
+
+    await kad.startProviding(second)
+
+    check:
+      keys.len == 2
+      keys.hasKey(first.toKey())
+      keys.hasKey(second.toKey())
+
   asyncTest "Provider limits":
     let kads = setupKadSwitches(2, republishProvidedKeysInterval = chronos.hours(1))
     startAndDeferStop(kads)
@@ -467,6 +488,26 @@ suite "KadDHT - Add Provider":
       kads[0].providerManager.providerRecords.len == 1
       kads[0].providerManager.providerRecords[0].provider.id.get() ==
         kads[1].rtable.selfId
+
+  asyncTest "Optimistic provider RPCs belong to the DHT before the lookup returns":
+    var cfg = testKadConfig(timeout = 3.seconds, providerRejection = true)
+    cfg.optimisticProvide = true
+    let sender = setupKad(cfg)
+    let receiver = setupMockKad(cfg)
+    receiver.handleAddProviderDelay = 1.seconds
+    startAndDeferStop(@[sender, KadDHT(receiver)])
+    await connect(sender, receiver)
+    sender.nsEstimator.seedLinearMeasurements(1000)
+
+    let pending = sender.addProvider(receiver.rtable.selfId.toCid())
+    checkUntilTimeout:
+      receiver.handleAddProviderCalls > 0
+    check not pending.finished()
+    let owned = sender.provideTasks
+    check owned.len > 0
+    await sender.stop()
+    await pending.wait(2.seconds)
+    check owned.allIt(it.finished())
 
   asyncTest "Optimistic provide falls back to classic without a size estimate":
     optimisticProvideStores(seedEstimate = false)


### PR DESCRIPTION
## Summary

Track optimistic provider RPCs as soon as they start so DHT shutdown can cancel them while the lookup is still running. Signal completion even when an RPC is cancelled, and remove the intermediate future list and later transfer step.

When refreshing an existing provided key at capacity, update its timestamp without evicting another key. Evict the oldest key only when adding a new one.

Add regression coverage for shutdown during optimistic providing and refreshing a provided key at capacity.
