### PR TITLE
fix(tests): copy lent loop variables before asyncTest capture

### DIFF
--- a/tests/libp2p/protocols/test_autonat_v2.nim
+++ b/tests/libp2p/protocols/test_autonat_v2.nim
@@ -249,6 +249,10 @@ suite "AutonatV2":
     for scenario in [
       "existing outbound", "existing inbound", "fresh outbound", "fresh identity"
     ]:
+      # the asyncTest closure cannot capture the lent loop variables
+      let
+        transport = transport
+        scenario = scenario
       asyncTest "DialBack connection binding: " & transport & ", " & scenario:
         dialbackConnectionTest(transport, scenario)
 


### PR DESCRIPTION
The daily Nim devel jobs fail on Linux and Windows with `'transport' is of type <lent string> which cannot be captured` in `tests/libp2p/protocols/test_autonat_v2.nim`. Nim devel now gives array `items` as `lent T`, and the `asyncTest` closure captures the `transport` and `scenario` loop variables. The fix copies both into local variables before `asyncTest`.

With a local Nim devel (2.3.1) and `--compileOnly --mm:refc`, the old file fails with the CI error, and `tests/test_all.nim` compiles with the CI flags. Check that the 12 test names stay the same, and check the next daily Nim devel run.
