### PR TITLE
fix(autonatv2): require fresh inbound dialback connections

### DIFF
--- a/libp2p/protocols/connectivity/autonatv2/client.nim
+++ b/libp2p/protocols/connectivity/autonatv2/client.nim
@@ -49,12 +49,7 @@ proc handleDialBack(
     return
 
   # A new muxed stream is not proof of a new inbound transport connection.
-  var transport = stream
-  while true:
-    let wrapped = transport.getWrapped()
-    if wrapped == nil or wrapped == transport:
-      break
-    transport = wrapped
+  let transport = stream.getUnderlying()
 
   if stream.transportDir != Direction.In or transport.dir != Direction.In or
       transport.openedAt <= pending.startedAt:

--- a/libp2p/protocols/connectivity/autonatv2/client.nim
+++ b/libp2p/protocols/connectivity/autonatv2/client.nim
@@ -22,11 +22,16 @@ const
   MaxDialDataResponsePayload* = 1024
   DefaultDialBackTimeout* = 5.seconds
 
-type AutonatV2Client* = ref object of LPProtocol
-  dialer*: Dial
-  dialBackTimeout: Duration
-  rng: Rng
-  expectedNonces: Table[Nonce, Opt[MultiAddress]]
+type
+  PendingDialBack = object
+    startedAt: Moment
+    localAddr: Opt[MultiAddress]
+
+  AutonatV2Client* = ref object of LPProtocol
+    dialer*: Dial
+    dialBackTimeout: Duration
+    rng: Rng
+    expectedNonces: Table[Nonce, PendingDialBack]
 
 proc handleDialBack(
     self: AutonatV2Client, stream: Stream, dialBack: DialBack
@@ -38,10 +43,29 @@ proc handleDialBack(
     trace "Not expecting this nonce", nonce = dialBack.nonce
     return
 
+  let pending = self.expectedNonces.getOrDefault(dialBack.nonce)
+  if pending.localAddr.isSome:
+    trace "Already received DialBack", nonce = dialBack.nonce
+    return
+
+  # A new muxed stream is not proof of a new inbound transport connection.
+  var transport = stream
+  while true:
+    let wrapped = transport.getWrapped()
+    if wrapped == nil or wrapped == transport:
+      break
+    transport = wrapped
+
+  if stream.transportDir != Direction.In or transport.dir != Direction.In or
+      transport.openedAt <= pending.startedAt:
+    trace "DialBack requires a fresh inbound connection", nonce = dialBack.nonce
+    return
+
   stream.localAddr.withValue(localAddr):
     trace "Setting expectedNonces",
       nonce = dialBack.nonce, localAddr = Opt.some(localAddr)
-    self.expectedNonces[dialBack.nonce] = Opt.some(localAddr)
+    self.expectedNonces[dialBack.nonce] =
+      PendingDialBack(startedAt: pending.startedAt, localAddr: Opt.some(localAddr))
   else:
     debug "Unable to get localAddr from connection"
     return
@@ -60,6 +84,9 @@ proc new*(
   proc handleStream(
       stream: Stream, proto: string
   ) {.async: (raises: [CancelledError]).} =
+    defer:
+      await stream.close()
+
     try:
       let dialBack = DialBack.decode(await stream.readLp(DialBackLpSize)).valueOr:
         trace "Unable to decode DialBack", err = error
@@ -123,7 +150,7 @@ proc checkAddrIdx(
     self: AutonatV2Client, addrIdx: AddrIdx, testAddrs: seq[MultiAddress], nonce: Nonce
 ): bool {.raises: [].} =
   trace "checking addrs", addrIdx = addrIdx, testAddrs = testAddrs, nonce = nonce
-  let dialBackAddrs = self.expectedNonces.getOrDefault(nonce).valueOr:
+  let dialBackAddrs = self.expectedNonces.getOrDefault(nonce).localAddr.valueOr:
     trace "Not expecting this nonce",
       nonce = nonce, expectedNonces = self.expectedNonces
     return false
@@ -149,13 +176,15 @@ method sendDialRequest*(
   ## Dials peer with `pid` and requests that it tries connecting to `testAddrs`
 
   let nonce = self.rng.generate(Nonce)
-  self.expectedNonces[nonce] = Opt.none(MultiAddress)
 
   var dialResp: DialResponse
   try:
     let stream = await self.dialer.dial(pid, @[$AutonatV2Codec.DialRequest])
     defer:
       await stream.close()
+
+    # Dialback identities may differ from pid, and NAT may rewrite IPs and ports.
+    self.expectedNonces[nonce] = PendingDialBack(startedAt: Moment.now())
 
     # send dialRequest
     await stream.writeLp(

--- a/libp2p/stream/connection.nim
+++ b/libp2p/stream/connection.nim
@@ -146,6 +146,15 @@ proc timeoutMonitor(s: Connection) {.async: (raises: []).} =
 method getWrapped*(s: Connection): Connection {.base, gcsafe.} =
   raiseAssert("[Connection.getWrapped] abstract method not implemented!")
 
+proc getUnderlying*(s: Connection): Connection =
+  ## Returns the innermost connection, stopping at a nil or self wrapper.
+  result = s
+  while result != nil:
+    let wrapped = result.getWrapped()
+    if wrapped == nil or wrapped == result:
+      break
+    result = wrapped
+
 when defined(libp2p_agents_metrics):
   proc setShortAgent*(s: Connection, shortAgent: string) =
     var conn = s

--- a/libp2p/stream/connection.nim
+++ b/libp2p/stream/connection.nim
@@ -30,6 +30,7 @@ type
     localAddr*: Opt[MultiAddress]
     protocol*: string # protocol used by the connection, used as metrics tag
     transportDir*: Direction # underlying transport (usually socket) direction
+    openedAt*: Moment # initialization time of this layer; unwrap for transport age
     when defined(libp2p_agents_metrics):
       shortAgent*: string
 
@@ -73,6 +74,7 @@ method initStream*(s: Connection) =
   if s.objName.len == 0:
     s.objName = ConnectionTrackerName
 
+  s.openedAt = Moment.now()
   procCall LPStream(s).initStream()
 
   doAssert(s.timerTaskFut == nil)
@@ -141,7 +143,7 @@ proc timeoutMonitor(s: Connection) {.async: (raises: []).} =
     if not await s.pollActivity():
       return
 
-method getWrapped*(s: Connection): Connection {.base.} =
+method getWrapped*(s: Connection): Connection {.base, gcsafe.} =
   raiseAssert("[Connection.getWrapped] abstract method not implemented!")
 
 when defined(libp2p_agents_metrics):

--- a/tests/libp2p/protocols/test_autonat_v2.nim
+++ b/tests/libp2p/protocols/test_autonat_v2.nim
@@ -46,6 +46,117 @@ proc checkedGetIPAddress(): string =
   except Exception:
     ""
 
+proc newDialbackSwitch(transport: string): Switch =
+  if transport == "yamux":
+    return SwitchBuilder
+      .new()
+      .withRng(rng())
+      .withNoise()
+      .withAddress(TcpAutoAddress)
+      .withTcpTransport()
+      .withYamux()
+      .build()
+  let address = if transport == "quic": QuicAutoAddress else: TcpAutoAddress
+  makeStandardSwitch(address)
+
+template dialbackConnectionTest(transport, scenario: string) =
+  let
+    src = newDialbackSwitch(transport)
+    dst = newDialbackSwitch(transport)
+    fresh = scenario == "fresh identity"
+    separatePeer = fresh or scenario == "fresh outbound"
+    backPeer =
+      if separatePeer:
+        newDialbackSwitch(transport)
+      else:
+        dst
+    client = AutonatV2Client.new(rng())
+  var acknowledged = false
+
+  proc sendBack(nonce: Nonce): Future[bool] {.async.} =
+    if fresh:
+      await backPeer.connect(src.peerInfo.peerId, src.peerInfo.addrs)
+    elif scenario == "fresh outbound":
+      await src.connect(backPeer.peerInfo.peerId, backPeer.peerInfo.addrs)
+    let back =
+      await backPeer.dialer.dial(src.peerInfo.peerId, @[$AutonatV2Codec.DialBack])
+    defer:
+      await back.close()
+      if separatePeer:
+        await backPeer.disconnect(src.peerInfo.peerId)
+    await back.writeLp(DialBack(nonce: nonce).encode())
+    try:
+      let response = await back.readLp(AutonatV2MsgLpSize).wait(1.seconds)
+      return DialBackResponse.decode(response).isOk
+    except LPStreamError:
+      return false
+
+  proc handleRequest(
+      stream: Stream, proto: string
+  ) {.async: (raises: [CancelledError]).} =
+    defer:
+      await stream.close()
+    try:
+      let req = AutonatV2Msg
+        .decode(await stream.readLp(AutonatV2MsgLpSize))
+        .get().oneof.dialRequest
+      if fresh:
+        check not await sendBack(req.nonce xor 1)
+      acknowledged = await sendBack(req.nonce)
+      if fresh:
+        # A second fresh connection must not overwrite an accepted proof.
+        check not await sendBack(req.nonce)
+      await stream.writeLp(
+        AutonatV2Msg(
+          oneof: AutonatV2MsgOneof(
+            kind: MsgKind.DialResponse,
+            dialResponse: DialResponse(
+              status: ResponseStatus.Ok,
+              addrIdx: Opt.some(0.AddrIdx),
+              dialStatus: Opt.some(DialStatus.Ok),
+            ),
+          )
+        ).encode()
+      )
+    except CancelledError as exc:
+      raise exc
+    except CatchableError as exc:
+      raiseAssert exc.msg
+
+  let verifier = LPProtocol()
+  verifier.handler = handleRequest
+  verifier.codec = $AutonatV2Codec.DialRequest
+  dst.mount(verifier)
+  client.setup(src)
+  src.mount(client)
+  await src.start()
+  await dst.start()
+  if separatePeer:
+    await backPeer.start()
+  defer:
+    if separatePeer:
+      await backPeer.stop()
+    await allFutures(src.stop(), dst.stop())
+  if scenario == "existing inbound":
+    await dst.connect(src.peerInfo.peerId, src.peerInfo.addrs)
+  else:
+    await src.connect(dst.peerInfo.peerId, dst.peerInfo.addrs)
+
+  if fresh:
+    let response = await client.sendDialRequest(dst.peerInfo.peerId, src.peerInfo.addrs)
+    check response.reachability == Reachable
+    check acknowledged
+  else:
+    # The verifier claims success without ever dialing this endpoint.
+    let unreachable =
+      if transport == "quic":
+        ma("/ip4/192.0.2.1/udp/1/quic-v1")
+      else:
+        ma("/ip4/192.0.2.1/tcp/1")
+    expect AutonatV2Error:
+      discard await client.sendDialRequest(dst.peerInfo.peerId, @[unreachable])
+    check not acknowledged
+
 suite "AutonatV2":
   teardown:
     checkTrackers()
@@ -139,116 +250,7 @@ suite "AutonatV2":
       "existing outbound", "existing inbound", "fresh outbound", "fresh identity"
     ]:
       asyncTest "DialBack connection binding: " & transport & ", " & scenario:
-        proc newSwitch(): Switch =
-          if transport == "yamux":
-            return SwitchBuilder
-              .new()
-              .withRng(rng())
-              .withNoise()
-              .withAddress(TcpAutoAddress)
-              .withTcpTransport()
-              .withYamux()
-              .build()
-          let address = if transport == "quic": QuicAutoAddress else: TcpAutoAddress
-          makeStandardSwitch(address)
-
-        let
-          src = newSwitch()
-          dst = newSwitch()
-          fresh = scenario == "fresh identity"
-          separatePeer = fresh or scenario == "fresh outbound"
-          backPeer =
-            if separatePeer:
-              newSwitch()
-            else:
-              dst
-          client = AutonatV2Client.new(rng())
-        var acknowledged = false
-
-        proc sendBack(nonce: Nonce): Future[bool] {.async.} =
-          if fresh:
-            await backPeer.connect(src.peerInfo.peerId, src.peerInfo.addrs)
-          elif scenario == "fresh outbound":
-            await src.connect(backPeer.peerInfo.peerId, backPeer.peerInfo.addrs)
-          let back =
-            await backPeer.dialer.dial(src.peerInfo.peerId, @[$AutonatV2Codec.DialBack])
-          defer:
-            await back.close()
-            if separatePeer:
-              await backPeer.disconnect(src.peerInfo.peerId)
-          await back.writeLp(DialBack(nonce: nonce).encode())
-          try:
-            let response = await back.readLp(AutonatV2MsgLpSize).wait(1.seconds)
-            return DialBackResponse.decode(response).isOk
-          except LPStreamError:
-            return false
-
-        proc handleRequest(
-            stream: Stream, proto: string
-        ) {.async: (raises: [CancelledError]).} =
-          defer:
-            await stream.close()
-          try:
-            let req = AutonatV2Msg
-              .decode(await stream.readLp(AutonatV2MsgLpSize))
-              .get().oneof.dialRequest
-            if fresh:
-              check not await sendBack(req.nonce xor 1)
-            acknowledged = await sendBack(req.nonce)
-            if fresh:
-              # A second fresh connection must not overwrite an accepted proof.
-              check not await sendBack(req.nonce)
-            await stream.writeLp(
-              AutonatV2Msg(
-                oneof: AutonatV2MsgOneof(
-                  kind: MsgKind.DialResponse,
-                  dialResponse: DialResponse(
-                    status: ResponseStatus.Ok,
-                    addrIdx: Opt.some(0.AddrIdx),
-                    dialStatus: Opt.some(DialStatus.Ok),
-                  ),
-                )
-              ).encode()
-            )
-          except CancelledError as exc:
-            raise exc
-          except CatchableError as exc:
-            raiseAssert exc.msg
-
-        let verifier = LPProtocol()
-        verifier.handler = handleRequest
-        verifier.codec = $AutonatV2Codec.DialRequest
-        dst.mount(verifier)
-        client.setup(src)
-        src.mount(client)
-        await src.start()
-        await dst.start()
-        if separatePeer:
-          await backPeer.start()
-        defer:
-          if separatePeer:
-            await backPeer.stop()
-          await allFutures(src.stop(), dst.stop())
-        if scenario == "existing inbound":
-          await dst.connect(src.peerInfo.peerId, src.peerInfo.addrs)
-        else:
-          await src.connect(dst.peerInfo.peerId, dst.peerInfo.addrs)
-
-        if fresh:
-          let response =
-            await client.sendDialRequest(dst.peerInfo.peerId, src.peerInfo.addrs)
-          check response.reachability == Reachable
-          check acknowledged
-        else:
-          # The verifier claims success without ever dialing this endpoint.
-          let unreachable =
-            if transport == "quic":
-              ma("/ip4/192.0.2.1/udp/1/quic-v1")
-            else:
-              ma("/ip4/192.0.2.1/tcp/1")
-          expect AutonatV2Error:
-            discard await client.sendDialRequest(dst.peerInfo.peerId, @[unreachable])
-          check not acknowledged
+        dialbackConnectionTest(transport, scenario)
 
   asyncTest "Successful DialRequest with amplification attack prevention":
     # use ip address other than 127.0.0.1 for client

--- a/tests/libp2p/protocols/test_autonat_v2.nim
+++ b/tests/libp2p/protocols/test_autonat_v2.nim
@@ -7,6 +7,7 @@ import chronos, net, sequtils
 import
   ../../../libp2p/[
     switch,
+    protocols/protocol,
     multiaddress,
     transports/tcptransport,
     upgrademngrs/upgrade,
@@ -132,6 +133,122 @@ suite "AutonatV2":
         ),
         addrs: Opt.some(src.peerInfo.addrs[0]),
       )
+
+  for transport in ["mplex", "yamux", "quic"]:
+    for scenario in [
+      "existing outbound", "existing inbound", "fresh outbound", "fresh identity"
+    ]:
+      asyncTest "DialBack connection binding: " & transport & ", " & scenario:
+        proc newSwitch(): Switch =
+          if transport == "yamux":
+            return SwitchBuilder
+              .new()
+              .withRng(rng())
+              .withNoise()
+              .withAddress(TcpAutoAddress)
+              .withTcpTransport()
+              .withYamux()
+              .build()
+          let address = if transport == "quic": QuicAutoAddress else: TcpAutoAddress
+          makeStandardSwitch(address)
+
+        let
+          src = newSwitch()
+          dst = newSwitch()
+          fresh = scenario == "fresh identity"
+          separatePeer = fresh or scenario == "fresh outbound"
+          backPeer =
+            if separatePeer:
+              newSwitch()
+            else:
+              dst
+          client = AutonatV2Client.new(rng())
+        var acknowledged = false
+
+        proc sendBack(nonce: Nonce): Future[bool] {.async.} =
+          if fresh:
+            await backPeer.connect(src.peerInfo.peerId, src.peerInfo.addrs)
+          elif scenario == "fresh outbound":
+            await src.connect(backPeer.peerInfo.peerId, backPeer.peerInfo.addrs)
+          let back =
+            await backPeer.dialer.dial(src.peerInfo.peerId, @[$AutonatV2Codec.DialBack])
+          defer:
+            await back.close()
+            if separatePeer:
+              await backPeer.disconnect(src.peerInfo.peerId)
+          await back.writeLp(DialBack(nonce: nonce).encode())
+          try:
+            let response = await back.readLp(AutonatV2MsgLpSize).wait(1.seconds)
+            return DialBackResponse.decode(response).isOk
+          except LPStreamError:
+            return false
+
+        proc handleRequest(
+            stream: Stream, proto: string
+        ) {.async: (raises: [CancelledError]).} =
+          defer:
+            await stream.close()
+          try:
+            let req = AutonatV2Msg
+              .decode(await stream.readLp(AutonatV2MsgLpSize))
+              .get().oneof.dialRequest
+            if fresh:
+              check not await sendBack(req.nonce xor 1)
+            acknowledged = await sendBack(req.nonce)
+            if fresh:
+              # A second fresh connection must not overwrite an accepted proof.
+              check not await sendBack(req.nonce)
+            await stream.writeLp(
+              AutonatV2Msg(
+                oneof: AutonatV2MsgOneof(
+                  kind: MsgKind.DialResponse,
+                  dialResponse: DialResponse(
+                    status: ResponseStatus.Ok,
+                    addrIdx: Opt.some(0.AddrIdx),
+                    dialStatus: Opt.some(DialStatus.Ok),
+                  ),
+                )
+              ).encode()
+            )
+          except CancelledError as exc:
+            raise exc
+          except CatchableError as exc:
+            raiseAssert exc.msg
+
+        let verifier = LPProtocol()
+        verifier.handler = handleRequest
+        verifier.codec = $AutonatV2Codec.DialRequest
+        dst.mount(verifier)
+        client.setup(src)
+        src.mount(client)
+        await src.start()
+        await dst.start()
+        if separatePeer:
+          await backPeer.start()
+        defer:
+          if separatePeer:
+            await backPeer.stop()
+          await allFutures(src.stop(), dst.stop())
+        if scenario == "existing inbound":
+          await dst.connect(src.peerInfo.peerId, src.peerInfo.addrs)
+        else:
+          await src.connect(dst.peerInfo.peerId, dst.peerInfo.addrs)
+
+        if fresh:
+          let response =
+            await client.sendDialRequest(dst.peerInfo.peerId, src.peerInfo.addrs)
+          check response.reachability == Reachable
+          check acknowledged
+        else:
+          # The verifier claims success without ever dialing this endpoint.
+          let unreachable =
+            if transport == "quic":
+              ma("/ip4/192.0.2.1/udp/1/quic-v1")
+            else:
+              ma("/ip4/192.0.2.1/tcp/1")
+          expect AutonatV2Error:
+            discard await client.sendDialRequest(dst.peerInfo.peerId, @[unreachable])
+          check not acknowledged
 
   asyncTest "Successful DialRequest with amplification attack prevention":
     # use ip address other than 127.0.0.1 for client

--- a/tests/libp2p/stream/test_connection.nim
+++ b/tests/libp2p/stream/test_connection.nim
@@ -7,7 +7,24 @@ import chronos
 import ../../../libp2p/[stream/connection, stream/bufferstream]
 import ../../tools/[unittest]
 
+type WrappedConnection = ref object of Connection
+  wrapped: Connection
+
+method getWrapped(s: WrappedConnection): Connection =
+  s.wrapped
+
 suite "Connection":
+  test "underlying connection":
+    let
+      transport = WrappedConnection()
+      inner = WrappedConnection(wrapped: transport)
+      outer = WrappedConnection(wrapped: inner)
+    check outer.getUnderlying() == transport
+    transport.wrapped = transport
+    check outer.getUnderlying() == transport
+    transport.wrapped = nil
+    check Connection(nil).getUnderlying() == nil
+
   asyncTest "close":
     var conn = BufferStream.new()
     await conn.close()


### PR DESCRIPTION
An AutoNAT v2 verifier could return the request nonce over an existing connection and falsely confirm reachability without dialing the candidate address. Require dialbacks to arrive on an inbound transport initialized after the request, accept each nonce only once, and close handled dialback streams.

Add regression coverage across Mplex, Yamux, and QUIC for existing inbound/outbound connections, fresh outbound connections, unknown and replayed nonces, and valid fresh dialbacks from a separate peer identity.
