### PR TITLE
fix(autonatv2): avoid lent captures in async tests

### DIFF
--- a/tests/libp2p/protocols/test_autonat_v2.nim
+++ b/tests/libp2p/protocols/test_autonat_v2.nim
@@ -245,10 +245,12 @@ suite "AutonatV2":
         addrs: Opt.some(src.peerInfo.addrs[0]),
       )
 
-  for transport in ["mplex", "yamux", "quic"]:
-    for scenario in [
+  for transportValue in ["mplex", "yamux", "quic"]:
+    let transport = transportValue
+    for scenarioValue in [
       "existing outbound", "existing inbound", "fresh outbound", "fresh identity"
     ]:
+      let scenario = scenarioValue
       asyncTest "DialBack connection binding: " & transport & ", " & scenario:
         dialbackConnectionTest(transport, scenario)
 


### PR DESCRIPTION
## Summary

Give the AutoNAT v2 DialBack test loop values owned string bindings before the async test captures them. This fixes Nim devel rejecting the borrowed (`lent string`) loop variables while preserving all transport/scenario cases.

## References

[Failing daily job](https://github.com/vacp2p/nim-libp2p/actions/runs/34446819053/job/102773396185)
