### PR TITLE
fix(pubsub): stop peer tasks before connection teardown

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -397,8 +397,6 @@ method unsubscribePeer*(g: GossipSub, peer: PeerId) =
     for topic, info in stats[].topicInfos.mpairs:
       info.firstMessageDeliveries = 0
 
-  pubSubPeer.stopTasks()
-
   g.extensionsState.removePeer(peer)
 
   procCall FloodSub(g).unsubscribePeer(peer)
@@ -1165,13 +1163,12 @@ proc createExtensionsState(g: GossipSub): ExtensionsState =
     g.parameters.preambleExtensionConfig,
   )
 
-method start*(
-    g: GossipSub
-): Future[void] {.async: (raises: [CancelledError], raw: true).} =
+method start*(g: GossipSub): Future[void] {.async: (raises: [CancelledError]).} =
   if g.started:
     warn "Starting gossipsub twice"
-    return newFutureCompleted[void]()
+    return
 
+  await procCall PubSub(g).start()
   info "gossipsub start"
 
   g.heartbeatFut = g.heartbeat()
@@ -1180,23 +1177,21 @@ method start*(
   reportBackgroundFailure(g.heartbeatFut, "gossipsub heartbeat")
   reportBackgroundFailure(g.scoringHeartbeatFut, "gossipsub scoring")
   reportBackgroundFailure(g.directPeersLoop, "gossipsub direct peer maintenance")
-  g.started = true
-  newFutureCompleted[void]()
 
-method stop*(g: GossipSub): Future[void] {.async: (raises: [], raw: true).} =
+method stop*(g: GossipSub) {.async: (raises: []).} =
   info "gossipsub stop"
 
-  if not g.started:
-    warn "Stopping gossipsub without starting it"
-    return newFutureCompleted[void]()
-
-  g.started = false
-  g.directPeersLoop.cancelSoon()
-  g.scoringHeartbeatFut.cancelSoon()
-  g.heartbeatFut.cancelSoon()
-  g.pendingTasks.cancelSoon()
+  let peersStopped = procCall PubSub(g).stop()
+  var pending = g.pendingTasks
+  for fut in [g.directPeersLoop, g.scoringHeartbeatFut, g.heartbeatFut]:
+    if not fut.isNil:
+      pending.add(fut)
+  await noCancel pending.cancelAndWait()
   g.pendingTasks = @[]
-  newFutureCompleted[void]()
+  g.directPeersLoop = nil
+  g.scoringHeartbeatFut = nil
+  g.heartbeatFut = nil
+  await peersStopped
 
 method initPubSub*(g: GossipSub) {.raises: [InitializationError].} =
   procCall FloodSub(g).initPubSub()

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -1181,20 +1181,20 @@ method start*(g: GossipSub): Future[void] {.async: (raises: [CancelledError]).} 
   reportBackgroundFailure(g.scoringHeartbeatFut, "gossipsub scoring")
   reportBackgroundFailure(g.directPeersLoop, "gossipsub direct peer maintenance")
 
-method stop*(g: GossipSub) {.async: (raises: []).} =
-  info "gossipsub stop"
+method stop*(g: GossipSub): Future[void] {.async: (raw: true, raises: []).} =
+  if not g.started:
+    warn "Stopping gossipsub without starting it"
+  if not g.stopFut.isNil and not g.stopFut.finished:
+    return g.stopFut
 
+  info "gossipsub stop"
   let peersStopped = procCall PubSub(g).stop()
-  var pending = g.pendingTasks
-  for fut in [g.directPeersLoop, g.scoringHeartbeatFut, g.heartbeatFut]:
+  var pending = move g.pendingTasks
+  for fut in [move g.directPeersLoop, move g.scoringHeartbeatFut, move g.heartbeatFut]:
     if not fut.isNil:
       pending.add(fut)
-  await noCancel chronos.cancelAndWait(pending)
-  g.pendingTasks = @[]
-  g.directPeersLoop = nil
-  g.scoringHeartbeatFut = nil
-  g.heartbeatFut = nil
-  await peersStopped
+  g.stopFut = noCancel allFutures(peersStopped, chronos.cancelAndWait(pending))
+  return g.stopFut
 
 method initPubSub*(g: GossipSub) {.raises: [InitializationError].} =
   procCall FloodSub(g).initPubSub()

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -1186,7 +1186,7 @@ method stop*(g: GossipSub) {.async: (raises: []).} =
   for fut in [g.directPeersLoop, g.scoringHeartbeatFut, g.heartbeatFut]:
     if not fut.isNil:
       pending.add(fut)
-  await noCancel pending.cancelAndWait()
+  await noCancel chronos.cancelAndWait(pending)
   g.pendingTasks = @[]
   g.directPeersLoop = nil
   g.scoringHeartbeatFut = nil

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -1042,6 +1042,8 @@ proc publishPartial*(
 proc maintainDirectPeer(
     g: GossipSub, id: PeerId, addrs: seq[MultiAddress]
 ) {.async: (raises: [CancelledError]).} =
+  if g.switch.isStopping:
+    return
   if id notin g.peers:
     trace "Attempting to dial a direct peer", peerId = id
     if g.switch.isConnected(id):
@@ -1050,7 +1052,8 @@ proc maintainDirectPeer(
     try:
       await g.switch.connect(id, addrs, forceDial = true)
       # populate the peer after it's connected
-      discard g.getOrCreatePeer(id, g.codecs)
+      if not g.switch.isStopping:
+        discard g.getOrCreatePeer(id, g.codecs)
     except CancelledError as exc:
       trace "Direct peer dial canceled"
       raise exc

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -210,6 +210,7 @@ type
     heartbeatEvents*: seq[AsyncEvent]
     scoringHeartbeatEvents*: seq[AsyncEvent]
     pendingTasks*: seq[Future[void]]
+    stopFut*: Future[void].Raising([]) # Concurrent stops share cleanup after tasks move.
     overheadMetricsWindowStart*: Moment
     rpcOverheadBytesMax*: int
     peerOverheadBytesPerSecondMax*: int

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -415,6 +415,8 @@ method getOrCreatePeer*(
   proc getStream(): Future[Stream] {.
       async: (raises: [CancelledError, GetStreamDialError])
   .} =
+    if p.stopping or p.switch.isStopping:
+      raise newException(CancelledError, "pubsub is stopping")
     try:
       return await p.switch.dial(peerId, protos)
     except DialFailedError as e:
@@ -538,7 +540,7 @@ method handleConn*(
   ## 2) handle RPC messages received on this stream
   ##
 
-  if p.stopping:
+  if p.stopping or p.switch.isStopping:
     await stream.close()
     return
 
@@ -556,7 +558,7 @@ method subscribePeer*(p: PubSub, peer: PeerId) {.base, gcsafe.} =
   ## messages
   ##
 
-  if p.stopping:
+  if p.stopping or p.switch.isStopping:
     return
 
   let pubSubPeer = p.getOrCreatePeer(peer, p.codecs)

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -164,6 +164,7 @@ type
     supportsSendingPartial*: bool
 
   PubSub* = ref object of LPProtocol
+    stopping: bool
     switch*: Switch # the switch used to dial/connect to peers
     peerInfo*: PeerInfo # this peer's info
     topics*: Table[string, TopicData] # the topics that _we_ are interested in
@@ -214,6 +215,8 @@ method unsubscribePeer*(p: PubSub, peerId: PeerId) {.base, gcsafe.} =
   ##
 
   debug "unsubscribing pubsub peer", peerId
+  p.peers.withValue(peerId, peer):
+    peer[].stopTasks()
   p.peers.del(peerId)
 
   libp2p_pubsub_peers.set(p.peers.len.int64)
@@ -507,6 +510,19 @@ template handleSelfPublishing*(p: PubSub, topic: string, data: seq[byte]) =
   if p.triggerSelf:
     await handleData(p, topic, data)
 
+method start*(p: PubSub) {.async: (raises: [CancelledError]).} =
+  p.stopping = false
+  await procCall LPProtocol(p).start()
+
+method stop*(p: PubSub) {.async: (raises: []).} =
+  p.stopping = true
+  p.started = false
+  var pending: seq[Future[void].Raising([])]
+  for peer in toSeq(p.peers.values):
+    pending.add(peer.stop())
+    p.unsubscribePeer(peer.peerId)
+  await noCancel allFutures(pending)
+
 method handleConn*(
     p: PubSub, stream: Stream, proto: string
 ) {.base, async: (raises: [CancelledError]).} =
@@ -516,6 +532,10 @@ method handleConn*(
   ## 1) register a new PubSubPeer for the connection
   ## 2) handle RPC messages received on this stream
   ##
+
+  if p.stopping:
+    await stream.close()
+    return
 
   let peer = p.getOrCreatePeer(stream.peerId, @[], proto)
 
@@ -530,6 +550,9 @@ method subscribePeer*(p: PubSub, peer: PeerId) {.base, gcsafe.} =
   ## subscribe to remote peer to receive/send pubsub
   ## messages
   ##
+
+  if p.stopping:
+    return
 
   let pubSubPeer = p.getOrCreatePeer(peer, p.codecs)
   pubSubPeer.connect()

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -217,7 +217,12 @@ method unsubscribePeer*(p: PubSub, peerId: PeerId) {.base, gcsafe.} =
 
   debug "unsubscribing pubsub peer", peerId
   p.peers.withValue(peerId, peer):
-    p.peerStopFuts.trackFut(peer[].stopTasks())
+    let stopped = peer[].stopTasks()
+    if p.stopping:
+      # Shutdown drains the whole batch; pruning on each removal is quadratic.
+      p.peerStopFuts.add(stopped)
+    else:
+      p.peerStopFuts.trackFut(stopped)
   p.peers.del(peerId)
 
   libp2p_pubsub_peers.set(p.peers.len.int64)

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -165,6 +165,7 @@ type
 
   PubSub* = ref object of LPProtocol
     stopping: bool
+    peerStopFuts: seq[Future[void].Raising([])] # cleanup outlives removal from peers
     switch*: Switch # the switch used to dial/connect to peers
     peerInfo*: PeerInfo # this peer's info
     topics*: Table[string, TopicData] # the topics that _we_ are interested in
@@ -216,7 +217,7 @@ method unsubscribePeer*(p: PubSub, peerId: PeerId) {.base, gcsafe.} =
 
   debug "unsubscribing pubsub peer", peerId
   p.peers.withValue(peerId, peer):
-    peer[].stopTasks()
+    p.peerStopFuts.trackFut(peer[].stopTasks())
   p.peers.del(peerId)
 
   libp2p_pubsub_peers.set(p.peers.len.int64)
@@ -517,11 +518,10 @@ method start*(p: PubSub) {.async: (raises: [CancelledError]).} =
 method stop*(p: PubSub) {.async: (raises: []).} =
   p.stopping = true
   p.started = false
-  var pending: seq[Future[void].Raising([])]
-  for peer in toSeq(p.peers.values):
-    pending.add(peer.stop())
-    p.unsubscribePeer(peer.peerId)
-  await noCancel allFutures(pending)
+  for peerId in toSeq(p.peers.keys):
+    p.unsubscribePeer(peerId)
+  await noCancel allFutures(p.peerStopFuts)
+  p.peerStopFuts = @[]
 
 method handleConn*(
     p: PubSub, stream: Stream, proto: string

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -334,7 +334,7 @@ proc runHandleLoop*(
   defer:
     trace "exiting pubsub read loop", stream, peerId = p, closed = stream.closed
 
-  while not stream.atEof:
+  while not p.disconnected and not stream.atEof:
     var data =
       try:
         await stream.readLp(p.maxMessageSize)
@@ -344,6 +344,9 @@ proc runHandleLoop*(
         trace "Exception occurred reading message PubSubPeer.handle",
           err = e.msg, stream, peer = p, closed = stream.closed
         return
+
+    if p.disconnected:
+      return
 
     trace "read data from peer",
       stream, peer = p, closed = stream.closed, messageSize = data.len
@@ -429,13 +432,13 @@ proc connectImpl(p: PubSubPeer) {.async: (raises: []).} =
         p.connectedFut.completeOnce()
         return
       await connectOnce(p)
-  except CancelledError as exc:
-    trace "Could not establish send stream", err = exc.msg
+  except CancelledError:
+    discard
   except GetStreamDialError as exc:
     trace "Could not establish send stream", err = exc.msg
 
 proc connect*(p: PubSubPeer) =
-  if p.connected:
+  if p.disconnected or p.connected:
     return
   if not p.connectFut.isNil() and not p.connectFut.finished():
     return
@@ -613,6 +616,9 @@ proc sendEncoded*(
   ## Low and medium priority messages are queued and sent only after all high
   ## priority messages have been sent.
   doAssert(not isNil(p), "pubsubpeer nil!")
+
+  if p.disconnected:
+    return newFutureCompleted[void]()
 
   p.clearSendPriorityQueue()
 
@@ -814,8 +820,9 @@ proc startSendNonHighPriorityTask(p: PubSubPeer) =
     p.rpcmessagequeue.sendNonHighPriorityTask = p.sendNonHighPriorityTask()
 
 proc stopTasks*(p: PubSubPeer) =
-  ## Peer-wide teardown: cancels the connector loop, in-flight sends, and the
-  ## non-high-priority sender task; clears its priority queues.
+  ## Prevents further work and requests cancellation of all peer tasks.
+  ## Use `stop` to wait for teardown to finish.
+  p.disconnected = true
   if not p.connectFut.isNil():
     p.connectFut.cancelSoon()
     p.connectFut = nil
@@ -840,6 +847,23 @@ proc stopTasks*(p: PubSubPeer) =
         labelValues = [$p.peerId], value = 0
       )
       libp2p_gossipsub_low_priority_queue_size.set(labelValues = [$p.peerId], value = 0)
+
+proc stop*(p: PubSubPeer) {.async: (raises: []).} =
+  ## Cancels peer tasks and waits for them before closing the send stream.
+  var pending = p.sendFuts
+  if not p.connectFut.isNil:
+    pending.add(p.connectFut)
+  if not p.rpcmessagequeue.sendNonHighPriorityTask.isNil:
+    pending.add(p.rpcmessagequeue.sendNonHighPriorityTask)
+  for fut in p.rpcmessagequeue.sendPriorityQueue:
+    pending.add(fut)
+
+  p.stopTasks()
+  await noCancel allFutures(pending)
+  if not p.sendStream.isNil:
+    await p.sendStream.close()
+    p.sendStream = nil
+  p.connectedFut.completeOnce()
 
 proc new(T: typedesc[RpcMessageQueue]): T =
   return T(

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -819,51 +819,33 @@ proc startSendNonHighPriorityTask(p: PubSubPeer) =
   if p.rpcmessagequeue.sendNonHighPriorityTask.isNil:
     p.rpcmessagequeue.sendNonHighPriorityTask = p.sendNonHighPriorityTask()
 
-proc stopTasks*(p: PubSubPeer) =
-  ## Prevents further work and requests cancellation of all peer tasks.
-  ## Use `stop` to wait for teardown to finish.
+proc stopTasks*(p: PubSubPeer) {.async: (raises: []).} =
+  ## Prevents further work, cancels peer tasks, and waits for cleanup to finish.
   p.stopped = true
-  if not p.connectFut.isNil():
-    p.connectFut.cancelSoon()
-    p.connectFut = nil
-  for fut in p.sendFuts:
-    fut.cancelSoon()
-  p.sendFuts = @[]
-  if not p.rpcmessagequeue.sendNonHighPriorityTask.isNil():
-    trace "stopping sendNonHighPriorityTask", peer = p
-    p.rpcmessagequeue.sendNonHighPriorityTask.cancelSoon()
-    p.rpcmessagequeue.sendNonHighPriorityTask = nil
-    for fut in p.rpcmessagequeue.sendPriorityQueue:
-      fut.cancelSoon()
-    p.rpcmessagequeue.sendPriorityQueue.clear()
-    p.rpcmessagequeue.mediumPriorityQueue.clear()
-    p.rpcmessagequeue.lowPriorityQueue.clear()
-
-    when defined(pubsubpeer_queue_metrics):
-      libp2p_gossipsub_high_priority_queue_size.set(
-        labelValues = [$p.peerId], value = 0
-      )
-      libp2p_gossipsub_medium_priority_queue_size.set(
-        labelValues = [$p.peerId], value = 0
-      )
-      libp2p_gossipsub_low_priority_queue_size.set(labelValues = [$p.peerId], value = 0)
-
-proc stop*(p: PubSubPeer) {.async: (raises: []).} =
-  ## Cancels peer tasks and waits for them before closing the send stream.
   var pending = p.sendFuts
   if not p.connectFut.isNil:
     pending.add(p.connectFut)
   if not p.rpcmessagequeue.sendNonHighPriorityTask.isNil:
+    trace "stopping sendNonHighPriorityTask", peer = p
     pending.add(p.rpcmessagequeue.sendNonHighPriorityTask)
   for fut in p.rpcmessagequeue.sendPriorityQueue:
     pending.add(fut)
 
-  p.stopTasks()
-  await noCancel allFutures(pending)
-  if not p.sendStream.isNil:
-    await p.sendStream.close()
-    p.sendStream = nil
-  p.connectedFut.completeOnce()
+  # Retain task handles until cancellation finishes, including for repeated stops.
+  await noCancel pending.cancelAndWait()
+  p.connectFut = nil
+  p.sendFuts = @[]
+  p.rpcmessagequeue.sendNonHighPriorityTask = nil
+  p.rpcmessagequeue.sendPriorityQueue.clear()
+  p.rpcmessagequeue.mediumPriorityQueue.clear()
+  p.rpcmessagequeue.lowPriorityQueue.clear()
+
+  when defined(pubsubpeer_queue_metrics):
+    libp2p_gossipsub_high_priority_queue_size.set(labelValues = [$p.peerId], value = 0)
+    libp2p_gossipsub_medium_priority_queue_size.set(
+      labelValues = [$p.peerId], value = 0
+    )
+    libp2p_gossipsub_low_priority_queue_size.set(labelValues = [$p.peerId], value = 0)
 
 proc new(T: typedesc[RpcMessageQueue]): T =
   return T(

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -832,7 +832,7 @@ proc stopTasks*(p: PubSubPeer) {.async: (raises: []).} =
     pending.add(fut)
 
   # Retain task handles until cancellation finishes, including for repeated stops.
-  await noCancel pending.cancelAndWait()
+  await noCancel chronos.cancelAndWait(pending)
   p.connectFut = nil
   p.sendFuts = @[]
   p.rpcmessagequeue.sendNonHighPriorityTask = nil

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -181,7 +181,7 @@ type
     maxHighPriorityQueueLen*: int
     maxMediumPriorityQueueLen*: int
     maxLowPriorityQueueLen*: int
-    disconnected: bool
+    stopped: bool
     customStreamCallbacks*: Opt[CustomStreamCallbacks]
     connectFut: Future[void]
     sendFuts: seq[Future[void]]
@@ -334,7 +334,7 @@ proc runHandleLoop*(
   defer:
     trace "exiting pubsub read loop", stream, peerId = p, closed = stream.closed
 
-  while not p.disconnected and not stream.atEof:
+  while not p.stopped and not stream.atEof:
     var data =
       try:
         await stream.readLp(p.maxMessageSize)
@@ -345,7 +345,7 @@ proc runHandleLoop*(
           err = e.msg, stream, peer = p, closed = stream.closed
         return
 
-    if p.disconnected:
+    if p.stopped:
       return
 
     trace "read data from peer",
@@ -390,7 +390,7 @@ proc connectOnce(
         await p.getStream().wait(5.seconds)
       except AsyncTimeoutError:
         raise newException(GetStreamDialError, "establishing stream timed out")
-    if p.disconnected:
+    if p.stopped:
       await newStream.close()
       return
 
@@ -428,7 +428,7 @@ proc connectImpl(p: PubSubPeer) {.async: (raises: []).} =
     # send stream might get disconnected due to a timeout or an unrelated
     # issue so we try to get a new one
     while true:
-      if p.disconnected:
+      if p.stopped:
         p.connectedFut.completeOnce()
         return
       await connectOnce(p)
@@ -438,7 +438,7 @@ proc connectImpl(p: PubSubPeer) {.async: (raises: []).} =
     trace "Could not establish send stream", err = exc.msg
 
 proc connect*(p: PubSubPeer) =
-  if p.disconnected or p.connected:
+  if p.stopped or p.connected:
     return
   if not p.connectFut.isNil() and not p.connectFut.finished():
     return
@@ -542,8 +542,8 @@ proc sendMsg(
     await sendMsgSlow(p, move(msg))
 
 proc disconnectPeer(p: PubSubPeer): Future[void] =
-  if not p.disconnected:
-    p.disconnected = true
+  if not p.stopped:
+    p.stopped = true
     when defined(pubsubpeer_queue_metrics):
       libp2p_pubsub_disconnects_over_high_priority_queue_limit.inc()
     return p.closeSendStream(PubSubPeerEventKind.DisconnectionRequested)
@@ -617,7 +617,7 @@ proc sendEncoded*(
   ## priority messages have been sent.
   doAssert(not isNil(p), "pubsubpeer nil!")
 
-  if p.disconnected:
+  if p.stopped:
     return newFutureCompleted[void]()
 
   p.clearSendPriorityQueue()
@@ -822,7 +822,7 @@ proc startSendNonHighPriorityTask(p: PubSubPeer) =
 proc stopTasks*(p: PubSubPeer) =
   ## Prevents further work and requests cancellation of all peer tasks.
   ## Use `stop` to wait for teardown to finish.
-  p.disconnected = true
+  p.stopped = true
   if not p.connectFut.isNil():
     p.connectFut.cancelSoon()
     p.connectFut = nil

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -67,6 +67,7 @@ type
     nameResolver*: NameResolver
     addressManager*: AddressManager
     started: bool
+    stopping: bool
     services*: seq[Service]
     rng*: Rng
 
@@ -338,6 +339,10 @@ when defined(libp2p_testing):
   proc acceptFuts*(s: Switch): seq[Future[void]] =
     s.acceptFuts
 
+proc isStopping*(s: Switch): bool =
+  ## True from the beginning of shutdown until the next start.
+  s.stopping
+
 proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
   ## Stop listening on every transport, and
   ## close every active connections
@@ -345,9 +350,7 @@ proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
   info "Stopping switch"
 
   s.started = false
-
-  # Stop protocol tasks before closing streams can trigger reconnect attempts.
-  await s.ms.stop()
+  s.stopping = true
 
   try:
     # Stop accepting incoming connections
@@ -368,6 +371,9 @@ proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
 
   for service in s.services:
     await service.stop(s)
+
+  # Drain incoming work and services before protocols, keeping established connections.
+  await s.ms.stop()
 
   # close and cleanup all connections
   await s.connManager.stop()
@@ -395,6 +401,7 @@ proc start*(s: Switch) {.async: (raises: [CancelledError, LPError]).} =
     return
 
   info "Starting switch for peer", peerInfo = s.peerInfo
+  s.stopping = false
 
   if not s.connManager.isRunning():
     s.connManager.start()

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -346,6 +346,9 @@ proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
 
   s.started = false
 
+  # Stop protocol tasks before closing streams can trigger reconnect attempts.
+  await s.ms.stop()
+
   try:
     # Stop accepting incoming connections
     await s.acceptFuts.cancelAndWait().wait(1.seconds)
@@ -376,8 +379,6 @@ proc stop*(s: Switch) {.async: (raises: [CancelledError]).} =
       raise exc
     except CatchableError as exc:
       warn "Transport cleanup failed", err = exc.msg
-
-  await s.ms.stop()
 
   # stopped last, after every component which can still feed an address
   doAssert not s.addressManager.isNil(), MissingAddressManager

--- a/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
+++ b/tests/libp2p/pubsub/component/test_gossipsub_control_messages.nim
@@ -46,9 +46,9 @@ suite "GossipSub Component - Control Messages":
       not n0.mesh.hasPeerId(topic, n1.peerInfo.peerId)
       not n1.mesh.hasPeerId(topic, n0.peerInfo.peerId)
 
-    # Stop both nodes in order to prevent GRAFT message to be sent by heartbeat 
-    await n0.stop()
-    await n1.stop()
+    # Pause automatic GRAFTs while testing explicit control messages.
+    await n0.heartbeatFut.cancelAndWait()
+    await n1.heartbeatFut.cancelAndWait()
 
     # Second part of the hack
     # Set values so peers can be GRAFTed

--- a/tests/libp2p/pubsub/test_gossipsub.nim
+++ b/tests/libp2p/pubsub/test_gossipsub.nim
@@ -376,7 +376,7 @@ suite "GossipSub":
         randomPeerId(), nil, nil, GossipSubCodec_12, 1024 * 1024, handler = handler
       )
     defer:
-      peer.stopTasks()
+      await peer.stopTasks()
       await stream.close()
 
     let handleFut = peer.runHandleLoop(stream)

--- a/tests/libp2p/pubsub/test_priority_queues.nim
+++ b/tests/libp2p/pubsub/test_priority_queues.nim
@@ -146,7 +146,7 @@ suite "Priority queue behavior":
     )
     let conn = createPendingConnection()
     defer:
-      peer.stopTasks()
+      await peer.stopTasks()
 
     peer.sendStream = conn
 
@@ -187,7 +187,7 @@ suite "Priority queue behavior":
     )
     let conn = createRecorderConnection()
     defer:
-      peer.stopTasks()
+      await peer.stopTasks()
 
     peer.sendStream = conn
 
@@ -224,7 +224,7 @@ suite "Priority queue behavior":
     )
     let conn = createRecorderConnection()
     defer:
-      peer.stopTasks()
+      await peer.stopTasks()
 
     peer.sendStream = conn
 
@@ -259,8 +259,8 @@ suite "Priority queue behavior":
     let mediumConn = createPendingConnection()
     let lowConn = createPendingConnection()
     defer:
-      mediumPeer.stopTasks()
-      lowPeer.stopTasks()
+      await mediumPeer.stopTasks()
+      await lowPeer.stopTasks()
 
     # This is required so we can test the send path
     mediumPeer.sendStream = mediumConn
@@ -298,7 +298,7 @@ suite "Priority queue behavior":
     let conn = createPendingConnection()
     defer:
       await conn.close()
-      peer.stopTasks()
+      await peer.stopTasks()
 
     peer.sendStream = conn
 
@@ -457,7 +457,7 @@ suite "PubSubPeer sendResponse":
     let conn = createRecorderConnection()
     peer.sendStream = conn
     defer:
-      peer.stopTasks()
+      await peer.stopTasks()
 
     let msg = RPCMsg(
       control: Opt.some(ControlMessage(graft: @[ControlGraft(topicID: topic)])),
@@ -486,7 +486,7 @@ suite "PubSubPeer sendResponse":
     let conn = createRecorderConnection()
     peer.sendStream = conn
     defer:
-      peer.stopTasks()
+      await peer.stopTasks()
 
     peer.sendResponse(msg, true, MessagePriority.High)
 
@@ -511,7 +511,7 @@ suite "PubSubPeer sendResponse":
     let conn = createRecorderConnection()
     peer.sendStream = conn
     defer:
-      peer.stopTasks()
+      await peer.stopTasks()
 
     peer.sendResponse(fullMsg, false, MessagePriority.High)
 
@@ -533,7 +533,7 @@ suite "PubSubPeer sendResponse":
     let conn = createRecorderConnection()
     peer.sendStream = conn
     defer:
-      peer.stopTasks()
+      await peer.stopTasks()
 
     peer.sendResponse(fullMsg, false, MessagePriority.High)
 
@@ -557,7 +557,7 @@ suite "PubSubPeer sendResponse":
     let conn = createRecorderConnection()
     peer.sendStream = conn
     defer:
-      peer.stopTasks()
+      await peer.stopTasks()
 
     peer.sendResponse(msg, false, MessagePriority.High)
 

--- a/tests/libp2p/pubsub/test_shutdown.nim
+++ b/tests/libp2p/pubsub/test_shutdown.nim
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+# Copyright (c) Status Research & Development GmbH
+
+{.used.}
+
+import chronos
+import ./utils
+import ../../../libp2p/connmanager
+import ../../../libp2p/protocols/pubsub/[pubsub, pubsubpeer, floodsub, gossipsub]
+import ../../tools/[unittest, switch_builder, bufferstream]
+
+suite "PubSub shutdown":
+  teardown:
+    checkTrackers()
+
+  asyncTest "switch cancels pubsub connectors before stopping connections":
+    let
+      sw = makeStandardSwitch()
+      gossip = GossipSub.init(sw, rng = rng())
+      dialing = newAsyncEvent()
+      never = newAsyncEvent()
+    var
+      attempts = 0
+      cancelled = false
+      connectionsRunningAtCancellation = false
+
+    proc getStream(): Future[Stream] {.
+        async: (raises: [CancelledError, GetStreamDialError])
+    .} =
+      inc attempts
+      dialing.fire()
+      try:
+        await never.wait()
+      finally:
+        cancelled = true
+        connectionsRunningAtCancellation = sw.connManager.isRunning()
+
+    let peer = PubSubPeer.new(
+      randomPeerId(), getStream, nil, GossipSubCodec_12, 1024, voidPeerHandler
+    )
+    gossip.peers[peer.peerId] = peer
+    sw.mount(gossip)
+    await sw.start()
+    peer.connect()
+    await dialing.wait()
+    await sw.stop()
+
+    check:
+      cancelled
+      connectionsRunningAtCancellation
+      gossip.peers.len == 0
+    peer.connect()
+    check attempts == 1
+    await peer.stop()
+
+  asyncTest "FloodSub stop cancels peers and rejects late peer events until restart":
+    let
+      sw = makeStandardSwitch()
+      flood = FloodSub.init(sw, rng = rng())
+      never = newAsyncEvent()
+    var cancelled = false
+
+    proc getStream(): Future[Stream] {.
+        async: (raises: [CancelledError, GetStreamDialError])
+    .} =
+      try:
+        await never.wait()
+      finally:
+        cancelled = true
+
+    let peer = PubSubPeer.new(
+      randomPeerId(), getStream, nil, FloodSubCodec, 1024, voidPeerHandler
+    )
+    flood.peers[peer.peerId] = peer
+    await flood.start()
+    peer.connect()
+    await flood.stop()
+    check:
+      cancelled
+      flood.peers.len == 0
+    flood.subscribePeer(randomPeerId())
+    check flood.peers.len == 0
+    let lateStream = TestBufferStream.new(noop)
+    await flood.handleConn(lateStream, FloodSubCodec)
+    check:
+      lateStream.closed
+      flood.peers.len == 0
+    await flood.start()
+    let nextPeer = PubSubPeer.new(
+      randomPeerId(), getStream, nil, FloodSubCodec, 1024, voidPeerHandler
+    )
+    flood.peers[nextPeer.peerId] = nextPeer
+    cancelled = false
+    flood.subscribePeer(nextPeer.peerId)
+    await flood.stop()
+    check cancelled
+    await peer.stop()
+    await sw.stop()
+
+  asyncTest "closing a send stream during switch shutdown does not redial":
+    let
+      sw = makeStandardSwitch()
+      gossip = GossipSub.init(sw, rng = rng())
+      stream = TestBufferStream.new(noop)
+    var attempts = 0
+
+    proc getStream(): Future[Stream] {.
+        async: (raises: [CancelledError, GetStreamDialError])
+    .} =
+      inc attempts
+      if attempts > 1:
+        raise newException(GetStreamDialError, "unexpected reconnect")
+      return stream
+
+    let peer = PubSubPeer.new(
+      randomPeerId(), getStream, nil, GossipSubCodec_12, 1024, voidPeerHandler
+    )
+    gossip.peers[peer.peerId] = peer
+    sw.mount(gossip)
+    await sw.start()
+    peer.connect()
+    checkUntilTimeout:
+      peer.connected
+
+    let stopped = sw.stop()
+    await stream.close()
+    await stopped
+    check attempts == 1
+    await peer.stop()
+
+  asyncTest "peer stop waits for connector cancellation cleanup":
+    let
+      never = newAsyncEvent()
+      cleaningUp = newAsyncEvent()
+      releaseCleanup = newAsyncEvent()
+    var cleanupFinished = false
+
+    proc getStream(): Future[Stream] {.
+        async: (raises: [CancelledError, GetStreamDialError])
+    .} =
+      try:
+        await never.wait()
+      finally:
+        cleaningUp.fire()
+        await noCancel releaseCleanup.wait()
+        cleanupFinished = true
+
+    let peer = PubSubPeer.new(
+      randomPeerId(), getStream, nil, GossipSubCodec_12, 1024, voidPeerHandler
+    )
+    peer.connect()
+    let stopped = peer.stop()
+    await cleaningUp.wait()
+    check not stopped.finished
+    releaseCleanup.fire()
+    await stopped
+    check cleanupFinished

--- a/tests/libp2p/pubsub/test_shutdown.nim
+++ b/tests/libp2p/pubsub/test_shutdown.nim
@@ -51,7 +51,6 @@ suite "PubSub shutdown":
       gossip.peers.len == 0
     peer.connect()
     check attempts == 1
-    await peer.stop()
 
   asyncTest "FloodSub stop cancels peers and rejects late peer events until restart":
     let
@@ -94,7 +93,6 @@ suite "PubSub shutdown":
     flood.subscribePeer(nextPeer.peerId)
     await flood.stop()
     check cancelled
-    await peer.stop()
     await sw.stop()
 
   asyncTest "closing a send stream during switch shutdown does not redial":
@@ -126,10 +124,11 @@ suite "PubSub shutdown":
     await stream.close()
     await stopped
     check attempts == 1
-    await peer.stop()
 
-  asyncTest "peer stop waits for connector cancellation cleanup":
+  asyncTest "stop waits for cleanup of an already removed peer":
     let
+      sw = makeStandardSwitch()
+      flood = FloodSub.init(sw, rng = rng())
       never = newAsyncEvent()
       cleaningUp = newAsyncEvent()
       releaseCleanup = newAsyncEvent()
@@ -146,12 +145,21 @@ suite "PubSub shutdown":
         cleanupFinished = true
 
     let peer = PubSubPeer.new(
-      randomPeerId(), getStream, nil, GossipSubCodec_12, 1024, voidPeerHandler
+      randomPeerId(), getStream, nil, FloodSubCodec, 1024, voidPeerHandler
     )
+    flood.peers[peer.peerId] = peer
     peer.connect()
-    let stopped = peer.stop()
+    flood.unsubscribePeer(peer.peerId)
+    let
+      peerStopped = peer.stopTasks()
+      stopped = flood.stop()
     await cleaningUp.wait()
-    check not stopped.finished
+    check:
+      flood.peers.len == 0
+      not peerStopped.finished
+      not stopped.finished
     releaseCleanup.fire()
     await stopped
+    await peerStopped
     check cleanupFinished
+    await sw.stop()

--- a/tests/libp2p/pubsub/test_shutdown.nim
+++ b/tests/libp2p/pubsub/test_shutdown.nim
@@ -7,7 +7,7 @@ import chronos
 import ./utils
 import ../../../libp2p/connmanager
 import ../../../libp2p/protocols/pubsub/[pubsub, pubsubpeer, floodsub, gossipsub]
-import ../../tools/[unittest, switch_builder, bufferstream]
+import ../../tools/[unittest, switch_builder, bufferstream, multiaddress, lifecycle]
 
 suite "PubSub shutdown":
   teardown:
@@ -95,35 +95,51 @@ suite "PubSub shutdown":
     check cancelled
     await sw.stop()
 
-  asyncTest "closing a send stream during switch shutdown does not redial":
+  asyncTest "pubsub refuses new dials while a registered upgrade drains":
     let
-      sw = makeStandardSwitch()
-      gossip = GossipSub.init(sw, rng = rng())
-      stream = TestBufferStream.new(noop)
-    var attempts = 0
+      server = makeStandardSwitch(MemoryAutoAddress())
+      client = makeStandardSwitch(MemoryAutoAddress())
+      gossip = GossipSub.init(server, rng = rng())
+      remoteGossip = GossipSub.init(client, rng = rng())
+      registered = newAsyncEvent()
+      releaseUpgrade = newAsyncEvent()
 
-    proc getStream(): Future[Stream] {.
-        async: (raises: [CancelledError, GetStreamDialError])
-    .} =
-      inc attempts
-      if attempts > 1:
-        raise newException(GetStreamDialError, "unexpected reconnect")
-      return stream
+    proc onConnected(
+        peerId: PeerId, event: ConnEvent
+    ) {.async: (raises: [CancelledError]).} =
+      registered.fire()
+      await releaseUpgrade.wait()
 
-    let peer = PubSubPeer.new(
-      randomPeerId(), getStream, nil, GossipSubCodec_12, 1024, voidPeerHandler
-    )
-    gossip.peers[peer.peerId] = peer
-    sw.mount(gossip)
-    await sw.start()
+    server.addConnEventHandler(onConnected, ConnEventKind.Connected)
+    server.mount(gossip)
+    client.mount(remoteGossip)
+    startAndDeferStop(@[server, client])
+    defer:
+      releaseUpgrade.fire()
+
+    let connecting = client.connect(server.peerInfo.peerId, server.peerInfo.addrs)
+    await registered.wait()
+    await connecting
+    let peer = gossip.getOrCreatePeer(client.peerInfo.peerId, @[GossipSubCodec_12])
     peer.connect()
     checkUntilTimeout:
       peer.connected
+    let stream = peer.sendStream
 
-    let stopped = sw.stop()
+    let stopped = server.stop()
+    let reconnect = peer.getStream()
+    check reconnect.cancelled
+    await noCancel reconnect.cancelAndWait()
+
+    let latePeer = randomPeerId()
+    gossip.subscribePeer(latePeer)
+    check latePeer notin gossip.peers
+    let directDial = gossip.addDirectPeer(latePeer, client.peerInfo.addrs)
+    check directDial.completed
+    await noCancel directDial.cancelAndWait()
+
     await stream.close()
     await stopped
-    check attempts == 1
 
   asyncTest "stop waits for cleanup of an already removed peer":
     let

--- a/tests/libp2p/pubsub/test_shutdown.nim
+++ b/tests/libp2p/pubsub/test_shutdown.nim
@@ -179,3 +179,36 @@ suite "PubSub shutdown":
     await peerStopped
     check cleanupFinished
     await sw.stop()
+
+  asyncTest "overlapping GossipSub stops wait for pending cleanup, even before start":
+    for started in [false, true]:
+      let
+        sw = makeStandardSwitch()
+        gossip = GossipSub.init(sw, rng = rng())
+        never = newAsyncEvent()
+        cleaningUp = newAsyncEvent()
+        releaseCleanup = newAsyncEvent()
+      var cleanupFinished = false
+
+      proc pendingTask() {.async: (raises: [CancelledError]).} =
+        try:
+          await never.wait()
+        finally:
+          cleaningUp.fire()
+          await noCancel releaseCleanup.wait()
+          cleanupFinished = true
+
+      if started:
+        await gossip.start()
+      gossip.pendingTasks.add(pendingTask())
+      let firstStop = gossip.stop()
+      await cleaningUp.wait()
+      let secondStop = gossip.stop()
+      check:
+        not firstStop.finished
+        not secondStop.finished
+      releaseCleanup.fire()
+      await firstStop
+      await secondStop
+      check cleanupFinished
+      await sw.stop()

--- a/tests/libp2p/test_switch_accept.nim
+++ b/tests/libp2p/test_switch_accept.nim
@@ -8,6 +8,7 @@ import chronos
 import
   ../../libp2p/
     [builders, switch, dial, multiaddress, transports/transport, stream/connection]
+import ../../libp2p/protocols/protocol
 import ../stubs/transportstub
 import ../tools/[unittest, crypto, lifecycle, multiaddress, switch_builder]
 
@@ -41,6 +42,22 @@ proc newStubAcceptSwitch(
 
   let switch = b.build()
   (switch, MemoryTransportStub(switch.transports[0]))
+
+type SlowStopProtocol = ref object of LPProtocol
+  stopping, release: AsyncEvent
+
+method stop(p: SlowStopProtocol) {.async: (raises: []).} =
+  p.stopping.fire()
+  await noCancel p.release.wait()
+  p.started = false
+
+proc newSlowStopProtocol(): SlowStopProtocol =
+  result = SlowStopProtocol(stopping: newAsyncEvent(), release: newAsyncEvent())
+  result.codec = "/test/slow-stop/1.0.0"
+  result.handler = proc(
+      stream: Stream, proto: string
+  ) {.async: (raises: [CancelledError]).} =
+    await stream.close()
 
 suite "Switch accept-loop failure handling":
   teardown:
@@ -149,3 +166,44 @@ suite "Switch accept-loop failure handling":
     let tcpAddrs = server.peerInfo.addrs.filterIt(TCP.match(it))
     await client.connect(server.peerInfo.peerId, tcpAddrs)
     check client.isConnected(server.peerInfo.peerId)
+
+  asyncTest "accepts and registered upgrades drain before slow protocol teardown":
+    let
+      server = makeStandardSwitch(MemoryAutoAddress())
+      client = makeStandardSwitch(MemoryAutoAddress())
+      protocol = newSlowStopProtocol()
+      registered = newAsyncEvent()
+      releaseUpgrade = newAsyncEvent()
+
+    proc onConnected(
+        peerId: PeerId, event: ConnEvent
+    ) {.async: (raises: [CancelledError]).} =
+      registered.fire()
+      await releaseUpgrade.wait()
+
+    server.addConnEventHandler(onConnected, ConnEventKind.Connected)
+    server.mount(protocol)
+    startAndDeferStop(@[server, client])
+    defer:
+      releaseUpgrade.fire()
+      protocol.release.fire()
+
+    let connecting = client.connect(server.peerInfo.peerId, server.peerInfo.addrs)
+    await registered.wait()
+    await connecting
+    let conn = server.connManager.selectMuxer(client.peerInfo.peerId).connection
+    check not conn.closed
+
+    let stopped = server.stop()
+    await protocol.stopping.wait()
+    check:
+      server.acceptFuts.allIt(it.finished)
+      conn.closed
+      server.connManager.isRunning()
+      not stopped.finished
+    releaseUpgrade.fire()
+    protocol.release.fire()
+    await stopped
+    check server.isStopping
+    await server.start()
+    check not server.isStopping


### PR DESCRIPTION
## Summary

Stop and await pubsub peer tasks before closing established switch connections, preventing closed send streams from triggering reconnect attempts during shutdown. Apply peer cleanup to both GossipSub and FloodSub, reject late peer events and incoming streams after stop, and treat connector cancellation as normal shutdown.

Use one awaitable peer teardown operation and retain cleanup futures even after peers leave the peer table. Add regression coverage for shutdown ordering with in-flight upgrades and slow protocol teardown, reconnect prevention, unfinished cleanup of removed peers, and restart. Update the GRAFT test to pause heartbeats directly instead of stopping the protocol.

## Impact on Library Users

Pubsub stop now tears down peers and waits for their tasks. The switch drains accepts, upgrades, and services before stopping mounted protocols, while established connections remain available for cleanup. Pubsub refuses new dials as soon as switch shutdown begins.

`PubSubPeer.stopTasks()` now returns a future. Callers must await it or explicitly retain/discard it; await it when teardown must finish before proceeding.

## References

Fixes #1926.

