### PR TITLE
chore(errors): valueOrRaise and onErrorRaise helpers

### DIFF
--- a/libp2p/errors.nim
+++ b/libp2p/errors.nim
@@ -23,13 +23,15 @@ func toException*(e: string): ref LPError =
 func toException*[E](e: E, X: typedesc): ref X =
   (ref X)(msg: $e)
 
-template raiseOr*[T, E](r: Result[T, E], X: typedesc): T =
+template valueOrRaise*[T: not void, E](r: Result[T, E], X: typedesc): T =
   ## Unwrap `r`, or raise `X` carrying the error message.
-  let res = r
-  if res.isErr():
-    raise res.error().toException(X)
-  when T isnot void:
-    res.unsafeGet()
+  r.valueOr:
+    raise error.toException(X)
+
+template onErrorRaise*[E](r: Result[void, E], X: typedesc) =
+  ## Raise `X` carrying the error message when `r` is an error.
+  r.isOkOr:
+    raise error.toException(X)
 
 # TODO: could not figure how to make it with a simple template
 # sadly nim needs more love for hygienic templates

--- a/libp2p/errors.nim
+++ b/libp2p/errors.nim
@@ -1,22 +1,51 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-# this module will be further extended in PR
-# https://github.com/status-im/nim-libp2p/pull/107/
-
 import chronos
 import chronicles
 import macros
+import results
+
+export results
+
+{.push raises: [].}
 
 type
   # Base exception type for libp2p
   LPError* = object of CatchableError
+
+  LPErrorObj*[K: enum] = object
+    ## Error value of a `Result`: `kind` to branch on, `msg` for logs.
+    kind*: K
+    msg*: string
+
+  LPResult*[T; K: enum] = Result[T, LPErrorObj[K]]
+
+func lpError*[K: enum](kind: K, msg = ""): LPErrorObj[K] =
+  LPErrorObj[K](kind: kind, msg: msg)
+
+func `$`*[K: enum](e: LPErrorObj[K]): string =
+  if e.msg.len == 0:
+    $e.kind
+  else:
+    $e.kind & ": " & e.msg
 
 func toException*(e: cstring): ref LPError =
   (ref LPError)(msg: $e)
 
 func toException*(e: string): ref LPError =
   (ref LPError)(msg: e)
+
+func toException*[E](e: E, X: typedesc): ref X =
+  (ref X)(msg: $e)
+
+template raiseOr*[T, E](r: Result[T, E], X: typedesc): T =
+  ## Unwrap `r`, or raise `X` carrying the error message.
+  let res = r
+  if res.isErr():
+    raise res.error().toException(X)
+  when T isnot void:
+    res.unsafeGet()
 
 # TODO: could not figure how to make it with a simple template
 # sadly nim needs more love for hygienic templates

--- a/libp2p/errors.nim
+++ b/libp2p/errors.nim
@@ -14,22 +14,6 @@ type
   # Base exception type for libp2p
   LPError* = object of CatchableError
 
-  LPErrorObj*[K: enum] = object
-    ## Error value of a `Result`: `kind` to branch on, `msg` for logs.
-    kind*: K
-    msg*: string
-
-  LPResult*[T; K: enum] = Result[T, LPErrorObj[K]]
-
-func lpError*[K: enum](kind: K, msg = ""): LPErrorObj[K] =
-  LPErrorObj[K](kind: kind, msg: msg)
-
-func `$`*[K: enum](e: LPErrorObj[K]): string =
-  if e.msg.len == 0:
-    $e.kind
-  else:
-    $e.kind & ": " & e.msg
-
 func toException*(e: cstring): ref LPError =
   (ref LPError)(msg: $e)
 

--- a/libp2p/protocols/connectivity/autonat/client.nim
+++ b/libp2p/protocols/connectivity/autonat/client.nim
@@ -85,8 +85,7 @@ method dialMe*(
   except CatchableError as e:
     raise newException(AutonatError, "read Dial response failed: " & e.msg, e)
 
-  let msg = AutonatMsg.decode(move(respBytes)).valueOr:
-    raise newException(AutonatError, error)
+  let msg = AutonatMsg.decode(move(respBytes)).raiseOr(AutonatError)
   let response = getResponseOrRaise(msg)
 
   return

--- a/libp2p/protocols/connectivity/autonat/client.nim
+++ b/libp2p/protocols/connectivity/autonat/client.nim
@@ -85,7 +85,7 @@ method dialMe*(
   except CatchableError as e:
     raise newException(AutonatError, "read Dial response failed: " & e.msg, e)
 
-  let msg = AutonatMsg.decode(move(respBytes)).raiseOr(AutonatError)
+  let msg = AutonatMsg.decode(move(respBytes)).valueOrRaise(AutonatError)
   let response = getResponseOrRaise(msg)
 
   return

--- a/libp2p/protocols/connectivity/autonat/server.nim
+++ b/libp2p/protocols/connectivity/autonat/server.nim
@@ -166,7 +166,7 @@ proc new*(
       stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     try:
-      let msg = AutonatMsg.decode(await stream.readLp(1024)).raiseOr(AutonatError)
+      let msg = AutonatMsg.decode(await stream.readLp(1024)).valueOrRaise(AutonatError)
       if msg.msgType.get(MsgType.Dial) != MsgType.Dial:
         raise newException(AutonatError, "Message type should be dial")
       await autonat.handleDial(stream, msg)

--- a/libp2p/protocols/connectivity/autonat/server.nim
+++ b/libp2p/protocols/connectivity/autonat/server.nim
@@ -166,8 +166,7 @@ proc new*(
       stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
     try:
-      let msg = AutonatMsg.decode(await stream.readLp(1024)).valueOr:
-        raise newException(AutonatError, error)
+      let msg = AutonatMsg.decode(await stream.readLp(1024)).raiseOr(AutonatError)
       if msg.msgType.get(MsgType.Dial) != MsgType.Dial:
         raise newException(AutonatError, "Message type should be dial")
       await autonat.handleDial(stream, msg)

--- a/libp2p/protocols/connectivity/autonatv2/client.nim
+++ b/libp2p/protocols/connectivity/autonatv2/client.nim
@@ -109,8 +109,9 @@ proc handleDialDataRequest*(
     trace "Sending DialDataResponse", index = i, messagesToSend = messagesToSend
 
   # get DialResponse
-  msg =
-    AutonatV2Msg.decode(await stream.readLp(AutonatV2MsgLpSize)).raiseOr(AutonatV2Error)
+  msg = AutonatV2Msg.decode(await stream.readLp(AutonatV2MsgLpSize)).valueOrRaise(
+      AutonatV2Error
+    )
 
   trace "Received message", kind = msg.oneof.kind
   if msg.oneof.kind != MsgKind.DialResponse:
@@ -166,7 +167,7 @@ method sendDialRequest*(
         )
       ).encode()
     )
-    let msg = AutonatV2Msg.decode(await stream.readLp(AutonatV2MsgLpSize)).raiseOr(
+    let msg = AutonatV2Msg.decode(await stream.readLp(AutonatV2MsgLpSize)).valueOrRaise(
         AutonatV2Error
       )
 

--- a/libp2p/protocols/connectivity/autonatv2/client.nim
+++ b/libp2p/protocols/connectivity/autonatv2/client.nim
@@ -109,8 +109,8 @@ proc handleDialDataRequest*(
     trace "Sending DialDataResponse", index = i, messagesToSend = messagesToSend
 
   # get DialResponse
-  msg = AutonatV2Msg.decode(await stream.readLp(AutonatV2MsgLpSize)).valueOr:
-    raise newException(AutonatV2Error, error)
+  msg =
+    AutonatV2Msg.decode(await stream.readLp(AutonatV2MsgLpSize)).raiseOr(AutonatV2Error)
 
   trace "Received message", kind = msg.oneof.kind
   if msg.oneof.kind != MsgKind.DialResponse:
@@ -166,8 +166,9 @@ method sendDialRequest*(
         )
       ).encode()
     )
-    let msg = AutonatV2Msg.decode(await stream.readLp(AutonatV2MsgLpSize)).valueOr:
-      raise newException(AutonatV2Error, error)
+    let msg = AutonatV2Msg.decode(await stream.readLp(AutonatV2MsgLpSize)).raiseOr(
+        AutonatV2Error
+      )
 
     dialResp =
       case msg.oneof.kind

--- a/libp2p/protocols/connectivity/autonatv2/server.nim
+++ b/libp2p/protocols/connectivity/autonatv2/server.nim
@@ -134,9 +134,9 @@ proc handleDialDataResponses(
   var dataReceived: uint64 = 0
 
   while dataReceived < self.config.dialDataSize:
-    let msg = AutonatV2Msg.decode(await stream.readLp(DialDataResponseLpSize)).raiseOr(
-        AutonatV2Error
-      )
+    let msg = AutonatV2Msg
+      .decode(await stream.readLp(DialDataResponseLpSize))
+      .valueOrRaise(AutonatV2Error)
     trace "Received message"
 
     if msg.oneof.kind != MsgKind.DialDataResponse:

--- a/libp2p/protocols/connectivity/autonatv2/server.nim
+++ b/libp2p/protocols/connectivity/autonatv2/server.nim
@@ -134,8 +134,9 @@ proc handleDialDataResponses(
   var dataReceived: uint64 = 0
 
   while dataReceived < self.config.dialDataSize:
-    let msg = AutonatV2Msg.decode(await stream.readLp(DialDataResponseLpSize)).valueOr:
-      raise newException(AutonatV2Error, error)
+    let msg = AutonatV2Msg.decode(await stream.readLp(DialDataResponseLpSize)).raiseOr(
+        AutonatV2Error
+      )
     trace "Received message"
 
     if msg.oneof.kind != MsgKind.DialDataResponse:

--- a/libp2p/protocols/connectivity/dcutr/client.nim
+++ b/libp2p/protocols/connectivity/dcutr/client.nim
@@ -46,7 +46,8 @@ proc startSync*(
     await stream.send(MsgType.Connect, addrs)
     trace "Dcutr initiator has sent a Connect message."
     let rttStart = Moment.now()
-    let connectAnswer = DcutrMsg.decode(await stream.readLp(1024)).raiseOr(DcutrError)
+    let connectAnswer =
+      DcutrMsg.decode(await stream.readLp(1024)).valueOrRaise(DcutrError)
 
     peerDialableAddrs = getHolePunchableAddrs(connectAnswer.addrs)
     if peerDialableAddrs.len == 0:

--- a/libp2p/protocols/connectivity/dcutr/client.nim
+++ b/libp2p/protocols/connectivity/dcutr/client.nim
@@ -46,8 +46,7 @@ proc startSync*(
     await stream.send(MsgType.Connect, addrs)
     trace "Dcutr initiator has sent a Connect message."
     let rttStart = Moment.now()
-    let connectAnswer = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
-      raise newException(DcutrError, error)
+    let connectAnswer = DcutrMsg.decode(await stream.readLp(1024)).raiseOr(DcutrError)
 
     peerDialableAddrs = getHolePunchableAddrs(connectAnswer.addrs)
     if peerDialableAddrs.len == 0:

--- a/libp2p/protocols/connectivity/dcutr/server.nim
+++ b/libp2p/protocols/connectivity/dcutr/server.nim
@@ -29,7 +29,8 @@ proc new*(
   ) {.async: (raises: [CancelledError]).} =
     var peerDialableAddrs: seq[MultiAddress]
     try:
-      let connectMsg = DcutrMsg.decode(await stream.readLp(1024)).raiseOr(DcutrError)
+      let connectMsg =
+        DcutrMsg.decode(await stream.readLp(1024)).valueOrRaise(DcutrError)
 
       trace "Dcutr receiver received a Connect message.", connectMsg = connectMsg
 
@@ -54,7 +55,8 @@ proc new*(
       if peerDialableAddrs.len == 0:
         await stream.send(MsgType.Connect, ourAddrs)
         trace "Dcutr receiver has sent a Connect message back."
-        let syncMsg = DcutrMsg.decode(await stream.readLp(1024)).raiseOr(DcutrError)
+        let syncMsg =
+          DcutrMsg.decode(await stream.readLp(1024)).valueOrRaise(DcutrError)
         trace "Dcutr receiver has received a Sync message.", syncMsg
         trace "Dcutr initiator has no supported dialable addresses to connect to. Aborting Dcutr.",
           addresses = connectMsg.addrs
@@ -76,7 +78,7 @@ proc new*(
 
       await stream.send(MsgType.Connect, ourAddrs)
       trace "Dcutr receiver has sent a Connect message back."
-      let syncMsg = DcutrMsg.decode(await stream.readLp(1024)).raiseOr(DcutrError)
+      let syncMsg = DcutrMsg.decode(await stream.readLp(1024)).valueOrRaise(DcutrError)
       trace "Dcutr receiver has received a Sync message.", syncMsg
 
       if peerDialableAddrs.len > maxDialableAddrs:

--- a/libp2p/protocols/connectivity/dcutr/server.nim
+++ b/libp2p/protocols/connectivity/dcutr/server.nim
@@ -29,8 +29,7 @@ proc new*(
   ) {.async: (raises: [CancelledError]).} =
     var peerDialableAddrs: seq[MultiAddress]
     try:
-      let connectMsg = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
-        raise newException(DcutrError, error)
+      let connectMsg = DcutrMsg.decode(await stream.readLp(1024)).raiseOr(DcutrError)
 
       trace "Dcutr receiver received a Connect message.", connectMsg = connectMsg
 
@@ -55,8 +54,7 @@ proc new*(
       if peerDialableAddrs.len == 0:
         await stream.send(MsgType.Connect, ourAddrs)
         trace "Dcutr receiver has sent a Connect message back."
-        let syncMsg = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
-          raise newException(DcutrError, error)
+        let syncMsg = DcutrMsg.decode(await stream.readLp(1024)).raiseOr(DcutrError)
         trace "Dcutr receiver has received a Sync message.", syncMsg
         trace "Dcutr initiator has no supported dialable addresses to connect to. Aborting Dcutr.",
           addresses = connectMsg.addrs
@@ -78,8 +76,7 @@ proc new*(
 
       await stream.send(MsgType.Connect, ourAddrs)
       trace "Dcutr receiver has sent a Connect message back."
-      let syncMsg = DcutrMsg.decode(await stream.readLp(1024)).valueOr:
-        raise newException(DcutrError, error)
+      let syncMsg = DcutrMsg.decode(await stream.readLp(1024)).raiseOr(DcutrError)
       trace "Dcutr receiver has received a Sync message.", syncMsg
 
       if peerDialableAddrs.len > maxDialableAddrs:

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -168,15 +168,13 @@ proc identify*(
     trace "identify: Empty message received!", stream
     raise newException(IdentityInvalidMsgError, "Empty message received")
 
-  var identifyMsg = IdentifyMsg.decode(move message).valueOr:
-    raise newException(IdentityInvalidMsgError, error)
+  var identifyMsg = IdentifyMsg.decode(move message).raiseOr(IdentityInvalidMsgError)
 
   trace "identify: info received", stream, identifyMsg
 
   var peer: PeerId
   identifyMsg.publicKey.withValue(pubkey):
-    peer = PeerId.init(pubkey).valueOr:
-      raise newException(IdentityInvalidMsgError, $error)
+    peer = PeerId.init(pubkey).raiseOr(IdentityInvalidMsgError)
     if peer != remotePeerId:
       trace "Peer ids don't match", remote = peer, local = remotePeerId
       raise newException(IdentityNoMatchError, "Peer ids don't match")

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -168,13 +168,14 @@ proc identify*(
     trace "identify: Empty message received!", stream
     raise newException(IdentityInvalidMsgError, "Empty message received")
 
-  var identifyMsg = IdentifyMsg.decode(move message).raiseOr(IdentityInvalidMsgError)
+  var identifyMsg =
+    IdentifyMsg.decode(move message).valueOrRaise(IdentityInvalidMsgError)
 
   trace "identify: info received", stream, identifyMsg
 
   var peer: PeerId
   identifyMsg.publicKey.withValue(pubkey):
-    peer = PeerId.init(pubkey).raiseOr(IdentityInvalidMsgError)
+    peer = PeerId.init(pubkey).valueOrRaise(IdentityInvalidMsgError)
     if peer != remotePeerId:
       trace "Peer ids don't match", remote = peer, local = remotePeerId
       raise newException(IdentityNoMatchError, "Peer ids don't match")

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -290,7 +290,7 @@ method getOrCreatePeer*(
 method initPubSub*(f: FloodSub) {.raises: [InitializationError].} =
   procCall PubSub(f).initPubSub()
 
-  f.validateOverheadRateLimit().raiseOr(InitializationError)
+  f.validateOverheadRateLimit().onErrorRaise(InitializationError)
 
   f.seen = TimedCache[SaltedId].init(2.minutes, maxSize = FloodSubSeenMaxSize)
   f.rng.generate(f.seenSalt)

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -290,8 +290,7 @@ method getOrCreatePeer*(
 method initPubSub*(f: FloodSub) {.raises: [InitializationError].} =
   procCall PubSub(f).initPubSub()
 
-  f.validateOverheadRateLimit().isOkOr:
-    raise newException(InitializationError, $error)
+  f.validateOverheadRateLimit().raiseOr(InitializationError)
 
   f.seen = TimedCache[SaltedId].init(2.minutes, maxSize = FloodSubSeenMaxSize)
   f.rng.generate(f.seenSalt)

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -1210,8 +1210,7 @@ method initPubSub*(g: GossipSub) {.raises: [InitializationError].} =
       "gossipsub: set the overhead rate limit through GossipSubParams, not the inherited FloodSub fields",
     )
 
-  g.parameters.validateParameters().isOkOr:
-    raise newException(InitializationError, $error)
+  g.parameters.validateParameters().raiseOr(InitializationError)
 
   # init the floodsub stuff here, we customize timedcache in gossip!
   g.seen =

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -1210,7 +1210,7 @@ method initPubSub*(g: GossipSub) {.raises: [InitializationError].} =
       "gossipsub: set the overhead rate limit through GossipSubParams, not the inherited FloodSub fields",
     )
 
-  g.parameters.validateParameters().raiseOr(InitializationError)
+  g.parameters.validateParameters().onErrorRaise(InitializationError)
 
   # init the floodsub stuff here, we customize timedcache in gossip!
   g.seen =

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -534,8 +534,9 @@ method handshake*(
         remotePubKey: PublicKey
         remoteSig: Signature
 
-      remoteMsg = NoiseHandshakePayloadMsg.decode(handshakeRes.remoteP2psecret).valueOr:
-        raise newException(NoiseHandshakeError, error)
+      remoteMsg = NoiseHandshakePayloadMsg.decode(handshakeRes.remoteP2psecret).raiseOr(
+          NoiseHandshakeError
+        )
 
       if remoteMsg.identityKey.isNone or remoteMsg.identitySig.isNone:
         raise newException(

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -534,9 +534,9 @@ method handshake*(
         remotePubKey: PublicKey
         remoteSig: Signature
 
-      remoteMsg = NoiseHandshakePayloadMsg.decode(handshakeRes.remoteP2psecret).raiseOr(
-          NoiseHandshakeError
-        )
+      remoteMsg = NoiseHandshakePayloadMsg
+        .decode(handshakeRes.remoteP2psecret)
+        .valueOrRaise(NoiseHandshakeError)
 
       if remoteMsg.identityKey.isNone or remoteMsg.identitySig.isNone:
         raise newException(

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -443,8 +443,7 @@ method start*(
 ) {.async: (raises: [LPError, transport.TransportError, CancelledError]).} =
   doAssert self.listeners.len == 0, "start() already called"
 
-  let addrsTa = self.toTransportAddress(addrs).valueOr:
-    raise newException(TransportStartError, $error)
+  let addrsTa = self.toTransportAddress(addrs).raiseOr(TransportStartError)
 
   var listenMAs: seq[MultiAddress]
   var initialized = false

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -443,7 +443,7 @@ method start*(
 ) {.async: (raises: [LPError, transport.TransportError, CancelledError]).} =
   doAssert self.listeners.len == 0, "start() already called"
 
-  let addrsTa = self.toTransportAddress(addrs).raiseOr(TransportStartError)
+  let addrsTa = self.toTransportAddress(addrs).valueOrRaise(TransportStartError)
 
   var listenMAs: seq[MultiAddress]
   var initialized = false

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -120,8 +120,7 @@ method start*(
 
   self.flags.incl(ServerFlags.ReusePort)
 
-  let addrsTa = self.toTransportAddress(addrs).valueOr:
-    raise newException(TransportStartError, $error)
+  let addrsTa = self.toTransportAddress(addrs).raiseOr(TransportStartError)
 
   var supported: seq[MultiAddress]
   var initialized = false

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -120,7 +120,7 @@ method start*(
 
   self.flags.incl(ServerFlags.ReusePort)
 
-  let addrsTa = self.toTransportAddress(addrs).raiseOr(TransportStartError)
+  let addrsTa = self.toTransportAddress(addrs).valueOrRaise(TransportStartError)
 
   var supported: seq[MultiAddress]
   var initialized = false

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -347,7 +347,7 @@ method start*(
 
   info "Starting WS transport"
 
-  let addrsTa = self.toTransportAddress(addrs).raiseOr(TransportStartError)
+  let addrsTa = self.toTransportAddress(addrs).valueOrRaise(TransportStartError)
 
   if not self.secure and self.autotls.isSome():
     self.autotls.withValue(autotls):

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -347,8 +347,7 @@ method start*(
 
   info "Starting WS transport"
 
-  let addrsTa = self.toTransportAddress(addrs).valueOr:
-    raise newException(TransportStartError, $error)
+  let addrsTa = self.toTransportAddress(addrs).raiseOr(TransportStartError)
 
   if not self.secure and self.autotls.isSome():
     self.autotls.withValue(autotls):

--- a/tests/libp2p/test_errors.nim
+++ b/tests/libp2p/test_errors.nim
@@ -20,35 +20,58 @@ suite "Errors":
       e of ref DemoError
       e.msg == "Malformed"
 
-  test "raiseOr returns the value":
+  test "valueOrRaise returns the value":
     let r = Result[int, string].ok(7)
-    check r.raiseOr(DemoError) == 7
+    check r.valueOrRaise(DemoError) == 7
 
-  test "raiseOr raises the requested exception with the message":
+  test "valueOrRaise raises the requested exception with the message":
     let r = Result[int, string].err("bad address")
     try:
-      discard r.raiseOr(DemoError)
-      check false
+      discard r.valueOrRaise(DemoError)
+      raiseAssert "should not get here"
     except DemoError as e:
       check e.msg == "bad address"
 
-  test "raiseOr evaluates its argument once":
+  test "valueOrRaise evaluates its argument once":
     var calls = 0
 
     proc make(): Result[int, string] =
       inc calls
       Result[int, string].ok(1)
 
-    discard make().raiseOr(DemoError)
+    discard make().valueOrRaise(DemoError)
     check calls == 1
 
-  test "raiseOr accepts a void result":
-    let ok = Result[void, cstring].ok()
-    ok.raiseOr(DemoError)
+  test "onErrorRaise passes an ok result":
+    Result[void, cstring].ok().onErrorRaise(DemoError)
 
-    let bad = Result[void, cstring].err("invalid parameters")
+  test "onErrorRaise raises the requested exception with the message":
+    let r = Result[void, cstring].err("invalid parameters")
     try:
-      bad.raiseOr(DemoError)
-      check false
+      r.onErrorRaise(DemoError)
+      raiseAssert "should not get here"
     except DemoError as e:
       check e.msg == "invalid parameters"
+
+  test "onErrorRaise evaluates its argument once":
+    var calls = 0
+
+    proc make(): Result[void, string] =
+      inc calls
+      Result[void, string].ok()
+
+    make().onErrorRaise(DemoError)
+    check calls == 1
+
+  test "each template can be called twice in the same scope":
+    let
+      a = Result[int, string].ok(1).valueOrRaise(DemoError)
+      b = Result[int, string].ok(2).valueOrRaise(DemoError)
+    Result[void, string].ok().onErrorRaise(DemoError)
+    Result[void, string].ok().onErrorRaise(DemoError)
+    check a + b == 3
+
+  test "each template accepts only its kind of result":
+    check:
+      not compiles(Result[void, string].ok().valueOrRaise(DemoError))
+      not compiles(Result[int, string].ok(1).onErrorRaise(DemoError))

--- a/tests/libp2p/test_errors.nim
+++ b/tests/libp2p/test_errors.nim
@@ -10,57 +10,45 @@ import ../tools/unittest
 type
   DemoErrorKind = enum
     Malformed
-    Unsupported
 
   DemoError = object of LPError
 
 suite "Errors":
-  test "$ shows the kind alone when there is no message":
-    check $lpError(Malformed) == "Malformed"
-
-  test "$ shows kind and message":
-    check $lpError(Unsupported, "quic") == "Unsupported: quic"
-
   test "toException carries the formatted error":
-    let e = lpError(Malformed, "short header").toException(DemoError)
+    let e = Malformed.toException(DemoError)
     check:
       e of ref DemoError
-      e.msg == "Malformed: short header"
+      e.msg == "Malformed"
 
   test "raiseOr returns the value":
-    let r = LPResult[int, DemoErrorKind].ok(7)
+    let r = Result[int, string].ok(7)
     check r.raiseOr(DemoError) == 7
 
   test "raiseOr raises the requested exception with the message":
-    let r = LPResult[int, DemoErrorKind].err(lpError(Unsupported, "onion"))
-    try:
-      discard r.raiseOr(DemoError)
-      check false
-    except DemoError as e:
-      check e.msg == "Unsupported: onion"
-
-  test "raiseOr evaluates its argument once":
-    var calls = 0
-
-    proc make(): LPResult[int, DemoErrorKind] =
-      inc calls
-      LPResult[int, DemoErrorKind].ok(1)
-
-    discard make().raiseOr(DemoError)
-    check calls == 1
-
-  test "raiseOr accepts a void result":
-    let ok = LPResult[void, DemoErrorKind].ok()
-    ok.raiseOr(DemoError)
-
-    let bad = LPResult[void, DemoErrorKind].err(lpError(Malformed))
-    expect DemoError:
-      bad.raiseOr(DemoError)
-
-  test "raiseOr accepts a string error":
     let r = Result[int, string].err("bad address")
     try:
       discard r.raiseOr(DemoError)
       check false
     except DemoError as e:
       check e.msg == "bad address"
+
+  test "raiseOr evaluates its argument once":
+    var calls = 0
+
+    proc make(): Result[int, string] =
+      inc calls
+      Result[int, string].ok(1)
+
+    discard make().raiseOr(DemoError)
+    check calls == 1
+
+  test "raiseOr accepts a void result":
+    let ok = Result[void, cstring].ok()
+    ok.raiseOr(DemoError)
+
+    let bad = Result[void, cstring].err("invalid parameters")
+    try:
+      bad.raiseOr(DemoError)
+      check false
+    except DemoError as e:
+      check e.msg == "invalid parameters"

--- a/tests/libp2p/test_errors.nim
+++ b/tests/libp2p/test_errors.nim
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import results
+import ../../libp2p/errors
+import ../tools/unittest
+
+type
+  DemoErrorKind = enum
+    Malformed
+    Unsupported
+
+  DemoError = object of LPError
+
+suite "Errors":
+  test "$ shows the kind alone when there is no message":
+    check $lpError(Malformed) == "Malformed"
+
+  test "$ shows kind and message":
+    check $lpError(Unsupported, "quic") == "Unsupported: quic"
+
+  test "toException carries the formatted error":
+    let e = lpError(Malformed, "short header").toException(DemoError)
+    check:
+      e of ref DemoError
+      e.msg == "Malformed: short header"
+
+  test "raiseOr returns the value":
+    let r = LPResult[int, DemoErrorKind].ok(7)
+    check r.raiseOr(DemoError) == 7
+
+  test "raiseOr raises the requested exception with the message":
+    let r = LPResult[int, DemoErrorKind].err(lpError(Unsupported, "onion"))
+    try:
+      discard r.raiseOr(DemoError)
+      check false
+    except DemoError as e:
+      check e.msg == "Unsupported: onion"
+
+  test "raiseOr evaluates its argument once":
+    var calls = 0
+
+    proc make(): LPResult[int, DemoErrorKind] =
+      inc calls
+      LPResult[int, DemoErrorKind].ok(1)
+
+    discard make().raiseOr(DemoError)
+    check calls == 1
+
+  test "raiseOr accepts a void result":
+    let ok = LPResult[void, DemoErrorKind].ok()
+    ok.raiseOr(DemoError)
+
+    let bad = LPResult[void, DemoErrorKind].err(lpError(Malformed))
+    expect DemoError:
+      bad.raiseOr(DemoError)
+
+  test "raiseOr accepts a string error":
+    let r = Result[int, string].err("bad address")
+    try:
+      discard r.raiseOr(DemoError)
+      check false
+    except DemoError as e:
+      check e.msg == "bad address"


### PR DESCRIPTION
`errors.nim` gains a generic `toException` overload and two templates that replace the `valueOr: raise newException(...)` and `isOkOr: raise newException(...)` blocks. `valueOrRaise(X)` returns the value of a `Result[T, E]` or raises `X` with the error message. `onErrorRaise(X)` raises `X` when a `Result[void, E]` holds an error. Each template accepts only its kind of result, so a wrong use fails at compile time.

The call sites in autonat, autonatv2, dcutr, identify, noise, floodsub, gossipsub and the tcp, ws and quic transports now use the templates. `tests/libp2p/test_errors.nim` covers the ok path, the raised exception and its message, the single evaluation of the argument, and the rejection of the wrong kind of result.
