### PR TITLE
chore(kad): add `Value` type

### DIFF
--- a/libp2p/protocols/kademlia/get.nim
+++ b/libp2p/protocols/kademlia/get.nim
@@ -77,7 +77,7 @@ proc getValue*(
         expected = key, got = record.key
       return
 
-    let value = record.value.valueOr:
+    let value: Value = record.value.valueOr:
       trace "Get-value reply has no value", messageType = "getValue"
       return
 

--- a/libp2p/protocols/kademlia/put.nim
+++ b/libp2p/protocols/kademlia/put.nim
@@ -48,7 +48,7 @@ proc manageExpiredRecords*(kad: KadDHT) {.async: (raises: [CancelledError]).} =
       trace "Expired record removed", key
 
 proc dispatchPutVal*(
-    kad: KadDHT, peer: PeerId, key: Key, value: seq[byte]
+    kad: KadDHT, peer: PeerId, key: Key, value: Value
 ): Future[Result[void, string]] {.async: (raises: [CancelledError]).} =
   let msg = Message(
     msgType: Opt.some(MessageType.putValue),
@@ -74,7 +74,7 @@ proc canStoreLocalRecord*(kad: KadDHT, key: Key): bool {.raises: [].} =
   true
 
 proc putValue*(
-    kad: KadDHT, key: Key, value: seq[byte]
+    kad: KadDHT, key: Key, value: Value
 ): Future[Result[void, string]] {.async: (raises: [CancelledError]), gcsafe.} =
   if value.len > kad.config.limits.maxValueSize:
     return err(
@@ -121,7 +121,7 @@ proc handlePutValue*(
       reason = "keyMismatch", messageType = "putValue", stream
     return
 
-  let value = record.value.valueOr:
+  let value: Value = record.value.valueOr:
     trace "Put-value request rejected",
       reason = "missingValue", messageType = "putValue", stream
     return

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -86,7 +86,9 @@ const
 
   MaxProviderKeyLen* = 80 ## Upper bound (bytes) on an ADD_PROVIDER key
 
-type Key* = seq[byte]
+type
+  Key* = seq[byte]
+  Value* = seq[byte]
 
 func init*(T: typedesc[Key], bytes: openArray[byte]): Key =
   ## Key of `IdLength` bytes holding `bytes`, zero-padded.
@@ -369,11 +371,11 @@ proc nowUnixSeconds*(): int64 {.gcsafe, raises: [].} =
   now().utc.toTime().toUnix()
 
 type EntryRecord* = object
-  value*: seq[byte]
+  value*: Value
   time*: Timestamp
 
 proc init*(
-    T: typedesc[EntryRecord], value: Key, time: Opt[Timestamp]
+    T: typedesc[EntryRecord], value: Value, time: Opt[Timestamp]
 ): EntryRecord {.gcsafe, raises: [].} =
   EntryRecord(value: value, time: time.get(Timestamp.now()))
 
@@ -383,7 +385,7 @@ type
   LocalTable* = Table[Key, EntryRecord]
 
 proc insert*(
-    self: var LocalTable, key: Key, value: sink seq[byte], time: Timestamp
+    self: var LocalTable, key: Key, value: sink Value, time: Timestamp
 ) {.raises: [].} =
   debug "Local Kademlia record stored", key, value = value.shortLog
   self[key] = EntryRecord(value: value, time: time)
@@ -422,7 +424,7 @@ method select*(
     return err("No records to choose from")
 
   # Map value -> (count, firstIndex)
-  var counts: Table[seq[byte], (int, int)]
+  var counts: Table[Value, (int, int)]
   for i, v in records.mapIt(it.value):
     try:
       let (cnt, idx) = counts[v]

--- a/libp2p/protocols/kademlia/types.nim
+++ b/libp2p/protocols/kademlia/types.nim
@@ -161,6 +161,9 @@ proc toPeerIds*(peers: seq[Peer]): seq[PeerId] =
 chronicles.formatIt(Key):
   it.shortLog
 
+chronicles.formatIt(Value):
+  it.shortLog
+
 type XorDistance* = array[IdLength, byte]
 type XorDHasher* = proc(input: seq[byte]): array[IdLength, byte] {.
   raises: [], nimcall, noSideEffect, gcsafe
@@ -387,7 +390,7 @@ type
 proc insert*(
     self: var LocalTable, key: Key, value: sink Value, time: Timestamp
 ) {.raises: [].} =
-  debug "Local Kademlia record stored", key, value = value.shortLog
+  debug "Local Kademlia record stored", key, value
   self[key] = EntryRecord(value: value, time: time)
 
 proc get*(self: LocalTable, key: Key): Opt[EntryRecord] {.raises: [].} =

--- a/tests/libp2p/kademlia/test_put.nim
+++ b/tests/libp2p/kademlia/test_put.nim
@@ -14,6 +14,16 @@ suite "KadDHT Put":
   teardown:
     checkTrackers()
 
+  test "EntryRecord initializer accepts a Value":
+    let
+      value: Value = @[1.byte, 2, 3]
+      time: Timestamp = "2026-01-01T00:00:00Z"
+      record = EntryRecord.init(value, Opt.some(time))
+
+    check:
+      record.value == value
+      record.time == time
+
   asyncTest "PUT_VALUE stores record at both sender and target peer":
     let kads = setupKadSwitches(2)
     startAndDeferStop(kads)
@@ -88,7 +98,7 @@ suite "KadDHT Put":
 
     let key = kads[0].rtable.selfId
     let value = @[1.byte, 2, 3, 4, 5]
-    let emptyVal: seq[byte] = @[]
+    let emptyVal: Value = @[]
 
     # Store initial value
     discard await kads[0].putValue(key, value)

--- a/tests/libp2p/kademlia/utils.nim
+++ b/tests/libp2p/kademlia/utils.nim
@@ -185,7 +185,7 @@ proc countBucketEntries*(buckets: seq[Bucket], key: Key): uint32 =
         res += 1
   return res
 
-proc containsData*(kad: KadDHT, key: Key, value: seq[byte]): bool =
+proc containsData*(kad: KadDHT, key: Key, value: Value): bool =
   let record = kad.dataTable.get(key).valueOr:
     checkpoint("containsData: key not found: " & $key.shortLog())
     return false


### PR DESCRIPTION
adds `Value` type alias similar to `Key` type.
adds `chronicles.formatIt` for `Value` type.

`Value` type enables future were `Key` and `Value` types could be made `distinct` to avoid interchangeable use (to avoid issue from comment below).