### PR TITLE
fix(service-disco): evict peers that reset discovery requests

### DIFF
--- a/libp2p/protocols/service_discovery/connection.nim
+++ b/libp2p/protocols/service_discovery/connection.nim
@@ -6,7 +6,8 @@ import chronos, chronicles, results
 import ../../[peerid, switch, multiaddress, extended_peer_record]
 import ../kademlia
 import ../kademlia/types
-import ./[types, service_discovery_metrics, registrar, dial_backoff]
+import
+  ./[types, service_discovery_metrics, registrar, dial_backoff, routing_table_manager]
 
 logScope:
   topics = "service-disco connection"
@@ -18,6 +19,19 @@ proc observedIps*(stream: Stream): seq[IpAddress] {.raises: [].} =
     ma.getIp().withValue(ip):
       ips.add(ip)
   ips
+
+func isRemoteReset(e: ref CatchableError): bool =
+  ## A reset during the negotiate arrives as the parent of `DialFailedError`.
+  e of LPStreamResetError or (not e.parent.isNil() and e.parent of LPStreamResetError)
+
+proc evictOnReset(disco: ServiceDiscovery, peerId: PeerId, e: ref CatchableError) =
+  ## A peer that resets a fresh stream mounts the codec but does not serve it.
+  if not e.isRemoteReset():
+    return
+
+  let tables = disco.removePeer(peerId, reason = "reset")
+  if tables > 0:
+    trace "Evicted peer that reset a discovery request", peerId, tables, err = e.msg
 
 proc send*(
     disco: ServiceDiscovery, peerId: PeerId, msg: Message
@@ -34,6 +48,7 @@ proc send*(
       await disco.switch.dial(peerId, addrs, disco.codec)
     except DialFailedError as e:
       disco.recordDialFailure(peerId, addrs)
+      disco.evictOnReset(peerId, e)
       return err("dialing peer failed: " & e.msg)
 
   var replyRead = false
@@ -57,11 +72,13 @@ proc send*(
       await stream.writeLp(encodedMsg)
     except LPStreamError as e:
       disco.recordDialFailure(peerId, addrs)
+      disco.evictOnReset(peerId, e)
       return err("connection writing failed: " & e.msg)
     try:
       replyBuf = await stream.readLp(ServiceDiscoveryMaxMsgSize)
     except LPStreamError as e:
       disco.recordDialFailure(peerId, addrs)
+      disco.evictOnReset(peerId, e)
       return err("connection reading failed: " & e.msg)
   replyRead = true
 

--- a/libp2p/protocols/service_discovery/routing_table_manager.nim
+++ b/libp2p/protocols/service_discovery/routing_table_manager.nim
@@ -144,6 +144,14 @@ proc admitPeers*(
 
   kad.admitPeers(table, peerInfos, onAdmit)
 
+proc removePeer*(disco: ServiceDiscovery, peerId: PeerId, reason: string): int =
+  var removed = ord(disco.rtable.removePeer(peerId, reason))
+  for table in disco.rtManager.tables.values:
+    removed += ord(table.removePeer(peerId, reason))
+  if removed > 0:
+    disco.rtManager.updateServiceTablesMetrics()
+  removed
+
 proc hasService*(manager: ServiceRoutingTableManager, serviceId: ServiceId): bool =
   ## Check if routing table exists for a service
   serviceId in manager.tables

--- a/tests/libp2p/service_discovery/component/test_client_mode.nim
+++ b/tests/libp2p/service_discovery/component/test_client_mode.nim
@@ -39,6 +39,39 @@ suite "Service Discovery Component - Client Mode":
       response.isErr
       clientNode.registrar.ads.len == 0
 
+  asyncTest "a peer that resets a request loses its seats":
+    let clientNode = setupServiceDiscoveryNode(client = true)
+    let serverNode = setupServiceDiscoveryNode()
+    let registrarNode = setupServiceDiscoveryNode()
+    startAndDeferStop(@[clientNode, serverNode, registrarNode])
+    await connect(serverNode, clientNode)
+    await connect(serverNode, registrarNode)
+
+    let serviceName = "service"
+    let serviceId = serviceName.hashServiceId()
+    check serverNode.rtManager.addService(
+      serviceId, serverNode.rtable, serverNode.config.replication,
+      serverNode.discoConfig.bucketsCount, Interest,
+    )
+
+    let clientId = clientNode.switch.peerInfo.peerId
+    let registrarId = registrarNode.switch.peerInfo.peerId
+    check:
+      serverNode.hasPeerInServiceTable(serviceId, clientId)
+      serverNode.hasPeerInServiceTable(serviceId, registrarId)
+
+    let ad = makeAdvertisement(serviceName).encode().get()
+    let refused = await serverNode.sendRegister(clientId, serviceId, ad)
+    let answered = await serverNode.sendRegister(registrarId, serviceId, ad)
+
+    check:
+      refused.isErr()
+      answered.isOk()
+      not serverNode.rtable.hasPeer(clientId.toKey())
+      not serverNode.hasPeerInServiceTable(serviceId, clientId)
+      serverNode.rtable.hasPeer(registrarId.toKey())
+      serverNode.hasPeerInServiceTable(serviceId, registrarId)
+
   asyncTest "client-mode node returns no ads when targeted by lookup":
     let clientNode = setupServiceDiscoveryNode(client = true)
     let discovererNode = setupServiceDiscoveryNode()


### PR DESCRIPTION

A peer that mounts the discovery codec but runs with `isServer = false` passes the identify codec gate from #3093. Identify lists the codec, because multistream has no unmount. The peer stays in the main Kademlia table and in the service tables. An advertiser or a discoverer then picks it, and the handler resets the stream (`Refusing inbound query while not serving`). The Kademlia admission probe refuses such a peer, but discovery's skip that probe: the registrar handlers, `acceptAdvertisement`, service-table seeding and a runtime `changeMode(isServer = false)`.

Evict the peer from the main table and from every service table when a discovery RPC in `connection.send` fails with a remote reset. `send` dials a fresh stream for each RPC, so a reset there means the peer refuses the request. The reset can arrive during `switch.dial` (yamux clears the receive queue on RST, so the negotiate ack can be lost, and the dial keeps the `LPStreamResetError` as the `parent` of `DialFailedError`), on `writeLp`, or on `readLp`. `send` checks all three.


