### PR TITLE
ci: increasing timeout test workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,7 +20,7 @@ jobs:
   codecov:
     name: Run coverage and upload to codecov
     runs-on: ubuntu-22.04
-    timeout-minutes: 55
+    timeout-minutes: 60
     env:
       NIMBLE_COMMIT: aa8e6ea09ecac774b6fad42552569ce07bef37ec # v0.24.1
       CICOV: YES

--- a/.github/workflows/daily_test_all_no_flags.yml
+++ b/.github/workflows/daily_test_all_no_flags.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       NIMBLE_COMMIT: aa8e6ea09ecac774b6fad42552569ce07bef37ec # v0.24.1
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-daily-ci')
-    timeout-minutes: 55
+    timeout-minutes: 60
     strategy:
       fail-fast: false
 

--- a/.github/workflows/test_all.yml
+++ b/.github/workflows/test_all.yml
@@ -21,7 +21,7 @@ jobs:
   test:
     env:
       NIMBLE_COMMIT: aa8e6ea09ecac774b6fad42552569ce07bef37ec # v0.24.1
-    timeout-minutes: 55
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test_multiformat_exts.yml
+++ b/.github/workflows/test_multiformat_exts.yml
@@ -55,7 +55,7 @@ jobs:
       contents: read
     env:
       NIMBLE_COMMIT: aa8e6ea09ecac774b6fad42552569ce07bef37ec # v0.24.1
-    timeout-minutes: 55
+    timeout-minutes: 30
     runs-on: ${{ needs.pick-platform.outputs.builder }}
     name: "test_multiformat_exts"
     defaults:


### PR DESCRIPTION
tests are getting timeout on windows occasionally - likely do a lot of new tests added recently (since timeout was set)