### PR TITLE
fix(autotls): handle auth edge cases and clean up pending DNS queries

### DIFF
--- a/libp2p/autotls/acme/api.nim
+++ b/libp2p/autotls/acme/api.nim
@@ -491,7 +491,7 @@ proc checkChallengeCompleted*(
   for i in 0 .. retries:
     let checkResponse = await self.requestCheck(checkURL, ACMEChallengeCheck, key, kid)
     case checkResponse.chalStatus
-    of ACMEChallengeStatus.PENDING:
+    of ACMEChallengeStatus.PENDING, ACMEChallengeStatus.PROCESSING:
       await sleepAsync(checkResponse.retryAfter) # try again after some delay
     of ACMEChallengeStatus.VALID:
       return true

--- a/libp2p/autotls/broker.nim
+++ b/libp2p/autotls/broker.nim
@@ -70,7 +70,11 @@ proc sendChallenge*(
     self.registrationURL, peerInfo, payload, self.bearer
   )
   # remember the latest bearer in case the broker rotated it
-  self.bearer = Opt.some(bearer)
+  self.bearer =
+    if response.status == 401:
+      Opt.none(BearerToken)
+    else:
+      Opt.some(bearer)
 
   if response.status != HttpOk:
     raise newException(

--- a/libp2p/nameresolving/dnsresolver.nim
+++ b/libp2p/nameresolving/dnsresolver.nim
@@ -6,7 +6,7 @@
 import std/[sets, sequtils], chronos, chronicles, ./dnsmessage
 
 import nameresolver
-import ../crypto/rng
+import ../crypto/rng, ../utils/future
 
 logScope:
   topics = "libp2p dnsresolver"
@@ -77,6 +77,9 @@ method resolveIp*(
         responseFutures.insert(fut)
       else:
         responseFutures.add(fut)
+
+    defer:
+      await noCancel responseFutures.cancelAndWait()
 
     var
       resolvedAddresses: OrderedSet[string]

--- a/libp2p/peeridauth/client.nim
+++ b/libp2p/peeridauth/client.nim
@@ -54,30 +54,21 @@ type SigParam = object
 proc new*(T: typedesc[PeerIDAuthClient], rng: Rng): PeerIDAuthClient =
   PeerIDAuthClient(session: HttpSessionRef.new(), rng: rng)
 
-proc sampleChar(ctx: Rng, choices: string): char {.raises: [ValueError].} =
-  ## Samples a random character from the input string using the DRBG context
-  if choices.len == 0:
-    raise newException(ValueError, "Cannot sample from an empty string")
-  var idx: uint32
-  ctx.generate(idx)
-  return choices[uint32(idx mod uint32(choices.len))]
-
 proc randomChallenge(
     rng: Rng, challengeLen: int = ChallengeDefaultLen
-): PeerIDAuthChallenge {.raises: [PeerIDAuthError].} =
-  var challenge = ""
-  try:
-    for _ in 0 ..< challengeLen:
-      challenge.add(rng.sampleChar(ChallengeCharset))
-  except ValueError as exc:
-    raise newException(PeerIDAuthError, "Failed to generate challenge", exc)
+): PeerIDAuthChallenge =
+  var challenge = newString(challengeLen)
+  for c in challenge.mitems:
+    c = ChallengeCharset[rng.rand(0, ChallengeCharset.high)]
   PeerIDAuthChallenge(challenge)
 
 proc extractField(data, key: string): string {.raises: [PeerIDAuthError].} =
-  # Helper to extract quoted value from key
-  for segment in data.split(","):
-    if key in segment:
-      return segment.split("=", 1)[1].strip(chars = {' ', '"'})
+  var fields = data
+  fields.removePrefix(PeerIDAuthPrefix & " ")
+  for segment in fields.split(","):
+    let parts = segment.split("=", 1)
+    if parts.len == 2 and parts[0].strip() == key:
+      return parts[1].strip(chars = {' ', '"'})
   raise newException(PeerIDAuthError, "Failed to find " & key & " in " & data)
 
 proc genDataToSign(
@@ -220,10 +211,18 @@ proc pubkeyBytes*(pubkey: PublicKey): seq[byte] {.raises: [PeerIDAuthError].} =
     )
 
 proc parse3339DateTime(timeStr: string): DateTime {.raises: [ValueError].} =
-  let parts = timeStr.split('.')
-  let base = parse(parts[0], "yyyy-MM-dd'T'HH:mm:ss")
-  let millis = parseInt(parts[1].strip(chars = {'Z'}))
-  base + initDuration(milliseconds = millis)
+  if timeStr.len > 19 and timeStr[19] == '.':
+    var fractionEnd = 20
+    while fractionEnd < timeStr.len and timeStr[fractionEnd] in {'0' .. '9'}:
+      inc fractionEnd
+    let digits = fractionEnd - 20
+    if digits < 1 or digits > 9:
+      raise newException(ValueError, "Invalid fractional second")
+    let normalized =
+      timeStr[0 ..< fractionEnd] & repeat('0', 9 - digits) & timeStr[fractionEnd .. ^1]
+    parse(normalized, "yyyy-MM-dd'T'HH:mm:ss'.'fffffffffzzz", utc())
+  else:
+    parse(timeStr, "yyyy-MM-dd'T'HH:mm:sszzz", utc())
 
 proc requestAuthorization*(
     self: PeerIDAuthClient,

--- a/tests/libp2p/autotls/test_autotls.nim
+++ b/tests/libp2p/autotls/test_autotls.nim
@@ -81,6 +81,14 @@ suite "AutoTLS ACME API":
       completed == true
       api.requestedUris == @[parseUri(ChallengeURL), parseUri(ChallengeURL)]
 
+  asyncTest "challenge processing is polled until valid":
+    api.queueStatus("processing")
+    api.queueStatus("valid")
+    check await api.checkChallengeCompleted(
+      parseUri(ChallengeURL), key, "kid", retries = 1
+    )
+    check api.requestedUris == @[parseUri(ChallengeURL), parseUri(ChallengeURL)]
+
   asyncTest "challenge completed max retries reached":
     api.queueChallengeCompleted()
     discard await api.sendChallengeCompleted(parseUri(ChallengeURL), key, "kid")

--- a/tests/libp2p/autotls/test_broker.nim
+++ b/tests/libp2p/autotls/test_broker.nim
@@ -105,7 +105,7 @@ suite "AutoTLS broker":
 
     check client.authHeaders[1] == PeerIDAuthPrefix & " bearer=\"" & client.token & "\""
 
-  asyncTest "a 401 does not trigger re-authentication":
+  asyncTest "a 401 clears the bearer for the next registration":
     client.status = 401
 
     expect(AutoTLSError):
@@ -113,8 +113,7 @@ suite "AutoTLS broker":
     expect(AutoTLSError):
       await broker.sendChallenge(peerInfo, addrs, KeyAuth)
 
-    # TODO: vacp2p/nim-libp2p#2972
     check:
-      client.requestedUris.len == 3
+      client.requestedUris.len == 4
       client.authHeaders.len == 2
-      client.authHeaders[1] == PeerIDAuthPrefix & " bearer=\"" & client.token & "\""
+      client.authHeaders[1].startsWith(PeerIDAuthPrefix & " public-key=")

--- a/tests/libp2p/autotls/test_peer_id_auth.nim
+++ b/tests/libp2p/autotls/test_peer_id_auth.nim
@@ -123,30 +123,51 @@ suite "PeerID Auth Client":
     expect PeerIDAuthError:
       discard await client.send(parseUri(ExampleURL), peerInfo, "somepayload")
 
-  asyncTest "bearer expiry is parsed in local time":
-    # TODO: vacp2p/nim-libp2p#2975
+  asyncTest "bearer expiry is parsed in UTC":
     let expires =
       (await requestWithExpires("2026-08-21T12:00:00.000Z")).bearer.expires.get()
+    check expires == dateTime(2026, mAug, 21, 12, zone = utc())
+    check expires.timezone == utc()
 
-    check expires.timezone == local()
-    check expires.format("yyyy-MM-dd'T'HH:mm:ss") == "2026-08-21T12:00:00"
-
-  asyncTest "bearer expiry reads a nanosecond fraction as milliseconds":
-    # TODO: vacp2p/nim-libp2p#2975
-    let expires =
+  asyncTest "bearer expiry preserves fractional seconds":
+    let base = dateTime(2026, mAug, 21, 11, 36, 41, zone = utc())
+    let nanos =
       (await requestWithExpires("2026-08-21T11:36:41.621940726Z")).bearer.expires.get()
+    let tenths =
+      (await requestWithExpires("2026-08-21T11:36:41.1Z")).bearer.expires.get()
+    check nanos - base == initDuration(nanoseconds = 621_940_726)
+    check tenths - base == initDuration(milliseconds = 100)
 
-    check expires - dateTime(2026, mAug, 21, 11, 36, 41, zone = local()) ==
-      initDuration(milliseconds = 621_940_726)
+  asyncTest "bearer expiry accepts whole seconds and timezone offsets":
+    let expected = dateTime(2026, mAug, 21, 12, zone = utc())
+    check (await requestWithExpires("2026-08-21T12:00:00Z")).bearer.expires.get() ==
+      expected
+    check (await requestWithExpires("2026-08-21T14:00:00+02:00")).bearer.expires.get() ==
+      expected
 
-  asyncTest "bearer expiry without a fractional second is dropped":
-    # TODO: vacp2p/nim-libp2p#2975
-    check (await requestWithExpires("2026-08-21T12:00:00Z")).bearer.expires.isNone()
+  asyncTest "malformed bearer expiry is dropped":
+    for expires in ["2026-08-21T12:00:00", "2026-08-21T12:00:00.Z", "invalid"]:
+      check (await requestWithExpires(expires)).bearer.expires.isNone()
 
-  asyncTest "bearer expiry without a zone raises IndexDefect":
-    # TODO: vacp2p/nim-libp2p#2975
-    expect IndexDefect:
-      discard await requestWithExpires("2026-08-21T12:00:00")
+  asyncTest "authentication field without a value is rejected":
+    client.wwwAuthenticate = Opt.some(PeerIDAuthPrefix & " public-key")
+    expect PeerIDAuthError:
+      discard await client.requestAuthentication(parseUri(ExampleURL))
+
+  asyncTest "authentication fields match names rather than substrings":
+    client.authenticationInfo = Opt.some(
+      PeerIDAuthPrefix & " other-sig=\"wrong\", sig=\"right\", bearer=\"somebearer\""
+    )
+    let response = await client.requestAuthorization(
+      peerInfo,
+      parseUri(ExampleURL),
+      "challenge",
+      "challenge",
+      specServerKey.getPublicKey().get(),
+      "opaque",
+      "payload",
+    )
+    check response.sig == "right"
 
   asyncTest "a url the session cannot turn into an address is an http error":
     # The stub overrides post, so this drives the real one.

--- a/tests/libp2p/test_name_resolve.nim
+++ b/tests/libp2p/test_name_resolve.nim
@@ -302,3 +302,24 @@ suite "Name resolving":
     #   var dnsresolver = DnsResolver.new(@[initTAddress("172.67.10.161:0")])
     #   let invalid = await dnsresolver.resolveIp("google.fr", 0.Port)
     #   check invalid.len == 0
+
+  suite "DNS cancellation":
+    teardown:
+      checkTrackers()
+
+    asyncTest "cancelling a dual-stack lookup closes both query sockets":
+      let received = newAsyncEvent()
+      var queries = 0
+      proc discardQuery(
+          transp: DatagramTransport, raddr: TransportAddress
+      ) {.async: (raises: []).} =
+        inc queries
+        if queries == 2:
+          received.fire()
+
+      let server = newDatagramTransport(discardQuery)
+      let resolver = DnsResolver.new(@[server.localAddress])
+      let lookup = resolver.resolveIp("example.com", Port(0))
+      await received.wait().wait(1.seconds)
+      await lookup.cancelAndWait()
+      await server.closeWait()

--- a/tests/stubs/peer_id_auth_client_stub.nim
+++ b/tests/stubs/peer_id_auth_client_stub.nim
@@ -113,7 +113,8 @@ method post*(
     var expires = ""
     if self.expires.isSome():
       expires =
-        ", expires=\"" & self.expires.get().format("yyyy-MM-dd'T'HH:mm:ss") & ".000Z\""
+        ", expires=\"" & self.expires.get().utc.format("yyyy-MM-dd'T'HH:mm:ss") &
+        ".000Z\""
 
     PeerIDAuthPrefix & " sig=\"" & sig & "\", bearer=\"" & self.token & "\"" & expires
 


### PR DESCRIPTION
## Summary

Handle AutoTLS authentication and validation states that previously caused registration failures: keep polling ACME challenges in `PROCESSING`, and discard a bearer rejected with HTTP 401 so the next registration authenticates again.

Parse PeerID Auth fields by exact name and reject fields without values. Parse bearer expiry timestamps with timezone offsets and optional fractional seconds, preserving their precision, and use the shared RNG sampler for challenge generation.

Cancel and await outstanding DNS queries when a lookup exits, including on cancellation, so their sockets are closed before returning. Add regression coverage for these behaviors and align the authentication stub's expiry timestamps with UTC.
