### PR TITLE
chore(opt): improvements

### DIFF
--- a/libp2p/utils/opt.nim
+++ b/libp2p/utils/opt.nim
@@ -8,13 +8,10 @@ export results
 
 func getOpt*[K, V](t: Table[K, V], key: K): Opt[V] =
   ## `Opt.some` of the value at `key`, `Opt.none` when `t` has no such key.
-  if key notin t:
-    return Opt.none(V)
-
   try:
     Opt.some(t[key])
   except KeyError:
-    raiseAssert "key presence checked above"
+    Opt.none(V)
 
 func toOpt*[T](v: Opt[T] | T): Opt[T] =
   when v is T:
@@ -70,7 +67,10 @@ template withValue*[T](self: Opt[T], value, body: untyped): untyped =
     body
 
 template withValue*[T, E](self: Result[T, E], value, body: untyped): untyped =
-  self.toOpt().withValue(value, body)
+  let temp = (self)
+  if temp.isOk:
+    let value {.inject, used.} = temp.unsafeGet()
+    body
 
 macro withValue*[T](self: Opt[T], value, body, elseStmt: untyped): untyped =
   let elseBody = elseStmt[0]

--- a/libp2p/utils/opt.nim
+++ b/libp2p/utils/opt.nim
@@ -42,7 +42,7 @@ func noneWhenEmpty*[T](O: type Opt, v: seq[T]): Opt[seq[T]] =
   else:
     Opt.some(v)
 
-template withValue*[T](self: Opt[T], value, body: untyped): untyped =
+template withValue*[T: not void](self: Opt[T], value, body: untyped): untyped =
   ## This template provides a convenient way to work with `Opt` types in Nim.
   ## It allows you to execute a block of code (`body`) only when the `Opt` is not empty.
   ##
@@ -66,13 +66,13 @@ template withValue*[T](self: Opt[T], value, body: untyped): untyped =
     let value {.inject, used.} = temp.get()
     body
 
-template withValue*[T, E](self: Result[T, E], value, body: untyped): untyped =
+template withValue*[T: not void, E](self: Result[T, E], value, body: untyped): untyped =
   let temp = (self)
   if temp.isOk:
     let value {.inject, used.} = temp.unsafeGet()
     body
 
-macro withValue*[T](self: Opt[T], value, body, elseStmt: untyped): untyped =
+macro withValue*[T: not void](self: Opt[T], value, body, elseStmt: untyped): untyped =
   let elseBody = elseStmt[0]
   quote:
     let temp = (`self`)

--- a/libp2p/utils/opt.nim
+++ b/libp2p/utils/opt.nim
@@ -8,10 +8,13 @@ export results
 
 func getOpt*[K, V](t: Table[K, V], key: K): Opt[V] =
   ## `Opt.some` of the value at `key`, `Opt.none` when `t` has no such key.
+  if key notin t:
+    return Opt.none(V)
+
   try:
     Opt.some(t[key])
   except KeyError:
-    Opt.none(V)
+    raiseAssert "key presence checked above"
 
 func toOpt*[T](v: Opt[T] | T): Opt[T] =
   when v is T:


### PR DESCRIPTION
- ~`getOpt` had unnecessary 2 lookups when value is in Table, since this pr it will always have 1 lookup~
  - reverted: description in comments
- avoid use of `toOpt()` inside utilities here. it crates unnecessary intermediate value 
- restrict some type parameters where type must not be void