### PR TITLE
refactor(service-disco): apply review follow-ups from #3080

### DIFF
--- a/libp2p/multicodec.nim
+++ b/libp2p/multicodec.nim
@@ -69,6 +69,10 @@ proc multiCodec*(code: int): MultiCodec {.compileTime.} =
   doAssert(name != "")
   MultiCodec(code)
 
+const
+  TcpMultiCodec* = multiCodec("tcp")
+  UdpMultiCodec* = multiCodec("udp")
+
 proc `$`*(mc: MultiCodec): string =
   ## Returns string representation of MultiCodec ``mc``.
   let name = CodeCodecs.getOrDefault(int(mc), "")

--- a/libp2p/protocols/service_discovery.nim
+++ b/libp2p/protocols/service_discovery.nim
@@ -41,30 +41,35 @@ proc refreshSelfSignedPeerRecord(
   (await disco.putValue(key, Value.fromBytes(encodedSR))).isOkOr:
     debug "Failed to put signed peer record", err = error
 
+template withBucketRefreshTimeout(fut: untyped, disco: ServiceDiscovery): untyped =
+  fut.withTimeout(disco.config.bucketRefreshTime)
+
+proc maintainSignedPeerRecord(
+    disco: ServiceDiscovery
+) {.async: (raises: [CancelledError]).} =
+  heartbeat "refresh signed peer record", disco.config.bucketRefreshTime:
+    if not await disco.refreshSelfSignedPeerRecord().withBucketRefreshTimeout(disco):
+      warn "Signed peer record refresh timed out",
+        timeout = disco.config.bucketRefreshTime
+
+proc republishAddresses(
+    disco: ServiceDiscovery, previous: Future[void]
+) {.async: (raises: [CancelledError]).} =
+  if not previous.isNil():
+    await previous.cancelAndWait()
+
+  # A restart publishes the new record at once and keeps one record publisher.
+  if disco.xprPublishing:
+    await disco.signedPeerRecordLoop.cancelAndWait()
+    disco.signedPeerRecordLoop = disco.maintainSignedPeerRecord()
+
+  if not await disco.republishProvidedAdverts().withBucketRefreshTimeout(disco):
+    warn "Provided advert republish timed out", timeout = disco.config.bucketRefreshTime
+
 proc republishOnAddressChange(disco: ServiceDiscovery): PeerInfoObserver =
   ## Without this, a moved address stays stale in the DHT for a `bucketRefreshTime`.
   proc(p: PeerInfo) {.gcsafe, raises: [].} =
-    disco.addressChanged.fire()
-
-proc maintainSelfPublications(
-    disco: ServiceDiscovery
-) {.async: (raises: [CancelledError]).} =
-  ## One publisher for both triggers: an address change never races the heartbeat.
-  var addressMoved = false
-  while true:
-    disco.addressChanged.clear()
-
-    let refresh = disco.config.bucketRefreshTime
-
-    if disco.xprPublishing:
-      if not await disco.refreshSelfSignedPeerRecord().withTimeout(refresh):
-        warn "Signed peer record refresh timed out", timeout = refresh
-
-    if addressMoved:
-      if not await disco.republishProvidedAdverts().withTimeout(refresh):
-        warn "Provided advert republish timed out", timeout = refresh
-
-    addressMoved = await disco.addressChanged.wait().withTimeout(refresh)
+    disco.addressRepublish = disco.republishAddresses(disco.addressRepublish)
 
 proc maintainRegistrar(disco: ServiceDiscovery) {.async: (raises: [CancelledError]).} =
   heartbeat "prune expired advertisements",
@@ -76,9 +81,7 @@ proc maintainServiceTables(
 ) {.async: (raises: [CancelledError]).} =
   heartbeat "refresh service routing tables",
     disco.config.bucketRefreshTime, sleepFirst = true:
-    if not await disco.rtManager.refreshAllTables(disco).withTimeout(
-      disco.config.bucketRefreshTime
-    ):
+    if not await disco.rtManager.refreshAllTables(disco).withBucketRefreshTimeout(disco):
       warn "Service routing table refresh timed out",
         timeout = disco.config.bucketRefreshTime, tables = disco.rtManager.tables.len
 
@@ -111,7 +114,6 @@ proc new*(
     services: toHashSet(services),
     discoConfig: discoConfig,
     xprPublishing: xprPublishing,
-    addressChanged: newAsyncEvent(),
   )
   disco.initKadBase(
     switch,
@@ -192,9 +194,11 @@ method start*(disco: ServiceDiscovery) {.async: (raises: [CancelledError]).} =
     disco.addProvidedService(serviceInfo).isOkOr:
       warn "Cannot advertise configured service", err = error, service = serviceInfo.id
 
+  if disco.xprPublishing:
+    disco.signedPeerRecordLoop = disco.maintainSignedPeerRecord()
+
   disco.addressObserver = disco.republishOnAddressChange()
   disco.switch.peerInfo.addObserver(disco.addressObserver)
-  disco.selfPublicationLoop = disco.maintainSelfPublications()
 
   disco.pruneExpiredAdsLoop = disco.maintainRegistrar()
   disco.refreshServiceTablesLoop = disco.maintainServiceTables()
@@ -211,9 +215,13 @@ method stop*(disco: ServiceDiscovery) {.async: (raises: []).} =
     disco.switch.peerInfo.removeObserver(disco.addressObserver)
     disco.addressObserver = nil
 
-  if not disco.selfPublicationLoop.isNil:
-    await disco.selfPublicationLoop.cancelAndWait()
-    disco.selfPublicationLoop = nil
+  if not disco.addressRepublish.isNil():
+    await disco.addressRepublish.cancelAndWait()
+    disco.addressRepublish = nil
+
+  if not disco.signedPeerRecordLoop.isNil():
+    await disco.signedPeerRecordLoop.cancelAndWait()
+    disco.signedPeerRecordLoop = nil
 
   if not disco.advertiserMaintenanceLoop.isNil:
     await disco.advertiserMaintenanceLoop.cancelAndWait()

--- a/libp2p/protocols/service_discovery/connection.nim
+++ b/libp2p/protocols/service_discovery/connection.nim
@@ -27,7 +27,7 @@ proc send*(
     return err("no address found for peer: " & $peerId)
 
   if disco.dialBackedOff(peerId, addrs):
-    return err("peer is in dial backoff: " & $peerId)
+    return err(makeDialBackoffError(peerId))
 
   let stream =
     try:

--- a/libp2p/protocols/service_discovery/dial_backoff.nim
+++ b/libp2p/protocols/service_discovery/dial_backoff.nim
@@ -13,6 +13,9 @@ import ./[routing_table_manager, types as disco_types]
 const MaxDialFailureEntries = 1024
   ## Cache size of failed dials; its keys come from remote replies.
 
+func makeDialBackoffError*(peerId: PeerId): string =
+  "peer is in dial backoff: " & $peerId
+
 proc dialBackedOff*(
     disco: ServiceDiscovery, peerId: PeerId, addrs: seq[MultiAddress]
 ): bool =

--- a/libp2p/protocols/service_discovery/types.nim
+++ b/libp2p/protocols/service_discovery/types.nim
@@ -135,13 +135,13 @@ type
     discoConfig*: ServiceDiscoveryConfig
       # can't use name "config", clashes with KadDHT's config
     xprPublishing*: bool
-    selfPublicationLoop*: Future[void]
+    signedPeerRecordLoop*: Future[void]
     pruneExpiredAdsLoop*: Future[void]
     refreshServiceTablesLoop*: Future[void]
     advertiserMaintenanceLoop*: Future[void]
     localRegistrationLoop*: Future[void]
     serviceBootstrapFuts*: Table[ServiceId, Future[void]]
-    addressChanged*: AsyncEvent
+    addressRepublish*: Future[void]
     addressObserver*: PeerInfoObserver
     dialFailures*: Table[PeerId, ProbeFailure]
 

--- a/libp2p/services/natservice.nim
+++ b/libp2p/services/natservice.nim
@@ -249,25 +249,22 @@ proc explicitIpMapped*(
 type ListenPort = tuple[port: Port, proto: MapProto, multiAddr: MultiAddress]
 
 proc transportProto(ma: MultiAddress): Opt[MapProto] =
-  if ma[multiCodec("tcp")].isOk:
+  if ma[TcpMultiCodec].isOk:
     Opt.some(mpTcp)
-  elif ma[multiCodec("udp")].isOk:
+  elif ma[UdpMultiCodec].isOk:
     Opt.some(mpUdp)
   else:
     Opt.none(MapProto)
 
 proc replaceTransportPort(ma: MultiAddress, port: Port): Opt[MultiAddress] =
   ## Mirrors ``MultiAddress.replaceIp`` but for the tcp/udp port component.
-  let
-    tcp = multiCodec("tcp")
-    udp = multiCodec("udp")
   var res = MultiAddress.init()
   for item in ma.items:
     let part = item.valueOr:
       return Opt.none(MultiAddress)
     let code = part.protoCode.valueOr:
       return Opt.none(MultiAddress)
-    if code == tcp or code == udp:
+    if code == TcpMultiCodec or code == UdpMultiCodec:
       let portMa = MultiAddress.init(code, int(port)).valueOr:
         return Opt.none(MultiAddress)
       res.append(portMa).isOkOr:

--- a/libp2p/transports/tortransport.nim
+++ b/libp2p/transports/tortransport.nim
@@ -177,7 +177,7 @@ proc parseIpTcp(
       raise newException(LPError, "IP address not supported")
   let
     dstAddr = address[codec].tryGet().protoArgument().tryGet()
-    dstPort = address[multiCodec("tcp")].tryGet().protoArgument().tryGet()
+    dstPort = address[TcpMultiCodec].tryGet().protoArgument().tryGet()
   (atyp, dstAddr, dstPort)
 
 proc parseDnsTcp(
@@ -188,7 +188,7 @@ proc parseDnsTcp(
     raise newException(LPError, "DNS address exceeds SOCKS5 domain length limit")
   let
     dstAddr = @(uint8(dnsAddress.len).toBytes()) & dnsAddress
-    dstPort = address[multiCodec("tcp")].tryGet().protoArgument().tryGet()
+    dstPort = address[TcpMultiCodec].tryGet().protoArgument().tryGet()
   (Socks5AddressType.FQDN.byte, dstAddr, dstPort)
 
 proc dialPeer(

--- a/libp2p/wire.nim
+++ b/libp2p/wire.nim
@@ -195,7 +195,7 @@ const
     ## ``::ffff:0.0.0.0``, the IPv4-mapped spelling of the wildcard host.
 
 proc portOf(ma: MultiAddress): Opt[Port] =
-  for codec in [multiCodec("tcp"), multiCodec("udp")]:
+  for codec in [TcpMultiCodec, UdpMultiCodec]:
     let arg = ma.getProtocolArgument(codec).valueOr:
       continue
     if arg.len == 2:

--- a/tests/libp2p/service_discovery/component/test_disco_dial_backoff.nim
+++ b/tests/libp2p/service_discovery/component/test_disco_dial_backoff.nim
@@ -2,7 +2,6 @@
 # Copyright (c) Status Research & Development GmbH
 {.used.}
 
-import std/strutils
 import chronos, results
 import
   ../../../../libp2p/[
@@ -34,30 +33,32 @@ suite "Service Discovery Component - Dial Backoff":
     check disco.addProvidedService(service).isOk()
     let table = disco.rtManager.getTable(service.id.hashServiceId()).get()
 
-    let dead = randomPeerId()
+    let deadPeerId = randomPeerId()
     let deadAddrs = @[ma("/ip4/127.0.0.1/tcp/1")]
-    disco.switch.peerStore[AddressBook].set(dead, deadAddrs, AddressConfidence.Low)
-    check table.insert(dead)
+    disco.switch.peerStore[AddressBook].set(
+      deadPeerId, deadAddrs, AddressConfidence.Low
+    )
+    check table.insert(deadPeerId)
 
     let msg = kad_protobuf.Message(msgType: kad_protobuf.MessageType.ping)
 
-    check (await disco.send(dead, msg)).isErr()
+    check (await disco.send(deadPeerId, msg)).isErr()
 
-    let backedOff = await disco.send(dead, msg)
+    let backedOff = await disco.send(deadPeerId, msg)
     check:
       backedOff.isErr()
-      strutils.contains(backedOff.error, "backoff")
-      table.contains(dead.toKey())
+      backedOff.error == makeDialBackoffError(deadPeerId)
+      table.contains(deadPeerId.toKey())
 
     # The gate blocks further dials, so the rest is recorded without a wait.
     for _ in 1 .. 2:
-      disco.recordDialFailure(dead, deadAddrs)
+      disco.recordDialFailure(deadPeerId, deadAddrs)
 
-    check not table.contains(dead.toKey())
+    check not table.contains(deadPeerId.toKey())
 
     # A re-admitted peer must stay backed off, or the eviction only restarts the loop.
-    check table.insert(dead)
-    let reAdmitted = await disco.send(dead, msg)
+    check table.insert(deadPeerId)
+    let reAdmitted = await disco.send(deadPeerId, msg)
     check:
       reAdmitted.isErr()
-      strutils.contains(reAdmitted.error, "backoff")
+      reAdmitted.error == makeDialBackoffError(deadPeerId)

--- a/tests/libp2p/service_discovery/test_advertiser.nim
+++ b/tests/libp2p/service_discovery/test_advertiser.nim
@@ -7,12 +7,85 @@ import
   ../../../libp2p/[
     extended_peer_record,
     peeraddrpolicy,
+    peerinfo,
     protocols/kademlia,
     protocols/service_discovery,
     protocols/service_discovery/advertiser,
   ]
-import ../../tools/[unittest, multiaddress]
+import ../../tools/[unittest, multiaddress, lifecycle]
 import ./utils
+
+proc holdUntil(gate: AsyncEvent) {.async: (raises: [CancelledError]).} =
+  ## A republish caught mid-flight: a cancel lands only once `gate` fires.
+  await noCancel gate.wait()
+
+proc settleStartupRepublish(disco: ServiceDiscovery) {.async.} =
+  if disco.addressRepublish.isNil():
+    return
+  await disco.addressRepublish
+
+suite "Advertiser - republish on address change":
+  teardown:
+    checkTrackers()
+
+  asyncTest "a newer address change waits for the pending republish to drain":
+    let disco = setupServiceDiscoveryNode(services = @[makeServiceInfo()])
+    startAndDeferStop(@[disco])
+    await disco.settleStartupRepublish()
+
+    let gate = newAsyncEvent()
+    let held = holdUntil(gate)
+    disco.addressRepublish = held
+    let loopBefore = disco.signedPeerRecordLoop
+
+    disco.switch.peerInfo.notifyObservers()
+    let first = disco.addressRepublish
+    disco.switch.peerInfo.notifyObservers()
+    let second = disco.addressRepublish
+
+    await sleepAsync(20.millis)
+    check:
+      first != held
+      second != first
+      not first.finished()
+      not second.finished()
+      disco.signedPeerRecordLoop == loopBefore
+
+    gate.fire()
+    await second
+    check:
+      held.completed()
+      first.finished()
+      second.completed()
+      disco.signedPeerRecordLoop != loopBefore
+
+  asyncTest "stop drains the pending republish before it clears the advertiser":
+    let disco = setupServiceDiscoveryNode(services = @[makeServiceInfo()])
+    startAndDeferStop(@[disco])
+    await disco.settleStartupRepublish()
+
+    let gate = newAsyncEvent()
+    disco.addressRepublish = holdUntil(gate)
+    disco.switch.peerInfo.notifyObservers()
+    let pending = disco.addressRepublish
+
+    let stopping = disco.stop()
+    await sleepAsync(20.millis)
+    check:
+      not stopping.finished()
+      not pending.finished()
+      disco.advertiser.providedAdverts.len == 1
+
+    gate.fire()
+    await stopping
+    check:
+      pending.finished()
+      disco.addressRepublish.isNil()
+      disco.addressObserver.isNil()
+      disco.advertiser.providedAdverts.len == 0
+
+    disco.switch.peerInfo.notifyObservers()
+    check disco.addressRepublish.isNil()
 
 suite "Advertiser - addProvidedService":
   teardown:

--- a/tests/libp2p/service_discovery/test_routing_table_manager.nim
+++ b/tests/libp2p/service_discovery/test_routing_table_manager.nim
@@ -314,10 +314,16 @@ suite "ServiceRoutingTableManager":
 
     let peerInfo = makePeerInfo(addrs = @[ma("/ip4/0.0.0.0/tcp/60000")])
     check not disco.insertPeer(serviceId, peerInfo)
+    check not disco.hasPeerInServiceTable(serviceId, peerInfo.peerId)
 
     disco.switch.peerStore.allowUndialableAddrs = true
     check disco.insertPeer(serviceId, peerInfo)
     check disco.hasPeerInServiceTable(serviceId, peerInfo.peerId)
+
+    disco.switch.peerStore.allowUndialableAddrs = false
+    let otherPeerInfo = makePeerInfo(addrs = @[ma("/ip4/0.0.0.0/tcp/60001")])
+    check not disco.insertPeer(serviceId, otherPeerInfo)
+    check not disco.hasPeerInServiceTable(serviceId, otherPeerInfo.peerId)
 
   test "insertPeer on non-existent service is a no-op":
     let disco = setupServiceDiscoveryNode()

--- a/tests/libp2p/service_discovery/utils.nim
+++ b/tests/libp2p/service_discovery/utils.nim
@@ -145,9 +145,8 @@ proc setupServiceDiscoveryNode*(
     mount: bool = true,
 ): ServiceDiscovery =
   let switch = createSwitch(privateKey, addresses)
-  # `peerInfo.addrs` only fills in on `switch.start()`, which most tests skip.
-  if switch.peerInfo.addrs.len == 0:
-    switch.peerInfo.addrs = @[makeMultiAddress("127.0.0.1")]
+  # `addrs` stays empty until `switch.start()`, and `record()` refuses empty `addrs`.
+  switch.peerInfo.addrs = @[makeMultiAddress("127.0.0.1")]
 
   let node = ServiceDiscovery.new(
     switch,


### PR DESCRIPTION
Applies the post-merge review of #3080. The signed peer record heartbeat runs only with `xprPublishing`, and an address change starts `republishAddresses` in the background, so the `AsyncEvent` loop is gone. `withBucketRefreshTimeout`, `makeDialBackoffError`, `TcpMultiCodec` and `UdpMultiCodec` replace repeated code. The exported fields `signedPeerRecordLoop` and `addressRepublish` replace `selfPublicationLoop` and `addressChanged`.
`nim check` passes on the service discovery, wire, NAT service and tor stub tests; CI runs the tests. Check that an address change cancels the older republish, and that `stop()` cancels it before the XPR loop.
