### PR TITLE
chore: bump lsquic

### DIFF
--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -11,7 +11,7 @@ requires "nim >= 2.2.4",
   "nimcrypto >= 0.6.0", "bearssl >= 0.2.7",
   "https://github.com/vacp2p/nim-boringssl >= 0.0.8", "chronicles >= 0.12.3",
   "chronos >= 4.2.2", "metrics >= 0.2.2", "secp256k1", "stew >= 0.4.2", "results",
-  "serialization >= 0.5.0", "json_serialization >= 0.4.4", "lsquic >= 0.8.1",
+  "serialization >= 0.5.0", "json_serialization >= 0.4.4", "lsquic >= 0.9.0",
   "protobuf_serialization >= 0.6.0",
   "https://github.com/status-im/nim-websock >= 0.4.1",
   "https://github.com/logos-storage/nim-libplum >= 0.6.2"

--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -9,7 +9,7 @@ skipDirs = @["cbind", "examples", "interop", "simulation", "tests", "tools"]
 
 requires "nim >= 2.2.4",
   "nimcrypto >= 0.6.0", "bearssl >= 0.2.7",
-  "https://github.com/vacp2p/nim-boringssl >= 0.0.8", "chronicles >= 0.12.3",
+  "https://github.com/vacp2p/nim-boringssl >= 0.0.11", "chronicles >= 0.12.3",
   "chronos >= 4.2.2", "metrics >= 0.2.2", "secp256k1", "stew >= 0.4.2", "results",
   "serialization >= 0.5.0", "json_serialization >= 0.4.4", "lsquic >= 0.9.0",
   "protobuf_serialization >= 0.6.0",

--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -145,15 +145,15 @@
 
   boringssl = pkgs.fetchgit {
     url = "https://github.com/vacp2p/nim-boringssl";
-    rev = "e77caabae78fbc9aa5b78a0a521181b077c82571";
-    sha256 = "15k4dqh1hlcpq9zm30lpr728h7apdmgm22xzqhdm3clq9kia6fr8";
+    rev = "346429e4cda48e775f2d1eb3ccb8757edf4f3648";
+    sha256 = "0x46sdq75zp84qahwh472qr33xw38adrsp41fksh7xwwd6384fl3";
     fetchSubmodules = true;
   };
 
   lsquic = pkgs.fetchgit {
     url = "https://github.com/vacp2p/nim-lsquic";
-    rev = "d6d8f81d854cbc575f6206aa6d72bcdfbe5d07aa";
-    sha256 = "0syyig0jlpph5fghd0ijngq2m99zl4pq5ajckax4y9cpy6ljs532";
+    rev = "fb293834a3f90368e1f6c57aec2360cf8d840c5a";
+    sha256 = "0mixc5vm5s6ppbf289rmqs7mjbvwpaj96aczfjsqjapinig92xy1";
     fetchSubmodules = true;
   };
 

--- a/nix/libp2p.lock
+++ b/nix/libp2p.lock
@@ -291,20 +291,20 @@
       }
     },
     "boringssl": {
-      "version": "0.0.8",
-      "vcsRevision": "e77caabae78fbc9aa5b78a0a521181b077c82571",
+      "version": "0.0.11",
+      "vcsRevision": "346429e4cda48e775f2d1eb3ccb8757edf4f3648",
       "url": "https://github.com/vacp2p/nim-boringssl",
       "downloadMethod": "git",
       "dependencies": [
         "nim"
       ],
       "checksums": {
-        "sha1": "2f603bb6d70683393bbb091bf6bd325d9c52be9f"
+        "sha1": "49acb43d56a26b30587c9758edb34e3c44b63d8f"
       }
     },
     "lsquic": {
-      "version": "0.8.1",
-      "vcsRevision": "c9acf6a37347b24ba158f53ff4851e68245950b7",
+      "version": "0.9.0",
+      "vcsRevision": "fb293834a3f90368e1f6c57aec2360cf8d840c5a",
       "url": "https://github.com/vacp2p/nim-lsquic",
       "downloadMethod": "git",
       "dependencies": [
@@ -312,13 +312,12 @@
         "zlib",
         "stew",
         "chronos",
-        "nimcrypto",
         "unittest2",
         "chronicles",
         "boringssl"
       ],
       "checksums": {
-        "sha1": "94e84841563554409861fbe7dd3047c6ce05f1a6"
+        "sha1": "6ca2849ff7c7a0d5271dc57ce869c72ba3111a2f"
       }
     }
   },

--- a/tests/libp2p/transports/stream_tests.nim
+++ b/tests/libp2p/transports/stream_tests.nim
@@ -460,7 +460,7 @@ template streamTransportTest*(
           check (await stream.readExactlyAsStr(clientMessage.len)) == clientMessage
 
           successfulReadsWG.done()
-        except LPStreamIncompleteError:
+        except LPStreamIncompleteError, LPStreamResetError:
           # Error is expected when muxer is closed while waiting in readExactly
           discard
 

--- a/tests/libp2p/transports/test_quic.nim
+++ b/tests/libp2p/transports/test_quic.nim
@@ -381,8 +381,7 @@ suite "Quic transport":
     expect QuicTransportAcceptStopped:
       discard await server.accept()
 
-  asyncTest "remote connection close leaves the dialer with a live session":
-    # TODO: vacp2p/nim-lsquic#162
+  asyncTest "remote connection close closes the dialer's session":
     let server = await createQuicTransport(isServer = true)
     let client = await createQuicTransport()
     defer:
@@ -408,12 +407,10 @@ suite "Quic transport":
     defer:
       await readFut.cancelAndWait()
 
-    # a CONNECTION_CLOSE crosses loopback in well under a millisecond
-    # the dialer instead waits out lsquic's 30s idle timeout
     check:
-      not (await readFut.withTimeout(1.seconds))
+      await readFut.withTimeout(1.seconds)
       serverConn.closed
-      not clientConn.closed
+      clientConn.closed
 
   asyncTest "stream idle timeout resets only the idle stream":
     let server = await createQuicTransport(


### PR DESCRIPTION
## Summary

- Bump the minimum `nim-lsquic` version to `0.9.0`.
- Update the Nimble lock and Nix source pin for `nim-lsquic`.
- Bump `nim-boringssl` to `0.0.11`, the minimum required by `nim-lsquic 0.9.0`, and synchronize its lock and Nix source pin.
- Update the QUIC lifecycle test to expect remote close propagation provided by `nim-lsquic 0.9.0`.

## Affected Areas

- [x] Transports — QUIC dependency and lifecycle expectation
- [x] Build / Tooling — Nimble lock and Nix dependency pins

## Impact on Library Users

The minimum supported versions are now `nim-lsquic 0.9.0` and `nim-boringssl 0.0.11`. This PR does not change the nim-libp2p API.

## Risk Assessment

The change updates the native QUIC and TLS dependencies. Their revisions and source hashes are pinned in the Nix configuration.

## References

- [nim-lsquic #162](https://github.com/vacp2p/nim-lsquic/issues/162)
