### PR TITLE
fix(service-disco): gate registrar seats on the discovery codec

### DIFF
--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -260,18 +260,14 @@ proc acceptAdvertisement*(
   disco.registrar.updateRegistrarMetrics()
 
 proc seatSender(disco: ServiceDiscovery, serviceId: ServiceId, peerId: PeerId) =
-  ## A querier that does not serve the codec would take a dead registrar seat.
-  if disco.codec notin disco.switch.peerStore[ProtoBook][peerId]:
-    trace "Sender does not serve the discovery codec", peerId
-    return
-
-  discard disco.rtable.insert(peerId)
-
+  ## The admission probe dials the codec, so a querier that does not serve it gets no seat.
   let senderAddrs = disco.switch.peerStore[AddressBook][peerId]
   if senderAddrs.len == 0:
     return
 
-  discard disco.insertPeer(serviceId, PeerInfo(peerId: peerId, addrs: senderAddrs))
+  let sender = @[PeerInfo(peerId: peerId, addrs: senderAddrs)]
+  disco.admitPeers(sender)
+  disco.rtManager.admitPeers(disco, serviceId, sender)
 
 proc getCloserPeers(
     disco: ServiceDiscovery, serviceId: ServiceId, count: int

--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -259,6 +259,20 @@ proc acceptAdvertisement*(
   disco.registrar.ads.put(serviceId, advertiser, ad, advertiserIps, now)
   disco.registrar.updateRegistrarMetrics()
 
+proc seatSender(disco: ServiceDiscovery, serviceId: ServiceId, peerId: PeerId) =
+  ## A querier that does not serve the codec would take a dead registrar seat.
+  if disco.codec notin disco.switch.peerStore[ProtoBook][peerId]:
+    trace "Sender does not serve the discovery codec", peerId
+    return
+
+  discard disco.rtable.insert(peerId)
+
+  let senderAddrs = disco.switch.peerStore[AddressBook][peerId]
+  if senderAddrs.len == 0:
+    return
+
+  discard disco.insertPeer(serviceId, PeerInfo(peerId: peerId, addrs: senderAddrs))
+
 proc getCloserPeers(
     disco: ServiceDiscovery, serviceId: ServiceId, count: int
 ): seq[Peer] =
@@ -280,10 +294,7 @@ proc registration*(
     trace "Key not set: registration", msg = inMsg
     return
 
-  discard disco.rtable.insert(peerId)
-  let senderAddrs = disco.switch.peerStore[AddressBook][peerId]
-  if senderAddrs.len > 0:
-    discard disco.insertPeer(serviceId, PeerInfo(peerId: peerId, addrs: senderAddrs))
+  disco.seatSender(serviceId, peerId)
 
   let closerPeers = disco.getCloserPeers(serviceId, disco.discoConfig.fReturn)
 
@@ -386,10 +397,7 @@ proc getAdvertisements*(
     trace "Key not set: getAdvertisements", msg
     return
 
-  discard disco.rtable.insert(peerId)
-  let senderAddrs = disco.switch.peerStore[AddressBook][peerId]
-  if senderAddrs.len > 0:
-    discard disco.insertPeer(serviceId, PeerInfo(peerId: peerId, addrs: senderAddrs))
+  disco.seatSender(serviceId, peerId)
 
   let cap = disco.discoConfig.fReturn
   let ads = disco.registrar.ads.getServiceCachedAds(serviceId, cap).mapIt(it.ad)

--- a/tests/libp2p/service_discovery/component/test_registrar_closer_peers.nim
+++ b/tests/libp2p/service_discovery/component/test_registrar_closer_peers.nim
@@ -161,6 +161,39 @@ suite "Service Discovery Component - Registrar Closer Peers":
       tableAfterWait.isSome()
       tableAfterWait.get().hasPeer(waitKey)
 
+  asyncTest "REGISTER from a node without the codec mounted seats it nowhere":
+    let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0)
+    let registrarNode = setupServiceDiscoveryNode(discoConfig = conf)
+    let unmountedNode = setupServiceDiscoveryNode(discoConfig = conf, mount = false)
+    startAndDeferStop(@[registrarNode, unmountedNode])
+
+    # A switch starts and stops the protocols it mounts, so this one needs both by hand.
+    await unmountedNode.start()
+    defer:
+      await unmountedNode.stop()
+
+    let serviceName = "service"
+    let serviceId = serviceName.hashServiceId()
+
+    unmountedNode.switch.peerStore[AddressBook][registrarNode.switch.peerInfo.peerId] =
+      registrarNode.switch.peerInfo.addrs
+
+    let adBytes = makeAdvertisement(serviceName).encode().get()
+    let response = await unmountedNode.sendRegister(
+      registrarNode.switch.peerInfo.peerId, serviceId, adBytes
+    )
+
+    check:
+      response.isOk()
+      response.get().status == kad_protobuf.RegistrationStatus.Confirmed
+
+    let senderId = unmountedNode.switch.peerInfo.peerId
+    check:
+      ExtendedServiceDiscoveryCodec notin
+        registrarNode.switch.peerStore[ProtoBook][senderId]
+      not registrarNode.hasPeerInMainTable(senderId)
+      not registrarNode.hasPeerInServiceTable(serviceId, senderId)
+
   asyncTest "GET_ADS adds discoverer to RegT":
     let conf = ServiceDiscoveryConfig.new(safetyParam = 0.0)
     let registrarNode = setupServiceDiscoveryNode(discoConfig = conf)

--- a/tests/libp2p/service_discovery/component/test_registrar_closer_peers.nim
+++ b/tests/libp2p/service_discovery/component/test_registrar_closer_peers.nim
@@ -157,8 +157,8 @@ suite "Service Discovery Component - Registrar Closer Peers":
       waitResponse.get().status == kad_protobuf.RegistrationStatus.Wait
 
     let tableAfterWait = registrarNode.rtManager.getTable(serviceId)
-    check:
-      tableAfterWait.isSome()
+    check tableAfterWait.isSome()
+    checkUntilTimeout:
       tableAfterWait.get().hasPeer(waitKey)
 
   asyncTest "REGISTER from a node without the codec mounted seats it nowhere":
@@ -174,9 +174,16 @@ suite "Service Discovery Component - Registrar Closer Peers":
 
     let serviceName = "service"
     let serviceId = serviceName.hashServiceId()
+    let senderId = unmountedNode.switch.peerInfo.peerId
 
     unmountedNode.switch.peerStore[AddressBook][registrarNode.switch.peerInfo.peerId] =
       registrarNode.switch.peerInfo.addrs
+    registrarNode.switch.peerStore[AddressBook][senderId] =
+      unmountedNode.switch.peerInfo.addrs
+    discard registrarNode.rtManager.addService(
+      serviceId, registrarNode.rtable, registrarNode.config.replication,
+      conf.bucketsCount, Interest,
+    )
 
     let adBytes = makeAdvertisement(serviceName).encode().get()
     let response = await unmountedNode.sendRegister(
@@ -187,10 +194,9 @@ suite "Service Discovery Component - Registrar Closer Peers":
       response.isOk()
       response.get().status == kad_protobuf.RegistrationStatus.Confirmed
 
-    let senderId = unmountedNode.switch.peerInfo.peerId
+    checkUntilTimeout:
+      registrarNode.admissionProbes.len == 0
     check:
-      ExtendedServiceDiscoveryCodec notin
-        registrarNode.switch.peerStore[ProtoBook][senderId]
       not registrarNode.hasPeerInMainTable(senderId)
       not registrarNode.hasPeerInServiceTable(serviceId, senderId)
 
@@ -231,6 +237,6 @@ suite "Service Discovery Component - Registrar Closer Peers":
     check found.get().len == 1
 
     let tableAfter = registrarNode.rtManager.getTable(serviceId)
-    check:
-      tableAfter.isSome()
+    check tableAfter.isSome()
+    checkUntilTimeout:
       tableAfter.get().hasPeer(discovererKey)

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -1517,63 +1517,6 @@ suite "Service Discovery Registrar - registration response":
       disco.countAdsInCache(serviceId) == 1
       disco.getAdsInCache(serviceId)[0].data.peerId == advertiserId
 
-suite "Service Discovery Registrar - sender seating":
-  proc setupSender(disco: ServiceDiscovery): PeerId =
-    let senderId = randomPeerId()
-    disco.switch.peerStore[AddressBook][senderId] = @[makeMultiAddress("10.0.0.1")]
-    senderId
-
-  template checkSeatsOnlyWithCodec(
-      disco: ServiceDiscovery, serviceId: ServiceId, senderId: PeerId, query: untyped
-  ) =
-    query
-
-    check:
-      not disco.hasPeerInMainTable(senderId)
-      not disco.hasPeerInServiceTable(serviceId, senderId)
-
-    disco.serveCodec(senderId)
-    query
-
-    check:
-      disco.hasPeerInMainTable(senderId)
-      disco.hasPeerInServiceTable(serviceId, senderId)
-
-  test "registration seats the sender only when it serves the codec":
-    let disco = setupServiceDiscoveryNode(
-      discoConfig = ServiceDiscoveryConfig.new(safetyParam = 0.0)
-    )
-    let serviceId = "service".hashServiceId()
-    disco.populateAdvertisementTable(serviceId)
-
-    let senderId = disco.setupSender()
-    let inMsg = kadprotobuf.Message(
-      msgType: kadprotobuf.MessageType.register,
-      key: serviceId,
-      register: Opt.some(
-        kadprotobuf.RegisterMessage(
-          advertisement: makeAdvertisement("service").encode().get(),
-          status: Opt.none(kadprotobuf.RegistrationStatus),
-          ticket: Opt.none(Ticket),
-        )
-      ),
-    )
-
-    disco.checkSeatsOnlyWithCodec(serviceId, senderId):
-      discard disco.registration(senderId, inMsg)
-
-  test "getAdvertisements seats the sender only when it serves the codec":
-    let disco = setupServiceDiscoveryNode()
-    let serviceId = "service".hashServiceId()
-    disco.populateAdvertisementTable(serviceId)
-
-    let senderId = disco.setupSender()
-    let inMsg =
-      kadprotobuf.Message(msgType: kadprotobuf.MessageType.getAds, key: serviceId)
-
-    disco.checkSeatsOnlyWithCodec(serviceId, senderId):
-      discard disco.getAdvertisements(senderId, inMsg)
-
 suite "Service Discovery Registrar - connection IPs":
   asyncTest "observedIps extracts IP from stream.observedAddr":
     let peerId = randomPeerId()

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -1517,6 +1517,63 @@ suite "Service Discovery Registrar - registration response":
       disco.countAdsInCache(serviceId) == 1
       disco.getAdsInCache(serviceId)[0].data.peerId == advertiserId
 
+suite "Service Discovery Registrar - sender seating":
+  proc setupSender(disco: ServiceDiscovery): PeerId =
+    let senderId = randomPeerId()
+    disco.switch.peerStore[AddressBook][senderId] = @[makeMultiAddress("10.0.0.1")]
+    senderId
+
+  template checkSeatsOnlyWithCodec(
+      disco: ServiceDiscovery, serviceId: ServiceId, senderId: PeerId, query: untyped
+  ) =
+    query
+
+    check:
+      not disco.hasPeerInMainTable(senderId)
+      not disco.hasPeerInServiceTable(serviceId, senderId)
+
+    disco.serveCodec(senderId)
+    query
+
+    check:
+      disco.hasPeerInMainTable(senderId)
+      disco.hasPeerInServiceTable(serviceId, senderId)
+
+  test "registration seats the sender only when it serves the codec":
+    let disco = setupServiceDiscoveryNode(
+      discoConfig = ServiceDiscoveryConfig.new(safetyParam = 0.0)
+    )
+    let serviceId = "service".hashServiceId()
+    disco.populateAdvertisementTable(serviceId)
+
+    let senderId = disco.setupSender()
+    let inMsg = kadprotobuf.Message(
+      msgType: kadprotobuf.MessageType.register,
+      key: serviceId,
+      register: Opt.some(
+        kadprotobuf.RegisterMessage(
+          advertisement: makeAdvertisement("service").encode().get(),
+          status: Opt.none(kadprotobuf.RegistrationStatus),
+          ticket: Opt.none(Ticket),
+        )
+      ),
+    )
+
+    disco.checkSeatsOnlyWithCodec(serviceId, senderId):
+      discard disco.registration(senderId, inMsg)
+
+  test "getAdvertisements seats the sender only when it serves the codec":
+    let disco = setupServiceDiscoveryNode()
+    let serviceId = "service".hashServiceId()
+    disco.populateAdvertisementTable(serviceId)
+
+    let senderId = disco.setupSender()
+    let inMsg =
+      kadprotobuf.Message(msgType: kadprotobuf.MessageType.getAds, key: serviceId)
+
+    disco.checkSeatsOnlyWithCodec(serviceId, senderId):
+      discard disco.getAdvertisements(senderId, inMsg)
+
 suite "Service Discovery Registrar - connection IPs":
   asyncTest "observedIps extracts IP from stream.observedAddr":
     let peerId = randomPeerId()

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -136,6 +136,7 @@ proc setupServiceDiscoveryNode*(
     privateKey: Opt[PrivateKey] = Opt.none(PrivateKey),
     kadConfig: KadDHTConfig = testKadDHTConfig(),
     addresses: seq[MultiAddress] = @[TcpAutoAddress()],
+    mount: bool = true,
 ): ServiceDiscovery =
   let switch = createSwitch(privateKey, addresses)
   let node = ServiceDiscovery.new(
@@ -148,7 +149,8 @@ proc setupServiceDiscoveryNode*(
     discoConfig = discoConfig,
     xprPublishing = xprPublishing,
   )
-  switch.mount(node)
+  if mount:
+    switch.mount(node)
   node
 
 proc setupServiceDiscoveryNodes*(
@@ -167,8 +169,14 @@ proc setupServiceDiscoveryNodes*(
     )
   nodes
 
+proc serveCodec*(disco: ServiceDiscovery, peerId: PeerId) =
+  ## Fake the identify result that lists our codec among the peer's protocols.
+  disco.switch.peerStore[ProtoBook][peerId] = @[disco.codec]
+
 proc connect*(disco1, disco2: ServiceDiscovery) {.async.} =
   ## Bidirectionally connect two ServiceDiscovery instances.
+  disco1.serveCodec(disco2.switch.peerInfo.peerId)
+  disco2.serveCodec(disco1.switch.peerInfo.peerId)
   discard disco1.rtable.insert(disco2.switch.peerInfo.peerId)
   discard disco2.rtable.insert(disco1.switch.peerInfo.peerId)
   disco1.switch.peerStore[AddressBook][disco2.switch.peerInfo.peerId] =
@@ -178,6 +186,9 @@ proc connect*(disco1, disco2: ServiceDiscovery) {.async.} =
 
 proc hasPeer*(rtable: RoutingTable, peerKey: Key): bool =
   peerKey in rtable
+
+proc hasPeerInMainTable*(disco: ServiceDiscovery, peerId: PeerId): bool =
+  disco.rtable.hasPeer(peerId.toKey())
 
 proc populateRoutingTable*(disco: ServiceDiscovery, count: int) =
   for i in 0 ..< count:

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -169,14 +169,8 @@ proc setupServiceDiscoveryNodes*(
     )
   nodes
 
-proc serveCodec*(disco: ServiceDiscovery, peerId: PeerId) =
-  ## Fake the identify result that lists our codec among the peer's protocols.
-  disco.switch.peerStore[ProtoBook][peerId] = @[disco.codec]
-
 proc connect*(disco1, disco2: ServiceDiscovery) {.async.} =
   ## Bidirectionally connect two ServiceDiscovery instances.
-  disco1.serveCodec(disco2.switch.peerInfo.peerId)
-  disco2.serveCodec(disco1.switch.peerInfo.peerId)
   discard disco1.rtable.insert(disco2.switch.peerInfo.peerId)
   discard disco2.rtable.insert(disco1.switch.peerInfo.peerId)
   disco1.switch.peerStore[AddressBook][disco2.switch.peerInfo.peerId] =


### PR DESCRIPTION
`registration` and `getAdvertisements` seated the sender in both routing tables with no codec check, so any node that queries a registrar becomes one. An advertiser picks that seat and the dial fails with `Unable to select sub-protocol`. Nothing logs it until a deficit forces the pick.

Both paths now call `seatSender`, which seats only when identify lists our codec. Identify is self-reported, so this stops misconfiguration, not a hostile peer; a probe would. Two gaps remain: a peer that mounts the codec but sets `isServer = false`, and `acceptAdvertisement`, which never checks the advertised peer. Closes #3092