### PR TITLE
fix(service-disco): admit the registering peer instead of the advertised one

### DIFF
--- a/libp2p/protocols/service_discovery/registrar.nim
+++ b/libp2p/protocols/service_discovery/registrar.nim
@@ -251,11 +251,16 @@ proc acceptAdvertisement*(
     serviceId, disco.rtable, disco.config.replication, disco.discoConfig.bucketsCount,
     Interest,
   )
-  disco.rtManager.admitPeers(
-    disco,
-    serviceId,
-    @[PeerInfo(peerId: ad.data.peerId, addrs: ad.data.addresses.mapIt(it.address))],
-  )
+  # Admit the registering DHT peer, not the advertised subject. Under proxy
+  # advertising ad.data.peerId need not participate in KadDHT; the DHT peer is
+  # `advertiser`. Mirror seatSender and use its peerstore addresses.
+  let advertiserAddrs = disco.switch.peerStore[AddressBook][advertiser]
+  if advertiserAddrs.len > 0:
+    disco.rtManager.admitPeers(
+      disco,
+      serviceId,
+      @[PeerInfo(peerId: advertiser, addrs: advertiserAddrs)],
+    )
 
   disco.registrar.ads.put(serviceId, advertiser, ad, advertiserIps, now)
   disco.registrar.updateRegistrarMetrics()


### PR DESCRIPTION
Noticed while investigating the module integration in Delivery. The `peerId` and `addresses` encoded in the advertisement does not necessarily match those of the advertiser (i.e. the actual module participating in the KadDHT). In fact, when using the Service Discovery module as a proxy (as Delivery does), it never will. Fix ensures its the advertiser's information that is admitted to the routing table and not the unrelated info in the advertisement.

cc @NagyZoltanPeter 