### PR TITLE
fix(service-disco): admit advertised peers through the kad admission probe

### DIFF
--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -251,9 +251,10 @@ proc acceptAdvertisement*(
     serviceId, disco.rtable, disco.config.replication, disco.discoConfig.bucketsCount,
     Interest,
   )
-  discard disco.insertPeer(
+  disco.rtManager.admitPeers(
+    disco,
     serviceId,
-    PeerInfo(peerId: ad.data.peerId, addrs: ad.data.addresses.mapIt(it.address)),
+    @[PeerInfo(peerId: ad.data.peerId, addrs: ad.data.addresses.mapIt(it.address))],
   )
 
   disco.registrar.ads.put(serviceId, advertiser, ad, advertiserIps, now)

--- a/tests/libp2p/service_discovery/test_registrar.nim
+++ b/tests/libp2p/service_discovery/test_registrar.nim
@@ -21,6 +21,7 @@ import
     stream/connection,
   ]
 import ../../../libp2p/protocols/kademlia/protobuf as kadprotobuf
+import ../../../libp2p/utils/future
 import ../../tools/[crypto, unittest, multiaddress]
 import ./utils
 
@@ -1065,6 +1066,9 @@ suite "Service Discovery Registrar - registration replaces by advertiser":
       ad2.envelope.signature.data
 
 suite "Service Discovery Registrar - acceptAdvertisement":
+  teardown:
+    checkTrackers()
+
   test "new peer ad is added to cache":
     let disco =
       setupServiceDiscoveryNode(discoConfig = ServiceDiscoveryConfig.new(fReturn = 3))
@@ -1077,6 +1081,21 @@ suite "Service Discovery Registrar - acceptAdvertisement":
     check disco.registrar.ads.serviceCacheAdsLen(serviceId) == 1
     check disco.registrar.ads.getServiceCachedAds(serviceId, int.high).mapIt(it.ad)[0].data.peerId ==
       ad.data.peerId
+
+  asyncTest "advertised peer is not seated when its admission probe fails":
+    let disco = setupServiceDiscoveryNode()
+    let serviceId = makeServiceId()
+    let ad = makeAdvertisement($serviceId, addrs = @[ma("/ip4/127.0.0.1/tcp/59997")])
+
+    disco.acceptAd(Moment.now(), serviceId, ad)
+    check not disco.hasPeerInServiceTable(serviceId, ad.data.peerId)
+
+    checkUntilTimeout:
+      disco.admissionProbes.len == 0
+    check:
+      disco.probeFailures.getOrDefault(ad.data.peerId).count == 1
+      not disco.hasPeerInServiceTable(serviceId, ad.data.peerId)
+      disco.registrar.ads.serviceCacheAdsLen(serviceId) == 1
 
   test "same advertiser higher seqNo replaces existing ad":
     let disco =
@@ -1128,7 +1147,7 @@ suite "Service Discovery Registrar - acceptAdvertisement":
 
     check disco.registrar.ads.serviceCacheAdsLen(serviceId) == 2
 
-  test "replace updates IP tree without doubling":
+  asyncTest "replace updates IP tree without doubling":
     let disco =
       setupServiceDiscoveryNode(discoConfig = ServiceDiscoveryConfig.new(fReturn = 3))
     let serviceName = "service"
@@ -1157,6 +1176,9 @@ suite "Service Discovery Registrar - acceptAdvertisement":
 
     check disco.registrar.ads.serviceCacheAdsLen(serviceId) == 1
     check disco.registrar.ads.ipTree.ipsLen == counterAfterFirst
+
+    let probes = move disco.admissionProbes
+    await noCancel probes.values.toSeq().cancelAndWait()
 
 suite "Service Discovery Registrar - waitingTime never negative":
   test "waitingTime returns non-negative with stale high service lower bound":


### PR DESCRIPTION


`acceptAdvertisement` (`registrar.nim`) put the advertised peer (`ad.data.peerId`) into the service routing table through `insertPeer`, with no admission probe. The addresses come from the signed record, and `registration` does not require the signer to be the sender. A sender can thus register ads signed by other keys and seat those peers, with any addresses, in the service table.

Send the advertised peer through `rtManager.admitPeers`, the probed admission that `discoverer.nim` and `advertiser.nim` already use. `admitPeers` applies the same address policy and IP diversity checks as `insertPeer`, records the addresses at Low confidence, and seats the peer only after it answers a FIND_NODE probe. The advertisement still goes into the cache at once.

