### PR TITLE
fix(service-discovery): stop publishing and dialing undialable addresses

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -105,6 +105,7 @@ type
     addressManagerConfig: Opt[AddressManagerConfig]
     enableWildcardResolver: bool
     addressPolicy: PeerAddressPolicy
+    allowUndialableAddrs: bool
 
 proc new*(T: type[SwitchBuilder]): T =
   ## Creates a SwitchBuilder
@@ -128,6 +129,7 @@ proc new*(T: type[SwitchBuilder]): T =
     identifyPusherEnabled: false,
     enableWildcardResolver: true,
     addressPolicy: defaultAddressPolicy,
+    allowUndialableAddrs: false,
     addressTtls: AddressConfidenceTtls(),
     addressManagerConfig: Opt.none(AddressManagerConfig),
   )
@@ -455,6 +457,11 @@ proc withAddressPolicy*(
   b.addressPolicy = addressPolicy
   b
 
+proc withUndialableAddresses*(b: SwitchBuilder, allow = true): SwitchBuilder =
+  ## Publishes, stores and dials a wildcard host and a port `0`, for a local test only.
+  b.allowUndialableAddrs = allow
+  b
+
 proc withPrivateAddressFilter*(b: SwitchBuilder): SwitchBuilder =
   ## Filter private (RFC1918/link-local) addresses from all peer address
   ## announcements and incoming peer address records. When enabled:
@@ -500,6 +507,7 @@ proc buildSwitch(b: SwitchBuilder): Switch {.raises: [LPError].} =
     else:
       PeerStore.new(identify, addressTtls = b.addressTtls)
   peerStore.addressPolicy = b.addressPolicy
+  peerStore.allowUndialableAddrs = b.allowUndialableAddrs
 
   var connManager = ConnManager.new(
     maxConnsPerPeer = b.maxConnsPerPeer,

--- a/libp2p/peeraddrpolicy.nim
+++ b/libp2p/peeraddrpolicy.nim
@@ -19,6 +19,12 @@ proc filterAddrs*(
 ): seq[MultiAddress] =
   addrs.filterIt(policy.accepts(it))
 
+proc dialableAddrs*(
+    policy: PeerAddressPolicy, addrs: openArray[MultiAddress]
+): seq[MultiAddress] =
+  ## A preset chooses `policy`, but no preset ever wants to dial `0.0.0.0`.
+  addrs.filterIt(isDialableMA(it) and policy(it))
+
 const publicRoutableAddressPolicy* = proc(
     ma: MultiAddress
 ): bool {.gcsafe, raises: [].} =

--- a/libp2p/peeraddrpolicy.nim
+++ b/libp2p/peeraddrpolicy.nim
@@ -20,10 +20,10 @@ proc filterAddrs*(
   addrs.filterIt(policy.accepts(it))
 
 proc dialableAddrs*(
-    policy: PeerAddressPolicy, addrs: openArray[MultiAddress]
+    policy: PeerAddressPolicy, addrs: openArray[MultiAddress], allowUndialable = false
 ): seq[MultiAddress] =
-  ## A preset chooses `policy`, but no preset ever wants to dial `0.0.0.0`.
-  addrs.filterIt(isDialableMA(it) and policy(it))
+  ## A preset chooses `policy`, and `allowUndialable` keeps `0.0.0.0` for a local test.
+  addrs.filterIt((allowUndialable or isDialableMA(it)) and policy(it))
 
 const publicRoutableAddressPolicy* = proc(
     ma: MultiAddress

--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -488,7 +488,7 @@ proc updatePeerInfo*(
     direction: Opt[Direction] = Opt.none(Direction),
 ) =
   if len(info.addrs) > 0:
-    let addrs = peerStore.addressPolicy.filterAddrs(info.addrs)
+    let addrs = peerStore.addressPolicy.dialableAddrs(info.addrs)
     if addrs.len > 0:
       peerStore[AddressBook].set(info.peerId, addrs, AddressConfidence.Medium)
     else:

--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -114,6 +114,7 @@ type
     toClean*: seq[PeerId]
     addressPolicy*: PeerAddressPolicy
       ## Gate on an inbound peer address: storage, redistribution, hole punch, lookup.
+    allowUndialableAddrs*: bool ## Local test setups store a wildcard host too.
     addressTtls*: AddressConfidenceTtls ## Per-confidence TTLs for address expiry.
     pruneHandle*: Future[void]
 
@@ -488,7 +489,8 @@ proc updatePeerInfo*(
     direction: Opt[Direction] = Opt.none(Direction),
 ) =
   if len(info.addrs) > 0:
-    let addrs = peerStore.addressPolicy.dialableAddrs(info.addrs)
+    let addrs =
+      peerStore.addressPolicy.dialableAddrs(info.addrs, peerStore.allowUndialableAddrs)
     if addrs.len > 0:
       peerStore[AddressBook].set(info.peerId, addrs, AddressConfidence.Medium)
     else:

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -71,7 +71,8 @@ proc admissibleAddrs(
     caps: DiversityCaps,
     pending: seq[PeerId] = @[],
 ): seq[MultiAddress] {.raises: [].} =
-  let addrs = addressPolicy.dialableAddrs(p.addrs)
+  let addrs =
+    addressPolicy.dialableAddrs(p.addrs, switch.peerStore.allowUndialableAddrs)
   if addrs.len == 0:
     return @[]
   if not switch.peerStore[AddressBook].hasIpDiversity(

--- a/libp2p/protocols/kademlia/find.nim
+++ b/libp2p/protocols/kademlia/find.nim
@@ -71,7 +71,7 @@ proc admissibleAddrs(
     caps: DiversityCaps,
     pending: seq[PeerId] = @[],
 ): seq[MultiAddress] {.raises: [].} =
-  let addrs = addressPolicy.filterAddrs(p.addrs)
+  let addrs = addressPolicy.dialableAddrs(p.addrs)
   if addrs.len == 0:
     return @[]
   if not switch.peerStore[AddressBook].hasIpDiversity(

--- a/libp2p/protocols/kademlia/probe_backoff.nim
+++ b/libp2p/protocols/kademlia/probe_backoff.nim
@@ -29,44 +29,62 @@ func probeAddrsDigest(addrs: seq[MultiAddress]): Hash =
     digest = digest + cast[uint64](hash(ma))
   cast[Hash](digest)
 
-proc probeBackedOff*(kad: KadDHT, peerId: PeerId, addrs: seq[MultiAddress]): bool =
+proc backedOff*(
+    failures: Table[PeerId, ProbeFailure], peerId: PeerId, addrs: seq[MultiAddress]
+): bool =
   ## An unprobed address set earns a probe, so a bogus address cannot hold back the real one.
-  let failure = kad.probeFailures.getOrDefault(peerId)
+  let failure = failures.getOrDefault(peerId)
   failure.count > 0 and Moment.now() < failure.until and
     failure.addrs == addrs.probeAddrsDigest()
 
-proc probePruneFailures(kad: KadDHT, now: Moment) =
+proc pruneFailures(failures: var Table[PeerId, ProbeFailure], now: Moment, cap: int) =
   ## Make room for one entry: elapsed backoffs first, then soonest to elapse.
-  let cap = kad.config.limits.maxProbeFailures
-  if kad.probeFailures.len < cap:
+  if failures.len < cap:
     return
 
-  for peerId in kad.probeFailures.keys().toSeq():
-    if now >= kad.probeFailures.getOrDefault(peerId).until:
-      kad.probeFailures.del(peerId)
+  for peerId in failures.keys().toSeq():
+    if now >= failures.getOrDefault(peerId).until:
+      failures.del(peerId)
 
-  let excess = kad.probeFailures.len - cap + 1
+  let excess = failures.len - cap + 1
   if excess <= 0:
     return
 
-  var byExpiry = kad.probeFailures.pairs().toSeq()
+  var byExpiry = failures.pairs().toSeq()
   byExpiry.sort(
     proc(a, b: (PeerId, ProbeFailure)): int =
       cmp(a[1].until, b[1].until)
   )
   for i in 0 ..< excess:
-    kad.probeFailures.del(byExpiry[i][0])
+    failures.del(byExpiry[i][0])
 
-proc probeRecordFailure*(kad: KadDHT, peerId: PeerId, addrs: seq[MultiAddress]) =
+proc recordFailure*(
+    failures: var Table[PeerId, ProbeFailure],
+    peerId: PeerId,
+    addrs: seq[MultiAddress],
+    base, cap: Duration,
+    maxEntries: int,
+): int {.discardable.} =
+  ## Returns the consecutive failure count the peer has now reached.
   let now = Moment.now()
-  let count = kad.probeFailures.getOrDefault(peerId).count + 1
+  let count = failures.getOrDefault(peerId).count + 1
   ## A repeat offender overwrites its own entry, so a prune would drop the count it just read.
   if count == 1:
-    kad.probePruneFailures(now)
-  kad.probeFailures[peerId] = ProbeFailure(
+    failures.pruneFailures(now, maxEntries)
+  failures[peerId] = ProbeFailure(
     count: count,
-    until: now + probeBackoff(count, kad.config.timeout, kad.config.probeBackoffMax),
+    until: now + probeBackoff(count, base, cap),
     addrs: addrs.probeAddrsDigest(),
+  )
+  count
+
+proc probeBackedOff*(kad: KadDHT, peerId: PeerId, addrs: seq[MultiAddress]): bool =
+  kad.probeFailures.backedOff(peerId, addrs)
+
+proc probeRecordFailure*(kad: KadDHT, peerId: PeerId, addrs: seq[MultiAddress]) =
+  kad.probeFailures.recordFailure(
+    peerId, addrs, kad.config.timeout, kad.config.probeBackoffMax,
+    kad.config.limits.maxProbeFailures,
   )
 
 proc probeClearFailures*(kad: KadDHT, peerId: PeerId) =

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -41,26 +41,30 @@ proc refreshSelfSignedPeerRecord(
   (await disco.putValue(key, Value.fromBytes(encodedSR))).isOkOr:
     debug "Failed to put signed peer record", err = error
 
-proc republishInFlight(disco: ServiceDiscovery): bool =
-  not disco.selfRecordRepublish.isNil() and not disco.selfRecordRepublish.finished()
-
 proc republishOnAddressChange(disco: ServiceDiscovery): PeerInfoObserver =
   ## Without this, a moved address stays stale in the DHT for a `bucketRefreshTime`.
   proc(p: PeerInfo) {.gcsafe, raises: [].} =
-    if disco.stopping or disco.republishInFlight():
-      return
+    disco.addressChanged.fire()
 
-    disco.selfRecordRepublish = disco.refreshSelfSignedPeerRecord()
-
-proc maintainSelfSignedPeerRecord(
+proc maintainSelfPublications(
     disco: ServiceDiscovery
 ) {.async: (raises: [CancelledError]).} =
-  heartbeat "refresh self signed peer record", disco.config.bucketRefreshTime:
-    if not await disco.refreshSelfSignedPeerRecord().withTimeout(
-      disco.config.bucketRefreshTime
-    ):
-      warn "Signed peer record refresh timed out",
-        timeout = disco.config.bucketRefreshTime
+  ## One publisher for both triggers: an address change never races the heartbeat.
+  var addressMoved = false
+  while true:
+    disco.addressChanged.clear()
+
+    let refresh = disco.config.bucketRefreshTime
+
+    if disco.xprPublishing:
+      if not await disco.refreshSelfSignedPeerRecord().withTimeout(refresh):
+        warn "Signed peer record refresh timed out", timeout = refresh
+
+    if addressMoved:
+      if not await disco.republishProvidedAdverts().withTimeout(refresh):
+        warn "Provided advert republish timed out", timeout = refresh
+
+    addressMoved = await disco.addressChanged.wait().withTimeout(refresh)
 
 proc maintainRegistrar(disco: ServiceDiscovery) {.async: (raises: [CancelledError]).} =
   heartbeat "prune expired advertisements",
@@ -107,6 +111,7 @@ proc new*(
     services: toHashSet(services),
     discoConfig: discoConfig,
     xprPublishing: xprPublishing,
+    addressChanged: newAsyncEvent(),
   )
   disco.initKadBase(
     switch,
@@ -183,14 +188,13 @@ method start*(disco: ServiceDiscovery) {.async: (raises: [CancelledError]).} =
 
   await procCall start(KadDHT(disco))
 
-  if disco.xprPublishing:
-    disco.selfSignedPeerRecordLoop = disco.maintainSelfSignedPeerRecord()
-    disco.addressObserver = disco.republishOnAddressChange()
-    disco.switch.peerInfo.addObserver(disco.addressObserver)
-
   for serviceInfo in disco.services:
     disco.addProvidedService(serviceInfo).isOkOr:
       warn "Cannot advertise configured service", err = error, service = serviceInfo.id
+
+  disco.addressObserver = disco.republishOnAddressChange()
+  disco.switch.peerInfo.addObserver(disco.addressObserver)
+  disco.selfPublicationLoop = disco.maintainSelfPublications()
 
   disco.pruneExpiredAdsLoop = disco.maintainRegistrar()
   disco.refreshServiceTablesLoop = disco.maintainServiceTables()
@@ -202,8 +206,15 @@ method stop*(disco: ServiceDiscovery) {.async: (raises: []).} =
   if not disco.started:
     return
 
-  # stops the advertiser maintenance loop before draining advertiser tasks, 
-  # so shutdown cannot spawn new registration work while cleanup is running
+  # every loop that schedules advertiser tasks stops before the drain below
+  if not disco.addressObserver.isNil():
+    disco.switch.peerInfo.removeObserver(disco.addressObserver)
+    disco.addressObserver = nil
+
+  if not disco.selfPublicationLoop.isNil:
+    await disco.selfPublicationLoop.cancelAndWait()
+    disco.selfPublicationLoop = nil
+
   if not disco.advertiserMaintenanceLoop.isNil:
     await disco.advertiserMaintenanceLoop.cancelAndWait()
     disco.advertiserMaintenanceLoop = nil
@@ -212,18 +223,6 @@ method stop*(disco: ServiceDiscovery) {.async: (raises: []).} =
 
   let serviceBootstrapFuts = move disco.serviceBootstrapFuts
   await noCancel serviceBootstrapFuts.values.toSeq().cancelAndWait()
-
-  if not disco.addressObserver.isNil():
-    disco.switch.peerInfo.removeObserver(disco.addressObserver)
-    disco.addressObserver = nil
-
-  if not disco.selfSignedPeerRecordLoop.isNil:
-    await disco.selfSignedPeerRecordLoop.cancelAndWait()
-    disco.selfSignedPeerRecordLoop = nil
-
-  if not disco.selfRecordRepublish.isNil:
-    await disco.selfRecordRepublish.cancelAndWait()
-    disco.selfRecordRepublish = nil
 
   if not disco.pruneExpiredAdsLoop.isNil:
     await disco.pruneExpiredAdsLoop.cancelAndWait()

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -41,6 +41,17 @@ proc refreshSelfSignedPeerRecord(
   (await disco.putValue(key, Value.fromBytes(encodedSR))).isOkOr:
     debug "Failed to put signed peer record", err = error
 
+proc republishInFlight(disco: ServiceDiscovery): bool =
+  not disco.selfRecordRepublish.isNil() and not disco.selfRecordRepublish.finished()
+
+proc republishOnAddressChange(disco: ServiceDiscovery): PeerInfoObserver =
+  ## Without this, a moved address stays stale in the DHT for a `bucketRefreshTime`.
+  proc(p: PeerInfo) {.gcsafe, raises: [].} =
+    if disco.stopping or disco.republishInFlight():
+      return
+
+    disco.selfRecordRepublish = disco.refreshSelfSignedPeerRecord()
+
 proc maintainSelfSignedPeerRecord(
     disco: ServiceDiscovery
 ) {.async: (raises: [CancelledError]).} =
@@ -174,6 +185,8 @@ method start*(disco: ServiceDiscovery) {.async: (raises: [CancelledError]).} =
 
   if disco.xprPublishing:
     disco.selfSignedPeerRecordLoop = disco.maintainSelfSignedPeerRecord()
+    disco.addressObserver = disco.republishOnAddressChange()
+    disco.switch.peerInfo.addObserver(disco.addressObserver)
 
   for serviceInfo in disco.services:
     disco.addProvidedService(serviceInfo).isOkOr:
@@ -200,9 +213,17 @@ method stop*(disco: ServiceDiscovery) {.async: (raises: []).} =
   let serviceBootstrapFuts = move disco.serviceBootstrapFuts
   await noCancel serviceBootstrapFuts.values.toSeq().cancelAndWait()
 
+  if not disco.addressObserver.isNil():
+    disco.switch.peerInfo.removeObserver(disco.addressObserver)
+    disco.addressObserver = nil
+
   if not disco.selfSignedPeerRecordLoop.isNil:
     await disco.selfSignedPeerRecordLoop.cancelAndWait()
     disco.selfSignedPeerRecordLoop = nil
+
+  if not disco.selfRecordRepublish.isNil:
+    await disco.selfRecordRepublish.cancelAndWait()
+    disco.selfRecordRepublish = nil
 
   if not disco.pruneExpiredAdsLoop.isNil:
     await disco.pruneExpiredAdsLoop.cancelAndWait()

--- a/libp2p/protocols/service_discovery/advertiser.nim
+++ b/libp2p/protocols/service_discovery/advertiser.nim
@@ -20,7 +20,7 @@ type RegistrationResponse* = object
   ticket*: Opt[Ticket]
   closerPeers*: seq[PeerInfo]
 
-proc clear*(a: Advertiser) {.async: (raises: []).} =
+proc cancelRunningTasks(a: Advertiser) {.async: (raises: []).} =
   var running = move a.running
   var runningFuts: seq[Future[void]]
   for task in running:
@@ -28,8 +28,11 @@ proc clear*(a: Advertiser) {.async: (raises: []).} =
 
   await runningFuts.cancelAndWait()
 
-  a.providedAdverts = initTable[ServiceId, seq[byte]]()
   cd_advertiser_pending_actions.set(0)
+
+proc clear*(a: Advertiser) {.async: (raises: []).} =
+  await a.cancelRunningTasks()
+  a.providedAdverts = initTable[ServiceId, ProvidedAdvert]()
 
 proc cleanupFinishedTasks(a: Advertiser) =
   var toRemove: HashSet[AdvertiseTask]
@@ -52,7 +55,7 @@ proc getAdvertBytes(disco: ServiceDiscovery, explicit: Opt[seq[byte]]): Opt[seq[
 proc advertFor(disco: ServiceDiscovery, serviceId: ServiceId): seq[byte] =
   ## The bytes stored when the service was added, a fresh record only after a clear().
   disco.advertiser.providedAdverts.withValue(serviceId, stored):
-    return stored[]
+    return stored[].bytes
 
   disco.getAdvertBytes(Opt.none(seq[byte])).get(@[])
 
@@ -187,6 +190,28 @@ proc maintainRegistrations*(
   if disco.services.len > 0 and
       (disco.localRegistrationLoop.isNil or disco.localRegistrationLoop.finished):
     disco.startLocalRegistration()
+
+proc republishProvidedAdverts*(
+    disco: ServiceDiscovery
+) {.async: (raises: [CancelledError]).} =
+  ## Registrars keep serving the bytes cached at `addProvidedService`.
+  let fresh = disco.getAdvertBytes(Opt.none(seq[byte])).valueOr:
+    return
+
+  var refreshed = false
+  for advert in disco.advertiser.providedAdverts.mvalues:
+    if advert.callerSupplied:
+      continue
+    advert.bytes = fresh
+    refreshed = true
+
+  if not refreshed:
+    return
+
+  await disco.advertiser.cancelRunningTasks()
+  await disco.stopLocalRegistration()
+  disco.startLocalRegistration()
+  await disco.maintainRegistrations()
 
 proc maintainAdvertiser*(
     disco: ServiceDiscovery
@@ -397,7 +422,8 @@ proc addProvidedService*(
     return err("cannot build the extended peer record to advertise")
 
   # Rotations reuse these bytes; a later seqNo would duplicate this node in a lookup.
-  disco.advertiser.providedAdverts[serviceId] = advertBytes
+  disco.advertiser.providedAdverts[serviceId] =
+    ProvidedAdvert(bytes: advertBytes, callerSupplied: advert.isSome())
 
   debug "Added provided service", service = service.id, serviceId
   cd_advertiser_services_added.inc()

--- a/libp2p/protocols/service_discovery/connection.nim
+++ b/libp2p/protocols/service_discovery/connection.nim
@@ -6,7 +6,7 @@ import chronos, chronicles, results
 import ../../[peerid, switch, multiaddress, extended_peer_record]
 import ../kademlia
 import ../kademlia/types
-import ./[types, service_discovery_metrics, registrar]
+import ./[types, service_discovery_metrics, registrar, dial_backoff]
 
 logScope:
   topics = "service-disco connection"
@@ -26,11 +26,17 @@ proc send*(
   if addrs.len == 0:
     return err("no address found for peer: " & $peerId)
 
+  if disco.dialBackedOff(peerId, addrs):
+    return err("peer is in dial backoff: " & $peerId)
+
   let stream =
     try:
       await disco.switch.dial(peerId, addrs, disco.codec)
     except DialFailedError as e:
+      disco.recordDialFailure(peerId, addrs)
       return err("dialing peer failed: " & e.msg)
+  disco.clearDialFailures(peerId)
+
   var replyRead = false
   defer:
     # Closing only half-closes the channel: an abandoned RPC leaves its unread

--- a/libp2p/protocols/service_discovery/connection.nim
+++ b/libp2p/protocols/service_discovery/connection.nim
@@ -35,7 +35,6 @@ proc send*(
     except DialFailedError as e:
       disco.recordDialFailure(peerId, addrs)
       return err("dialing peer failed: " & e.msg)
-  disco.clearDialFailures(peerId)
 
   var replyRead = false
   defer:
@@ -57,10 +56,12 @@ proc send*(
     try:
       await stream.writeLp(encodedMsg)
     except LPStreamError as e:
+      disco.recordDialFailure(peerId, addrs)
       return err("connection writing failed: " & e.msg)
     try:
       replyBuf = await stream.readLp(ServiceDiscoveryMaxMsgSize)
     except LPStreamError as e:
+      disco.recordDialFailure(peerId, addrs)
       return err("connection reading failed: " & e.msg)
   replyRead = true
 
@@ -68,8 +69,10 @@ proc send*(
   cd_message_bytes_received.inc(replyBuf.len.float64, labelValues = [$msg.msgType])
 
   let reply = Message.decode(replyBuf).valueOr:
+    disco.recordDialFailure(peerId, addrs)
     return err("failed to decode message response: " & $error)
 
+  disco.clearDialFailures(peerId)
   return ok(reply)
 
 proc handleMessage*(

--- a/libp2p/protocols/service_discovery/dial_backoff.nim
+++ b/libp2p/protocols/service_discovery/dial_backoff.nim
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+## Hold back a peer whose service-discovery dial failed. An address policy
+## rejects an address no one can reach; only the failure count catches a
+## well-formed public address that is simply dead.
+
+{.push raises: [].}
+
+import std/tables
+import ../../[multiaddress, peerid]
+import ../kademlia/[probe_backoff, types]
+import ./[routing_table_manager, types as disco_types]
+
+const MaxDialFailureEntries = 1024
+  ## Cache size of failed dials; its keys come from remote replies.
+
+proc dialBackedOff*(
+    disco: ServiceDiscovery, peerId: PeerId, addrs: seq[MultiAddress]
+): bool =
+  disco.dialFailures.backedOff(peerId, addrs)
+
+proc clearDialFailures*(disco: ServiceDiscovery, peerId: PeerId) =
+  disco.dialFailures.del(peerId)
+
+proc recordDialFailure*(
+    disco: ServiceDiscovery, peerId: PeerId, addrs: seq[MultiAddress]
+) =
+  let count = disco.dialFailures.recordFailure(
+    peerId, addrs, disco.discoConfig.dialBackoffBase, disco.discoConfig.dialBackoffMax,
+    MaxDialFailureEntries,
+  )
+
+  # The entry outlives the eviction, so a re-admitted peer stays backed off.
+  if count >= disco.discoConfig.maxDialFailures:
+    disco.rtManager.removePeer(peerId, "unreachable")

--- a/libp2p/protocols/service_discovery/dial_backoff.nim
+++ b/libp2p/protocols/service_discovery/dial_backoff.nim
@@ -1,9 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-## Hold back a peer whose service-discovery dial failed. An address policy
-## rejects an address no one can reach; only the failure count catches a
-## well-formed public address that is simply dead.
+## Hold back a peer whose exchange failed anywhere from the dial to the decoded reply.
 
 {.push raises: [].}
 

--- a/libp2p/protocols/service_discovery/routing_table_manager.nim
+++ b/libp2p/protocols/service_discovery/routing_table_manager.nim
@@ -103,6 +103,7 @@ proc removePeer*(manager: ServiceRoutingTableManager, peerId: PeerId, reason: st
   ## The main Kad table is left alone; it runs its own liveness probes.
   for table in manager.tables.values:
     discard table.removePeer(peerId, reason)
+  manager.updateServiceTablesMetrics()
 
 proc insertPeer*(
     disco: ServiceDiscovery, serviceId: ServiceId, peerInfo: PeerInfo
@@ -111,7 +112,9 @@ proc insertPeer*(
     return false
 
   let addressBook = disco.switch.peerStore[AddressBook]
-  let addrs = disco.config.addressPolicy.dialableAddrs(peerInfo.addrs)
+  let addrs = disco.config.addressPolicy.dialableAddrs(
+    peerInfo.addrs, disco.switch.peerStore.allowUndialableAddrs
+  )
   if addrs.len == 0:
     return false
   if not addressBook.hasIpDiversity(

--- a/libp2p/protocols/service_discovery/routing_table_manager.nim
+++ b/libp2p/protocols/service_discovery/routing_table_manager.nim
@@ -99,6 +99,11 @@ proc getTable*(
 
   return Opt.some(table)
 
+proc removePeer*(manager: ServiceRoutingTableManager, peerId: PeerId, reason: string) =
+  ## The main Kad table is left alone; it runs its own liveness probes.
+  for table in manager.tables.values:
+    discard table.removePeer(peerId, reason)
+
 proc insertPeer*(
     disco: ServiceDiscovery, serviceId: ServiceId, peerInfo: PeerInfo
 ): bool =
@@ -106,7 +111,7 @@ proc insertPeer*(
     return false
 
   let addressBook = disco.switch.peerStore[AddressBook]
-  let addrs = disco.config.addressPolicy.filterAddrs(peerInfo.addrs)
+  let addrs = disco.config.addressPolicy.dialableAddrs(peerInfo.addrs)
   if addrs.len == 0:
     return false
   if not addressBook.hasIpDiversity(

--- a/libp2p/protocols/service_discovery/types.nim
+++ b/libp2p/protocols/service_discovery/types.nim
@@ -79,10 +79,14 @@ type
     registrar*: PeerId
     bucketIdx*: int
 
+  ProvidedAdvert* = object
+    bytes*: seq[byte]
+    callerSupplied*: bool ## Bytes we did not build carry addresses we cannot refresh.
+
   Advertiser* = ref object
     running*: HashSet[AdvertiseTask]
     seqNo*: uint64
-    providedAdverts*: Table[ServiceId, seq[byte]]
+    providedAdverts*: Table[ServiceId, ProvidedAdvert]
 
   ServiceDiscoveryConfig* = object
     kRegister*: int
@@ -97,8 +101,7 @@ type
     registrationWindow*: Duration
     bucketsCount*: int
     dialBackoffBase*: Duration
-    dialBackoffMax*: Duration
-      ## Cap of the doubling dial backoff, reached only above 5 failures.
+    dialBackoffMax*: Duration ## Cap of the exponential dial backoff.
     maxDialFailures*: int
       ## Consecutive failed dials before the peer leaves every service table.
 
@@ -132,13 +135,13 @@ type
     discoConfig*: ServiceDiscoveryConfig
       # can't use name "config", clashes with KadDHT's config
     xprPublishing*: bool
-    selfSignedPeerRecordLoop*: Future[void]
+    selfPublicationLoop*: Future[void]
     pruneExpiredAdsLoop*: Future[void]
     refreshServiceTablesLoop*: Future[void]
     advertiserMaintenanceLoop*: Future[void]
     localRegistrationLoop*: Future[void]
     serviceBootstrapFuts*: Table[ServiceId, Future[void]]
-    selfRecordRepublish*: Future[void]
+    addressChanged*: AsyncEvent
     addressObserver*: PeerInfoObserver
     dialFailures*: Table[PeerId, ProbeFailure]
 
@@ -163,6 +166,7 @@ proc new*(
   doAssert ipSimCoefficient >= 0.0, "ipSimCoefficient must be >= 0"
   doAssert maxDialFailures > 0, "maxDialFailures must be > 0"
   doAssert dialBackoffBase > 0.nanoseconds, "dialBackoffBase must be > 0"
+  doAssert dialBackoffMax > 0.nanoseconds, "dialBackoffMax must be > 0"
   ServiceDiscoveryConfig(
     kRegister: kRegister,
     kLookup: kLookup,
@@ -225,7 +229,7 @@ proc new*(T: typedesc[Advertiser]): T =
   T(
     running: initHashSet[AdvertiseTask](),
     seqNo: Moment.now().epochSeconds.uint64,
-    providedAdverts: initTable[ServiceId, seq[byte]](),
+    providedAdverts: initTable[ServiceId, ProvidedAdvert](),
   )
 
 proc toKey*(service: ServiceInfo): Key =
@@ -282,7 +286,9 @@ method select*(
 
 proc record*(disco: ServiceDiscovery): Result[SignedExtendedPeerRecord, string] =
   let peerInfo = disco.switch.peerInfo
-  let filteredAddresses = disco.config.addressPolicy.dialableAddrs(peerInfo.addrs)
+  let filteredAddresses = disco.config.addressPolicy.dialableAddrs(
+    peerInfo.addrs, disco.switch.peerStore.allowUndialableAddrs
+  )
   # Before the transports bind, `addrs` still holds the raw listen address.
   if filteredAddresses.len == 0:
     return err("no dialable address to publish yet")

--- a/libp2p/protocols/service_discovery/types.nim
+++ b/libp2p/protocols/service_discovery/types.nim
@@ -34,6 +34,9 @@ const
   Default_Delta* = 1.secs
   Default_M_buckets* = 16
   Default_IpSimCoefficient* = 1.0
+  Default_DialBackoffBase* = 30.secs
+  Default_DialBackoffMax* = 30.minutes
+  Default_MaxDialFailures* = 5
 
 type
   ServiceId* = Key
@@ -93,6 +96,11 @@ type
     ipSimCoefficient*: float64
     registrationWindow*: Duration
     bucketsCount*: int
+    dialBackoffBase*: Duration
+    dialBackoffMax*: Duration
+      ## Cap of the doubling dial backoff, reached only above 5 failures.
+    maxDialFailures*: int
+      ## Consecutive failed dials before the peer leaves every service table.
 
   DiscoverySource* = enum
     FromLookup
@@ -130,6 +138,9 @@ type
     advertiserMaintenanceLoop*: Future[void]
     localRegistrationLoop*: Future[void]
     serviceBootstrapFuts*: Table[ServiceId, Future[void]]
+    selfRecordRepublish*: Future[void]
+    addressObserver*: PeerInfoObserver
+    dialFailures*: Table[PeerId, ProbeFailure]
 
 proc new*(
     T: typedesc[ServiceDiscoveryConfig],
@@ -144,9 +155,14 @@ proc new*(
     ipSimCoefficient = Default_IpSimCoefficient,
     registrationWindow = Default_Delta,
     bucketsCount = Default_M_buckets,
+    dialBackoffBase = Default_DialBackoffBase,
+    dialBackoffMax = Default_DialBackoffMax,
+    maxDialFailures = Default_MaxDialFailures,
 ): T {.raises: [].} =
   doAssert advertCacheCap > 0, "advertCacheCap must be > 0"
   doAssert ipSimCoefficient >= 0.0, "ipSimCoefficient must be >= 0"
+  doAssert maxDialFailures > 0, "maxDialFailures must be > 0"
+  doAssert dialBackoffBase > 0.nanoseconds, "dialBackoffBase must be > 0"
   ServiceDiscoveryConfig(
     kRegister: kRegister,
     kLookup: kLookup,
@@ -159,6 +175,9 @@ proc new*(
     ipSimCoefficient: ipSimCoefficient,
     registrationWindow: registrationWindow,
     bucketsCount: bucketsCount,
+    dialBackoffBase: dialBackoffBase,
+    dialBackoffMax: dialBackoffMax,
+    maxDialFailures: maxDialFailures,
   )
 
 proc hash*(t: AdvertiseTask): Hash =
@@ -263,7 +282,10 @@ method select*(
 
 proc record*(disco: ServiceDiscovery): Result[SignedExtendedPeerRecord, string] =
   let peerInfo = disco.switch.peerInfo
-  let filteredAddresses = disco.config.addressPolicy.filterAddrs(peerInfo.addrs)
+  let filteredAddresses = disco.config.addressPolicy.dialableAddrs(peerInfo.addrs)
+  # Before the transports bind, `addrs` still holds the raw listen address.
+  if filteredAddresses.len == 0:
+    return err("no dialable address to publish yet")
 
   let peerRecord = ExtendedPeerRecord.init(
     peerId = peerInfo.peerId,

--- a/libp2p/wire.nim
+++ b/libp2p/wire.nim
@@ -187,3 +187,23 @@ proc isPrivateMA*(ma: MultiAddress): bool =
     return false
 
   hostIP.isPrivate() or hostIP.isShared() or hostIP.isLinkLocal()
+
+const AnyAddress4Mapped = [0'u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0, 0, 0, 0]
+  ## ``::ffff:0.0.0.0``, the IPv4-mapped spelling of the wildcard host.
+
+proc isDialableMA*(ma: MultiAddress): bool =
+  ## False for a wildcard bind host (``0.0.0.0`` / ``::``) or an unresolved ephemeral port.
+  if isCircuitRelayMA(ma):
+    return true
+
+  let hostIP = initTAddress(ma).valueOr:
+    return true
+
+  case hostIP.family
+  of AddressFamily.IPv4:
+    hostIP.port != Port(0) and hostIP.address_v4 != AnyAddress.address_v4
+  of AddressFamily.IPv6:
+    hostIP.port != Port(0) and hostIP.address_v6 != AnyAddress6.address_v6 and
+      hostIP.address_v6 != AnyAddress4Mapped
+  else:
+    true

--- a/libp2p/wire.nim
+++ b/libp2p/wire.nim
@@ -188,22 +188,34 @@ proc isPrivateMA*(ma: MultiAddress): bool =
 
   hostIP.isPrivate() or hostIP.isShared() or hostIP.isLinkLocal()
 
-const AnyAddress4Mapped = [0'u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0, 0, 0, 0]
-  ## ``::ffff:0.0.0.0``, the IPv4-mapped spelling of the wildcard host.
+const
+  AnyAddressV4 = [0'u8, 0, 0, 0]
+  AnyAddressV6 = [0'u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+  AnyAddressV4Mapped = [0'u8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0, 0, 0, 0]
+    ## ``::ffff:0.0.0.0``, the IPv4-mapped spelling of the wildcard host.
+
+proc portOf(ma: MultiAddress): Opt[Port] =
+  for codec in [multiCodec("tcp"), multiCodec("udp")]:
+    let arg = ma.getProtocolArgument(codec).valueOr:
+      continue
+    if arg.len == 2:
+      return Opt.some(Port(uint16.fromBytesBE(arg)))
+  Opt.none(Port)
 
 proc isDialableMA*(ma: MultiAddress): bool =
   ## False for a wildcard bind host (``0.0.0.0`` / ``::``) or an unresolved ephemeral port.
   if isCircuitRelayMA(ma):
     return true
 
-  let hostIP = initTAddress(ma).valueOr:
-    return true
+  ma.portOf().withValue(port):
+    if port == Port(0):
+      return false
 
-  case hostIP.family
-  of AddressFamily.IPv4:
-    hostIP.port != Port(0) and hostIP.address_v4 != AnyAddress.address_v4
-  of AddressFamily.IPv6:
-    hostIP.port != Port(0) and hostIP.address_v6 != AnyAddress6.address_v6 and
-      hostIP.address_v6 != AnyAddress4Mapped
-  else:
-    true
+  ma.getIp().withValue(ip):
+    case ip.family
+    of IpAddressFamily.IPv4:
+      return ip.address_v4 != AnyAddressV4
+    of IpAddressFamily.IPv6:
+      return ip.address_v6 != AnyAddressV6 and ip.address_v6 != AnyAddressV4Mapped
+
+  true

--- a/tests/libp2p/service_discovery/component/test_disco_dial_backoff.nim
+++ b/tests/libp2p/service_discovery/component/test_disco_dial_backoff.nim
@@ -10,6 +10,7 @@ import
     protocols/kademlia,
     protocols/service_discovery/advertiser,
     protocols/service_discovery/connection,
+    protocols/service_discovery/dial_backoff,
     protocols/service_discovery/types,
     switch,
   ]
@@ -22,8 +23,9 @@ suite "Service Discovery Component - Dial Backoff":
     checkTrackers()
 
   asyncTest "an unreachable peer backs off, then leaves the service table":
+    # A backoff no test run can outlive keeps the assertions off the scheduler.
     let discoConfig = ServiceDiscoveryConfig.new(
-      dialBackoffBase = 1.millis, dialBackoffMax = 1.millis, maxDialFailures = 3
+      dialBackoffBase = 1.hours, dialBackoffMax = 1.hours, maxDialFailures = 3
     )
     let disco = setupServiceDiscoveryNode(discoConfig = discoConfig)
     startAndDeferStop(@[disco])
@@ -33,9 +35,8 @@ suite "Service Discovery Component - Dial Backoff":
     let table = disco.rtManager.getTable(service.id.hashServiceId()).get()
 
     let dead = randomPeerId()
-    disco.switch.peerStore[AddressBook].set(
-      dead, @[ma("/ip4/127.0.0.1/tcp/1")], AddressConfidence.Low
-    )
+    let deadAddrs = @[ma("/ip4/127.0.0.1/tcp/1")]
+    disco.switch.peerStore[AddressBook].set(dead, deadAddrs, AddressConfidence.Low)
     check table.insert(dead)
 
     let msg = kad_protobuf.Message(msgType: kad_protobuf.MessageType.ping)
@@ -48,9 +49,9 @@ suite "Service Discovery Component - Dial Backoff":
       strutils.contains(backedOff.error, "backoff")
       table.contains(dead.toKey())
 
+    # The gate blocks further dials, so the rest is recorded without a wait.
     for _ in 1 .. 2:
-      await sleepAsync(10.millis)
-      check (await disco.send(dead, msg)).isErr()
+      disco.recordDialFailure(dead, deadAddrs)
 
     check not table.contains(dead.toKey())
 

--- a/tests/libp2p/service_discovery/component/test_disco_dial_backoff.nim
+++ b/tests/libp2p/service_discovery/component/test_disco_dial_backoff.nim
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+{.used.}
+
+import std/strutils
+import chronos, results
+import
+  ../../../../libp2p/[
+    peerstore,
+    protocols/kademlia,
+    protocols/service_discovery/advertiser,
+    protocols/service_discovery/connection,
+    protocols/service_discovery/types,
+    switch,
+  ]
+import ../../../../libp2p/protocols/kademlia/protobuf as kad_protobuf
+import ../../../tools/[lifecycle, multiaddress, unittest]
+import ../utils
+
+suite "Service Discovery Component - Dial Backoff":
+  teardown:
+    checkTrackers()
+
+  asyncTest "an unreachable peer backs off, then leaves the service table":
+    let discoConfig = ServiceDiscoveryConfig.new(
+      dialBackoffBase = 1.millis, dialBackoffMax = 1.millis, maxDialFailures = 3
+    )
+    let disco = setupServiceDiscoveryNode(discoConfig = discoConfig)
+    startAndDeferStop(@[disco])
+
+    let service = makeServiceInfo()
+    check disco.addProvidedService(service).isOk()
+    let table = disco.rtManager.getTable(service.id.hashServiceId()).get()
+
+    let dead = randomPeerId()
+    disco.switch.peerStore[AddressBook].set(
+      dead, @[ma("/ip4/127.0.0.1/tcp/1")], AddressConfidence.Low
+    )
+    check table.insert(dead)
+
+    let msg = kad_protobuf.Message(msgType: kad_protobuf.MessageType.ping)
+
+    check (await disco.send(dead, msg)).isErr()
+
+    let backedOff = await disco.send(dead, msg)
+    check:
+      backedOff.isErr()
+      strutils.contains(backedOff.error, "backoff")
+      table.contains(dead.toKey())
+
+    for _ in 1 .. 2:
+      await sleepAsync(10.millis)
+      check (await disco.send(dead, msg)).isErr()
+
+    check not table.contains(dead.toKey())
+
+    # A re-admitted peer must stay backed off, or the eviction only restarts the loop.
+    check table.insert(dead)
+    let reAdmitted = await disco.send(dead, msg)
+    check:
+      reAdmitted.isErr()
+      strutils.contains(reAdmitted.error, "backoff")

--- a/tests/libp2p/service_discovery/test_advertiser.nim
+++ b/tests/libp2p/service_discovery/test_advertiser.nim
@@ -11,7 +11,7 @@ import
     protocols/service_discovery,
     protocols/service_discovery/advertiser,
   ]
-import ../../tools/unittest
+import ../../tools/[unittest, multiaddress]
 import ./utils
 
 suite "Advertiser - addProvidedService":
@@ -268,7 +268,8 @@ suite "Advertiser - removeProvidedService":
 
     disco.populateRoutingTable(1)
     check disco.addProvidedService(service).isOk()
-    check disco.registerInterest(service.id)
+    discard disco.registerInterest(service.id)
+    check disco.rtManager.serviceStatus[sid] == Both
 
     let bootstrapFut = newFuture[void]("test service bootstrap")
     disco.serviceBootstrapFuts[sid] = bootstrapFut
@@ -385,3 +386,25 @@ suite "Advertiser - record creation":
     let recDef = discoDef.record()
     check recDef.isOk()
     check recDef.get().data.addresses.len == 2
+
+  test "record creation drops addresses that no policy can make dialable":
+    let disco = setupServiceDiscoveryNode(services = @[makeServiceInfo("service")])
+    let routable = makeMultiAddress("10.0.0.1")
+    disco.switch.peerInfo.addrs =
+      @[ma("/ip4/0.0.0.0/tcp/60000"), ma("/ip4/127.0.0.1/tcp/0"), routable]
+
+    let rec = disco.record()
+    check rec.isOk()
+    let xprAddrs = rec.get().data.addresses
+    check:
+      xprAddrs.len == 1
+      xprAddrs[0].address == routable
+
+  test "record creation fails while nothing dialable is announced":
+    let disco = setupServiceDiscoveryNode(services = @[makeServiceInfo("service")])
+
+    disco.switch.peerInfo.addrs = @[ma("/ip4/0.0.0.0/tcp/60000")]
+    check disco.record().isErr()
+
+    disco.switch.peerInfo.addrs = @[]
+    check disco.record().isErr()

--- a/tests/libp2p/service_discovery/test_advertiser.nim
+++ b/tests/libp2p/service_discovery/test_advertiser.nim
@@ -36,7 +36,7 @@ suite "Advertiser - addProvidedService":
     disco.populateRoutingTable(1)
     check disco.addProvidedService(service).isOk()
 
-    let cached = disco.advertiser.providedAdverts[serviceId]
+    let cached = disco.advertiser.providedAdverts[serviceId].bytes
     let ad = Advertisement.decode(cached).get()
     check:
       ad.data.peerId == disco.switch.peerInfo.peerId
@@ -44,7 +44,37 @@ suite "Advertiser - addProvidedService":
 
     disco.switch.peerInfo.addrs = @[makeMultiAddress("10.0.0.2")]
     check disco.record().get().encode() != cached
-    check disco.advertiser.providedAdverts[serviceId] == cached
+    check disco.advertiser.providedAdverts[serviceId].bytes == cached
+
+  asyncTest "a moved address rebuilds the cached record":
+    let disco = setupServiceDiscoveryNode()
+    let service = makeServiceInfo()
+    let serviceId = service.id.hashServiceId()
+
+    check disco.addProvidedService(service).isOk()
+
+    let moved = makeMultiAddress("10.0.0.2")
+    disco.switch.peerInfo.addrs = @[moved]
+    await disco.republishProvidedAdverts()
+
+    let ad =
+      Advertisement.decode(disco.advertiser.providedAdverts[serviceId].bytes).get()
+    check:
+      ad.data.addresses.len == 1
+      ad.data.addresses[0].address == moved
+
+  asyncTest "a moved address keeps a caller-supplied advertisement":
+    let disco = setupServiceDiscoveryNode()
+    let service = makeServiceInfo()
+    let serviceId = service.id.hashServiceId()
+    let advert = makeAdvertisement(service.id).encode()
+
+    check disco.addProvidedService(service, Opt.some(advert)).isOk()
+
+    disco.switch.peerInfo.addrs = @[makeMultiAddress("10.0.0.2")]
+    await disco.republishProvidedAdverts()
+
+    check disco.advertiser.providedAdverts[serviceId].bytes == advert
 
   test "with empty routing table: creates table but schedules no actions":
     let disco = setupServiceDiscoveryNode()
@@ -155,7 +185,7 @@ suite "Advertiser - caller-supplied advertisement":
     disco.populateRoutingTable(1)
 
     check disco.addProvidedService(service, Opt.some(advert)).isOk()
-    check disco.advertiser.providedAdverts[service.id.hashServiceId()] == advert
+    check disco.advertiser.providedAdverts[service.id.hashServiceId()].bytes == advert
 
   test "rejects an advertisement that does not decode":
     let disco = setupServiceDiscoveryNode()
@@ -204,12 +234,12 @@ suite "Advertiser - caller-supplied advertisement":
 
     check disco.startAdvertising(service, Opt.some(first)).isOk()
     check disco.startAdvertising(service, Opt.some(second)).isErr()
-    check disco.advertiser.providedAdverts[serviceId] == first
+    check disco.advertiser.providedAdverts[serviceId].bytes == first
 
     await disco.stopAdvertising(service.id)
 
     check disco.startAdvertising(service, Opt.some(second)).isOk()
-    check disco.advertiser.providedAdverts[serviceId] == second
+    check disco.advertiser.providedAdverts[serviceId].bytes == second
 
 suite "Advertiser - maintainRegistrations":
   teardown:
@@ -387,7 +417,7 @@ suite "Advertiser - record creation":
     check recDef.isOk()
     check recDef.get().data.addresses.len == 2
 
-  test "record creation drops addresses that no policy can make dialable":
+  test "record creation drops an undialable address by default":
     let disco = setupServiceDiscoveryNode(services = @[makeServiceInfo("service")])
     let routable = makeMultiAddress("10.0.0.1")
     disco.switch.peerInfo.addrs =
@@ -408,3 +438,17 @@ suite "Advertiser - record creation":
 
     disco.switch.peerInfo.addrs = @[]
     check disco.record().isErr()
+
+  test "record creation keeps an undialable address for a local test network":
+    let disco = setupServiceDiscoveryNode(services = @[makeServiceInfo("service")])
+    disco.switch.peerStore.allowUndialableAddrs = true
+
+    let wildcard = ma("/ip4/0.0.0.0/tcp/60000")
+    disco.switch.peerInfo.addrs = @[wildcard]
+
+    let rec = disco.record()
+    check rec.isOk()
+    let xprAddrs = rec.get().data.addresses
+    check:
+      xprAddrs.len == 1
+      xprAddrs[0].address == wildcard

--- a/tests/libp2p/service_discovery/test_routing_table_manager.nim
+++ b/tests/libp2p/service_discovery/test_routing_table_manager.nim
@@ -9,7 +9,7 @@ import
   ../../../libp2p/protocols/kademlia,
   ../../../libp2p/protocols/service_discovery,
   ../../../libp2p/protocols/service_discovery/[types, routing_table_manager]
-import ../../tools/[lifecycle, unittest]
+import ../../tools/[lifecycle, multiaddress, unittest]
 import ../kademlia/[mock_kademlia, utils]
 import ./utils
 
@@ -304,6 +304,20 @@ suite "ServiceRoutingTableManager":
     let peerInfo = makePeerInfo()
     check not disco.insertPeer(serviceId, peerInfo)
     check not disco.hasPeerInServiceTable(serviceId, peerInfo.peerId)
+
+  test "insertPeer rejects an undialable address unless the switch allows it":
+    let disco = setupServiceDiscoveryNode()
+    let serviceId = makeServiceId(1)
+    check disco.rtManager.addService(
+      serviceId, disco.rtable, DefaultReplication, DefaultMaxBuckets, Interest
+    )
+
+    let peerInfo = makePeerInfo(addrs = @[ma("/ip4/0.0.0.0/tcp/60000")])
+    check not disco.insertPeer(serviceId, peerInfo)
+
+    disco.switch.peerStore.allowUndialableAddrs = true
+    check disco.insertPeer(serviceId, peerInfo)
+    check disco.hasPeerInServiceTable(serviceId, peerInfo.peerId)
 
   test "insertPeer on non-existent service is a no-op":
     let disco = setupServiceDiscoveryNode()

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -139,6 +139,10 @@ proc setupServiceDiscoveryNode*(
     mount: bool = true,
 ): ServiceDiscovery =
   let switch = createSwitch(privateKey, addresses)
+  # `peerInfo.addrs` only fills in on `switch.start()`, which most tests skip.
+  if switch.peerInfo.addrs.len == 0:
+    switch.peerInfo.addrs = @[makeMultiAddress("127.0.0.1")]
+
   let node = ServiceDiscovery.new(
     switch,
     bootstrapNodes = bootstrapNodes,

--- a/tests/libp2p/test_wire.nim
+++ b/tests/libp2p/test_wire.nim
@@ -192,3 +192,27 @@ suite "isGlobalMA":
   test "rejects a name":
     check not isGlobalMA(ma("/dns4/example.com/tcp/4001"))
     check not isGlobalMA(ma("/dns/example.com/tcp/4001"))
+
+suite "isDialableMA":
+  test "wildcard bind hosts are not dialable":
+    check not isDialableMA(ma("/ip4/0.0.0.0/tcp/60000"))
+    check not isDialableMA(ma("/ip6/::/tcp/60000"))
+    check not isDialableMA(ma("/ip6/::ffff:0.0.0.0/tcp/60000"))
+
+  test "an unresolved ephemeral port is not dialable":
+    check not isDialableMA(ma("/ip4/127.0.0.1/tcp/0"))
+    check not isDialableMA(ma("/ip4/1.1.1.1/tcp/0"))
+
+  test "private and loopback addresses stay dialable":
+    check isDialableMA(ma("/ip4/127.0.0.1/tcp/4001"))
+    check isDialableMA(ma("/ip4/192.168.1.87/tcp/59203"))
+    check isDialableMA(ma("/ip4/1.1.1.1/tcp/4001"))
+
+  test "non-wire addresses pass through":
+    check isDialableMA(ma("/dns4/example.com/tcp/4001"))
+    check isDialableMA(ma("/unix/tmp/socket"))
+    check isDialableMA(
+      ma(
+        "/ip4/0.0.0.0/tcp/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/p2p-circuit"
+      )
+    )

--- a/tests/libp2p/test_wire.nim
+++ b/tests/libp2p/test_wire.nim
@@ -202,6 +202,19 @@ suite "isDialableMA":
   test "an unresolved ephemeral port is not dialable":
     check not isDialableMA(ma("/ip4/127.0.0.1/tcp/0"))
     check not isDialableMA(ma("/ip4/1.1.1.1/tcp/0"))
+    check not isDialableMA(ma("/ip4/1.1.1.1/udp/0/quic-v1"))
+    check not isDialableMA(ma("/dns4/example.com/tcp/0"))
+
+  test "a terminal peer id does not hide the host or the port":
+    check not isDialableMA(
+      ma("/ip4/0.0.0.0/tcp/60000/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
+    )
+    check not isDialableMA(
+      ma("/ip4/1.1.1.1/tcp/0/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
+    )
+    check isDialableMA(
+      ma("/ip4/1.1.1.1/tcp/4001/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC")
+    )
 
   test "private and loopback addresses stay dialable":
     check isDialableMA(ma("/ip4/127.0.0.1/tcp/4001"))


### PR DESCRIPTION
A node floods its logs with `Dialing failed` on `/logos/service-discovery/1.0.0` against addresses nobody can reach, `/ip4/0.0.0.0/tcp/60000` and `/ip4/127.0.0.1/tcp/0`, and repeats it every discovery cycle. `ServiceDiscovery.record()` published `switch.peerInfo.addrs`, which holds the raw bind address until `switch.start()` resolves it, and nothing rejected such an address on the way in either, since `KadDHTConfig.addressPolicy` defaults to accepting everything.

New `isDialableMA` in `wire.nim` rejects a wildcard host and an unresolved port `0`; `peeraddrpolicy.dialableAddrs` pairs it with the configured policy and replaces `filterAddrs` wherever an address is stored to dial later. `record()` now fails rather than publish nothing dialable, an address change republishes at once instead of waiting for `bucketRefreshTime`, and `send` backs off a peer that will not answer, dropping it from the service tables after `maxDialFailures`. The policy itself stays the caller's choice, so a private testnet keeps its LAN peers.