### PR TITLE
chore(logs): add `formatIt` for all types

### DIFF
--- a/libp2p/address_manager.nim
+++ b/libp2p/address_manager.nim
@@ -439,6 +439,7 @@ proc notifyReachability(self: AddressManager) {.async: (raises: [CancelledError]
     notified = self.notifiedReachability
   if summary == notified:
     return
+  info "Network reachability changed", previous = notified, current = summary
   if self.onReachabilityChange.isNil():
     self.notifiedReachability = summary
     return

--- a/libp2p/autotls/service.nim
+++ b/libp2p/autotls/service.nim
@@ -216,6 +216,8 @@ proc hasTcpStarted(switch: Switch): bool =
   switch.transports.filterIt(it of TcpTransport and it.running).len == 0
 
 proc tryIssueCertificate(self: AutotlsService) {.async: (raises: [CancelledError]).} =
+  var lastError: ref CatchableError
+  let operation = if self.cert.isSome(): "renewal" else: "initial issuance"
   for attempt in 0 .. self.config.issueRetries:
     if attempt > 0:
       await sleepAsync(self.config.issueRetryTime)
@@ -225,8 +227,20 @@ proc tryIssueCertificate(self: AutotlsService) {.async: (raises: [CancelledError
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
+      lastError = exc
       debug "Certificate issuance failed", err = exc.msg, errType = exc.name
-  error "Failed to issue certificate"
+  let expiry =
+    if self.cert.isSome():
+      $self.cert.get().expiry
+    else:
+      "none"
+  error "Failed to issue certificate",
+    err = (if lastError.isNil: "no issuance attempts" else: lastError.msg),
+    errType = (if lastError.isNil: "" else: $lastError.name),
+    operation,
+    maxAttempts = self.config.issueRetries + 1,
+    hasCertificate = self.cert.isSome(),
+    expiry
 
 method start*(
     self: AutotlsService, switch: Switch

--- a/libp2p/crypto/crypto.nim
+++ b/libp2p/crypto/crypto.nim
@@ -5,7 +5,7 @@
 {.push raises: [].}
 
 from strutils import split, strip, cmpIgnoreCase
-import protobuf_serialization
+import protobuf_serialization, chronicles
 
 const libp2p_pki_schemes* {.strdefine.} = "rsa,ed25519,secp256k1,ecnist"
 
@@ -738,6 +738,12 @@ func shortLog*(key: PrivateKey | PublicKey): string =
       "secp256k1 key (" & ($key.skkey).shortLog & ")"
     else:
       "unsupported secp256k1 key"
+
+chronicles.formatIt(PrivateKey):
+  "[PrivateKey Redacted]"
+
+chronicles.formatIt(PublicKey):
+  shortLog(it)
 
 proc `$`*(sig: Signature): string =
   ## Get string representation of signature ``sig``.

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -384,7 +384,7 @@ proc dialInOrder(
 
   for rawAddress in addrs:
     if deadline.timeLeft().isZero():
-      debug "Peer dial timed out", peerId, addresses = addrs
+      debug "Peer dial timed out", peerId, addresses = addrs.shortLog
       return nil
 
     let advertised = DialCandidate(address: rawAddress, peerId: peerId)
@@ -521,7 +521,7 @@ proc dialAndUpgrade*(
   ## Dial the addresses, sharing one `deadline`. Nil when all of them fail.
 
   let dialAddrs = normalizedDialAddrs(peerId, addrs)
-  debug "Peer dial started", peerId, addresses = dialAddrs
+  debug "Peer dial started", peerId, addresses = dialAddrs.shortLog
 
   if self.dialRanking:
     await self.dialRanked(peerId, dialAddrs, dir, deadline, forceDial, reach)
@@ -636,7 +636,7 @@ proc establishConnection(
     raise newException(
       DialFailedError,
       "Unable to establish outgoing link in establishConnection: peer_id=" &
-        shortLog(peerId) & " addrs=" & $dialAddrs,
+        shortLog(peerId) & " addrs=" & dialAddrs.shortLog,
     )
 
   slot.trackMuxer(muxed)
@@ -757,7 +757,7 @@ proc tryDial*(
   ## Returns the observed address when the probe succeeds.
   ##
 
-  trace "Peer reachability probe started", peerId, address = addrs
+  trace "Peer reachability probe started", peerId, addresses = addrs.shortLog
   try:
     let mux = await self.dialAndUpgrade(Opt.some(peerId), addrs)
     if mux.isNil():
@@ -818,7 +818,7 @@ method dial*(
       await stream.reset()
 
   try:
-    trace "Peer dial started", peerId, addresses = dialAddrs
+    trace "Peer dial started", peerId, addresses = dialAddrs.shortLog
     conn = await self.internalConnect(Opt.some(peerId), dialAddrs, forceDial)
     trace "Protocol stream opening started", peerId, protocols = protos, conn
     stream = await self.connManager.getStream(conn)
@@ -837,12 +837,12 @@ method dial*(
     raise exc
   except CatchableError as exc:
     debug "Protocol stream establishment failed",
-      err = exc.msg, peerId, protocols = protos, addresses = dialAddrs, conn
+      err = exc.msg, peerId, protocols = protos, addresses = dialAddrs.shortLog, conn
     await cleanup()
     raise newException(
       DialFailedError,
-      "failed new dial: peer_id=" & shortLog(peerId) & " protos=" & $protos & " addrs=" &
-        $dialAddrs & ": " & exc.msg,
+      "failed new dial: peer_id=" & shortLog(peerId) & " protos=" & protos.shortLog &
+        " addrs=" & dialAddrs.shortLog & ": " & exc.msg,
       exc,
     )
 

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -384,7 +384,7 @@ proc dialInOrder(
 
   for rawAddress in addrs:
     if deadline.timeLeft().isZero():
-      debug "Peer dial timed out", peerId, addresses = addrs.shortLog
+      debug "Peer dial timed out", peerId, addresses = addrs
       return nil
 
     let advertised = DialCandidate(address: rawAddress, peerId: peerId)
@@ -521,7 +521,7 @@ proc dialAndUpgrade*(
   ## Dial the addresses, sharing one `deadline`. Nil when all of them fail.
 
   let dialAddrs = normalizedDialAddrs(peerId, addrs)
-  debug "Peer dial started", peerId, addresses = dialAddrs.shortLog
+  debug "Peer dial started", peerId, addresses = dialAddrs
 
   if self.dialRanking:
     await self.dialRanked(peerId, dialAddrs, dir, deadline, forceDial, reach)
@@ -757,7 +757,7 @@ proc tryDial*(
   ## Returns the observed address when the probe succeeds.
   ##
 
-  trace "Peer reachability probe started", peerId, addresses = addrs.shortLog
+  trace "Peer reachability probe started", peerId, addresses = addrs
   try:
     let mux = await self.dialAndUpgrade(Opt.some(peerId), addrs)
     if mux.isNil():
@@ -818,7 +818,7 @@ method dial*(
       await stream.reset()
 
   try:
-    trace "Peer dial started", peerId, addresses = dialAddrs.shortLog
+    trace "Peer dial started", peerId, addresses = dialAddrs
     conn = await self.internalConnect(Opt.some(peerId), dialAddrs, forceDial)
     trace "Protocol stream opening started", peerId, protocols = protos, conn
     stream = await self.connManager.getStream(conn)
@@ -837,7 +837,7 @@ method dial*(
     raise exc
   except CatchableError as exc:
     debug "Protocol stream establishment failed",
-      err = exc.msg, peerId, protocols = protos, addresses = dialAddrs.shortLog, conn
+      err = exc.msg, peerId, protocols = protos, addresses = dialAddrs, conn
     await cleanup()
     raise newException(
       DialFailedError,

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -1378,6 +1378,9 @@ func shortLog*(addrs: seq[MultiAddress], maxAddrs = ShortCollectionMax): string 
     res.add(" more)")
   return res
 
+chronicles.formatIt(seq[MultiAddress]):
+  shortLog(it)
+
 ## protobuf_serialization extension
 
 Protobuf.extensionDefaults(MultiAddress, pbytes, defaultWriteSeq = true)

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -1365,7 +1365,7 @@ proc replaceIp*(ma: MultiAddress, ip: IpAddress): MaResult[MultiAddress] =
 
 const AvgMultiAddressStringLength = 32
 
-func shortLog*(addrs: seq[MultiAddress], maxAddrs: int): string =
+func shortLog*(addrs: seq[MultiAddress], maxAddrs = ShortCollectionMax): string =
   let limit = min(addrs.len, maxAddrs)
   var res = newStringOfCap(limit * AvgMultiAddressStringLength)
   for i in 0 ..< limit:

--- a/libp2p/protocols/connectivity/autonat/client.nim
+++ b/libp2p/protocols/connectivity/autonat/client.nim
@@ -70,7 +70,7 @@ method dialMe*(
         debug "Unexpected error", err = e.msg
 
   try:
-    trace "sending Dial", addresses = switch.peerInfo.addrs.shortLog
+    trace "sending Dial", addresses = switch.peerInfo.addrs
     await stream.sendDial(switch.peerInfo.peerId, switch.peerInfo.addrs)
   except CancelledError as e:
     raise e

--- a/libp2p/protocols/connectivity/autonat/client.nim
+++ b/libp2p/protocols/connectivity/autonat/client.nim
@@ -70,7 +70,7 @@ method dialMe*(
         debug "Unexpected error", err = e.msg
 
   try:
-    trace "sending Dial", addresses = switch.peerInfo.addrs
+    trace "sending Dial", addresses = switch.peerInfo.addrs.shortLog
     await stream.sendDial(switch.peerInfo.peerId, switch.peerInfo.addrs)
   except CancelledError as e:
     raise e

--- a/libp2p/protocols/connectivity/autonat/server.nim
+++ b/libp2p/protocols/connectivity/autonat/server.nim
@@ -92,10 +92,10 @@ proc tryDial(
   except CancelledError as exc:
     raise exc
   except AllFuturesFailedError as exc:
-    debug "All dial attempts failed", err = exc.msg, addresses = addrs.shortLog
+    debug "All dial attempts failed", err = exc.msg, addresses = addrs
     await stream.sendResponseError(DialError, "All dial attempts failed")
   except AsyncTimeoutError as exc:
-    debug "Dial timeout", err = exc.msg, addresses = addrs.shortLog
+    debug "Dial timeout", err = exc.msg, addresses = addrs
     await stream.sendResponseError(DialError, "Dial timeout")
   finally:
     try:
@@ -128,7 +128,7 @@ proc handleDial(autonat: Autonat, stream: Stream, msg: AutonatMsg): Future[void]
     return stream.sendResponseError(InternalError, "Expected an IP address")
   var addrs = initHashSet[MultiAddress]()
   addrs.incl(observedAddr)
-  trace "addrs received", addresses = peerInfo.addrs.shortLog
+  trace "addrs received", addresses = peerInfo.addrs
   for ma in peerInfo.addrs:
     isRelayed = ma.contains(multiCodec("p2p-circuit")).valueOr:
       continue
@@ -154,7 +154,7 @@ proc handleDial(autonat: Autonat, stream: Stream, msg: AutonatMsg): Future[void]
   if len(addrs) == 0:
     return stream.sendResponseError(DialRefused, "No dialable address")
   let addrsSeq = toSeq(addrs)
-  trace "trying to dial", addresses = addrsSeq.shortLog
+  trace "trying to dial", addresses = addrsSeq
   return autonat.tryDial(stream, addrsSeq)
 
 proc new*(

--- a/libp2p/protocols/connectivity/autonat/server.nim
+++ b/libp2p/protocols/connectivity/autonat/server.nim
@@ -92,10 +92,10 @@ proc tryDial(
   except CancelledError as exc:
     raise exc
   except AllFuturesFailedError as exc:
-    debug "All dial attempts failed", addrs, err = exc.msg
+    debug "All dial attempts failed", err = exc.msg, addresses = addrs.shortLog
     await stream.sendResponseError(DialError, "All dial attempts failed")
   except AsyncTimeoutError as exc:
-    debug "Dial timeout", addrs, err = exc.msg
+    debug "Dial timeout", err = exc.msg, addresses = addrs.shortLog
     await stream.sendResponseError(DialError, "Dial timeout")
   finally:
     try:
@@ -128,7 +128,7 @@ proc handleDial(autonat: Autonat, stream: Stream, msg: AutonatMsg): Future[void]
     return stream.sendResponseError(InternalError, "Expected an IP address")
   var addrs = initHashSet[MultiAddress]()
   addrs.incl(observedAddr)
-  trace "addrs received", addresses = peerInfo.addrs
+  trace "addrs received", addresses = peerInfo.addrs.shortLog
   for ma in peerInfo.addrs:
     isRelayed = ma.contains(multiCodec("p2p-circuit")).valueOr:
       continue
@@ -154,7 +154,7 @@ proc handleDial(autonat: Autonat, stream: Stream, msg: AutonatMsg): Future[void]
   if len(addrs) == 0:
     return stream.sendResponseError(DialRefused, "No dialable address")
   let addrsSeq = toSeq(addrs)
-  trace "trying to dial", addresses = addrsSeq
+  trace "trying to dial", addresses = addrsSeq.shortLog
   return autonat.tryDial(stream, addrsSeq)
 
 proc new*(

--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -109,6 +109,12 @@ proc handleAnswer(
       self.networkReachability = reachability
       self.confidence = Opt.some(confidence)
 
+  if self.networkReachability != oldNetworkReachability:
+    info "Network reachability changed",
+      previous = oldNetworkReachability,
+      current = self.networkReachability,
+      confidence = self.confidence
+
   debug "Current status",
     currentStats = $self.networkReachability,
     confidence = $self.confidence,

--- a/libp2p/protocols/connectivity/autonatv2/server.nim
+++ b/libp2p/protocols/connectivity/autonatv2/server.nim
@@ -182,7 +182,7 @@ proc canDial(self: AutonatV2, addrs: MultiAddress): bool =
       if not self.config.allowPrivateAddresses and isPrivate($addrIp):
         return false
     except ValueError:
-      trace "Unable to parse IP address, skipping", addresses = $addrIp
+      trace "Unable to parse IP address, skipping", address = $addrs
       return false
   for t in self.switch.transports:
     if t.handles(addrs):

--- a/libp2p/protocols/connectivity/dcutr/client.nim
+++ b/libp2p/protocols/connectivity/dcutr/client.nim
@@ -39,7 +39,7 @@ proc startSync*(
     var ourDialableAddrs = getHolePunchableAddrs(addrs)
     if ourDialableAddrs.len == 0:
       trace "Dcutr initiator has no supported dialable addresses. Aborting Dcutr.",
-        addresses = addrs.shortLog
+        addresses = addrs
       return
 
     stream = await switch.dial(remotePeerId, DcutrCodec)
@@ -52,12 +52,12 @@ proc startSync*(
     peerDialableAddrs = getHolePunchableAddrs(connectAnswer.addrs)
     if peerDialableAddrs.len == 0:
       trace "Dcutr receiver has no supported dialable addresses to connect to. Aborting Dcutr.",
-        addresses = connectAnswer.addrs.shortLog
+        addresses = connectAnswer.addrs
       return
 
     let rttEnd = Moment.now()
     trace "Dcutr initiator has received a Connect message back.",
-      connectAnswer = connectAnswer.shortLog
+      connectAnswer = connectAnswer
     let halfRtt = (rttEnd - rttStart) div 2'i64
 
     # Expected DCUtR connections bypass ConnManager limits.
@@ -74,7 +74,7 @@ proc startSync*(
     if peerDialableAddrs.len > self.maxDialableAddrs:
       peerDialableAddrs = peerDialableAddrs[0 ..< self.maxDialableAddrs]
     trace "Dcutr initiator starting direct dial attempts",
-      addresses = peerDialableAddrs.shortLog, connectTimeout = self.connectTimeout
+      addresses = peerDialableAddrs, connectTimeout = self.connectTimeout
     let dialFuts = peerDialableAddrs.mapIt(
       switch.connect(
         stream.peerId,
@@ -105,7 +105,7 @@ proc startSync*(
     raise err
   except AllFuturesFailedError as err:
     trace "Dcutr initiator could not connect to the remote peer, all connect attempts failed",
-      err = err.msg, addresses = peerDialableAddrs.shortLog
+      err = err.msg, addresses = peerDialableAddrs
     raise newException(
       DcutrError,
       "Dcutr initiator could not connect to the remote peer, all connect attempts failed",
@@ -113,7 +113,7 @@ proc startSync*(
     )
   except AsyncTimeoutError as err:
     trace "Dcutr initiator could not connect to the remote peer, all connect attempts timed out",
-      err = err.msg, addresses = peerDialableAddrs.shortLog
+      err = err.msg, addresses = peerDialableAddrs
     raise newException(
       DcutrError,
       "Dcutr initiator could not connect to the remote peer, all connect attempts timed out",

--- a/libp2p/protocols/connectivity/dcutr/client.nim
+++ b/libp2p/protocols/connectivity/dcutr/client.nim
@@ -39,7 +39,7 @@ proc startSync*(
     var ourDialableAddrs = getHolePunchableAddrs(addrs)
     if ourDialableAddrs.len == 0:
       trace "Dcutr initiator has no supported dialable addresses. Aborting Dcutr.",
-        addrs
+        addresses = addrs.shortLog
       return
 
     stream = await switch.dial(remotePeerId, DcutrCodec)
@@ -52,11 +52,12 @@ proc startSync*(
     peerDialableAddrs = getHolePunchableAddrs(connectAnswer.addrs)
     if peerDialableAddrs.len == 0:
       trace "Dcutr receiver has no supported dialable addresses to connect to. Aborting Dcutr.",
-        addresses = connectAnswer.addrs
+        addresses = connectAnswer.addrs.shortLog
       return
 
     let rttEnd = Moment.now()
-    trace "Dcutr initiator has received a Connect message back.", connectAnswer
+    trace "Dcutr initiator has received a Connect message back.",
+      connectAnswer = connectAnswer.shortLog
     let halfRtt = (rttEnd - rttStart) div 2'i64
 
     # Expected DCUtR connections bypass ConnManager limits.
@@ -73,7 +74,7 @@ proc startSync*(
     if peerDialableAddrs.len > self.maxDialableAddrs:
       peerDialableAddrs = peerDialableAddrs[0 ..< self.maxDialableAddrs]
     trace "Dcutr initiator starting direct dial attempts",
-      peerDialableAddrs, connectTimeout = self.connectTimeout
+      addresses = peerDialableAddrs.shortLog, connectTimeout = self.connectTimeout
     let dialFuts = peerDialableAddrs.mapIt(
       switch.connect(
         stream.peerId,
@@ -104,7 +105,7 @@ proc startSync*(
     raise err
   except AllFuturesFailedError as err:
     trace "Dcutr initiator could not connect to the remote peer, all connect attempts failed",
-      peerDialableAddrs, err = err.msg
+      err = err.msg, addresses = peerDialableAddrs.shortLog
     raise newException(
       DcutrError,
       "Dcutr initiator could not connect to the remote peer, all connect attempts failed",
@@ -112,7 +113,7 @@ proc startSync*(
     )
   except AsyncTimeoutError as err:
     trace "Dcutr initiator could not connect to the remote peer, all connect attempts timed out",
-      peerDialableAddrs, err = err.msg
+      err = err.msg, addresses = peerDialableAddrs.shortLog
     raise newException(
       DcutrError,
       "Dcutr initiator could not connect to the remote peer, all connect attempts timed out",

--- a/libp2p/protocols/connectivity/dcutr/core.nim
+++ b/libp2p/protocols/connectivity/dcutr/core.nim
@@ -5,7 +5,7 @@
 
 import std/sequtils
 
-import chronos
+import chronos, chronicles
 import stew/objects
 import protobuf_serialization, protobuf_serialization/std/enums
 import results
@@ -38,6 +38,9 @@ type
 
 func shortLog*(msg: DcutrMsg): auto =
   (msgType: msg.msgType, addresses: msg.addrs.shortLog)
+
+chronicles.formatIt(DcutrMsg):
+  shortLog(it)
 
 Protobuf.serializerFor([DcutrMsg], withMetrics = true, domain = "dcutr")
 

--- a/libp2p/protocols/connectivity/dcutr/core.nim
+++ b/libp2p/protocols/connectivity/dcutr/core.nim
@@ -36,6 +36,9 @@ type
 
   DcutrError* = object of LPError
 
+func shortLog*(msg: DcutrMsg): auto =
+  (msgType: msg.msgType, addresses: msg.addrs.shortLog)
+
 Protobuf.serializerFor([DcutrMsg], withMetrics = true, domain = "dcutr")
 
 proc expectDcutrConnection*(

--- a/libp2p/protocols/connectivity/dcutr/server.nim
+++ b/libp2p/protocols/connectivity/dcutr/server.nim
@@ -32,7 +32,8 @@ proc new*(
       let connectMsg = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
         raise newException(DcutrError, error)
 
-      trace "Dcutr receiver received a Connect message.", connectMsg
+      trace "Dcutr receiver received a Connect message.",
+        connectMsg = connectMsg.shortLog
 
       var ourAddrs = switch.addressManager.mostObservedProtosAndPorts()
         # likely empty when the peer is reachable
@@ -48,7 +49,7 @@ proc new*(
       var ourDialableAddrs = getHolePunchableAddrs(ourAddrs)
       if ourDialableAddrs.len == 0:
         trace "Dcutr receiver has no supported dialable addresses. Aborting Dcutr.",
-          ourAddrs
+          addresses = ourAddrs.shortLog
         return
 
       peerDialableAddrs = getHolePunchableAddrs(connectMsg.addrs)
@@ -57,9 +58,9 @@ proc new*(
         trace "Dcutr receiver has sent a Connect message back."
         let syncMsg = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
           raise newException(DcutrError, error)
-        trace "Dcutr receiver has received a Sync message.", syncMsg
+        trace "Dcutr receiver has received a Sync message.", syncMsg = syncMsg.shortLog
         trace "Dcutr initiator has no supported dialable addresses to connect to. Aborting Dcutr.",
-          addresses = connectMsg.addrs
+          addresses = connectMsg.addrs.shortLog
         return
 
       # Expected DCUtR connections bypass ConnManager limits.
@@ -80,12 +81,12 @@ proc new*(
       trace "Dcutr receiver has sent a Connect message back."
       let syncMsg = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
         raise newException(DcutrError, error)
-      trace "Dcutr receiver has received a Sync message.", syncMsg
+      trace "Dcutr receiver has received a Sync message.", syncMsg = syncMsg.shortLog
 
       if peerDialableAddrs.len > maxDialableAddrs:
         peerDialableAddrs = peerDialableAddrs[0 ..< maxDialableAddrs]
       trace "Dcutr receiver starting direct dial attempts",
-        peerDialableAddrs, connectTimeout
+        addresses = peerDialableAddrs.shortLog, connectTimeout
       let dialFuts = peerDialableAddrs.mapIt(
         switch.connect(
           stream.peerId,
@@ -115,10 +116,12 @@ proc new*(
       raise err
     except AllFuturesFailedError as err:
       trace "Dcutr receiver could not connect to the remote peer, " &
-        "all connect attempts failed", peerDialableAddrs, err = err.msg
+        "all connect attempts failed",
+        err = err.msg, addresses = peerDialableAddrs.shortLog
     except AsyncTimeoutError as err:
       trace "Dcutr receiver could not connect to the remote peer, " &
-        "all connect attempts timed out", peerDialableAddrs, err = err.msg
+        "all connect attempts timed out",
+        err = err.msg, addresses = peerDialableAddrs.shortLog
     except CatchableError as err:
       trace "Unexpected error when Dcutr receiver tried to connect " &
         "to the remote peer", err = err.msg

--- a/libp2p/protocols/connectivity/dcutr/server.nim
+++ b/libp2p/protocols/connectivity/dcutr/server.nim
@@ -32,8 +32,7 @@ proc new*(
       let connectMsg = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
         raise newException(DcutrError, error)
 
-      trace "Dcutr receiver received a Connect message.",
-        connectMsg = connectMsg.shortLog
+      trace "Dcutr receiver received a Connect message.", connectMsg = connectMsg
 
       var ourAddrs = switch.addressManager.mostObservedProtosAndPorts()
         # likely empty when the peer is reachable
@@ -49,7 +48,7 @@ proc new*(
       var ourDialableAddrs = getHolePunchableAddrs(ourAddrs)
       if ourDialableAddrs.len == 0:
         trace "Dcutr receiver has no supported dialable addresses. Aborting Dcutr.",
-          addresses = ourAddrs.shortLog
+          addresses = ourAddrs
         return
 
       peerDialableAddrs = getHolePunchableAddrs(connectMsg.addrs)
@@ -58,9 +57,9 @@ proc new*(
         trace "Dcutr receiver has sent a Connect message back."
         let syncMsg = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
           raise newException(DcutrError, error)
-        trace "Dcutr receiver has received a Sync message.", syncMsg = syncMsg.shortLog
+        trace "Dcutr receiver has received a Sync message.", syncMsg
         trace "Dcutr initiator has no supported dialable addresses to connect to. Aborting Dcutr.",
-          addresses = connectMsg.addrs.shortLog
+          addresses = connectMsg.addrs
         return
 
       # Expected DCUtR connections bypass ConnManager limits.
@@ -81,12 +80,12 @@ proc new*(
       trace "Dcutr receiver has sent a Connect message back."
       let syncMsg = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
         raise newException(DcutrError, error)
-      trace "Dcutr receiver has received a Sync message.", syncMsg = syncMsg.shortLog
+      trace "Dcutr receiver has received a Sync message.", syncMsg
 
       if peerDialableAddrs.len > maxDialableAddrs:
         peerDialableAddrs = peerDialableAddrs[0 ..< maxDialableAddrs]
       trace "Dcutr receiver starting direct dial attempts",
-        addresses = peerDialableAddrs.shortLog, connectTimeout
+        addresses = peerDialableAddrs, connectTimeout
       let dialFuts = peerDialableAddrs.mapIt(
         switch.connect(
           stream.peerId,
@@ -116,12 +115,10 @@ proc new*(
       raise err
     except AllFuturesFailedError as err:
       trace "Dcutr receiver could not connect to the remote peer, " &
-        "all connect attempts failed",
-        err = err.msg, addresses = peerDialableAddrs.shortLog
+        "all connect attempts failed", err = err.msg, addresses = peerDialableAddrs
     except AsyncTimeoutError as err:
       trace "Dcutr receiver could not connect to the remote peer, " &
-        "all connect attempts timed out",
-        err = err.msg, addresses = peerDialableAddrs.shortLog
+        "all connect attempts timed out", err = err.msg, addresses = peerDialableAddrs
     except CatchableError as err:
       trace "Unexpected error when Dcutr receiver tried to connect " &
         "to the remote peer", err = err.msg

--- a/libp2p/protocols/connectivity/relay/client.nim
+++ b/libp2p/protocols/connectivity/relay/client.nim
@@ -144,7 +144,7 @@ proc dialPeerV1*(
     dstPeer: Opt.some(RelayPeer(peerId: dstPeerId, addrs: dstAddrs)),
   )
 
-  trace "Dial peer", msgSend = msg
+  trace "Dial peer", msgSend = msg.shortLog
 
   try:
     await stream.writeLp(encode(msg))
@@ -229,7 +229,7 @@ proc handleStopStreamV2(
   let msg = StopMessage.decode(await stream.readLp(RelayClientMsgSize)).valueOr:
     await sendHopStatus(stream, MalformedMessage)
     return
-  trace "client circuit relay v2 handle stream", msg
+  trace "client circuit relay v2 handle stream", msg = msg.shortLog
 
   if msg.msgType.isSome and msg.msgType.get() == StopMessageType.Connect:
     await cl.handleRelayedConnect(stream, msg)
@@ -272,7 +272,7 @@ proc handleStreamV1(
   let msg = RelayMessage.decode(await stream.readLp(RelayClientMsgSize)).valueOr:
     await sendStatus(stream, StatusV1.MalformedMessage)
     return
-  trace "client circuit relay v1 handle stream", msg
+  trace "client circuit relay v1 handle stream", msg = msg.shortLog
 
   let typ = msg.msgType.valueOr:
     trace "Message type not set"

--- a/libp2p/protocols/connectivity/relay/client.nim
+++ b/libp2p/protocols/connectivity/relay/client.nim
@@ -144,7 +144,7 @@ proc dialPeerV1*(
     dstPeer: Opt.some(RelayPeer(peerId: dstPeerId, addrs: dstAddrs)),
   )
 
-  trace "Dial peer", msgSend = msg.shortLog
+  trace "Dial peer", msgSend = msg
 
   try:
     await stream.writeLp(encode(msg))
@@ -229,7 +229,7 @@ proc handleStopStreamV2(
   let msg = StopMessage.decode(await stream.readLp(RelayClientMsgSize)).valueOr:
     await sendHopStatus(stream, MalformedMessage)
     return
-  trace "client circuit relay v2 handle stream", msg = msg.shortLog
+  trace "client circuit relay v2 handle stream", msg
 
   if msg.msgType.isSome and msg.msgType.get() == StopMessageType.Connect:
     await cl.handleRelayedConnect(stream, msg)
@@ -272,7 +272,7 @@ proc handleStreamV1(
   let msg = RelayMessage.decode(await stream.readLp(RelayClientMsgSize)).valueOr:
     await sendStatus(stream, StatusV1.MalformedMessage)
     return
-  trace "client circuit relay v1 handle stream", msg = msg.shortLog
+  trace "client circuit relay v1 handle stream", msg
 
   let typ = msg.msgType.valueOr:
     trace "Message type not set"

--- a/libp2p/protocols/connectivity/relay/messages.nim
+++ b/libp2p/protocols/connectivity/relay/messages.nim
@@ -3,7 +3,7 @@
 
 {.push raises: [].}
 
-import results
+import results, chronicles
 import
   protobuf_serialization,
   protobuf_serialization/pkg/results,
@@ -108,6 +108,9 @@ type
 func shortLog*(peer: RelayPeer): auto =
   (peerId: peer.peerId.shortLog, addresses: peer.addrs.shortLog)
 
+chronicles.formatIt(RelayPeer):
+  shortLog(it)
+
 func shortLog*(msg: RelayMessage): auto =
   (
     messageType: msg.msgType,
@@ -115,6 +118,9 @@ func shortLog*(msg: RelayMessage): auto =
     hasDestinationPeer: msg.dstPeer.isSome,
     status: msg.status,
   )
+
+chronicles.formatIt(RelayMessage):
+  shortLog(it)
 
 func shortLog*(msg: HopMessage): auto =
   (
@@ -125,6 +131,9 @@ func shortLog*(msg: HopMessage): auto =
     status: msg.status,
   )
 
+chronicles.formatIt(HopMessage):
+  shortLog(it)
+
 func shortLog*(msg: StopMessage): auto =
   (
     messageType: msg.msgType,
@@ -132,6 +141,9 @@ func shortLog*(msg: StopMessage): auto =
     hasLimit: msg.limit.isSome,
     status: msg.status,
   )
+
+chronicles.formatIt(StopMessage):
+  shortLog(it)
 
 Protobuf.serializerFor([Voucher])
 Protobuf.serializerFor(

--- a/libp2p/protocols/connectivity/relay/messages.nim
+++ b/libp2p/protocols/connectivity/relay/messages.nim
@@ -10,7 +10,7 @@ import
   protobuf_serialization/std/enums,
   ../../../peerinfo,
   ../../../signed_envelope,
-  ../../../utils/protobuf
+  ../../../utils/[protobuf, shortlog]
 
 # Circuit Relay V1 Message
 
@@ -104,6 +104,34 @@ type
     peer* {.fieldNumber: 2.}: Opt[Peer]
     limit* {.fieldNumber: 3.}: Opt[Limit]
     status* {.fieldNumber: 4, ext.}: Opt[StatusV2]
+
+func shortLog*(peer: RelayPeer): auto =
+  (peerId: peer.peerId.shortLog, addresses: peer.addrs.shortLog)
+
+func shortLog*(msg: RelayMessage): auto =
+  (
+    messageType: msg.msgType,
+    hasSourcePeer: msg.srcPeer.isSome,
+    hasDestinationPeer: msg.dstPeer.isSome,
+    status: msg.status,
+  )
+
+func shortLog*(msg: HopMessage): auto =
+  (
+    messageType: msg.msgType,
+    hasPeer: msg.peer.isSome,
+    hasReservation: msg.reservation.isSome,
+    hasLimit: msg.limit.isSome,
+    status: msg.status,
+  )
+
+func shortLog*(msg: StopMessage): auto =
+  (
+    messageType: msg.msgType,
+    hasPeer: msg.peer.isSome,
+    hasLimit: msg.limit.isSome,
+    status: msg.status,
+  )
 
 Protobuf.serializerFor([Voucher])
 Protobuf.serializerFor(

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -226,7 +226,7 @@ proc handleHopStreamV2*(
   let msg = HopMessage.decode(await stream.readLp(r.msgSize)).valueOr:
     await sendHopStatus(stream, MalformedMessage)
     return
-  trace "relayv2 handle stream", hopMsg = msg
+  trace "relayv2 handle stream", hopMsg = msg.shortLog
 
   if msg.msgType.isNone:
     trace "relayv2 mesage type not set"
@@ -315,13 +315,13 @@ proc handleHop*(
       return
 
   let msgRcvFromDst = msgRcvFromDstOpt.valueOr:
-    trace "error reading stop response", response = msgRcvFromDstOpt
+    trace "error reading stop response", responsePresent = msgRcvFromDstOpt.isOk
     await sendStatus(srcStream, StatusV1.HopCantOpenDstStream)
     return
 
   if msgRcvFromDst.msgType.get(RelayType.Stop) != RelayType.Status or
       msgRcvFromDst.status.get(StatusV1.StopRelayRefused) != StatusV1.Success:
-    trace "unexcepted relay stop response", msgRcvFromDst
+    trace "Unexpected relay stop response", response = msgRcvFromDst.shortLog
     await sendStatus(srcStream, StatusV1.HopCantOpenDstStream)
     return
 
@@ -335,7 +335,7 @@ proc handleStreamV1(
   let msg = RelayMessage.decode(await stream.readLp(r.msgSize)).valueOr:
     await sendStatus(stream, StatusV1.MalformedMessage)
     return
-  trace "relay handle stream", msg
+  trace "relay handle stream", msg = msg.shortLog
 
   let typ = msg.msgType.valueOr:
     trace "Message type not set"

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -314,7 +314,7 @@ proc handleHop*(
       await sendStatus(srcStream, StatusV1.HopCantOpenDstStream)
       return
 
-  let msgRcvFromDst = msgRcvFromDstOpt.valueOr:
+  let msgRcvFromDst: RelayMessage = msgRcvFromDstOpt.valueOr:
     trace "error reading stop response", responsePresent = msgRcvFromDstOpt.isOk
     await sendStatus(srcStream, StatusV1.HopCantOpenDstStream)
     return

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -226,7 +226,7 @@ proc handleHopStreamV2*(
   let msg = HopMessage.decode(await stream.readLp(r.msgSize)).valueOr:
     await sendHopStatus(stream, MalformedMessage)
     return
-  trace "relayv2 handle stream", hopMsg = msg.shortLog
+  trace "relayv2 handle stream", hopMsg = msg
 
   if msg.msgType.isNone:
     trace "relayv2 mesage type not set"
@@ -321,7 +321,7 @@ proc handleHop*(
 
   if msgRcvFromDst.msgType.get(RelayType.Stop) != RelayType.Status or
       msgRcvFromDst.status.get(StatusV1.StopRelayRefused) != StatusV1.Success:
-    trace "Unexpected relay stop response", response = msgRcvFromDst.shortLog
+    trace "Unexpected relay stop response", response = msgRcvFromDst
     await sendStatus(srcStream, StatusV1.HopCantOpenDstStream)
     return
 
@@ -335,7 +335,7 @@ proc handleStreamV1(
   let msg = RelayMessage.decode(await stream.readLp(r.msgSize)).valueOr:
     await sendStatus(stream, StatusV1.MalformedMessage)
     return
-  trace "relay handle stream", msg = msg.shortLog
+  trace "relay handle stream", msg
 
   let typ = msg.msgType.valueOr:
     trace "Message type not set"

--- a/libp2p/protocols/kademlia.nim
+++ b/libp2p/protocols/kademlia.nim
@@ -66,7 +66,7 @@ proc checkAndEvictPeer(
   if kad.stopping:
     return
   if not kad.livenessSem.tryAcquire():
-    trace "Liveness probe skipped: no free slot", peerId = peerId.shortLog()
+    trace "Liveness probe skipped: no free slot", peerId
     kad_routing_table_liveness_probes.inc(labelValues = ["skipped"])
     return
   defer:
@@ -85,8 +85,7 @@ proc checkAndEvictPeer(
     if rtable.isReplaceable(peerId, grace, Moment.now()):
       dueTables.add(rtable)
   if dueTables.len == 0:
-    trace "Liveness probe skipped: peer no longer replaceable",
-      peerId = peerId.shortLog()
+    trace "Liveness probe skipped: peer no longer replaceable", peerId
     return
 
   let addrs = kad.dialAddrs(peerId)
@@ -99,17 +98,15 @@ proc checkAndEvictPeer(
       discard rtable.removePeer(peerId, reason = "liveness")
       inc evicted
     if evicted > 0:
-      trace "Evicting peer with no known addresses",
-        peer = peerId.shortLog(), tables = evicted
+      trace "Evicting peer with no known addresses", peer = peerId, tables = evicted
       kad_routing_table_liveness_probes.inc(labelValues = ["no_addrs"])
     else:
-      trace "Liveness probe skipped: peer no longer replaceable",
-        peer = peerId.shortLog()
+      trace "Liveness probe skipped: peer no longer replaceable", peer = peerId
     return
 
-  trace "Probing peer for liveness", peerId = peerId.shortLog(), tables = dueTables.len
+  trace "Probing peer for liveness", peerId, tables = dueTables.len
   if (await kad.lookupCheck(peerId, addrs)):
-    trace "Liveness probe succeeded", peerId = peerId.shortLog()
+    trace "Liveness probe succeeded", peerId
     # Peer is reachable: one registry write refreshes usefulness for every index.
     kad.rtable.markUseful(peerId)
     kad_routing_table_liveness_probes.inc(labelValues = ["ok"])
@@ -123,22 +120,21 @@ proc checkAndEvictPeer(
     discard rtable.removePeer(peerId, reason = "liveness")
     inc evicted
   if evicted == 0:
-    trace "Liveness probe failed but peer refreshed mid-flight",
-      peer = peerId.shortLog()
+    trace "Liveness probe failed but peer refreshed mid-flight", peer = peerId
     return
 
   trace "Evicting unresponsive peer after liveness probe",
-    peer = peerId.shortLog(), tables = evicted
+    peer = peerId, tables = evicted
   kad_routing_table_liveness_probes.inc(labelValues = ["fail"])
 
 proc launchLivenessProbe(kad: KadDHT, peerId: PeerId) {.raises: [].} =
   ## Starts a liveness probe unless one is already in flight for this peer.
   if kad.livenessProbes.hasKey(peerId):
-    trace "Liveness probe already in flight", peerId = peerId.shortLog()
+    trace "Liveness probe already in flight", peerId
     return
   if kad.stopping:
     return
-  trace "Launching liveness probe", peerId = peerId.shortLog()
+  trace "Launching liveness probe", peerId
   kad.trackLivenessProbe(peerId, kad.checkAndEvictPeer(peerId))
 
 proc probeAndEvictPeers*(
@@ -160,7 +156,7 @@ proc probeAndEvictPeers*(
   var futs = newSeqOfCap[Future[void]](peers.len)
   for peerId in peers:
     kad.livenessProbes.withValue(peerId, existing):
-      trace "Liveness batch reusing in-flight probe", peerId = peerId.shortLog()
+      trace "Liveness batch reusing in-flight probe", peerId
       futs.add(existing[])
       continue
     let fut = kad.checkAndEvictPeer(peerId)

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -286,11 +286,10 @@ proc lookupCheck*(
     await noCancel probe.cancelAndWait()
   discard await probe.withTimeout(kad.config.timeout)
   if not probe.completed():
-    trace "Kad probe timed out",
-      peerId = peerId.shortLog(), timeout = kad.config.timeout
+    trace "Kad probe timed out", peerId, timeout = kad.config.timeout
     return false
   let reply = probe.value().valueOr:
-    trace "Kademlia probe failed", peerId = peerId.shortLog(), err = error
+    trace "Kademlia probe failed", peerId, err = error
     return false
   reply.msgType == Opt.some(MessageType.findNode)
 
@@ -307,7 +306,7 @@ proc admitPeer(
     except CancelledError:
       return
   if not reachable:
-    trace "Kad admission probe failed, not inserting peer", peerId = peerId.shortLog()
+    trace "Kad admission probe failed, not inserting peer", peerId
     kad.probeRecordFailure(peerId, addrs)
     return
   kad.probeClearFailures(peerId)
@@ -316,7 +315,7 @@ proc admitPeer(
 
   # Table may have been detachAll'd (e.g. service uninterest) while the probe ran.
   if rtable.detached:
-    trace "Kad admission probe abandoned: table detached", peerId = peerId.shortLog()
+    trace "Kad admission probe abandoned: table detached", peerId
     return
   if rtable.insert(peerId) and not onAdmit.isNil():
     onAdmit(peerId)
@@ -352,12 +351,12 @@ proc scheduleAdmissionProbe(
     return false
 
   if kad.probeBackedOff(peerId, addrs):
-    trace "Kad admission probe backed off", peerId = peerId.shortLog()
+    trace "Kad admission probe backed off", peerId
     kad_admission_probes_backed_off.inc()
     return false
 
   if not kad.admissionSem.tryAcquire():
-    trace "Kad admission probe dropped: no free slot", peerId = peerId.shortLog()
+    trace "Kad admission probe dropped: no free slot", peerId
     kad_admission_probes_dropped.inc()
     return false
 

--- a/libp2p/protocols/kademlia/protobuf.nim
+++ b/libp2p/protocols/kademlia/protobuf.nim
@@ -3,7 +3,7 @@
 
 import std/hashes
 import chronos
-import ../../utils/opt
+import ../../utils/[opt, shortlog]
 import results
 import ../../multiaddress
 import stew/endians2
@@ -88,6 +88,35 @@ type
     providerStatus* {.fieldNumber: 11, ext.}: Opt[AddProviderStatus]
     register* {.fieldNumber: 21.}: Opt[RegisterMessage]
     getAds* {.fieldNumber: 22.}: Opt[GetAdsMessage]
+
+func shortLog*(record: Record): auto =
+  (
+    key: record.key.get(@[]).shortLog,
+    value: record.value.get(@[]).shortLog,
+    timeReceived: record.timeReceived.get("").shortLog,
+  )
+
+func shortLog*(peer: Peer): auto =
+  (
+    id: peer.id.get(@[]).shortLog,
+    addresses: peer.addrs.shortLog,
+    connection: peer.connection,
+  )
+
+func shortLog*(msg: Message): auto =
+  (
+    messageType: msg.msgType,
+    key: msg.key.get(@[]).shortLog,
+    record: msg.record.get(Record()).shortLog,
+    closerPeers: msg.closerPeers.shortLog,
+    providerPeers: msg.providerPeers.shortLog,
+    hasRegistration: msg.register.isSome,
+    advertisementCount:
+      if msg.getAds.isSome:
+        msg.getAds.get().advertisements.len
+      else:
+        0,
+  )
 
 func hide(c: Opt[ConnectionStatus], hideConnectionStatus: bool): Opt[ConnectionStatus] =
   if hideConnectionStatus:

--- a/libp2p/protocols/kademlia/protobuf.nim
+++ b/libp2p/protocols/kademlia/protobuf.nim
@@ -2,7 +2,7 @@
 # Copyright (c) Status Research & Development GmbH
 
 import std/hashes
-import chronos
+import chronos, chronicles
 import ../../utils/[opt, shortlog]
 import results
 import ../../multiaddress
@@ -96,12 +96,18 @@ func shortLog*(record: Record): auto =
     timeReceived: record.timeReceived.get("").shortLog,
   )
 
+chronicles.formatIt(Record):
+  shortLog(it)
+
 func shortLog*(peer: Peer): auto =
   (
     id: peer.id.get(@[]).shortLog,
     addresses: peer.addrs.shortLog,
     connection: peer.connection,
   )
+
+chronicles.formatIt(Peer):
+  shortLog(it)
 
 func shortLog*(msg: Message): auto =
   (
@@ -117,6 +123,9 @@ func shortLog*(msg: Message): auto =
       else:
         0,
   )
+
+chronicles.formatIt(Message):
+  shortLog(it)
 
 func hide(c: Opt[ConnectionStatus], hideConnectionStatus: bool): Opt[ConnectionStatus] =
   if hideConnectionStatus:

--- a/libp2p/protocols/kademlia/provider.nim
+++ b/libp2p/protocols/kademlia/provider.nim
@@ -402,9 +402,12 @@ proc republishProvidedKeys(kad: KadDHT) {.async: (raises: [CancelledError]).} =
 
 proc manageRepublishProvidedKeys*(kad: KadDHT) {.async: (raises: [CancelledError]).} =
   heartbeat "republish provided keys", kad.config.republishProvidedKeysInterval:
-    discard await kad.republishProvidedKeys().withTimeout(
+    if not await kad.republishProvidedKeys().withTimeout(
       kad.config.republishProvidedKeysInterval
-    )
+    ):
+      warn "Provider republishing timed out",
+        timeout = kad.config.republishProvidedKeysInterval,
+        providedKeys = kad.providerManager.providedKeys.provided.len
 
 proc anyExpired(pr: ProviderRecords): bool =
   pr.len() > 0 and pr.records[0] < chronos.Moment.now()

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -480,7 +480,7 @@ proc handleControl(g: GossipSub, peer: PubSubPeer, control: ControlMessage) =
       for prune in respControl.prune:
         libp2p_pubsub_broadcast_prune.inc(labelValues = [g.topicLabel(prune.topicID)])
 
-    trace "sending control message", control = shortLog(respControl), peer
+    trace "sending control message", control = respControl, peer
     g.sendResponse(peer, RPCMsg.withControl(respControl), MessagePriority.High)
 
   if messages.len > 0:

--- a/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
+++ b/libp2p/protocols/pubsub/gossipsub/extension_partial_message.nim
@@ -416,7 +416,7 @@ proc publishPartialToPeer(
         )
         if unionRes.isErr:
           debug "failed to create union from the two parts metadata",
-            msg = unionRes.error
+            err = unionRes.error
           # technically should never happen since materializeParts was successful
         else:
           peerState.receivedPartsMetadata = Opt.some(unionRes.get())

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -239,7 +239,7 @@ proc send*(
   ##   High priority messages are sent immediately, medium and low priority messages are queued
   ##   and sent only after all high priority messages have been sent.
 
-  trace "sending pubsub message to peer", peer, msg = msg.shortLog
+  trace "sending pubsub message to peer", peer, msg
   peer.send(msg, p.anonymize, priority, useCustomStream)
 
 proc countBroadcastMetrics*(
@@ -300,7 +300,7 @@ proc broadcast*(
 
   countBroadcastMetrics(p, sendPeers, msg)
 
-  trace "broadcasting messages to peers", peersCount = sendPeers.len, msg = msg.shortLog
+  trace "broadcasting messages to peers", peersCount = sendPeers.len, msg
 
   if anyIt(sendPeers, it.hasObservers):
     for peer in sendPeers:

--- a/libp2p/protocols/pubsub/rpc/message.nim
+++ b/libp2p/protocols/pubsub/rpc/message.nim
@@ -60,7 +60,7 @@ proc verify*(m: Message): bool =
 
     var remote: Signature
     let key = m.extractPublicKey().valueOr:
-      trace "could not extract public key", msg = m
+      trace "could not extract public key", msg = m.shortLog
       return false
 
     if remote.init(m.signature):

--- a/libp2p/protocols/pubsub/rpc/message.nim
+++ b/libp2p/protocols/pubsub/rpc/message.nim
@@ -60,7 +60,7 @@ proc verify*(m: Message): bool =
 
     var remote: Signature
     let key = m.extractPublicKey().valueOr:
-      trace "could not extract public key", msg = m.shortLog
+      trace "could not extract public key", msg = m
       return false
 
     if remote.init(m.signature):

--- a/libp2p/protocols/pubsub/rpc/messages.nim
+++ b/libp2p/protocols/pubsub/rpc/messages.nim
@@ -3,7 +3,7 @@
 
 {.push raises: [].}
 
-import sequtils
+import sequtils, chronicles
 import protobuf_serialization
 import ../../../[peerid, routing_record]
 import ../../../utils/[opt, shortlog]
@@ -143,20 +143,38 @@ func len[T](opt: Opt[T]): int =
 func shortLog*(s: ControlIHave): auto =
   (topic: s.topicID.shortLog, messageIDs: mapIt(s.messageIDs, it.shortLog))
 
+chronicles.formatIt(ControlIHave):
+  shortLog(it)
+
 func shortLog*(s: ControlIWant): auto =
   (messageIDs: mapIt(s.messageIDs, it.shortLog))
+
+chronicles.formatIt(ControlIWant):
+  shortLog(it)
 
 func shortLog*(s: ControlGraft): auto =
   (topic: s.topicID.shortLog)
 
+chronicles.formatIt(ControlGraft):
+  shortLog(it)
+
 func shortLog*(s: ControlPrune): auto =
   (topic: s.topicID.shortLog)
+
+chronicles.formatIt(ControlPrune):
+  shortLog(it)
 
 func shortLog*(s: Preamble): auto =
   (topic: s.topicID.shortLog, messageID: s.messageID.shortLog)
 
+chronicles.formatIt(Preamble):
+  shortLog(it)
+
 func shortLog*(s: IMReceiving): auto =
   (messageID: s.messageID.shortLog)
+
+chronicles.formatIt(IMReceiving):
+  shortLog(it)
 
 func shortLog*(so: Opt[ControlExtensions]): auto =
   if so.isNone():
@@ -175,6 +193,9 @@ func shortLog*(so: Opt[ControlExtensions]): auto =
       preambleExtension: shortLog(s.preambleExtension),
     )
 
+chronicles.formatIt(Opt[ControlExtensions]):
+  shortLog(it)
+
 func shortLog*(c: ControlMessage): auto =
   (
     ihave: mapIt(c.ihave, it.shortLog),
@@ -183,6 +204,9 @@ func shortLog*(c: ControlMessage): auto =
     prune: mapIt(c.prune, it.shortLog),
     extensions: shortLog(c.extensions),
   )
+
+chronicles.formatIt(ControlMessage):
+  shortLog(it)
 
 func shortLog*(msg: Message): auto =
   (
@@ -194,6 +218,9 @@ func shortLog*(msg: Message): auto =
     key: msg.key.shortLog,
   )
 
+chronicles.formatIt(Message):
+  shortLog(it)
+
 func shortLog*(pme: PartialMessageExtensionRPC): auto =
   (
     topicID: pme.topicID.shortLog,
@@ -202,14 +229,23 @@ func shortLog*(pme: PartialMessageExtensionRPC): auto =
     partsMetadata: pme.partsMetadata.shortLog,
   )
 
+chronicles.formatIt(PartialMessageExtensionRPC):
+  shortLog(it)
+
 func shortLog*(rpc: PingPongExtensionRPC): auto =
   (ping: rpc.ping.shortLog, pong: rpc.pong.shortLog)
+
+chronicles.formatIt(PingPongExtensionRPC):
+  shortLog(it)
 
 func shortLog*(rpc: PreambleExtensionRPC): auto =
   (
     preamble: mapIt(rpc.preamble, it.shortLog),
     imreceiving: mapIt(rpc.imreceiving, it.shortLog),
   )
+
+chronicles.formatIt(PreambleExtensionRPC):
+  shortLog(it)
 
 func shortLog*(m: RPCMsg): auto =
   (
@@ -222,6 +258,9 @@ func shortLog*(m: RPCMsg): auto =
     pingpongExtension: m.pingpongExtension.valueOr(PingPongExtensionRPC()).shortLog,
     preambleExtension: m.preambleExtension.valueOr(PreambleExtensionRPC()).shortLog,
   )
+
+chronicles.formatIt(RPCMsg):
+  shortLog(it)
 
 static:
   expectedFields(PeerInfoMsg, @["peerId", "signedPeerRecord"])

--- a/libp2p/protocols/pubsub/rpc_send.nim
+++ b/libp2p/protocols/pubsub/rpc_send.nim
@@ -28,7 +28,7 @@ proc sendResponse*(
   ## This should not be used for application-published messages; use `send`
   ## instead.
 
-  trace "sending pubsub response to peer", peer, rpcMsg = shortLog(msg)
+  trace "sending pubsub response to peer", peer, rpcMsg = msg
   peer.sendResponse(msg, p.anonymize, priority, useCustomStream)
 
 proc broadcastResponse*(
@@ -47,7 +47,7 @@ proc broadcastResponse*(
 
   countBroadcastMetrics(p, sendPeers, msg)
 
-  trace "broadcasting responses to peers", peers = sendPeers.len, rpcMsg = shortLog(msg)
+  trace "broadcasting responses to peers", peers = sendPeers.len, rpcMsg = msg
 
   if anyIt(sendPeers, it.hasObservers) or msg.messages.len > 1:
     for peer in sendPeers:

--- a/libp2p/protocols/rendezvous/protobuf.nim
+++ b/libp2p/protocols/rendezvous/protobuf.nim
@@ -4,6 +4,7 @@
 {.push raises: [].}
 
 import
+  chronicles,
   results,
   protobuf_serialization,
   protobuf_serialization/pkg/results,
@@ -71,11 +72,17 @@ type
 func shortLog*(response: RegisterResponse): auto =
   (status: response.status, text: response.text.get("").shortLog, ttl: response.ttl)
 
+chronicles.formatIt(RegisterResponse):
+  shortLog(it)
+
 func shortLog*(response: Opt[RegisterResponse]): string =
   if response.isSome:
     $response.get().shortLog
   else:
     "<unset>"
+
+chronicles.formatIt(Opt[RegisterResponse]):
+  shortLog(it)
 
 func shortLog*(response: DiscoverResponse): auto =
   (
@@ -85,11 +92,17 @@ func shortLog*(response: DiscoverResponse): auto =
     text: response.text.get("").shortLog,
   )
 
+chronicles.formatIt(DiscoverResponse):
+  shortLog(it)
+
 func shortLog*(response: Opt[DiscoverResponse]): string =
   if response.isSome:
     $response.get().shortLog
   else:
     "<unset>"
+
+chronicles.formatIt(Opt[DiscoverResponse]):
+  shortLog(it)
 
 Protobuf.serializerFor(
   [Cookie, Register, RegisterResponse, Unregister, Discover, DiscoverResponse]

--- a/libp2p/protocols/rendezvous/protobuf.nim
+++ b/libp2p/protocols/rendezvous/protobuf.nim
@@ -8,7 +8,7 @@ import
   protobuf_serialization,
   protobuf_serialization/pkg/results,
   protobuf_serialization/std/enums,
-  ../../utils/protobuf
+  ../../utils/[protobuf, shortlog]
 
 export results
 
@@ -67,6 +67,29 @@ type
     unregister* {.fieldNumber: 4.}: Opt[Unregister]
     discover* {.fieldNumber: 5.}: Opt[Discover]
     discoverResponse* {.fieldNumber: 6.}: Opt[DiscoverResponse]
+
+func shortLog*(response: RegisterResponse): auto =
+  (status: response.status, text: response.text.get("").shortLog, ttl: response.ttl)
+
+func shortLog*(response: Opt[RegisterResponse]): string =
+  if response.isSome:
+    $response.get().shortLog
+  else:
+    "<unset>"
+
+func shortLog*(response: DiscoverResponse): auto =
+  (
+    status: response.status,
+    registrationCount: response.registrations.len,
+    cookie: response.cookie.get(@[]).shortLog,
+    text: response.text.get("").shortLog,
+  )
+
+func shortLog*(response: Opt[DiscoverResponse]): string =
+  if response.isSome:
+    $response.get().shortLog
+  else:
+    "<unset>"
 
 Protobuf.serializerFor(
   [Cookie, Register, RegisterResponse, Unregister, Discover, DiscoverResponse]

--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -323,10 +323,9 @@ proc advertisePeer[E](
       if msgRecv.msgType != MessageType.RegisterResponse:
         trace "Unexpected register response", peer, msgType = msgRecv.msgType
       elif msgRecv.registerResponse.tryGet().status != ResponseStatus.Ok:
-        trace "Refuse to register", peer, response = msgRecv.registerResponse.shortLog
+        trace "Refuse to register", peer, response = msgRecv.registerResponse
       else:
-        trace "Successfully registered",
-          peer, response = msgRecv.registerResponse.shortLog
+        trace "Successfully registered", peer, response = msgRecv.registerResponse
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
@@ -594,15 +593,14 @@ proc new*(
           stream, msg.register.tryGet(), rdv.switch.peerInfo.signedPeerRecord.data
         )
       of MessageType.RegisterResponse:
-        trace "Got an unexpected Register Response",
-          response = msg.registerResponse.shortLog
+        trace "Got an unexpected Register Response", response = msg.registerResponse
       of MessageType.Unregister:
         rdv.unregister(stream, msg.unregister.tryGet())
       of MessageType.Discover:
         await rdv.discover(stream, msg.discover.tryGet())
       of MessageType.DiscoverResponse:
         trace "Got an unexpected Discover Response",
-          response = msg.discoverResponse.get(DiscoverResponse()).shortLog
+          response = msg.discoverResponse.get(DiscoverResponse())
     except CancelledError as exc:
       trace "Cancelled rendezvous handler"
       raise exc

--- a/libp2p/protocols/rendezvous/rendezvous.nim
+++ b/libp2p/protocols/rendezvous/rendezvous.nim
@@ -323,9 +323,10 @@ proc advertisePeer[E](
       if msgRecv.msgType != MessageType.RegisterResponse:
         trace "Unexpected register response", peer, msgType = msgRecv.msgType
       elif msgRecv.registerResponse.tryGet().status != ResponseStatus.Ok:
-        trace "Refuse to register", peer, response = msgRecv.registerResponse
+        trace "Refuse to register", peer, response = msgRecv.registerResponse.shortLog
       else:
-        trace "Successfully registered", peer, response = msgRecv.registerResponse
+        trace "Successfully registered",
+          peer, response = msgRecv.registerResponse.shortLog
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
@@ -593,13 +594,15 @@ proc new*(
           stream, msg.register.tryGet(), rdv.switch.peerInfo.signedPeerRecord.data
         )
       of MessageType.RegisterResponse:
-        trace "Got an unexpected Register Response", response = msg.registerResponse
+        trace "Got an unexpected Register Response",
+          response = msg.registerResponse.shortLog
       of MessageType.Unregister:
         rdv.unregister(stream, msg.unregister.tryGet())
       of MessageType.Discover:
         await rdv.discover(stream, msg.discover.tryGet())
       of MessageType.DiscoverResponse:
-        trace "Got an unexpected Discover Response", response = msg.discoverResponse
+        trace "Got an unexpected Discover Response",
+          response = msg.discoverResponse.get(DiscoverResponse()).shortLog
     except CancelledError as exc:
       trace "Cancelled rendezvous handler"
       raise exc

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -45,9 +45,11 @@ proc maintainSelfSignedPeerRecord(
     disco: ServiceDiscovery
 ) {.async: (raises: [CancelledError]).} =
   heartbeat "refresh self signed peer record", disco.config.bucketRefreshTime:
-    discard await disco.refreshSelfSignedPeerRecord().withTimeout(
+    if not await disco.refreshSelfSignedPeerRecord().withTimeout(
       disco.config.bucketRefreshTime
-    )
+    ):
+      warn "Signed peer record refresh timed out",
+        timeout = disco.config.bucketRefreshTime
 
 proc maintainRegistrar(disco: ServiceDiscovery) {.async: (raises: [CancelledError]).} =
   heartbeat "prune expired advertisements",
@@ -59,9 +61,11 @@ proc maintainServiceTables(
 ) {.async: (raises: [CancelledError]).} =
   heartbeat "refresh service routing tables",
     disco.config.bucketRefreshTime, sleepFirst = true:
-    discard await disco.rtManager.refreshAllTables(disco).withTimeout(
+    if not await disco.rtManager.refreshAllTables(disco).withTimeout(
       disco.config.bucketRefreshTime
-    )
+    ):
+      warn "Service routing table refresh timed out",
+        timeout = disco.config.bucketRefreshTime, tables = disco.rtManager.tables.len
 
 proc bootstrapServiceTable*(
     disco: ServiceDiscovery, serviceId: ServiceId

--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -269,7 +269,7 @@ proc registration*(
     connectionIps: seq[IpAddress] = @[],
 ): Message =
   let serviceId = inMsg.key.valueOr:
-    trace "Key not set: registration", msg = inMsg.shortLog
+    trace "Key not set: registration", msg = inMsg
     return
 
   discard disco.rtable.insert(peerId)
@@ -375,7 +375,7 @@ proc getAdvertisements*(
     disco: ServiceDiscovery, peerId: PeerId, msg: Message
 ): Message =
   let serviceId = msg.key.valueOr:
-    trace "Key not set: getAdvertisements", msg = msg.shortLog
+    trace "Key not set: getAdvertisements", msg
     return
 
   discard disco.rtable.insert(peerId)

--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -269,7 +269,7 @@ proc registration*(
     connectionIps: seq[IpAddress] = @[],
 ): Message =
   let serviceId = inMsg.key.valueOr:
-    trace "Key not set: registration", msg = inMsg
+    trace "Key not set: registration", msg = inMsg.shortLog
     return
 
   discard disco.rtable.insert(peerId)
@@ -375,7 +375,7 @@ proc getAdvertisements*(
     disco: ServiceDiscovery, peerId: PeerId, msg: Message
 ): Message =
   let serviceId = msg.key.valueOr:
-    trace "Key not set: getAdvertisements", msg = msg
+    trace "Key not set: getAdvertisements", msg = msg.shortLog
     return
 
   discard disco.rtable.insert(peerId)

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -352,7 +352,10 @@ proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    debug "Cannot cancel accepts", err = exc.msg
+    warn "Accept loop cancellation failed",
+      err = exc.msg,
+      errType = exc.name,
+      pendingAccepts = s.acceptFuts.countIt(not it.finished())
 
   await s.upgradeFuts.cancelAndWait()
   s.upgradeFuts = @[]

--- a/libp2p/transports/memorytransport.nim
+++ b/libp2p/transports/memorytransport.nim
@@ -48,7 +48,7 @@ method start*(
   if self.running:
     return
 
-  info "Starting memory transport on addrs", address = addrs.shortLog
+  info "Starting memory transport on addrs", address = addrs
 
   self.addrs = addrs.mapIt(self.listenAddress(it))
   self.running = true
@@ -58,7 +58,7 @@ method stop*(self: MemoryTransport) {.async: (raises: []).} =
   if not self.running:
     return
 
-  info "Stopping memory transport", address = self.addrs.shortLog
+  info "Stopping memory transport", address = self.addrs
   self.running = false
   self.onStop.fire()
 

--- a/libp2p/transports/memorytransport.nim
+++ b/libp2p/transports/memorytransport.nim
@@ -48,7 +48,7 @@ method start*(
   if self.running:
     return
 
-  info "Starting memory transport on addrs", address = $addrs
+  info "Starting memory transport on addrs", address = addrs.shortLog
 
   self.addrs = addrs.mapIt(self.listenAddress(it))
   self.running = true
@@ -58,7 +58,7 @@ method stop*(self: MemoryTransport) {.async: (raises: []).} =
   if not self.running:
     return
 
-  info "Stopping memory transport", address = $self.addrs
+  info "Stopping memory transport", address = self.addrs.shortLog
   self.running = false
   self.onStop.fire()
 

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -63,7 +63,7 @@ proc connHandler*(
   proc onClose() {.async: (raises: []).} =
     await noCancel client.join()
 
-    trace "Cleaning up client", addresses = $client.remoteAddress, conn
+    trace "Cleaning up client", addresses = ($client.remoteAddress).shortLog, conn
 
     self.clients[dir].keepItIf(it != client)
 
@@ -76,7 +76,7 @@ proc connHandler*(
 
     await conn.close()
 
-    trace "Cleaned up client", addresses = $client.remoteAddress, conn
+    trace "Cleaned up client", addresses = ($client.remoteAddress).shortLog, conn
 
   self.clients[dir].add(client)
 

--- a/libp2p/transports/transport.nim
+++ b/libp2p/transports/transport.nim
@@ -48,7 +48,7 @@ method start*(
   ## start the transport
   ##
 
-  info "Transport starting", addresses = addrs
+  info "Transport starting", addresses = addrs.shortLog
   self.addrs = addrs
   self.running = true
   self.onRunning.fire()
@@ -58,7 +58,7 @@ method stop*(self: Transport) {.base, async: (raises: []).} =
   ## including all outstanding connections
   ##
 
-  info "Transport stopping", addresses = self.addrs
+  info "Transport stopping", addresses = self.addrs.shortLog
   self.running = false
   self.onStop.fire()
 

--- a/libp2p/transports/transport.nim
+++ b/libp2p/transports/transport.nim
@@ -48,7 +48,7 @@ method start*(
   ## start the transport
   ##
 
-  info "Transport starting", addresses = addrs.shortLog
+  info "Transport starting", addresses = addrs
   self.addrs = addrs
   self.running = true
   self.onRunning.fire()
@@ -58,7 +58,7 @@ method stop*(self: Transport) {.base, async: (raises: []).} =
   ## including all outstanding connections
   ##
 
-  info "Transport stopping", addresses = self.addrs.shortLog
+  info "Transport stopping", addresses = self.addrs
   self.running = false
   self.onStop.fire()
 

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -417,7 +417,7 @@ method start*(
   await procCall Transport(self).start(resolvedAddrs)
   self.acceptLoop = self.wsAcceptDispatcher()
 
-  trace "Listening on", addresses = self.addrs.shortLog
+  trace "Listening on", addresses = self.addrs
 
 method stop*(self: WsTransport) {.async: (raises: []).} =
   ## stop the transport

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -414,7 +414,7 @@ method start*(
   await procCall Transport(self).start(resolvedAddrs)
   self.acceptLoop = self.wsAcceptDispatcher()
 
-  trace "Listening on", addresses = self.addrs
+  trace "Listening on", addresses = self.addrs.shortLog
 
 method stop*(self: WsTransport) {.async: (raises: []).} =
   ## stop the transport

--- a/libp2p/utils/shortlog.nim
+++ b/libp2p/utils/shortlog.nim
@@ -6,7 +6,7 @@
 import stew/byteutils
 
 const ShortDumpMax = 12
-const ShortCollectionMax* = 3
+const ShortCollectionMax* = 5
 
 func shortLog*(item: seq[byte]): string =
   if item.len <= ShortDumpMax:

--- a/libp2p/utils/shortlog.nim
+++ b/libp2p/utils/shortlog.nim
@@ -50,7 +50,7 @@ func shortLog*(item: string): string =
 func shortLog*[T](items: openArray[T], maxItems = ShortCollectionMax): string =
   ## Render a bounded collection preview without falling back to an unbounded
   ## ``$items`` representation. Elements with their own ``shortLog`` overload
-  ## retain a useful preview; all other elements are deliberately summarized.
+  ## retain a useful preview.
   let limit = min(items.len, maxItems)
   var res = newStringOfCap(limit * ShortDumpMax)
   res.add('[')

--- a/libp2p/utils/shortlog.nim
+++ b/libp2p/utils/shortlog.nim
@@ -6,6 +6,7 @@
 import stew/byteutils
 
 const ShortDumpMax = 12
+const ShortCollectionMax* = 3
 
 func shortLog*(item: seq[byte]): string =
   if item.len <= ShortDumpMax:
@@ -45,3 +46,24 @@ func shortLog*(item: string): string =
     s &= "..."
     s &= item[(item.len - split) .. item.high]
     s
+
+func shortLog*[T](items: openArray[T], maxItems = ShortCollectionMax): string =
+  ## Render a bounded collection preview without falling back to an unbounded
+  ## ``$items`` representation. Elements with their own ``shortLog`` overload
+  ## retain a useful preview; all other elements are deliberately summarized.
+  let limit = min(items.len, maxItems)
+  var res = newStringOfCap(limit * ShortDumpMax)
+  res.add('[')
+  for i in 0 ..< limit:
+    if i > 0:
+      res.add(", ")
+    when compiles(shortLog(items[i])):
+      res.add($shortLog(items[i]))
+    else:
+      res.add($items[i])
+  res.add(']')
+  if items.len > maxItems:
+    res.add("...(+")
+    res.add($(items.len - maxItems))
+    res.add(" more)")
+  res

--- a/tools/audit_log_fields.py
+++ b/tools/audit_log_fields.py
@@ -22,6 +22,17 @@ UNBOUNDED_FIELD = re.compile(
 )
 FIELD_ASSIGNMENT = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*=")
 FIELD_NAME = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)")
+SHORTLOG_TYPE = re.compile(r"^func shortLog\*?\([^:]+:\s*([^)=]+)", re.MULTILINE)
+FORMATIT = re.compile(
+    r"chronicles\.formatIt\(([^)]+)\):\s*\n\s*(?:shortLog\(it\)|it\.shortLog)"
+)
+DECLARATION = re.compile(r"\b(?:let|var)\s+(\w+)\s*:\s*([^=\n]+)")
+INFERRED_DECLARATION = re.compile(r"\b(?:let|var)\s+(\w+)\s*=\s*(\w+)\.")
+PARAMETER = re.compile(r"\b(\w+)\s*:\s*([\w\[\], |]+)")
+FIELD_DECLARATION = re.compile(
+    r"^\s*(\w+)\*?\s*(?:\{[^}]+\})?\s*:\s*([^=\n]+)", re.MULTILINE
+)
+RETURN_TYPE = re.compile(r"\b(?:func|proc)\s+(\w+)\*?\([^)]*\)\s*:\s*([^=\n{]+)")
 
 # These established identifiers are clearer than a longer expansion in their
 # logging contexts. Every other log field name must be at least three
@@ -123,9 +134,74 @@ def short_positional_fields(block: str):
             yield name
 
 
+def normalized_type(type_name: str) -> str:
+    return re.sub(r"\s+", "", type_name).split(",", 1)[0].rstrip("*")
+
+
+def source_types(paths):
+    """Return types with a compact Chronicles formatter and simple declarations.
+
+    This deliberately handles only declarations visible in Nim source. If an
+    expression cannot be resolved, the audit keeps requiring explicit
+    ``shortLog`` rather than guessing from a field name.
+    """
+    shortlog_types = set()
+    formatter_types = set()
+    declarations = {}
+    fields = {}
+    returns = {}
+    for path in paths:
+        text = path.read_text()
+        shortlog_types.update(normalized_type(t) for t in SHORTLOG_TYPE.findall(text))
+        formatter_types.update(normalized_type(t) for t in FORMATIT.findall(text))
+        for name, type_name in FIELD_DECLARATION.findall(text):
+            fields.setdefault(name, set()).add(normalized_type(type_name))
+        for name, type_name in RETURN_TYPE.findall(text):
+            returns[name] = normalized_type(type_name)
+
+    for path in paths:
+        text = path.read_text()
+        values = declarations.setdefault(path, {})
+        for name, type_name in PARAMETER.findall(text):
+            values.setdefault(name, set()).add(normalized_type(type_name))
+        for name, type_name in DECLARATION.findall(text):
+            values.setdefault(name, set()).add(normalized_type(type_name))
+        for name, constructor in INFERRED_DECLARATION.findall(text):
+            values.setdefault(name, set()).add(constructor)
+        for name, expression in re.findall(r"\b(?:let|var)\s+(\w+)\s*=\s*([^\n]+)", text):
+            for field_name in re.findall(r"\.(\w+)", expression):
+                candidates = fields.get(field_name, set())
+                if len(candidates) == 1:
+                    values.setdefault(name, set()).add(next(iter(candidates)))
+            callee = re.match(r"(?:await\s+)?(\w+)\(", expression.strip())
+            if callee and callee.group(1) in returns:
+                values.setdefault(name, set()).add(returns[callee.group(1)])
+
+    return shortlog_types & formatter_types, declarations, fields
+
+
+def has_compact_formatter(value: str, declarations, fields) -> bool:
+    """Whether a simple log expression resolves to a compact formatter type."""
+    value = value.strip()
+    if value in declarations:
+        if declarations[value] & COMPACT_FORMAT_TYPES:
+            return True
+    if value in fields:
+        return bool(fields[value] & COMPACT_FORMAT_TYPES)
+    if "addr" in value.lower():
+        return "seq[MultiAddress]" in COMPACT_FORMAT_TYPES
+    field_names = re.findall(r"\.(\w+)", value)
+    if field_names:
+        return any(fields.get(name, set()) & COMPACT_FORMAT_TYPES for name in field_names)
+    return False
+
+
 def main() -> int:
     violations = []
-    for path in ROOT.joinpath("libp2p").rglob("*.nim"):
+    paths = list(ROOT.joinpath("libp2p").rglob("*.nim"))
+    global COMPACT_FORMAT_TYPES
+    COMPACT_FORMAT_TYPES, declarations, fields = source_types(paths)
+    for path in paths:
         for line, level, block in log_blocks(path):
             if EXCEPTION_ALIAS.search(block):
                 violations.append(
@@ -140,7 +216,11 @@ def main() -> int:
             # is intentionally structural; it only checks field names that
             # conventionally carry byte arrays or unbounded protocol objects.
             for value in UNBOUNDED_FIELD.findall(block):
-                if "shortLog" not in value and ".len" not in value:
+                if (
+                    "shortLog" not in value
+                    and ".len" not in value
+                    and not has_compact_formatter(value, declarations[path], fields)
+                ):
                     violations.append(
                         f"{path.relative_to(ROOT)}:{line}: potentially unbounded log field must use shortLog"
                     )

--- a/tools/audit_log_fields.py
+++ b/tools/audit_log_fields.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""Reject deprecated Chronicle error fields, unsafe elevated payload logs and
-log fields whose names are too short to be useful (single/two characters)."""
+"""Reject unsafe Chronicle log fields and unhelpfully short field names."""
 
 from pathlib import Path
 import re
@@ -15,6 +14,11 @@ EXCEPTION_ALIAS = re.compile(
 PAYLOAD_FIELD = re.compile(
     r"\b(?:msg|message|buffer|record|reply|response|rpcMsg|data|encoded|"
     r"certificate|ticket|key)\s*="
+)
+UNBOUNDED_FIELD = re.compile(
+    r"\b(?:data|buffer|payload|encoded|certificate|ticket|signature|"
+    r"advertisement|msg|message|request|response|record|addresses|addrs)\s*="
+    r"\s*([^,\n]+)"
 )
 FIELD_ASSIGNMENT = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*=")
 FIELD_NAME = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)")
@@ -131,6 +135,15 @@ def main() -> int:
                 violations.append(
                     f"{path.relative_to(ROOT)}:{line}: elevated log contains payload field"
                 )
+            # Payloads and collections must be bounded even at trace/debug:
+            # peers can otherwise make a single event arbitrarily large. This
+            # is intentionally structural; it only checks field names that
+            # conventionally carry byte arrays or unbounded protocol objects.
+            for value in UNBOUNDED_FIELD.findall(block):
+                if "shortLog" not in value and ".len" not in value:
+                    violations.append(
+                        f"{path.relative_to(ROOT)}:{line}: potentially unbounded log field must use shortLog"
+                    )
             # Structured `name = value` fields ...
             for field_name in FIELD_ASSIGNMENT.findall(block):
                 if len(field_name) < 3 and field_name not in SHORT_FIELD_EXCEPTIONS:


### PR DESCRIPTION
this pr add `chronicles.formatIt` for all types that have `shortLog` to avoid calling `shortLog` when logging this type.

improved logging lint that will check if type has `formatIt`.