### PR TITLE
feat(dialer): rank dials by relay and transport

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -89,7 +89,7 @@ type
     protoVersion: string
     agentVersion: string
     nameResolver: NameResolver
-    dialRanking: bool
+    dialRanking: Opt[DialRankingConfig]
     dialBackoff: Opt[DialBackoffConfig]
     peerStoreCapacity: Opt[int]
     addressTtls: AddressConfidenceTtls
@@ -359,7 +359,16 @@ proc withNameResolver*(b: SwitchBuilder, nameResolver: NameResolver): SwitchBuil
   b
 
 proc withDialRanking*(b: SwitchBuilder, enabled: bool = true): SwitchBuilder =
-  b.dialRanking = enabled
+  b.dialRanking =
+    if enabled:
+      Opt.some(DefaultDialRanking)
+    else:
+      Opt.none(DialRankingConfig)
+  b
+
+proc withDialRanking*(b: SwitchBuilder, config: DialRankingConfig): SwitchBuilder =
+  ## Rank and race the dials: QUIC first, the other direct transports next, relays last.
+  b.dialRanking = Opt.some(config)
   b
 
 proc withDialBackoff*(b: SwitchBuilder, config = DefaultDialBackoff): SwitchBuilder =
@@ -548,7 +557,8 @@ proc buildSwitch(b: SwitchBuilder): Switch {.raises: [LPError].} =
     transports,
     ms,
     b.nameResolver,
-    dialRanking = b.dialRanking,
+    dialRanking = b.dialRanking.isSome(),
+    dialRankingConfig = b.dialRanking.get(DefaultDialRanking),
     dialBackoff = b.dialBackoff,
   )
 

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -89,7 +89,7 @@ type
     protoVersion: string
     agentVersion: string
     nameResolver: NameResolver
-    dialRanking: Opt[DialRankingConfig]
+    dialRanking: bool
     dialBackoff: Opt[DialBackoffConfig]
     peerStoreCapacity: Opt[int]
     addressTtls: AddressConfidenceTtls
@@ -359,16 +359,7 @@ proc withNameResolver*(b: SwitchBuilder, nameResolver: NameResolver): SwitchBuil
   b
 
 proc withDialRanking*(b: SwitchBuilder, enabled: bool = true): SwitchBuilder =
-  b.dialRanking =
-    if enabled:
-      Opt.some(DefaultDialRanking)
-    else:
-      Opt.none(DialRankingConfig)
-  b
-
-proc withDialRanking*(b: SwitchBuilder, config: DialRankingConfig): SwitchBuilder =
-  ## Rank and race the dials: QUIC first, the other direct transports next, relays last.
-  b.dialRanking = Opt.some(config)
+  b.dialRanking = enabled
   b
 
 proc withDialBackoff*(b: SwitchBuilder, config = DefaultDialBackoff): SwitchBuilder =
@@ -557,8 +548,7 @@ proc buildSwitch(b: SwitchBuilder): Switch {.raises: [LPError].} =
     transports,
     ms,
     b.nameResolver,
-    dialRanking = b.dialRanking.isSome(),
-    dialRankingConfig = b.dialRanking.get(DefaultDialRanking),
+    dialRanking = b.dialRanking,
     dialBackoff = b.dialBackoff,
   )
 

--- a/libp2p/dialcandidate.nim
+++ b/libp2p/dialcandidate.nim
@@ -3,15 +3,92 @@
 
 {.push raises: [].}
 
-import multiaddress, peerid
+import pkg/chronos
 
-type DialCandidate* = object
-  ## One address a dial can attempt, with dnsaddr and DNS already resolved.
-  address*: MultiAddress
-  hostname*: string ## Host the address was reached under, for TLS and the Host header.
-  peerId*: Opt[PeerId] ## Pinned by a dnsaddr record, otherwise the dialed peer's.
-  fromName*: bool ## A lookup chose this address, so the address policy sees it again.
+import multiaddress, multicodec, peerid, wire
+
+type
+  DialCandidate* = object
+    ## One address a dial can attempt, with dnsaddr and DNS already resolved.
+    address*: MultiAddress
+    hostname*: string ## Host the address was reached under, for TLS and the Host header.
+    peerId*: Opt[PeerId] ## Pinned by a dnsaddr record, otherwise the dialed peer's.
+    fromName*: bool ## A lookup chose this address, so the address policy sees it again.
+
+  DialGroup* {.pure.} = enum
+    ## Ranked from the first group dialed to the last.
+    Quic ## a direct QUIC address
+    Direct ## a direct address over any other transport
+    Relay ## an address behind a circuit relay
+
+  DialScope {.pure.} = enum
+    Public ## a globally routable address
+    Private ## loopback, link-local, a private network, or no IP at all
+
+  DialRankingConfig* = object
+    quicHeadStart*: Duration
+      ## how long public QUIC dials alone before the other public direct transports join
+    privateQuicHeadStart*: Duration
+      ## the same head start among private addresses, where a handshake takes milliseconds
+    relayDelay*: Duration ## how long direct dials run alone before the relays join them
+    maxParallelDials*: int ## attempts one peer dial holds open at once
+
+  DialPlan* = object
+    ## What one peer dial learned so far, which sets how long each candidate waits.
+    config: DialRankingConfig
+    quicScopes: set[DialScope]
+    direct: bool
+
+const DefaultDialRanking* = DialRankingConfig(
+  quicHeadStart: 250.milliseconds,
+  privateQuicHeadStart: 30.milliseconds,
+  relayDelay: 500.milliseconds,
+  maxParallelDials: 8,
+)
+
+const circuitCodec = multiCodec("p2p-circuit")
 
 func key*(candidate: DialCandidate): string =
   ## Two candidates with the same key stand for the same dial.
   $candidate.address & "|" & candidate.hostname & "|" & $candidate.peerId
+
+proc dialGroup*(candidate: DialCandidate): DialGroup =
+  if candidate.address.contains(circuitCodec).get(false):
+    DialGroup.Relay
+  elif QUIC_V1.match(candidate.address) or QUIC.match(candidate.address):
+    DialGroup.Quic
+  else:
+    DialGroup.Direct
+
+proc dialScope(candidate: DialCandidate): DialScope =
+  if candidate.address.isPublicMA(): DialScope.Public else: DialScope.Private
+
+func init*(T: type DialPlan, config: DialRankingConfig): T =
+  T(config: config)
+
+proc add*(plan: var DialPlan, candidate: DialCandidate) =
+  ## Learn a candidate of the dial, whether it is dialed yet or not.
+  case candidate.dialGroup()
+  of DialGroup.Quic:
+    plan.quicScopes.incl(candidate.dialScope())
+    plan.direct = true
+  of DialGroup.Direct:
+    plan.direct = true
+  of DialGroup.Relay:
+    discard
+
+proc dialDelay*(plan: DialPlan, candidate: DialCandidate): Duration =
+  ## How long after the dial starts the candidate waits, given what the dial learned.
+  case candidate.dialGroup()
+  of DialGroup.Quic:
+    ZeroDuration
+  of DialGroup.Direct:
+    let scope = candidate.dialScope()
+    if scope notin plan.quicScopes:
+      ZeroDuration
+    elif scope == DialScope.Public:
+      plan.config.quicHeadStart
+    else:
+      plan.config.privateQuicHeadStart
+  of DialGroup.Relay:
+    if plan.direct: plan.config.relayDelay else: ZeroDuration

--- a/libp2p/dialcandidate.nim
+++ b/libp2p/dialcandidate.nim
@@ -3,9 +3,7 @@
 
 {.push raises: [].}
 
-import pkg/chronos
-
-import multiaddress, multicodec, peerid, wire
+import multiaddress, multicodec, peerid
 
 type
   DialCandidate* = object
@@ -15,36 +13,12 @@ type
     peerId*: Opt[PeerId] ## Pinned by a dnsaddr record, otherwise the dialed peer's.
     fromName*: bool ## A lookup chose this address, so the address policy sees it again.
 
-  DialGroup* {.pure.} = enum
-    ## Ranked from the first group dialed to the last.
-    Quic ## a direct QUIC address
-    Direct ## a direct address over any other transport
-    Relay ## an address behind a circuit relay
-
-  DialScope {.pure.} = enum
-    Public ## a globally routable address
-    Private ## loopback, link-local, a private network, or no IP at all
-
-  DialRankingConfig* = object
-    quicHeadStart*: Duration
-      ## how long public QUIC dials alone before the other public direct transports join
-    privateQuicHeadStart*: Duration
-      ## the same head start among private addresses, where a handshake takes milliseconds
-    relayDelay*: Duration ## how long direct dials run alone before the relays join them
-    maxParallelDials*: int ## attempts one peer dial holds open at once
-
-  DialPlan* = object
-    ## What one peer dial learned so far, which sets how long each candidate waits.
-    config: DialRankingConfig
-    quicScopes: set[DialScope]
-    direct: bool
-
-const DefaultDialRanking* = DialRankingConfig(
-  quicHeadStart: 250.milliseconds,
-  privateQuicHeadStart: 30.milliseconds,
-  relayDelay: 500.milliseconds,
-  maxParallelDials: 8,
-)
+  DialRank* {.pure.} = enum
+    ## Ranked from the first candidate dialed to the last.
+    DirectQuic
+    Direct
+    RelayQuic
+    Relay
 
 const circuitCodec = multiCodec("p2p-circuit")
 
@@ -52,43 +26,13 @@ func key*(candidate: DialCandidate): string =
   ## Two candidates with the same key stand for the same dial.
   $candidate.address & "|" & candidate.hostname & "|" & $candidate.peerId
 
-proc dialGroup*(candidate: DialCandidate): DialGroup =
-  if candidate.address.contains(circuitCodec).get(false):
-    DialGroup.Relay
-  elif QUIC_V1.match(candidate.address) or QUIC.match(candidate.address):
-    DialGroup.Quic
+func dialRank*(candidate: DialCandidate): DialRank =
+  ## A circuit address starts with the relay's own transport, so a prefix match ranks both.
+  let
+    relayed = candidate.address.contains(circuitCodec).get(false)
+    quic =
+      QUIC_V1.matchPartial(candidate.address) or QUIC.matchPartial(candidate.address)
+  if relayed:
+    if quic: DialRank.RelayQuic else: DialRank.Relay
   else:
-    DialGroup.Direct
-
-proc dialScope(candidate: DialCandidate): DialScope =
-  if candidate.address.isPublicMA(): DialScope.Public else: DialScope.Private
-
-func init*(T: type DialPlan, config: DialRankingConfig): T =
-  T(config: config)
-
-proc add*(plan: var DialPlan, candidate: DialCandidate) =
-  ## Learn a candidate of the dial, whether it is dialed yet or not.
-  case candidate.dialGroup()
-  of DialGroup.Quic:
-    plan.quicScopes.incl(candidate.dialScope())
-    plan.direct = true
-  of DialGroup.Direct:
-    plan.direct = true
-  of DialGroup.Relay:
-    discard
-
-proc dialDelay*(plan: DialPlan, candidate: DialCandidate): Duration =
-  ## How long after the dial starts the candidate waits, given what the dial learned.
-  case candidate.dialGroup()
-  of DialGroup.Quic:
-    ZeroDuration
-  of DialGroup.Direct:
-    let scope = candidate.dialScope()
-    if scope notin plan.quicScopes:
-      ZeroDuration
-    elif scope == DialScope.Public:
-      plan.config.quicHeadStart
-    else:
-      plan.config.privateQuicHeadStart
-  of DialGroup.Relay:
-    if plan.direct: plan.config.relayDelay else: ZeroDuration
+    if quic: DialRank.DirectQuic else: DialRank.Direct

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 # Copyright (c) Status Research & Development GmbH
 
-import std/[sequtils, sets, tables]
+import std/[algorithm, sequtils, sets, tables]
 
 import pkg/[chronos, chronicles, metrics, results]
 
@@ -25,7 +25,7 @@ import
   utils/future,
   errors
 
-export dial, dial_backoff, errors, results
+export dial, dial_backoff, dialcandidate, errors, results
 
 logScope:
   topics = "libp2p dialer"
@@ -71,7 +71,8 @@ type
     peerStore: PeerStore
     nameResolver: NameResolver
     ms: MultistreamSelect
-    dialRanking: bool ## overlap the name lookups with the dials
+    dialRanking: bool ## overlap the name lookups with the dials, and rank the dials
+    dialRankingConfig: DialRankingConfig
     dialBackoff: Opt[DialBackoff] ## none unless the switch opted in
     ongoingReleaseOnClose: seq[Future[void].Raising([])]
 
@@ -430,83 +431,157 @@ proc dropLosers(attempts: seq[DialAttempt]) {.async: (raises: []).} =
       if not isNil(mux):
         await mux.close()
 
-proc firstConnected(
-    attempts: seq[DialAttempt]
-): Future[Muxer] {.async: (raises: [CancelledError]).} =
-  ## The first attempt that connects. Nil when none of them does.
+type RankedDial = ref object
+  ## One ranked peer dial: what waits, what is in flight, and what lookups can still add.
+  plan: DialPlan
+  maxParallel: int
+  started: Moment
+  deadline: Moment
+  dir: Direction
+  forceDial: bool
+  reach: DialReach
+  dialable: DialBudget
+  unresolved: DialBudget
+  queued: seq[DialCandidate]
+  pending: seq[DialAttempt]
+  lookups: int ## advertised names whose lookups can still queue candidates
+  changed: Future[void] ## completes when a candidate is queued or a name lookup ends
 
-  var pending = attempts
-  defer:
-    await dropLosers(pending)
+proc wake(dial: RankedDial) =
+  if not dial.changed.finished():
+    dial.changed.complete()
 
-  while pending.len > 0:
-    let done =
-      try:
-        await one(pending)
-      except ValueError as e:
-        raiseAssert "one() over a non-empty seq: " & e.msg
-    pending.del(pending.find(done))
+proc dueAt(dial: RankedDial, candidate: DialCandidate): Moment =
+  dial.started + dial.plan.dialDelay(candidate)
 
-    if not done.completed():
+proc queue(dial: RankedDial, candidates: seq[DialCandidate]) =
+  ## Queue the fresh candidates, within the candidate limit of the dial.
+  for candidate in dial.dialable.take(candidates):
+    dial.plan.add(candidate)
+    dial.queued.add(candidate)
+
+  dial.queued.sort(
+    proc(a, b: DialCandidate): int =
+      let byDue = cmp(dial.dueAt(a), dial.dueAt(b))
+      if byDue != 0:
+        byDue
+      else:
+        cmp(a.dialGroup(), b.dialGroup())
+  )
+  dial.wake()
+
+proc openDue(self: Dialer, dial: RankedDial) =
+  ## Start the due candidates up to the parallel limit. With nothing in flight, the next ones are due.
+
+  if dial.queued.len == 0 or dial.deadline.timeLeft().isZero():
+    return
+
+  let openUntil =
+    if dial.pending.len == 0:
+      max(Moment.now(), dial.dueAt(dial.queued[0]))
+    else:
+      Moment.now()
+
+  while dial.queued.len > 0 and dial.pending.len < dial.maxParallel:
+    let candidate = dial.queued[0]
+    if dial.dueAt(candidate) > openUntil:
+      return
+
+    dial.queued.delete(0)
+    trace "Ranked dial attempt opened",
+      peerId = candidate.peerId,
+      address = candidate.address,
+      group = candidate.dialGroup(),
+      elapsed = Moment.now() - dial.started
+    dial.pending.add(
+      self.dialAndUpgrade(
+        candidate.peerId, candidate.hostname, candidate.address, dial.dir,
+        dial.deadline, dial.forceDial, dial.reach,
+      )
+    )
+
+proc takeWinner(dial: RankedDial): Muxer =
+  ## Drop the attempts that ended, and hand over one that connected.
+
+  var i = 0
+  while i < dial.pending.len:
+    let attempt = dial.pending[i]
+    if not attempt.finished():
+      i.inc()
       continue
 
-    let mux = done.value()
+    dial.pending.del(i)
+    if attempt.completed() and not isNil(attempt.value()):
+      return attempt.value()
+
+  nil
+
+proc nextWake(dial: RankedDial): Moment =
+  if dial.queued.len == 0 or dial.pending.len >= dial.maxParallel:
+    return dial.deadline
+
+  min(dial.dueAt(dial.queued[0]), dial.deadline)
+
+proc firstOf(events: seq[FutureBase]) {.async: (raises: [CancelledError]).} =
+  try:
+    discard await race(events)
+  except ValueError as e:
+    raiseAssert "race() over a non-empty seq: " & e.msg
+
+proc nextEvent(dial: RankedDial) {.async: (raises: [CancelledError]).} =
+  let events = dial.pending.mapIt(FutureBase(it)) & FutureBase(dial.changed)
+  if dial.deadline.timeLeft().isZero():
+    await firstOf(events)
+    return
+
+  let timer = sleepAsync(dial.nextWake().timeLeft())
+  defer:
+    await noCancel timer.cancelAndWait()
+
+  await firstOf(events & FutureBase(timer))
+
+proc run(
+    self: Dialer, dial: RankedDial
+): Future[Muxer] {.async: (raises: [CancelledError]).} =
+  ## The first attempt that connects. Nil once nothing waits, runs, or can still arrive.
+
+  defer:
+    await dropLosers(dial.pending)
+
+  while true:
+    if dial.changed.finished():
+      dial.changed = newFuture[void]("libp2p.dialer.changed")
+
+    let mux = dial.takeWinner()
     if not isNil(mux):
       return mux
 
-proc dialAll(
-    self: Dialer,
-    candidates: seq[DialCandidate],
-    dir: Direction,
-    deadline: Moment,
-    forceDial: bool,
-    reach: DialReach,
-): Future[Muxer] {.async: (raises: [CancelledError]).} =
-  ## Dial every candidate at once. Nil when none of them connects.
+    self.openDue(dial)
+    let nothingToOpen = dial.queued.len == 0 or dial.deadline.timeLeft().isZero()
+    if nothingToOpen and dial.pending.len == 0 and dial.lookups == 0:
+      return nil
 
-  await firstConnected(
-    candidates.mapIt(
-      self.dialAndUpgrade(
-        it.peerId, it.hostname, it.address, dir, deadline, forceDial, reach
-      )
-    )
-  )
+    await dial.nextEvent()
 
-proc dialResolved(
+proc queueResolved(
     self: Dialer,
+    dial: RankedDial,
     lookup: Future[seq[DialCandidate]].Raising([CancelledError]),
-    budget: DialBudget,
-    dir: Direction,
-    deadline: Moment,
-    forceDial: bool,
-    reach: DialReach,
-): Future[Muxer] {.async: (raises: [CancelledError]).} =
-  ## Dial one name's addresses the moment that name answers.
+) {.async: (raises: [CancelledError]).} =
+  dial.queue(await dial.dialable.awaitLookup(lookup))
 
-  await self.dialAll(
-    budget.take(await budget.awaitLookup(lookup)), dir, deadline, forceDial, reach
+proc queueName(
+    self: Dialer, dial: RankedDial, candidate: DialCandidate
+) {.async: (raises: [CancelledError]).} =
+  defer:
+    dial.lookups.dec()
+    dial.wake()
+
+  let expanded = dial.unresolved.take(
+    await dial.dialable.awaitLookup(self.expandCandidate(candidate, dial.deadline))
   )
-
-proc dialName(
-    self: Dialer,
-    candidate: DialCandidate,
-    expandedBudget: DialBudget,
-    dialBudget: DialBudget,
-    dir: Direction,
-    deadline: Moment,
-    forceDial: bool,
-    reach: DialReach,
-): Future[Muxer] {.async: (raises: [CancelledError]).} =
-  ## Dial each address from one advertised name as soon as it resolves.
-
-  let expanded = expandedBudget.take(
-    await dialBudget.awaitLookup(self.expandCandidate(candidate, deadline))
-  )
-  let lookups = expanded.mapIt(self.resolveCandidate(it, deadline))
-
-  await firstConnected(
-    lookups.mapIt(self.dialResolved(it, dialBudget, dir, deadline, forceDial, reach))
-  )
+  let lookups = expanded.mapIt(self.resolveCandidate(it, dial.deadline))
+  await allOrCancel(lookups.mapIt(self.queueResolved(dial, it)))
 
 proc dialRanked(
     self: Dialer,
@@ -517,20 +592,29 @@ proc dialRanked(
     forceDial: bool,
     reach: DialReach,
 ): Future[Muxer] {.async: (raises: [CancelledError]).} =
-  ## Dial the wire addresses at once, and each name's as soon as it resolves.
+  ## Queue the wire addresses at once and each name's as soon as it resolves, and dial them by rank.
 
-  let
-    dialable = newBudget(MaxDialCandidates)
-    names = newBudget(MaxDialCandidates)
-    unresolved = newBudget(MaxExpandedAddresses)
-    direct = dialable.take(self.directCandidates(peerId, addrs))
-    nameDials = names.take(dnsCandidates(peerId, addrs)).mapIt(
-        self.dialName(it, unresolved, dialable, dir, deadline, forceDial, reach)
-      )
-
-  await firstConnected(
-    @[self.dialAll(direct, dir, deadline, forceDial, reach)] & nameDials
+  let dial = RankedDial(
+    plan: DialPlan.init(self.dialRankingConfig),
+    maxParallel: max(self.dialRankingConfig.maxParallelDials, 1),
+    started: Moment.now(),
+    deadline: deadline,
+    dir: dir,
+    forceDial: forceDial,
+    reach: reach,
+    dialable: newBudget(MaxDialCandidates),
+    unresolved: newBudget(MaxExpandedAddresses),
+    changed: newFuture[void]("libp2p.dialer.changed"),
   )
+  dial.queue(self.directCandidates(peerId, addrs))
+
+  let names = newBudget(MaxDialCandidates).take(dnsCandidates(peerId, addrs))
+  dial.lookups = names.len
+  let lookups = names.mapIt(self.queueName(dial, it))
+  defer:
+    await noCancel lookups.cancelAndWait()
+
+  await self.run(dial)
 
 proc dialAndUpgrade*(
     self: Dialer,
@@ -877,6 +961,7 @@ proc new*(
     nameResolver: NameResolver = nil,
     dialTimeout = DefaultDialerTimeout,
     dialRanking = false,
+    dialRankingConfig = DefaultDialRanking,
     dialBackoff = Opt.none(DialBackoffConfig),
 ): Dialer {.raises: [].} =
   var backoff = Opt.none(DialBackoff)
@@ -892,5 +977,6 @@ proc new*(
     ms: ms,
     dialTimeout: dialTimeout,
     dialRanking: dialRanking,
+    dialRankingConfig: dialRankingConfig,
     dialBackoff: backoff,
   )

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -25,7 +25,7 @@ import
   utils/future,
   errors
 
-export dial, dial_backoff, dialcandidate, errors, results
+export dial, dial_backoff, errors, results
 
 logScope:
   topics = "libp2p dialer"
@@ -41,6 +41,8 @@ declarePublicHistogram libp2p_dial_duration_ms,
 
 const MaxDialCandidates* = 32
   ## A peer names as many addresses as it likes, and each dnsaddr fans out further.
+
+const MaxParallelDials* = 8 ## Attempts one ranked peer dial holds open at once.
 
 const MaxExpandedAddresses = MaxDialCandidates * 8
   ## Ceiling on what one peer's dnsaddr chain holds in flight before the filter.
@@ -72,7 +74,6 @@ type
     nameResolver: NameResolver
     ms: MultistreamSelect
     dialRanking: bool ## overlap the name lookups with the dials, and rank the dials
-    dialRankingConfig: DialRankingConfig
     dialBackoff: Opt[DialBackoff] ## none unless the switch opted in
     ongoingReleaseOnClose: seq[Future[void].Raising([])]
 
@@ -432,17 +433,13 @@ proc dropLosers(attempts: seq[DialAttempt]) {.async: (raises: []).} =
         await mux.close()
 
 type RankedDial = ref object
-  ## One ranked peer dial: what waits, what is in flight, and what lookups can still add.
-  plan: DialPlan
-  maxParallel: int
-  started: Moment
   deadline: Moment
   dir: Direction
   forceDial: bool
   reach: DialReach
   dialable: DialBudget
   unresolved: DialBudget
-  queued: seq[DialCandidate]
+  queued: seq[DialCandidate] ## best rank first, in arrival order within a rank
   pending: seq[DialAttempt]
   lookups: int ## advertised names whose lookups can still queue candidates
   changed: Future[void] ## completes when a candidate is queued or a name lookup ends
@@ -451,48 +448,25 @@ proc wake(dial: RankedDial) =
   if not dial.changed.finished():
     dial.changed.complete()
 
-proc dueAt(dial: RankedDial, candidate: DialCandidate): Moment =
-  dial.started + dial.plan.dialDelay(candidate)
+func byRank(a, b: DialCandidate): int =
+  cmp(a.dialRank(), b.dialRank())
 
 proc queue(dial: RankedDial, candidates: seq[DialCandidate]) =
-  ## Queue the fresh candidates, within the candidate limit of the dial.
   for candidate in dial.dialable.take(candidates):
-    dial.plan.add(candidate)
-    dial.queued.add(candidate)
-
-  dial.queued.sort(
-    proc(a, b: DialCandidate): int =
-      let byDue = cmp(dial.dueAt(a), dial.dueAt(b))
-      if byDue != 0:
-        byDue
-      else:
-        cmp(a.dialGroup(), b.dialGroup())
-  )
+    dial.queued.insert(candidate, dial.queued.upperBound(candidate, byRank))
   dial.wake()
 
-proc openDue(self: Dialer, dial: RankedDial) =
-  ## Start the due candidates up to the parallel limit. With nothing in flight, the next ones are due.
-
-  if dial.queued.len == 0 or dial.deadline.timeLeft().isZero():
+proc openSlots(self: Dialer, dial: RankedDial) =
+  if dial.deadline.timeLeft().isZero():
     return
 
-  let openUntil =
-    if dial.pending.len == 0:
-      max(Moment.now(), dial.dueAt(dial.queued[0]))
-    else:
-      Moment.now()
-
-  while dial.queued.len > 0 and dial.pending.len < dial.maxParallel:
+  while dial.queued.len > 0 and dial.pending.len < MaxParallelDials:
     let candidate = dial.queued[0]
-    if dial.dueAt(candidate) > openUntil:
-      return
-
     dial.queued.delete(0)
     trace "Ranked dial attempt opened",
       peerId = candidate.peerId,
       address = candidate.address,
-      group = candidate.dialGroup(),
-      elapsed = Moment.now() - dial.started
+      rank = candidate.dialRank()
     dial.pending.add(
       self.dialAndUpgrade(
         candidate.peerId, candidate.hostname, candidate.address, dial.dir,
@@ -516,29 +490,12 @@ proc takeWinner(dial: RankedDial): Muxer =
 
   nil
 
-proc nextWake(dial: RankedDial): Moment =
-  if dial.queued.len == 0 or dial.pending.len >= dial.maxParallel:
-    return dial.deadline
-
-  min(dial.dueAt(dial.queued[0]), dial.deadline)
-
-proc firstOf(events: seq[FutureBase]) {.async: (raises: [CancelledError]).} =
+proc nextEvent(dial: RankedDial) {.async: (raises: [CancelledError]).} =
+  ## Every attempt and lookup ends by the dial deadline, so no timer wakes the loop.
   try:
-    discard await race(events)
+    discard await race(dial.pending.mapIt(FutureBase(it)) & FutureBase(dial.changed))
   except ValueError as e:
     raiseAssert "race() over a non-empty seq: " & e.msg
-
-proc nextEvent(dial: RankedDial) {.async: (raises: [CancelledError]).} =
-  let events = dial.pending.mapIt(FutureBase(it)) & FutureBase(dial.changed)
-  if dial.deadline.timeLeft().isZero():
-    await firstOf(events)
-    return
-
-  let timer = sleepAsync(dial.nextWake().timeLeft())
-  defer:
-    await noCancel timer.cancelAndWait()
-
-  await firstOf(events & FutureBase(timer))
 
 proc run(
     self: Dialer, dial: RankedDial
@@ -556,9 +513,8 @@ proc run(
     if not isNil(mux):
       return mux
 
-    self.openDue(dial)
-    let nothingToOpen = dial.queued.len == 0 or dial.deadline.timeLeft().isZero()
-    if nothingToOpen and dial.pending.len == 0 and dial.lookups == 0:
+    self.openSlots(dial)
+    if dial.pending.len == 0 and dial.lookups == 0:
       return nil
 
     await dial.nextEvent()
@@ -592,12 +548,9 @@ proc dialRanked(
     forceDial: bool,
     reach: DialReach,
 ): Future[Muxer] {.async: (raises: [CancelledError]).} =
-  ## Queue the wire addresses at once and each name's as soon as it resolves, and dial them by rank.
+  ## Dial the wire addresses at once and each name's addresses as it resolves, best rank first.
 
   let dial = RankedDial(
-    plan: DialPlan.init(self.dialRankingConfig),
-    maxParallel: max(self.dialRankingConfig.maxParallelDials, 1),
-    started: Moment.now(),
     deadline: deadline,
     dir: dir,
     forceDial: forceDial,
@@ -961,7 +914,6 @@ proc new*(
     nameResolver: NameResolver = nil,
     dialTimeout = DefaultDialerTimeout,
     dialRanking = false,
-    dialRankingConfig = DefaultDialRanking,
     dialBackoff = Opt.none(DialBackoffConfig),
 ): Dialer {.raises: [].} =
   var backoff = Opt.none(DialBackoff)
@@ -977,6 +929,5 @@ proc new*(
     ms: ms,
     dialTimeout: dialTimeout,
     dialRanking: dialRanking,
-    dialRankingConfig: dialRankingConfig,
     dialBackoff: backoff,
   )

--- a/tests/libp2p/test_dialer.nim
+++ b/tests/libp2p/test_dialer.nim
@@ -7,12 +7,12 @@ import chronos, sequtils, results
 import
   ../../libp2p/[
     builders,
+    dialcandidate,
     muxers/muxer,
     nameresolving/mockresolver,
     peerstore,
     stream/bridgestream,
     switch,
-    transports/quictransport,
     transports/transport,
     upgrademngrs/upgrade,
   ]
@@ -45,24 +45,24 @@ proc stallAfterIdentify(sw: Switch) =
 
   sw.replaceIdentifyHandler(hold)
 
-const PlanRanking = DialRankingConfig(
-  quicHeadStart: 1.seconds,
-  privateQuicHeadStart: 10.milliseconds,
-  relayDelay: 2.seconds,
-  maxParallelDials: 8,
-)
-
 proc relayAddr(relay: string): MultiAddress =
   ma(relay & "/p2p/" & $PeerId.random(rng()).tryGet() & "/p2p-circuit")
 
-proc planOf(addrs: varargs[MultiAddress]): DialPlan =
-  var plan = DialPlan.init(PlanRanking)
-  for address in addrs:
-    plan.add(DialCandidate(address: address))
-  plan
+proc rankOf(address: MultiAddress): DialRank =
+  DialCandidate(address: address).dialRank()
 
-proc delayOf(plan: DialPlan, address: MultiAddress): Duration =
-  plan.dialDelay(DialCandidate(address: address))
+proc tcpAddrs(count: int): seq[MultiAddress] =
+  (0 ..< count).mapIt(ma("/ip4/1.2.3.4/tcp/" & $(4001 + it)))
+
+proc rankedDialer(src: Switch, transports: seq[Transport]): Dialer =
+  Dialer.new(
+    src.peerInfo.peerId,
+    src.connManager,
+    src.peerStore,
+    transports,
+    src.ms,
+    dialRanking = true,
+  )
 
 suite "Dialer":
   teardown:
@@ -474,86 +474,95 @@ suite "Dialer":
 
     check transport.dialedHosts == @["1.2.3.4"]
 
-  test "A dial plan ranks QUIC, then the other direct transports, then relays":
+  test "Dial ranks put direct before relay, and QUIC before TCP within each":
+    check rankOf(ma("/ip4/1.2.3.4/udp/4001/quic-v1")) == DialRank.DirectQuic
+    check rankOf(ma("/ip4/1.2.3.4/udp/4001/quic")) == DialRank.DirectQuic
+    check rankOf(ma("/ip4/1.2.3.4/tcp/4001")) == DialRank.Direct
+    check rankOf(ma("/ip4/1.2.3.4/tcp/4002/ws")) == DialRank.Direct
+    check rankOf(relayAddr("/ip4/5.6.7.8/udp/4001/quic-v1")) == DialRank.RelayQuic
+    check rankOf(relayAddr("/ip4/5.6.7.8/tcp/4001")) == DialRank.Relay
+
+  asyncTest "Ranked dialing opens the attempts in rank order":
+    let src = makeStandardSwitch()
+    await src.start()
+    defer:
+      await src.stop()
+
     let
-      relay = relayAddr("/ip4/5.6.7.8/tcp/4001")
+      transport = FailingDialTransport.new(Upgrade(), rng(), handlesAny = true)
+      dialer = src.rankedDialer(@[Transport(transport)])
+      relayTcp = relayAddr("/ip4/5.6.7.8/tcp/4001")
       tcp = ma("/ip4/1.2.3.4/tcp/4001")
+      relayQuic = relayAddr("/ip4/5.6.7.8/udp/4001/quic-v1")
       quic = ma("/ip4/1.2.3.4/udp/4001/quic-v1")
-      ws = ma("/ip4/1.2.3.4/tcp/4002/ws")
-      plan = planOf(relay, tcp, quic, ws)
+    expect DialFailedError:
+      await dialer.connect(
+        PeerId.random(rng()).tryGet(), @[relayTcp, tcp, relayQuic, quic]
+      )
 
-    check plan.delayOf(quic) == ZeroDuration
-    check plan.delayOf(tcp) == 1.seconds
-    check plan.delayOf(ws) == 1.seconds
-    check plan.delayOf(relay) == 2.seconds
+    check transport.dialedAddrs == @[quic, tcp, relayQuic, relayTcp]
 
-  test "A dial plan dials TCP right away when the peer has no QUIC address":
+  asyncTest "Ranked dialing fills its parallel limit with the best ranked candidates":
+    let src = makeStandardSwitch()
+    await src.start()
+    defer:
+      await src.stop()
+
     let
-      relay = relayAddr("/ip4/5.6.7.8/tcp/4001")
-      tcp = ma("/ip4/1.2.3.4/tcp/4001")
-      plan = planOf(relay, tcp)
-
-    check plan.delayOf(tcp) == ZeroDuration
-    check plan.delayOf(relay) == 2.seconds
-
-  test "A dial plan dials a relay right away when the peer has no direct address":
-    let
-      quicRelay = relayAddr("/ip4/5.6.7.8/udp/4001/quic-v1")
-      tcpRelay = relayAddr("/ip4/5.6.7.8/tcp/4001")
-      plan = planOf(quicRelay, tcpRelay)
-
-    check plan.delayOf(quicRelay) == ZeroDuration
-    check plan.delayOf(tcpRelay) == ZeroDuration
-
-  test "A dial plan gives private addresses their own QUIC head start":
-    let
-      privateQuic = ma("/ip4/192.168.1.2/udp/4001/quic-v1")
-      privateTcp = ma("/ip4/192.168.1.2/tcp/4001")
-      loopbackTcp = ma("/ip4/127.0.0.1/tcp/4001")
-      publicTcp = ma("/ip4/1.2.3.4/tcp/4001")
-      plan = planOf(privateQuic, privateTcp, loopbackTcp, publicTcp)
-
-    check plan.delayOf(privateTcp) == 10.milliseconds
-    check plan.delayOf(loopbackTcp) == 10.milliseconds
-    check plan.delayOf(publicTcp) == ZeroDuration
-
-  test "A dial plan holds back a waiting TCP address once a QUIC address arrives":
-    let
-      tcp = ma("/ip4/1.2.3.4/tcp/4001")
+      tcps = tcpAddrs(MaxParallelDials)
       quic = ma("/ip4/1.2.3.4/udp/4001/quic-v1")
-    var plan = planOf(tcp)
-    check plan.delayOf(tcp) == ZeroDuration
+      transport = ScriptedDialTransport.new(Upgrade(), rng(), handled = tcps & @[quic])
+      dialer = src.rankedDialer(@[Transport(transport)])
+      dialing = dialer.connect(PeerId.random(rng()).tryGet(), tcps & @[quic])
 
-    plan.add(DialCandidate(address: quic))
-    check plan.delayOf(tcp) == 1.seconds
+    checkUntilTimeout:
+      transport.dialedAddrs.len == MaxParallelDials
+    await dialing.cancelAndWait()
 
-  asyncTest "Ranked dialing connects over QUIC when the peer also listens on TCP":
+    check transport.dialedAddrs == @[quic] & tcps[0 ..< MaxParallelDials - 1]
+    check transport.cancelledAddrs.len == MaxParallelDials
+
+  asyncTest "Ranked dialing gives a failed attempt's slot to the next candidate":
+    let src = makeStandardSwitch()
+    await src.start()
+    defer:
+      await src.stop()
+
     let
-      src = makeStandardSwitchBuilder(@[QuicAutoAddress, TcpAutoAddress])
-        .withDialRanking(
-          DialRankingConfig(
-            quicHeadStart: 10.seconds,
-            privateQuicHeadStart: 10.seconds,
-            relayDelay: 10.seconds,
-            maxParallelDials: 8,
-          )
-        )
-        .build()
-      dst = makeStandardSwitch(@[QuicAutoAddress, TcpAutoAddress])
+      tcps = tcpAddrs(MaxParallelDials)
+      quic = ma("/ip4/1.2.3.4/udp/4001/quic-v1")
+      transport = ScriptedDialTransport.new(
+        Upgrade(), rng(), handled = tcps & @[quic], failing = @[quic]
+      )
+      dialer = src.rankedDialer(@[Transport(transport)])
+      dialing = dialer.connect(PeerId.random(rng()).tryGet(), tcps & @[quic])
+    defer:
+      await dialing.cancelAndWait()
+
+    checkUntilTimeout:
+      transport.dialedAddrs == @[quic] & tcps
+
+  asyncTest "Ranked dialing cancels a stalled QUIC attempt once TCP connects":
+    let
+      src = makeStandardSwitch(TcpAutoAddress)
+      dst = makeStandardSwitch(TcpAutoAddress)
     await src.start()
     await dst.start()
     defer:
       await allFutures(src.stop(), dst.stop())
 
     let
-      tcpAddrs = dst.peerInfo.addrs.filterIt(TCP.match(it))
-      quicAddrs = dst.peerInfo.addrs.filterIt(QUIC_V1.match(it))
-    check tcpAddrs.len > 0
-    check quicAddrs.len > 0
+      quic = ma("/ip4/127.0.0.1/udp/1/quic-v1")
+      stalling = ScriptedDialTransport.new(Upgrade(), rng(), handled = @[quic])
+      dialer = src.rankedDialer(@[Transport(stalling)] & src.transports)
 
-    await src.connect(dst.peerInfo.peerId, tcpAddrs & quicAddrs).wait(5.seconds)
+    await dialer.connect(dst.peerInfo.peerId, @[quic] & dst.peerInfo.addrs).wait(
+      5.seconds
+    )
 
-    check src.connManager.selectMuxer(dst.peerInfo.peerId) of QuicMuxer
+    check src.connManager.connCount(dst.peerInfo.peerId) == 1
+    check stalling.dialedAddrs == @[quic]
+    check stalling.cancelledAddrs == @[quic]
 
   asyncTest "Dialing skips an address that fails to resolve":
     let src = makeStandardSwitch()

--- a/tests/libp2p/test_dialer.nim
+++ b/tests/libp2p/test_dialer.nim
@@ -12,6 +12,7 @@ import
     peerstore,
     stream/bridgestream,
     switch,
+    transports/quictransport,
     transports/transport,
     upgrademngrs/upgrade,
   ]
@@ -43,6 +44,25 @@ proc stallAfterIdentify(sw: Switch) =
     await stream.join()
 
   sw.replaceIdentifyHandler(hold)
+
+const PlanRanking = DialRankingConfig(
+  quicHeadStart: 1.seconds,
+  privateQuicHeadStart: 10.milliseconds,
+  relayDelay: 2.seconds,
+  maxParallelDials: 8,
+)
+
+proc relayAddr(relay: string): MultiAddress =
+  ma(relay & "/p2p/" & $PeerId.random(rng()).tryGet() & "/p2p-circuit")
+
+proc planOf(addrs: varargs[MultiAddress]): DialPlan =
+  var plan = DialPlan.init(PlanRanking)
+  for address in addrs:
+    plan.add(DialCandidate(address: address))
+  plan
+
+proc delayOf(plan: DialPlan, address: MultiAddress): Duration =
+  plan.dialDelay(DialCandidate(address: address))
 
 suite "Dialer":
   teardown:
@@ -453,6 +473,87 @@ suite "Dialer":
       await dialer.connect(PeerId.random(rng()).tryGet(), @[wss])
 
     check transport.dialedHosts == @["1.2.3.4"]
+
+  test "A dial plan ranks QUIC, then the other direct transports, then relays":
+    let
+      relay = relayAddr("/ip4/5.6.7.8/tcp/4001")
+      tcp = ma("/ip4/1.2.3.4/tcp/4001")
+      quic = ma("/ip4/1.2.3.4/udp/4001/quic-v1")
+      ws = ma("/ip4/1.2.3.4/tcp/4002/ws")
+      plan = planOf(relay, tcp, quic, ws)
+
+    check plan.delayOf(quic) == ZeroDuration
+    check plan.delayOf(tcp) == 1.seconds
+    check plan.delayOf(ws) == 1.seconds
+    check plan.delayOf(relay) == 2.seconds
+
+  test "A dial plan dials TCP right away when the peer has no QUIC address":
+    let
+      relay = relayAddr("/ip4/5.6.7.8/tcp/4001")
+      tcp = ma("/ip4/1.2.3.4/tcp/4001")
+      plan = planOf(relay, tcp)
+
+    check plan.delayOf(tcp) == ZeroDuration
+    check plan.delayOf(relay) == 2.seconds
+
+  test "A dial plan dials a relay right away when the peer has no direct address":
+    let
+      quicRelay = relayAddr("/ip4/5.6.7.8/udp/4001/quic-v1")
+      tcpRelay = relayAddr("/ip4/5.6.7.8/tcp/4001")
+      plan = planOf(quicRelay, tcpRelay)
+
+    check plan.delayOf(quicRelay) == ZeroDuration
+    check plan.delayOf(tcpRelay) == ZeroDuration
+
+  test "A dial plan gives private addresses their own QUIC head start":
+    let
+      privateQuic = ma("/ip4/192.168.1.2/udp/4001/quic-v1")
+      privateTcp = ma("/ip4/192.168.1.2/tcp/4001")
+      loopbackTcp = ma("/ip4/127.0.0.1/tcp/4001")
+      publicTcp = ma("/ip4/1.2.3.4/tcp/4001")
+      plan = planOf(privateQuic, privateTcp, loopbackTcp, publicTcp)
+
+    check plan.delayOf(privateTcp) == 10.milliseconds
+    check plan.delayOf(loopbackTcp) == 10.milliseconds
+    check plan.delayOf(publicTcp) == ZeroDuration
+
+  test "A dial plan holds back a waiting TCP address once a QUIC address arrives":
+    let
+      tcp = ma("/ip4/1.2.3.4/tcp/4001")
+      quic = ma("/ip4/1.2.3.4/udp/4001/quic-v1")
+    var plan = planOf(tcp)
+    check plan.delayOf(tcp) == ZeroDuration
+
+    plan.add(DialCandidate(address: quic))
+    check plan.delayOf(tcp) == 1.seconds
+
+  asyncTest "Ranked dialing connects over QUIC when the peer also listens on TCP":
+    let
+      src = makeStandardSwitchBuilder(@[QuicAutoAddress, TcpAutoAddress])
+        .withDialRanking(
+          DialRankingConfig(
+            quicHeadStart: 10.seconds,
+            privateQuicHeadStart: 10.seconds,
+            relayDelay: 10.seconds,
+            maxParallelDials: 8,
+          )
+        )
+        .build()
+      dst = makeStandardSwitch(@[QuicAutoAddress, TcpAutoAddress])
+    await src.start()
+    await dst.start()
+    defer:
+      await allFutures(src.stop(), dst.stop())
+
+    let
+      tcpAddrs = dst.peerInfo.addrs.filterIt(TCP.match(it))
+      quicAddrs = dst.peerInfo.addrs.filterIt(QUIC_V1.match(it))
+    check tcpAddrs.len > 0
+    check quicAddrs.len > 0
+
+    await src.connect(dst.peerInfo.peerId, tcpAddrs & quicAddrs).wait(5.seconds)
+
+    check src.connManager.selectMuxer(dst.peerInfo.peerId) of QuicMuxer
 
   asyncTest "Dialing skips an address that fails to resolve":
     let src = makeStandardSwitch()

--- a/tests/stubs/transportstub.nim
+++ b/tests/stubs/transportstub.nim
@@ -94,6 +94,47 @@ method dial*(
   self.dialedHosts.add(hostname)
   raise newException(MemoryTransportError, "stub dial always fails")
 
+type ScriptedDialTransport* = ref object of MemoryTransport
+  ## Handles the `handled` addresses: a dial of a `failing` one fails, any other stalls.
+  handled: seq[MultiAddress]
+  failing: seq[MultiAddress]
+  dialedAddrs*: seq[MultiAddress]
+  cancelledAddrs*: seq[MultiAddress]
+
+proc new*(
+    T: typedesc[ScriptedDialTransport],
+    upgrade: Upgrade,
+    rng: Rng,
+    handled: seq[MultiAddress],
+    failing: seq[MultiAddress] = @[],
+): T =
+  let self = T(upgrader: upgrade, rng: rng, handled: handled, failing: failing)
+  procCall Transport(self).initialize()
+  self
+
+method handles*(
+    self: ScriptedDialTransport, ma: MultiAddress
+): bool {.gcsafe, raises: [].} =
+  ma in self.handled
+
+method dial*(
+    self: ScriptedDialTransport,
+    hostname: string,
+    ma: MultiAddress,
+    peerId: Opt[PeerId] = Opt.none(PeerId),
+    dir: Direction = Direction.Out,
+): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =
+  self.dialedAddrs.add(ma)
+  if ma in self.failing:
+    raise newException(MemoryTransportError, "stub dial fails as scripted")
+
+  try:
+    await sleepAsync(1.hours)
+  except CancelledError as e:
+    self.cancelledAddrs.add(ma)
+    raise e
+  raise newException(MemoryTransportError, "stub dial stalled past its hour")
+
 method accept*(
     self: MemoryTransportStub
 ): Future[RawConn] {.async: (raises: [transport.TransportError, CancelledError]).} =


### PR DESCRIPTION
The ranked dial path from #2992 and #3001 races every candidate with no order or limit. `RankedDial` in `libp2p/dialer.nim` now queues the candidates of a peer dial by `DialRank`: direct QUIC, other direct, relay QUIC, other relay. A free slot dials the best queued candidate, with 8 slots at most, and a connection cancels the rest.
Tests check each rank, the dial order, the slot limit, the reuse of a failed attempt's slot, and the cancel of a stalled attempt. Check `run` and `nextEvent` for lost wake-ups, because the loop has no timer and trusts the dial deadline.
