### PR TITLE
fix(quic): avoid caching partially constructed dial endpoints

### DIFF
--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -596,14 +596,17 @@ proc listenerEndpointFor(
 proc dialOnlyEndpointFor(
     self: QuicTransport, family: AddressFamily
 ): QuicEndpoint {.raises: [TLSCertificateError, QuicError, TransportOsError].} =
+  # Construct before caching: an exception must not leave a partially written Opt.
   case family
   of AddressFamily.IPv4:
     if self.dialEndpoint4.isNone():
-      self.dialEndpoint4 = Opt.some(QuicEndpoint.new(self.makeConfig(), family))
+      let endpoint = QuicEndpoint.new(self.makeConfig(), family)
+      self.dialEndpoint4 = Opt.some(endpoint)
     self.dialEndpoint4.get()
   of AddressFamily.IPv6:
     if self.dialEndpoint6.isNone():
-      self.dialEndpoint6 = Opt.some(QuicEndpoint.new(self.makeConfig(), family))
+      let endpoint = QuicEndpoint.new(self.makeConfig(), family)
+      self.dialEndpoint6 = Opt.some(endpoint)
     self.dialEndpoint6.get()
   else:
     raise newException(QuicError, "client supports only IPv4/IPv6 address")

--- a/libp2p/transports/quictransport.nim
+++ b/libp2p/transports/quictransport.nim
@@ -596,7 +596,6 @@ proc listenerEndpointFor(
 proc dialOnlyEndpointFor(
     self: QuicTransport, family: AddressFamily
 ): QuicEndpoint {.raises: [TLSCertificateError, QuicError, TransportOsError].} =
-  # Construct before caching: an exception must not leave a partially written Opt.
   case family
   of AddressFamily.IPv4:
     if self.dialEndpoint4.isNone():

--- a/tests/libp2p/transports/test_quic.nim
+++ b/tests/libp2p/transports/test_quic.nim
@@ -8,6 +8,7 @@ import
   ../../../libp2p/[
     transports/transport,
     transports/quictransport,
+    transports/tls/certificate,
     upgrademngrs/upgrade,
     utils/future,
     muxers/muxer,
@@ -58,6 +59,43 @@ suite "Quic transport":
     quicTransProvider, ma(addressIP4), Opt.some(ma(addressIP6)), streamProvider
   )
   cancellationTransportTest(quicTransProvider, addressIP4)
+
+  asyncTest "dial retries after endpoint construction fails":
+    for address in [addressIP4, "/ip6/::1/udp/0/quic-v1"]:
+      let server = await createQuicTransport(
+        isServer = true, addresses = @[MultiAddress.init(address).tryGet()]
+      )
+      defer:
+        await server.stop()
+
+      var failNext = true
+      proc flakyCertGenerator(
+          kp: KeyPair
+      ): CertificateX509 {.gcsafe, raises: [TLSCertificateError].} =
+        if failNext:
+          failNext = false
+          raise newException(TLSCertificateError, "simulated endpoint creation failure")
+        generateX509(kp, encodingFormat = EncodingFormat.PEM)
+
+      let client = QuicTransport.new(
+        Upgrade(), PrivateKey.random(ECDSA, rng()).tryGet(), rng(), flakyCertGenerator
+      )
+      defer:
+        await client.stop()
+
+      expect QuicTransportDialError:
+        discard await client.dial("", server.addrs[0])
+      check not failNext
+
+      let acceptFut = server.accept()
+      defer:
+        await acceptFut.cancelAndWait()
+      let clientConn = await client.dial("", server.addrs[0])
+      let serverConn = await acceptFut
+      check:
+        not clientConn.closed()
+        not serverConn.closed()
+      await allFutures(clientConn.close(), serverConn.close())
 
   asyncTest "listener-role dial sends UDP hole-punch packets":
     let packetReceived =


### PR DESCRIPTION
## Summary

An exception while constructing a dial-only QUIC endpoint can partially write the cached `Opt`, leaving `some(nil)` and causing a subsequent dial to segfault. Construct the endpoint before assigning it to the IPv4 or IPv6 cache so failed initialization leaves the cache empty and retryable.

Add coverage that injects a certificate-generation failure, retries successfully against a local peer, and shuts down cleanly for both address families.


## References

- https://github.com/nim-lang/Nim/issues/26208 (missing warnings for partial writes during construction)
