### PR TITLE
fix(service-disco): admit registrar senders through the shared Kademlia path

### DIFF
--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -291,8 +291,6 @@ proc registration*(
     return
   let serviceId = Key.fromBytes(serviceIdBytes)
 
-  disco.seatSender(serviceId, peerId)
-
   let closerPeers = disco.getCloserPeers(serviceId, disco.discoConfig.fReturn)
 
   var msg = Message(
@@ -340,6 +338,8 @@ proc registration*(
     )
 
     return msg
+
+  disco.seatSender(serviceId, peerId)
 
   let ips = disco.advertiserIps(peerId, connectionIps)
   var tWait = disco.registrar.waitingTime(disco.discoConfig, serviceId, ips, now)

--- a/tests/libp2p/service_discovery/component/test_registrar_closer_peers.nim
+++ b/tests/libp2p/service_discovery/component/test_registrar_closer_peers.nim
@@ -200,6 +200,38 @@ suite "Service Discovery Component - Registrar Closer Peers":
       not registrarNode.hasPeerInMainTable(senderId)
       not registrarNode.hasPeerInServiceTable(serviceId, senderId)
 
+  asyncTest "REGISTER with an invalid advertisement seats the sender nowhere":
+    let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0)
+    let registrarNode = setupServiceDiscoveryNode(discoConfig = conf)
+    let senderNode = setupServiceDiscoveryNode(discoConfig = conf)
+    startAndDeferStop(@[registrarNode, senderNode])
+
+    let serviceId = "service".hashServiceId()
+    let senderId = senderNode.switch.peerInfo.peerId
+
+    senderNode.switch.peerStore[AddressBook][registrarNode.switch.peerInfo.peerId] =
+      registrarNode.switch.peerInfo.addrs
+    registrarNode.switch.peerStore[AddressBook][senderId] =
+      senderNode.switch.peerInfo.addrs
+    discard registrarNode.rtManager.addService(
+      serviceId, registrarNode.rtable, registrarNode.config.replication,
+      conf.bucketsCount, Interest,
+    )
+
+    let response = await senderNode.sendRegister(
+      registrarNode.switch.peerInfo.peerId, serviceId, @[1'u8, 2, 3, 4]
+    )
+
+    check:
+      response.isOk()
+      response.get().status == kad_protobuf.RegistrationStatus.Rejected
+
+    checkUntilTimeout:
+      registrarNode.admissionProbes.len == 0
+    check:
+      not registrarNode.hasPeerInMainTable(senderId)
+      not registrarNode.hasPeerInServiceTable(serviceId, senderId)
+
   asyncTest "GET_ADS adds discoverer to RegT":
     let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0)
     let registrarNode = setupServiceDiscoveryNode(discoConfig = conf)

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -1602,7 +1602,7 @@ suite "Service Discovery Registrar - sender admission":
 
     let inMsg = kadprotobuf.Message(
       msgType: kadprotobuf.MessageType.register,
-      key: Opt.some(serviceId.toBytes()),
+      key: serviceId,
       register: Opt.some(
         kadprotobuf.RegisterMessage(
           advertisement: ad.encode().get(),
@@ -1629,7 +1629,7 @@ suite "Service Discovery Registrar - sender admission":
 
     let inMsg = kadprotobuf.Message(
       msgType: kadprotobuf.MessageType.register,
-      key: Opt.some(serviceId.toBytes()),
+      key: serviceId,
       register: Opt.some(
         kadprotobuf.RegisterMessage(
           advertisement: ad.encode().get(),

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -1588,3 +1588,55 @@ suite "Service Discovery Registrar - connection IPs":
     check slot.ips == connectionIps
     check slot.ips != @[parseIpAddress("10.0.0.1")]
     check slot.ips != @[parseIpAddress("10.0.0.99")]
+
+suite "Service Discovery Registrar - sender admission":
+  test "registration does not insert the sender into the main routing table":
+    let disco = setupServiceDiscoveryNode(
+      discoConfig = ServiceDiscoveryConfig.new(safetyParam = 0.0)
+    )
+    let serviceName = "service"
+    let serviceId = serviceName.hashServiceId()
+    let ad = makeAdvertisement(serviceName)
+    let senderId = ad.data.peerId
+    disco.switch.peerStore[AddressBook][senderId] = @[makeMultiAddress("198.51.100.7")]
+
+    let inMsg = kadprotobuf.Message(
+      msgType: kadprotobuf.MessageType.register,
+      key: Opt.some(serviceId.toBytes()),
+      register: Opt.some(
+        kadprotobuf.RegisterMessage(
+          advertisement: ad.encode().get(),
+          status: Opt.none(kadprotobuf.RegistrationStatus),
+          ticket: Opt.none(Ticket),
+        )
+      ),
+    )
+
+    let reply = disco.registration(senderId, inMsg).register.get()
+
+    check reply.status.get() == kadprotobuf.RegistrationStatus.Confirmed
+    check not disco.hasPeerInMainTable(senderId)
+
+  test "registration does not return the sender among its own closerPeers":
+    let disco = setupServiceDiscoveryNode(
+      discoConfig = ServiceDiscoveryConfig.new(safetyParam = 0.0)
+    )
+    let serviceName = "service"
+    let serviceId = serviceName.hashServiceId()
+    let ad = makeAdvertisement(serviceName)
+    let senderId = ad.data.peerId
+    disco.switch.peerStore[AddressBook][senderId] = @[makeMultiAddress("198.51.100.10")]
+
+    let inMsg = kadprotobuf.Message(
+      msgType: kadprotobuf.MessageType.register,
+      key: Opt.some(serviceId.toBytes()),
+      register: Opt.some(
+        kadprotobuf.RegisterMessage(
+          advertisement: ad.encode().get(),
+          status: Opt.none(kadprotobuf.RegistrationStatus),
+          ticket: Opt.none(Ticket),
+        )
+      ),
+    )
+
+    check disco.registration(senderId, inMsg).closerPeers.len == 0


### PR DESCRIPTION
Both registrar handlers inserted the stream peer into the main Kademlia table through the low-level primitive, skipping the address policy, diversity and liveness checks that `admitPeers` applies. `admitSender` now routes them through the same path, after the request validates.

Service-table admission keeps `insertPeer`, which stays synchronous and already applies policy and diversity; `test_registrar_closer_peers` pins that. Four new tests in `test_registrar` cover both handlers, a rejected request and the closer-peer list.