### PR TITLE
fix(autonat): remove race in 'Peer must be not reachable and then reachable'

### DIFF
--- a/tests/libp2p/protocols/test_autonat_service.nim
+++ b/tests/libp2p/protocols/test_autonat_service.nim
@@ -203,6 +203,7 @@ suite "Autonat Service":
 
     let notReachableAwaiter = newFuture[void]()
     let reachableAwaiter = newFuture[void]()
+    var notReachableConfidence = Opt.none(float)
     var reachableConfidence = Opt.none(float)
 
     proc reachabilityHandler(
@@ -211,6 +212,7 @@ suite "Autonat Service":
         dialBackAddr: Opt[MultiAddress],
     ) {.async: (raises: [CancelledError]).} =
       if settled(networkReachability, NetworkReachability.NotReachable, confidence):
+        notReachableConfidence = confidence
         autonatClientStub.answer = Reachable
         notReachableAwaiter.completeOnce()
       elif settled(networkReachability, NetworkReachability.Reachable, confidence) and
@@ -233,8 +235,8 @@ suite "Autonat Service":
 
     await notReachableAwaiter
 
-    check autonatService.networkReachability == NetworkReachability.NotReachable
-    check reachabilityConfidence(NetworkReachability.NotReachable) == 0.3
+    # The stub now answers Reachable, so the live state can already be Reachable.
+    check notReachableConfidence == Opt.some(0.3)
 
     await autonatClientStub.finished
     await reachableAwaiter


### PR DESCRIPTION
Fixes #3096. In `Peer must be not reachable and then reachable`, the handler switches the stub to `Reachable` before the test reads `networkReachability`. On a slow runner, the 1s heartbeat and the `Joined` handler can add three `Reachable` answers first, so the state is already `Reachable`. The handler now saves the `NotReachable` confidence at notify time, and the test checks that saved value.
I ran `nim check` on the file, and CI runs the test. Check the removed metric assertion: `Peer must be not reachable` still checks the `NotReachable` metric at 0.3.
